### PR TITLE
Improve escaping of strings in webapp.

### DIFF
--- a/src/org/opensolaris/opengrok/web/Util.java
+++ b/src/org/opensolaris/opengrok/web/Util.java
@@ -580,7 +580,8 @@ public final class Util {
             return q == null ? "" : URLEncoder.encode(q, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             // Should not happen. UTF-8 must be supported by JVMs.
-            Logger.getLogger(EftarFileReader.class.getName()).log(Level.WARNING, "Failed to URL-encode UTF-8: ", e);            
+            Logger.getLogger(Util.class.getName()).log(
+                    Level.WARNING, "Failed to URL-encode UTF-8: ", e);
         }
         return null;
     }
@@ -649,8 +650,8 @@ public final class Util {
     }
 
     /**
-     * Replace all quote characters (ASCI 0x22) with the corresponding html
-     * entity (&amp;quot;).
+     * Escape a string for use as in an HTML attribute value. The returned
+     * value is not enclosed in double quotes. The caller needs to add those.
      * @param q string to escape.
      * @return an empty string if a parameter is {@code null}, the mangled
      *  string otherwise.
@@ -665,6 +666,8 @@ public final class Util {
             c = q.charAt(i);
             if (c == '"') {
                 sb.append("&quot;");
+            } else if (c == '&') {
+                sb.append("&amp;");
             } else {
                 sb.append(c);
             }

--- a/test/org/opensolaris/opengrok/web/UtilTest.java
+++ b/test/org/opensolaris/opengrok/web/UtilTest.java
@@ -179,6 +179,7 @@ public class UtilTest {
         assertEquals("", Util.formQuoteEscape(null));
         assertEquals("abc", Util.formQuoteEscape("abc"));
         assertEquals("&quot;abc&quot;", Util.formQuoteEscape("\"abc\""));
+        assertEquals("&amp;aring;", Util.formQuoteEscape("&aring;"));
     }
 
     @Test

--- a/web/menu.jspf
+++ b/web/menu.jspf
@@ -18,8 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
-Use is subject to license terms.
+Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
 
 Portions Copyright 2011 Jens Elkner.
 
@@ -111,11 +110,11 @@ org.opensolaris.opengrok.web.Util"
                 <option value="">Any</option><%
                 for (Map.Entry<String, String> d : SearchHelper.getFileTypeDescirptions()) {
                     %>
-                <option value="<%= d.getKey() %>"<% 
+                <option value="<%= Util.formQuoteEscape(d.getKey()) %>"<%
                     if (d.getKey().equals(selection)) {
                         %> selected="selected"<%
                     }
-                    %>><%= Util.formQuoteEscape(d.getValue()) %></option><%
+                    %>><%= Util.htmlize(d.getValue()) %></option><%
                 }
             %>
             </select>

--- a/web/search.jsp
+++ b/web/search.jsp
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 
 --%><%@page session="false" errorPage="error.jsp" import="
@@ -134,18 +134,23 @@ include file="menu.jspf"
         for (Suggestion hint : hints) {
         %><p><font color="#cc0000">Did you mean (for <%= hint.name %>)</font>:<%
             for (String word : hint.freetext) {
-            %> <a href=search?q=<%= word %>><%= word %></a> &nbsp;  <%
+            %> <a href="search?q=<%= Util.URIEncode(word) %>"><%=
+                Util.htmlize(word) %></a> &nbsp; <%
             }
             for (String word : hint.refs) {
-            %> <a href=search?refs=<%= word %>><%= word %></a> &nbsp;  <%
+            %> <a href="search?refs=<%= Util.URIEncode(word) %>"><%=
+                Util.htmlize(word) %></a> &nbsp; <%
             }
             for (String word : hint.defs) {
-            %> <a href=search?defs=<%= word %>><%= word %></a> &nbsp;  <%
+            %> <a href="search?defs=<%= Util.URIEncode(word) %>"><%=
+                Util.htmlize(word) %></a> &nbsp; <%
             }
         %></p><%
         }
         %>
-        <p> Your search <b><%= searchHelper.query %></b> did not match any files.
+        <p> Your search <b><%
+            Util.htmlize(searchHelper.query.toString(), out); %></b>
+            did not match any files.
             <br/> Suggestions:<br/>
         </p>
         <ul>
@@ -198,7 +203,8 @@ include file="menu.jspf"
             thispage = totalHits - start;
         }
         %>
-        <p class="pagetitle">Searched <b><%= searchHelper.query
+        <p class="pagetitle">Searched <b><%
+            Util.htmlize(searchHelper.query.toString(), out);
             %></b> (Results <b> <%= start + 1 %> - <%= thispage + start
             %></b> of <b><%= totalHits %></b>) sorted by <%=
             searchHelper.order.getDesc() %></p><%


### PR DESCRIPTION
Util.java: Improve formQuoteEscape() to also escape '&' characters, and
clarify that it's for use in HTML attribute values.

UtilTest.java: Add test for the new behaviour of formQuoteEscape().

menu.jspf: Use correct form of escaping for file type selection.

search.jspf: Escape previously unescaped strings.
