### PR TITLE
Improve cleanup of resources opened by the analyze() methods.

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -231,19 +231,17 @@ public class AnalyzerGuru {
     }
         
     /**
-     * Create a Lucene document and fill in the required fields
+     * Populate a Lucene document with the required fields.
+     * @param doc The document to populate
      * @param file The file to index
      * @param path Where the file is located (from source root)
      * @param fa The analyzer to use on the file
      * @param xrefOut Where to write the xref (possibly {@code null})
-     * @return The Lucene document to add to the index database
-     * @throws java.io.IOException If an exception occurs while collecting the
-     *                             data
+     * @throws IOException If an exception occurs while collecting the data
      */
-    public Document getDocument(File file, String path,
-                                FileAnalyzer fa, Writer xrefOut)
+    public void populateDocument(Document doc, File file, String path,
+                                 FileAnalyzer fa, Writer xrefOut)
             throws IOException {
-        Document doc = new Document();
         String date = DateTools.timeToString(file.lastModified(),
             DateTools.Resolution.MILLISECOND);
         doc.add(new Field(QueryBuilder.U, Util.path2uid(path, date),
@@ -277,8 +275,6 @@ public class AnalyzerGuru {
             }                   
             fa.analyze(doc, StreamSource.fromFile(file), xrefOut);
         }
-
-        return doc;
     }
 
     /**


### PR DESCRIPTION
Before issue #8, there would be exactly one FileInputStream per file
that was being analyzed, and it was pretty easy to ensure that this
stream was closed. Issue #8 changed this, but it didn't add logic to
ensure that the extra streams were closed if there was an error before
the document was added to the index.

This change attempts to improve the situation by making sure that
readers or token streams associated with the fields in the Lucene
document are closed if something goes wrong.
