### PR TITLE
Change the analyzers so that they don't keep the entire file in memory

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -232,14 +232,16 @@ public class AnalyzerGuru {
     /**
      * Create a Lucene document and fill in the required fields
      * @param file The file to index
-     * @param in The data to generate the index for
      * @param path Where the file is located (from source root)
+     * @param fa The analyzer to use on the file
+     * @param xrefOut Where to write the xref (possibly {@code null})
      * @return The Lucene document to add to the index database
      * @throws java.io.IOException If an exception occurs while collecting the
      *                             datas
      */
-    public Document getDocument(File file, InputStream in, String path,
-                                FileAnalyzer fa) throws IOException {
+    public Document getDocument(File file, String path,
+                                FileAnalyzer fa, Writer xrefOut)
+            throws IOException {
         Document doc = new Document();
         String date = DateTools.timeToString(file.lastModified(),
             DateTools.Resolution.MILLISECOND);
@@ -272,7 +274,7 @@ public class AnalyzerGuru {
                 doc.add(new Field("t", g.typeName(), string_ft_stored_nanalyzed_norms
                     ));
             }                   
-            fa.analyze(doc, in);
+            fa.analyze(doc, StreamSource.fromFile(file), xrefOut);
         }
 
         return doc;

--- a/src/org/opensolaris/opengrok/analysis/FileAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/FileAnalyzer.java
@@ -23,24 +23,16 @@
  */
 package org.opensolaris.opengrok.analysis;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.util.logging.Level;
-import java.util.zip.GZIPOutputStream;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.opensolaris.opengrok.OpenGrokLogger;
 import org.opensolaris.opengrok.analysis.plain.PlainFullTokenizer;
 import org.opensolaris.opengrok.analysis.plain.PlainSymbolTokenizer;
 import org.opensolaris.opengrok.configuration.Project;
-import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 
 /**
  * Base class for all different File Analyzers
@@ -138,7 +130,15 @@ public class FileAnalyzer extends Analyzer {
                         
     }
 
-    public void analyze(Document doc, InputStream in) throws IOException {
+    /**
+     * Analyze the contents of a source file. This includes populating the
+     * Lucene document with fields to add to the index, and writing the
+     * cross-referenced data to the specified destination.
+     * @param doc the Lucene document
+     * @param src the input data source
+     * @param xrefOut where to write the xref (may be {@code null})
+     */
+    public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
         // not used
     }
         
@@ -159,28 +159,6 @@ public class FileAnalyzer extends Analyzer {
                 OpenGrokLogger.getLogger().log(
                         Level.WARNING, "Have no analyzer for: {0}", fieldName);
                 return null;
-        }
-    }
-
-    /**
-     * Write a cross referenced HTML file.
-     * @param out to writer HTML cross-reference
-     * @throws java.io.IOException if an error occurs
-     */
-    public void writeXref(Writer out) throws IOException {
-        out.write("Error General File X-Ref writer!");
-    }
-
-    public void writeXref(File xrefDir, String path) throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-
-        final boolean compressed = env.isCompressXref();
-        final File file = new File(xrefDir, path + (compressed ? ".gz" : ""));
-        try (OutputStream out = compressed ?
-                    new GZIPOutputStream(new FileOutputStream(file)) :
-                    new FileOutputStream(file);
-                Writer w = new BufferedWriter(new OutputStreamWriter(out))) {
-            writeXref(w);
         }
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/StreamSource.java
+++ b/src/org/opensolaris/opengrok/analysis/StreamSource.java
@@ -1,0 +1,67 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.analysis;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This class lets you create {@code InputStream}s that read data from a
+ * specific source. It could be used if you need to pass a stream as an
+ * argument to a method where the stream may need to be read multiple times.
+ * Instead of passing the stream directly, you pass a {@code StreamSource}
+ * instance that generates the stream. The receiver may call
+ * {@link #getStream()} multiple times, getting a fresh stream each time,
+ * so that there may be multiple, concurrent readers that don't interfere
+ * with each other.
+ */
+public abstract class StreamSource {
+    /**
+     * Get a stream that reads data from the input source. Every call should
+     * return a new instance so that multiple readers can read from the source
+     * without interfering with each other.
+     *
+     * @return an {@code InputStream}
+     * @throws IOException if an error occurs when opening the stream
+     */
+    public abstract InputStream getStream() throws IOException;
+
+    /**
+     * Helper method that creates a {@code StreamSource} instance that
+     * reads data from a file.
+     *
+     * @param file the data file
+     * @return a stream source that reads from {@code file}
+     */
+    public static StreamSource fromFile(final File file) {
+        return new StreamSource() {
+            @Override
+            public InputStream getStream() throws IOException {
+                return new BufferedInputStream(new FileInputStream(file));
+            }
+        };
+    }
+}

--- a/src/org/opensolaris/opengrok/analysis/TextAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/TextAnalyzer.java
@@ -18,16 +18,16 @@
  */
 
 /*
- * Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.analysis;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
-import org.apache.lucene.document.Document;
 
 public abstract class TextAnalyzer extends FileAnalyzer {
 
@@ -35,8 +35,10 @@ public abstract class TextAnalyzer extends FileAnalyzer {
         super(factory);
     }
 
-    @Override
-    public final void analyze(Document doc, InputStream in) throws IOException {
+    protected Reader getReader(InputStream stream) throws IOException {
+        InputStream in = stream.markSupported() ?
+                stream : new BufferedInputStream(stream);
+
         String charset = null;
 
         in.mark(3);
@@ -61,8 +63,6 @@ public abstract class TextAnalyzer extends FileAnalyzer {
             charset = Charset.defaultCharset().name();
         }
 
-        analyze(doc, new InputStreamReader(in, charset));
+        return new InputStreamReader(in, charset);
     }
-
-    protected abstract void analyze(Document doc, Reader reader) throws IOException;
 }

--- a/src/org/opensolaris/opengrok/analysis/archive/ZipAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/archive/ZipAnalyzer.java
@@ -23,15 +23,16 @@
 package org.opensolaris.opengrok.analysis.archive;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.TextField;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
+import org.opensolaris.opengrok.analysis.IteratorReader;
+import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.web.Util;
 
 /**
@@ -41,32 +42,26 @@ import org.opensolaris.opengrok.web.Util;
  */
 public class ZipAnalyzer extends FileAnalyzer {
 
-    private final StringBuilder content;
-
     protected ZipAnalyzer(FileAnalyzerFactory factory) {
         super(factory);
-        content = new StringBuilder(64 * 1024);
     }
 
     @Override
-    public void analyze(Document doc, InputStream in) throws IOException {
-        content.setLength(0);
-        ZipInputStream zis = new ZipInputStream(in);
-        ZipEntry entry;
-        while ((entry = zis.getNextEntry()) != null) {
-            content.append(entry.getName()).append('\n');
+    public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
+        ArrayList<String> names = new ArrayList<>();
+
+        try (ZipInputStream zis = new ZipInputStream(src.getStream())) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                String name = entry.getName();
+                names.add(name);
+                if (xrefOut != null) {
+                    Util.htmlize(name, xrefOut);
+                    xrefOut.append("<br/>");
+                }
+            }
         }
-        content.trimToSize();
-        doc.add(new TextField("full", content.toString(), Store.NO));
-    }
 
-    /**
-     * Write a cross referenced HTML file.
-     *
-     * @param out Writer to store HTML cross-reference
-     */
-    @Override
-    public void writeXref(Writer out) throws IOException {
-        out.write(Util.htmlize(content));
+        doc.add(new TextField("full", new IteratorReader(names)));
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/executables/JavaClassAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/executables/JavaClassAnalyzer.java
@@ -54,6 +54,7 @@ import org.apache.lucene.document.TextField;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.IteratorReader;
+import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.analysis.TagFilter;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 
@@ -66,10 +67,6 @@ import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 public class JavaClassAnalyzer extends FileAnalyzer {
 
     private final String urlPrefix = RuntimeEnvironment.getInstance().getUrlPrefix();
-    private List<String> defs;
-    private List<String> refs;
-    private List<String> full;
-    private String xref;
 
     /**
      * Creates a new instance of JavaClassAnalyzer
@@ -81,16 +78,25 @@ public class JavaClassAnalyzer extends FileAnalyzer {
     }
 
     @Override
-    public void analyze(Document doc, InputStream in) throws IOException {
-        defs = new ArrayList<String>();
-        refs = new ArrayList<String>();
-        full = new ArrayList<String>();
-        xref = null;
+    public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
+        try (InputStream in = src.getStream()) {
+            analyze(doc, in, xrefOut);
+        }
+    }
+
+    void analyze(Document doc, InputStream in, Writer xrefOut) throws IOException {
+        List<String> defs = new ArrayList<>();
+        List<String> refs = new ArrayList<>();
+        List<String> full = new ArrayList<>();
 
         ClassParser classparser = new ClassParser(in, doc.get("path"));
         StringWriter out = new StringWriter();
-        getContent(out, classparser.parse());
-        xref = out.toString();
+        getContent(out, classparser.parse(), defs, refs, full);
+        String xref = out.toString();
+
+        if (xrefOut != null) {
+            xrefOut.append(xref);
+        }
 
         out.getBuffer().setLength(0); // clear the buffer
         for (String fl : full) {
@@ -106,10 +112,6 @@ public class JavaClassAnalyzer extends FileAnalyzer {
         doc.add(new TextField("full", constants, Store.NO));
     }
 
-    public String getXref() {
-        return xref;
-    }
-
     protected String linkPath(String path) {
         return "<a href=\"" + urlPrefix + "path=" + path + "\">" + path + "</a>";
     }
@@ -123,7 +125,9 @@ public class JavaClassAnalyzer extends FileAnalyzer {
     }
 
 //TODO this class needs to be thread safe to avoid bug 13364, which was fixed by just updating bcel to 5.2
-    private void getContent(Writer out, JavaClass c) throws IOException {
+    private void getContent(Writer out, JavaClass c,
+            List<String> defs, List<String> refs, List<String> full)
+            throws IOException {
         String t;
         ConstantPool cp = c.getConstantPool();
         int[] v = new int[cp.getLength() + 1];
@@ -172,7 +176,7 @@ public class JavaClassAnalyzer extends FileAnalyzer {
                 for (Attribute ca : ((Code) a).getAttributes()) {
                     if (ca.getTag() == org.apache.bcel.Constants.ATTR_LOCAL_VARIABLE_TABLE) {
                         for (LocalVariable l : ((LocalVariableTable) ca).getLocalVariableTable()) {
-                            printLocal(out, l, v);
+                            printLocal(out, l, v, defs, refs);
                         }
                     }
                 }
@@ -252,7 +256,7 @@ public class JavaClassAnalyzer extends FileAnalyzer {
             if (!locals.isEmpty()) {
                 for (LocalVariable[] ls : locals) {
                     for (LocalVariable l : ls) {
-                        printLocal(out, l, v);
+                        printLocal(out, l, v, defs, refs);
                     }
                 }
             }
@@ -268,19 +272,8 @@ public class JavaClassAnalyzer extends FileAnalyzer {
         }
     }
 
-    /**
-     * Write a cross referenced HTML file.
-     *
-     * @param out Writer to write HTML cross-reference
-     */
-    @Override
-    public void writeXref(Writer out) throws IOException {
-        if (xref != null) {
-            out.write(xref);
-        }
-    }
-
-    private void printLocal(Writer out, LocalVariable l, int[] v) throws IOException {
+    private void printLocal(Writer out, LocalVariable l,
+            int[] v, List<String> defs, List<String> refs) throws IOException {
         v[l.getIndex()] = 1;
         v[l.getNameIndex()] = 1;
         v[l.getSignatureIndex()] = 1;

--- a/src/org/opensolaris/opengrok/analysis/plain/AbstractSourceCodeAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/AbstractSourceCodeAnalyzer.java
@@ -32,6 +32,7 @@ import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 import org.opensolaris.opengrok.analysis.JFlexXref;
+import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.history.Annotation;
 
@@ -40,8 +41,6 @@ import org.opensolaris.opengrok.history.Annotation;
  * @author Lubos Kosco
  */
 public abstract class AbstractSourceCodeAnalyzer extends PlainAnalyzer {
-
-    private JFlexXref xref;
 
     /**
      * Creates a new instance of abstract analyzer
@@ -62,12 +61,13 @@ public abstract class AbstractSourceCodeAnalyzer extends PlainAnalyzer {
      * @param reader the data to produce xref for
      * @return an xref instance
      */
+    @Override
     protected abstract JFlexXref newXref(Reader reader);
 
     @Override
-    public void analyze(Document doc, Reader in) throws IOException {
-        super.analyze(doc, in);
-        doc.add(new TextField("refs", getContentReader()));
+    public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
+        super.analyze(doc, src, xrefOut);
+        doc.add(new TextField("refs", getReader(src.getStream())));
     }
 
     @Override
@@ -76,23 +76,6 @@ public abstract class AbstractSourceCodeAnalyzer extends PlainAnalyzer {
             return new TokenStreamComponents(newSymbolTokenizer(reader));
         }
         return super.createComponents(fieldName, reader);
-    }
-
-    /**
-     * Write a cross referenced HTML file.
-     *
-     * @param out Writer to write HTML cross-reference
-     */
-    @Override
-    public void writeXref(Writer out) throws IOException {
-        if (xref == null) {
-            xref = newXref(getContentReader());
-        } else {
-            xref.reInit(getContentReader());
-        }
-        xref.setDefs(defs);
-        xref.project = project;
-        xref.write(out);
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzer.java
@@ -22,11 +22,10 @@
  */
 package org.opensolaris.opengrok.analysis.plain;
 
-import java.io.CharArrayReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.io.Writer;
-import java.util.Arrays;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.TextField;
@@ -34,6 +33,8 @@ import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.ExpandTabsReader;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.IteratorReader;
+import org.opensolaris.opengrok.analysis.JFlexXref;
+import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.analysis.TextAnalyzer;
 import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.history.Annotation;
@@ -45,66 +46,64 @@ import org.opensolaris.opengrok.history.Annotation;
  */
 public class PlainAnalyzer extends TextAnalyzer {
 
-    private char[] content;
-    private int len;
-    protected PlainXref xref = new PlainXref((Reader) null);
-    protected Definitions defs;
+    private JFlexXref xref;
+    private Definitions defs;
 
     /**
      * Creates a new instance of PlainAnalyzer
      */
     protected PlainAnalyzer(FileAnalyzerFactory factory) {
         super(factory);
-        content = new char[64 * 1024];
-        len = 0;
+    }
+
+    /**
+     * Create an xref for the language supported by this analyzer.
+     * @param reader the data to produce xref for
+     * @return an xref instance
+     */
+    protected JFlexXref newXref(Reader reader) {
+        return new PlainXref(reader);
     }
 
     @Override
-    public void analyze(Document doc, Reader in) throws IOException {
-        Reader inReader =
-                ExpandTabsReader.wrap(in, project);
+    protected Reader getReader(InputStream stream) throws IOException {
+        return ExpandTabsReader.wrap(super.getReader(stream), project);
+    }
 
-        len = 0;
-        do {
-            int rbytes = inReader.read(content, len, content.length - len);
-            if (rbytes >= 0) {
-                if (rbytes == (content.length - len)) {
-                    content = Arrays.copyOf(content, content.length * 2);
-                }
-                len += rbytes;
-            } else {
-                break;
-            }
-        } while (true);
-
-        doc.add(new TextField("full", getContentReader()));
+    @Override
+    public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
+        doc.add(new TextField("full", getReader(src.getStream())));
         String fullpath = doc.get("fullpath");
         if (fullpath != null && ctags != null) {
             defs = ctags.doCtags(fullpath + "\n");
             if (defs != null && defs.numberOfSymbols() > 0) {
                 doc.add(new TextField("defs", new IteratorReader(defs.getSymbols())));
-                doc.add(new TextField("refs", getContentReader()));
+                doc.add(new TextField("refs", getReader(src.getStream())));
                 byte[] tags = defs.serialize();
                 doc.add(new StoredField("tags", tags));
+            }
+        }
+
+        if (xrefOut != null) {
+            try (Reader in = getReader(src.getStream())) {
+                writeXref(in, xrefOut);
             }
         }
     }
 
     /**
-     * Get a reader that reads from the {@link #content} array.
-     */
-    protected Reader getContentReader() {
-        return new CharArrayReader(content, 0, len);
-    }
-
-    /**
      * Write a cross referenced HTML file.
      *
+     * @param in Input source
      * @param out Writer to write HTML cross-reference
      */
-    @Override
-    public void writeXref(Writer out) throws IOException {
-        xref.reInit(getContentReader());
+    private void writeXref(Reader in, Writer out) throws IOException {
+        if (xref == null) {
+            xref = newXref(in);
+        } else {
+            xref.reInit(in);
+        }
+        xref.setDefs(defs);
         xref.project = project;
         xref.write(out);
     }

--- a/src/org/opensolaris/opengrok/analysis/sql/PLSQLAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/sql/PLSQLAnalyzer.java
@@ -27,29 +27,20 @@ import java.io.Reader;
 import java.io.Writer;
 import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
+import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.PlainAnalyzer;
 import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.history.Annotation;
 
 public class PLSQLAnalyzer extends PlainAnalyzer {
 
-    private final PLSQLXref xref = new PLSQLXref((Reader) null);
-
     public PLSQLAnalyzer(FileAnalyzerFactory factory) {
         super(factory);
     }
 
-    /**
-     * Write a cross referenced HTML file.
-     *
-     * @param out Writer to write HTML cross-reference
-     */
     @Override
-    public void writeXref(Writer out) throws IOException {
-        xref.reInit(getContentReader());
-        xref.project = project;
-        xref.setDefs(defs);
-        xref.write(out);
+    protected JFlexXref newXref(Reader reader) {
+        return new PLSQLXref(reader);
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/sql/SQLAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/sql/SQLAnalyzer.java
@@ -27,29 +27,20 @@ import java.io.Reader;
 import java.io.Writer;
 import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
+import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.plain.PlainAnalyzer;
 import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.history.Annotation;
 
 public class SQLAnalyzer extends PlainAnalyzer {
 
-    private final SQLXref xref = new SQLXref((Reader) null);
-
     public SQLAnalyzer(FileAnalyzerFactory factory) {
         super(factory);
     }
 
-    /**
-     * Write a cross referenced HTML file.
-     *
-     * @param out Writer to write HTML cross-reference
-     */
     @Override
-    public void writeXref(Writer out) throws IOException {
-        xref.reInit(getContentReader());
-        xref.project = project;
-        xref.setDefs(defs);
-        xref.write(out);
+    protected JFlexXref newXref(Reader reader) {
+        return new SQLXref(reader);
     }
 
     /**

--- a/src/org/opensolaris/opengrok/web/Util.java
+++ b/src/org/opensolaris/opengrok/web/Util.java
@@ -70,7 +70,15 @@ public final class Util {
      */
     public static String htmlize(CharSequence q) {
         StringBuilder sb = new StringBuilder(q.length() * 2);
-        htmlize(q, sb);
+        try {
+            htmlize(q, sb);
+        } catch (IOException ioe) {
+            // IOException cannot happen when the destination is a
+            // StringBuilder. Wrap in an AssertionError so that callers
+            // don't have to check for an IOException that should never
+            // happen.
+            throw new AssertionError("StringBuilder threw IOException", ioe);
+        }
         return sb.toString();
     }
 
@@ -80,8 +88,10 @@ public final class Util {
      *
      * @param q     a character sequence to esacpe
      * @param dest  where to append the character sequence to
+     * @throws IOException if an error occurred when writing to {@code dest}
      */
-    public static void htmlize(CharSequence q, StringBuilder dest) {
+    public static void htmlize(CharSequence q, Appendable dest)
+            throws IOException {
         for (int i = 0; i < q.length(); i++ ) {
             htmlize(q.charAt(i), dest);
         }
@@ -91,11 +101,13 @@ public final class Util {
      * Append a character array to the given destination whereby
      * special characters for HTML are escaped accordingly.
      *
-     * @param cs    characters to esacpe
+     * @param cs    characters to escape
      * @param length max. number of characters to append, starting from index 0.
      * @param dest  where to append the character sequence to
+     * @throws IOException if an error occurred when writing to {@code dest}
      */
-    public static void htmlize(char[] cs, int length, StringBuilder dest) {
+    public static void htmlize(char[] cs, int length, Appendable dest)
+            throws IOException {
         int len = length;
         if (cs.length < length) {
             len = cs.length;
@@ -111,8 +123,9 @@ public final class Util {
      *
      * @param c the character to append
      * @param dest where to append the character to
+     * @throws IOException if an error occurred when writing to {@code dest}
      */
-    private static void htmlize(char c, StringBuilder dest) {
+    private static void htmlize(char c, Appendable dest) throws IOException {
         switch (c) {
             case '&':
                 dest.append("&amp;");
@@ -145,7 +158,7 @@ public final class Util {
     }
 
     /**
-     * Convinience method for {@code breadcrumbPath(urlPrefix, path, '/')}.
+     * Convenience method for {@code breadcrumbPath(urlPrefix, path, '/')}.
      * @param urlPrefix prefix to add to each url
      * @param path path to crack
      * @return HTML markup fro the breadcrumb or the path itself.

--- a/test/org/opensolaris/opengrok/analysis/document/TroffAnalyzerTest.java
+++ b/test/org/opensolaris/opengrok/analysis/document/TroffAnalyzerTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright 2009 - 2011 Jens Elkner.
+ * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.analysis.document;
 
@@ -27,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.CharArrayWriter;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
 
 import org.apache.lucene.document.Document;
@@ -38,6 +40,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.opensolaris.opengrok.web.Util;
 import static org.junit.Assert.*;
+import org.opensolaris.opengrok.analysis.StreamSource;
 
 /**
  * @author  Jens Elkner
@@ -99,19 +102,13 @@ public class TroffAnalyzerTest {
     @Test
     public void testAnalyze() throws IOException {
         Document doc = new Document();
-        analyzer.analyze(doc, new ByteArrayInputStream(content.getBytes()));
-    }
-
-    /**
-     * Test method for {@link org.opensolaris.opengrok.analysis.document
-     * .TroffAnalyzer#writeXref(java.io.Writer)}.
-     * @throws IOException 
-     */
-    @Test
-    public void testWriteXrefWriter() throws IOException {
-        testAnalyze();
-        StringWriter out = new StringWriter(content.length() + 1024);
-        analyzer.writeXref(out);
+        StringWriter xrefOut = new StringWriter();
+        analyzer.analyze(doc, new StreamSource() {
+            @Override
+            public InputStream getStream() throws IOException {
+                return new ByteArrayInputStream(content.getBytes());
+            }
+        }, xrefOut);
     }
 
     /**

--- a/test/org/opensolaris/opengrok/web/UtilTest.java
+++ b/test/org/opensolaris/opengrok/web/UtilTest.java
@@ -18,11 +18,12 @@
  */
 
 /*
- * Copyright (c) 2007, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.web;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Locale;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -52,7 +53,7 @@ public class UtilTest {
     }
 
     @Test
-    public void htmlize() {
+    public void htmlize() throws IOException {
         String[][] input_output = {
             {"This is a test", "This is a test" },
             {"Newline\nshould become <br/>",


### PR DESCRIPTION
Instead of passing a stream to the analyze() methods, and have them
cache the entire contents in a byte or char array, open a new stream
each time the source file should be read.

Also, write the xref files from the analyze() methods. In many
analyzers, this avoids the need for building up a data structure that
holds the full xref output in memory.

This fixes #8.
