### PR TITLE
Make sure history.jsp doesn't strip off too much when creating a relative path name.

### DIFF
--- a/src/org/opensolaris/opengrok/web/Util.java
+++ b/src/org/opensolaris/opengrok/web/Util.java
@@ -923,4 +923,33 @@ public final class Util {
         sb.append('"');
         return sb.toString();
     }
+
+    /**
+     * Make a path relative by stripping off a prefix. If the path does not
+     * have the given prefix, return the full path unchanged.
+     *
+     * @param prefix the prefix to strip off
+     * @param fullPath the path from which to remove the prefix
+     * @return a path relative to {@code prefix} if {@code prefix} is a
+     *     parent directory of {@code fullPath}; otherwise, {@code fullPath}
+     */
+    public static String stripPathPrefix(String prefix, String fullPath) {
+        // Find the length of the prefix to strip off. The prefix should
+        // represent a directory, so it could end with a slash. In case it
+        // doesn't end with a slash, increase the length by one so that we
+        // strip off the leading slash from the relative path.
+        int prefixLength = prefix.length();
+        if (!prefix.endsWith("/")) {
+            prefixLength++;
+        }
+
+        // If the full path starts with the prefix, strip off the prefix.
+        if (fullPath.length() > prefixLength && fullPath.startsWith(prefix)
+                && fullPath.charAt(prefixLength - 1) == '/') {
+            return fullPath.substring(prefixLength);
+        }
+
+        // Otherwise, return the full path.
+        return fullPath;
+    }
 }

--- a/test/org/opensolaris/opengrok/web/UtilTest.java
+++ b/test/org/opensolaris/opengrok/web/UtilTest.java
@@ -246,5 +246,22 @@ public class UtilTest {
         assertEquals("\"abc\\n\\r\\\"\\\\\"",
                      Util.jsStringLiteral("abc\n\r\"\\"));
     }
+
+    @Test
+    public void stripPathPrefix() {
+        assertEquals("/", Util.stripPathPrefix("/", "/"));
+        assertEquals("/abc", Util.stripPathPrefix("/abc", "/abc"));
+        assertEquals("/abc/", Util.stripPathPrefix("/abc", "/abc/"));
+        assertEquals("/abc", Util.stripPathPrefix("/abc/", "/abc"));
+        assertEquals("/abc/", Util.stripPathPrefix("/abc/", "/abc/"));
+        assertEquals("abc", Util.stripPathPrefix("/", "/abc"));
+        assertEquals("abc/def", Util.stripPathPrefix("/", "/abc/def"));
+        assertEquals("def", Util.stripPathPrefix("/abc", "/abc/def"));
+        assertEquals("def", Util.stripPathPrefix("/abc/", "/abc/def"));
+        assertEquals("/abcdef", Util.stripPathPrefix("/abc", "/abcdef"));
+        assertEquals("/abcdef", Util.stripPathPrefix("/abc/", "/abcdef"));
+        assertEquals("def/ghi", Util.stripPathPrefix("/abc", "/abc/def/ghi"));
+        assertEquals("def/ghi", Util.stripPathPrefix("/abc/", "/abc/def/ghi"));
+    }
 }
 

--- a/web/history.jsp
+++ b/web/history.jsp
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
 
 Portions Copyright 2011 Jens Elkner.
 
@@ -204,14 +204,7 @@ document.domReady.push(function() {domReadyHistory();});
                 if (files != null) {
                 %><span class="filelist-hidden"><br/><%
                     for (String ifile : files) {
-                        String jfile = ifile;
-                        if ("/".equals(path)) {
-                            jfile = ifile.substring(1);
-                        } else if (ifile.startsWith(path)
-                            && ifile.length() > (path.length() + 1))
-                        {
-                            jfile = ifile.substring(path.length() + 1);
-                        }
+                        String jfile = Util.stripPathPrefix(path, ifile);
                         if (rev == "") {
                 %>
 <a class="h" href="<%= context + Prefix.XREF_P + ifile %>"><%= jfile %></a><br/><%


### PR DESCRIPTION
Fixes #649.

Moved the logic from history.jsp to a helper method in Util so that it can be tested by a unit test.
