### PR TITLE
duplicate key value JDBC exception when indexing large Mercurial repo

### DIFF
--- a/src/org/opensolaris/opengrok/history/MercurialHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/MercurialHistoryParser.java
@@ -155,8 +155,9 @@ class MercurialHistoryParser implements Executor.StreamHandler {
                       */
                      String[] move = part.split(" \\(");
                      File f = new File(mydir + move[0]);
-                     if (!move[0].isEmpty() && f.exists()) {
-                        renamedFiles.add(move[0]);
+                     if (!move[0].isEmpty() && f.exists() &&
+                         !renamedFiles.contains(move[0])) {
+                             renamedFiles.add(move[0]);
                      }
                 }
 


### PR DESCRIPTION
fixes #683

I tested with complete index:

```
svcadm disable -t javadb
rm -rf /var/lib/javadb/data/cachedb
svcadm enable javadb
EXUBERANT_CTAGS=/opt/ctags\-5.8/ctags OPENGROK_DERBY=1 OPENGROK_TAG=1 \
      /usr/opengrok/bin/OpenGrok index
```

 and reindex.
