### PR TITLE
HistoryGuru: Skip history creation for defined directories

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -212,6 +212,9 @@ DefaultInstanceConfiguration()
 
     # OPTIONAL: Ignore these patterns as names of files or directories
     #IGNORE_PATTERNS="-i dummy"
+    # To ignore skipping just the history cache creation for a particular
+    # directory and all of it's subdirectories, touch an empty
+    # .opengrok_skip_history file at the root of that directory
 
     # OPTIONAL: Enable Projects
     #           (Every directory in SRC_ROOT is considered a separate project)

--- a/README.txt
+++ b/README.txt
@@ -117,6 +117,11 @@ by OpenGrok.
 
 Note that OpenGrok ignores symbolic links.
 
+If you want to skip indexing the history of a particular directory
+(and all of it's subdirectories), you can touch .opengrok_skip_history at the root
+of that directory
+
+
 4.2 Using Opengrok wrapper script to create indexes
 ---------------------------------------------------
 

--- a/src/org/opensolaris/opengrok/history/HistoryGuru.java
+++ b/src/org/opensolaris/opengrok/history/HistoryGuru.java
@@ -306,6 +306,15 @@ public final class HistoryGuru {
             IgnoredNames ignoredNames, boolean recursiveSearch, int depth) {
         for (File file : files) {
             Repository repository = null;
+            if (file.getName().equals(".opengrok_skip_history")) {
+                log.log(Level.INFO, "Skipping history cache creation for "
+                        + file.getParentFile().getAbsolutePath()
+                        + " and it's subdirectories");
+                return;
+            }
+        }
+        for (File file : files) {
+            Repository repository = null;
             try {
                 repository = RepositoryFactory.getRepository(file);
             } catch (InstantiationException ie) {

--- a/src/org/opensolaris/opengrok/index/IgnoredNames.java
+++ b/src/org/opensolaris/opengrok/index/IgnoredNames.java
@@ -73,6 +73,7 @@ public final class IgnoredNames extends Filter {
         ".sln",
         ".vsmdi",
         ".dll",
+        ".opengrok_skip_history",
     };
 
     public IgnoredNames() {


### PR DESCRIPTION
If a project has an .opengrok_skip_history file, skip creating
it's historycache

Fixes #652
