### PR TITLE
let sendToConfigHost body use the parameter "env" to keep align with its signature and other methods

### DIFF
--- a/src/org/opensolaris/opengrok/index/Indexer.java
+++ b/src/org/opensolaris/opengrok/index/Indexer.java
@@ -803,7 +803,7 @@ public final class Indexer {
             if (cfg.length == 2) {
                 try {
                     InetAddress host = InetAddress.getByName(cfg[0]);
-                    RuntimeEnvironment.getInstance().writeConfiguration(host, Integer.parseInt(cfg[1]));
+                    env.writeConfiguration(host, Integer.parseInt(cfg[1]));
                 } catch (Exception ex) {
                     log.log(Level.SEVERE, "Failed to send configuration to " + configHost + " (is web application server running with opengrok deployed?)", ex);
                 }


### PR DESCRIPTION
Hello,

This change wants to avoid breaking an assumption.

Also note that Indexer#doIndexerExecution(...) doesn't have a parameter "env", which is different from #prepareIndexer(...) and #sendConfigToHost(...)

I guess that you want the non-static methods to have the parameter "env", while the static method main() can access RuntimeEnvironment.getInstance() directly. Is it right?

Thanks
