### PR TITLE
Fix tests on Maven.

### DIFF
--- a/opengrok-indexer/build.xml
+++ b/opengrok-indexer/build.xml
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2007, 2011, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
 
 -->
 <project name="OpenGrok" default="jar" basedir=".">
@@ -30,7 +30,7 @@ Copyright (c) 2007, 2011, Oracle and/or its affiliates. All rights reserved.
 
     <property name="test.repositories" value="../testdata/repositories"/>
     <property name="test.sources" value="../testdata/sources"/>
-    <property name="test.cvs" value="${test.repositories}/cvs"/>
+    <property name="test.cvs" value="${test.repositories}/cvs_test"/>
     <property name="test.cvs.repo" value="${test.cvs}/cvsrepo"/>
     <property name="test.cvs.root" value="${test.cvs}/cvsroot"/>
     <property name="test.hg" value="${test.repositories}/mercurial"/>

--- a/test/org/opensolaris/opengrok/analysis/CtagsTest.java
+++ b/test/org/opensolaris/opengrok/analysis/CtagsTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
  */
 
 package org.opensolaris.opengrok.analysis;
@@ -50,20 +50,22 @@ public class CtagsTest {
         ctags = new Ctags();
         ctags.setBinary(RuntimeEnvironment.getInstance().getCtags());
 
+        repository = new TestRepository();
+        repository.create(CtagsTest.class.getResourceAsStream(
+                "/org/opensolaris/opengrok/index/source.zip"));
+
         /*
          * This setting is only needed for bug19195 but it does not seem
          * that it is possible to specify it just for single test case.
          * The config file contains assembly specific settings so it should
          * not be harmful to other test cases.
          */
-        String extraOptionsFile = "testdata/sources/bug19195/ctags.config";
+        String extraOptionsFile =
+                repository.getSourceRoot() + "/bug19195/ctags.config";
         ctags.setCTagsExtraOptionsFile(extraOptionsFile);
 
         assertTrue("No point in running ctags tests without valid ctags",
                 RuntimeEnvironment.getInstance().validateExuberantCtags());
-        repository = new TestRepository();
-        repository.create(CtagsTest.class.getResourceAsStream(
-                "/org/opensolaris/opengrok/index/source.zip"));
     }
 
     @AfterClass
@@ -71,6 +73,7 @@ public class CtagsTest {
         ctags.close();
         ctags = null;
         repository.destroy();
+        repository = null;
     }
 
     @Before

--- a/test/org/opensolaris/opengrok/analysis/document/TroffAnalyzerTest.java
+++ b/test/org/opensolaris/opengrok/analysis/document/TroffAnalyzerTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.opensolaris.opengrok.web.Util;
 import static org.junit.Assert.*;
 import org.opensolaris.opengrok.analysis.StreamSource;
+import org.opensolaris.opengrok.util.TestRepository;
 
 /**
  * @author  Jens Elkner
@@ -50,19 +51,24 @@ public class TroffAnalyzerTest {
     private static TroffAnalyzerFactory factory;
     private static TroffAnalyzer analyzer;
     private static String content;
+    private static TestRepository repository;
     
     /**
      * Test method for {@link org.opensolaris.opengrok.analysis.document
      * .TroffAnalyzer#TroffAnalyzer(org.opensolaris.opengrok.analysis.FileAnalyzerFactory)}.
      */
     @BeforeClass
-    public static void setUpBeforeClass() {
+    public static void setUpBeforeClass() throws Exception {
         factory = new TroffAnalyzerFactory();
         assertNotNull(factory);
         analyzer = new TroffAnalyzer(factory);
         assertNotNull(analyzer);
+        repository = new TestRepository();
+        repository.create(TroffAnalyzerTest.class.getResourceAsStream(
+                "/org/opensolaris/opengrok/index/source.zip"));
+
         String file = System.getProperty("opengrok.test.troff.doc",
-            "testdata/sources/document/foobar.1");
+                repository.getSourceRoot() + "/document/foobar.1");
         File f = new File(file);
         if (!(f.canRead() && f.isFile())) {
             fail("troff testfile " + f + " not found");
@@ -77,6 +83,11 @@ public class TroffAnalyzerTest {
      */
     @AfterClass
     public static void tearDownAfterClass() throws Exception {
+        factory = null;
+        analyzer = null;
+        content = null;
+        repository.destroy();
+        repository = null;
     }
 
     /**


### PR DESCRIPTION
Use absolute paths so that the tests work regardless of the
directory from which they are started.
