### PR TITLE
Search the vb directory for a list of visual basic reserved words.

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -49,6 +49,13 @@ Copyright (c) 2010, 2011, Oracle and/or its affiliates. All rights reserved.
                 </includes>
             </resource>
             <resource>
+                <targetPath>org/opensolaris/opengrok/analysis/vb/</targetPath>
+                <directory>../src/org/opensolaris/opengrok/analysis/vb/</directory>
+                <includes>
+                  <include>*.dat</include>
+                </includes>
+            </resource>
+            <resource>
                 <targetPath>org/opensolaris/opengrok/index/</targetPath>
                 <directory>../src/org/opensolaris/opengrok/index/</directory>
                 <excludes><exclude>*.java</exclude></excludes>


### PR DESCRIPTION
Without this, an artifact built with maven won't work - the VB analyser will throw a NullPointerException at runtime because vbReservedWords.dat can't be opened.
