### PR TITLE
Handle situation where there is a directory or Symbolic link which is a directory in the project source folder.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -583,7 +583,7 @@ Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
             <filepath refid="jacoco.lib.search.path"/>
         </available>
         <fail unless="jacocoant.jar.present" message="Please install jacocoant.jar in lib-directory  (or in ant classpath) to run Jacoco, see README."/>                
-	<taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml"/>
+	<taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml" classpathref="jacoco.lib.search.path"/>
     </target>
         
     <property name="jacoco_out" value="jacoco.exec"/>
@@ -609,7 +609,9 @@ Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
             </executiondata>
             <structure name="Opengrok">
                 <classfiles>
-                    <fileset dir="build"/>
+                    <fileset dir="build/classes">
+                        <exclude name="**/org/opensolaris/opengrok/management/client/*.class" />
+                    </fileset>
                 </classfiles>
                 <sourcefiles encoding="UTF-8">
                     <fileset dir="src"/>                    

--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -335,7 +335,7 @@ public class IndexDatabase {
                     directories.add("");
                 } else {
                     directories.add(project.getPath());
-					                    /*
+		    /*
                      * Check if there are any directories in the PATH
                      * Also test for symbolic link directories.
                      * Add them to the directories list.


### PR DESCRIPTION
I have reviewed and tested the changes.

To be more concise:
Before Change: If the project folder had a symbolic link pointing to a directory, then the directory would not be indexed.
After Change: The directory to which the symbolic link is pointing to will be indexed.

This fixes Issue #469.

Please let me know if any other info is required for you to merge these changes.
