### PR TITLE
Bugfix/symlinks2

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -105,6 +105,7 @@ import org.opensolaris.opengrok.history.HistoryGuru;
 import org.opensolaris.opengrok.history.HistoryReader;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.search.QueryBuilder;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 import org.opensolaris.opengrok.util.IOUtils;
 import org.opensolaris.opengrok.web.Util;
 
@@ -383,10 +384,12 @@ public class AnalyzerGuru {
      * @param fa The analyzer to use on the file
      * @param xrefOut Where to write the xref (possibly {@code null})
      * @throws IOException If an exception occurs while collecting the data
+     * @throws ForbiddenSymlinkException if symbolic-link checking encounters
+     * an ineligible link
      */
     public void populateDocument(Document doc, File file, String path,
             FileAnalyzer fa, Writer xrefOut)
-            throws IOException {
+            throws IOException, ForbiddenSymlinkException {
 
         String date = DateTools.timeToString(file.lastModified(),
                 DateTools.Resolution.MILLISECOND);

--- a/src/org/opensolaris/opengrok/configuration/Project.java
+++ b/src/org/opensolaris/opengrok/configuration/Project.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
 import org.opensolaris.opengrok.util.ClassUtil;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 
 /**
  * Placeholder for the information that builds up a project
@@ -316,7 +317,7 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
             ret = getProject(RuntimeEnvironment.getInstance().getPathRelativeToSourceRoot(file));
         } catch (FileNotFoundException e) { // NOPMD
             // ignore if not under source root
-        } catch (IOException e) { // NOPMD
+        } catch (IOException|ForbiddenSymlinkException e) { // NOPMD
             // problem has already been logged, just return null
         }
         return ret;

--- a/src/org/opensolaris/opengrok/configuration/Project.java
+++ b/src/org/opensolaris/opengrok/configuration/Project.java
@@ -29,6 +29,9 @@ import java.io.Serializable;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.ClassUtil;
 import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 
@@ -38,6 +41,8 @@ import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 public class Project implements Comparable<Project>, Nameable, Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Project.class);
 
     static {
         ClassUtil.remarkTransientFields(Project.class);
@@ -317,7 +322,10 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
             ret = getProject(RuntimeEnvironment.getInstance().getPathRelativeToSourceRoot(file));
         } catch (FileNotFoundException e) { // NOPMD
             // ignore if not under source root
-        } catch (IOException|ForbiddenSymlinkException e) { // NOPMD
+        } catch (ForbiddenSymlinkException e) {
+            LOGGER.log(Level.FINER, e.getMessage());
+            // ignore
+        } catch (IOException e) { // NOPMD
             // problem has already been logged, just return null
         }
         return ret;

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -1328,6 +1328,7 @@ public final class RuntimeEnvironment {
                 repoPath = getPathRelativeToSourceRoot(
                     new File(r.getDirectoryName()), 0);
             } catch (ForbiddenSymlinkException e) {
+                LOGGER.log(Level.FINER, e.getMessage());
                 continue;
             }
 

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -100,6 +100,7 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static org.opensolaris.opengrok.configuration.Configuration.makeXMLStringAsConfiguration;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 import org.opensolaris.opengrok.util.PathUtils;
 
 /**
@@ -371,11 +372,14 @@ public final class RuntimeEnvironment {
      * source root.
      *
      * @param file A file to resolve
-     * @throws IOException If an IO error occurs
-     * @throws FileNotFoundException If the file is not relative to source root
      * @return Path relative to source root
+     * @throws IOException If an IO error occurs
+     * @throws FileNotFoundException if the file is not relative to source root
+     * @throws ForbiddenSymlinkException if symbolic-link checking encounters
+     * an ineligible link
      */
-    public String getPathRelativeToSourceRoot(File file) throws IOException {
+    public String getPathRelativeToSourceRoot(File file)
+            throws IOException, ForbiddenSymlinkException {
         return getPathRelativeToSourceRoot(file, 0);
     }
 
@@ -386,11 +390,14 @@ public final class RuntimeEnvironment {
      *
      * @param file A file to resolve
      * @param stripCount Number of characters past source root to strip
-     * @throws IOException If an IO error occurs
-     * @throws FileNotFoundException If the file is not relative to source root
      * @return Path relative to source root
+     * @throws IOException if an IO error occurs
+     * @throws FileNotFoundException if the file is not relative to source root
+     * @throws ForbiddenSymlinkException if symbolic-link checking encounters
+     * an ineligible link
      */
-    public String getPathRelativeToSourceRoot(File file, int stripCount) throws IOException {
+    public String getPathRelativeToSourceRoot(File file, int stripCount)
+            throws IOException, ForbiddenSymlinkException {
         String sourceRoot = getSourceRootPath();
         if (sourceRoot == null) {
             throw new FileNotFoundException("Source Root Not Found");
@@ -1317,9 +1324,12 @@ public final class RuntimeEnvironment {
         for (RepositoryInfo r : getRepositories()) {
             Project proj;
             String repoPath;
-
-            repoPath = getPathRelativeToSourceRoot(
+            try {
+                repoPath = getPathRelativeToSourceRoot(
                     new File(r.getDirectoryName()), 0);
+            } catch (ForbiddenSymlinkException e) {
+                continue;
+            }
 
             if ((proj = Project.getProject(repoPath)) != null) {
                 List<RepositoryInfo> values = repository_map.get(proj);

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -100,6 +100,7 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static org.opensolaris.opengrok.configuration.Configuration.makeXMLStringAsConfiguration;
+import org.opensolaris.opengrok.util.PathUtils;
 
 /**
  * The RuntimeEnvironment class is used as a placeholder for the current
@@ -135,7 +136,7 @@ public final class RuntimeEnvironment {
 
     private Statistics statistics = new Statistics();
     
-    private static IndexTimestamp indexTime = new IndexTimestamp();
+    private static final IndexTimestamp indexTime = new IndexTimestamp();
 
     /**
      * Instance of authorization framework.
@@ -390,24 +391,24 @@ public final class RuntimeEnvironment {
      * @return Path relative to source root
      */
     public String getPathRelativeToSourceRoot(File file, int stripCount) throws IOException {
-        String canonicalPath = file.getCanonicalPath();
         String sourceRoot = getSourceRootPath();
-        
-        if(sourceRoot == null){
+        if (sourceRoot == null) {
             throw new FileNotFoundException("Source Root Not Found");
         }
-        
-        if (canonicalPath.startsWith(sourceRoot)) {
-            return canonicalPath.substring(sourceRoot.length() + stripCount);
+
+        String maybeRelPath = PathUtils.getRelativeToCanonical(file.getPath(),
+            sourceRoot, getAllowedSymlinks());
+        File maybeRelFile = new File(maybeRelPath);
+        if (!maybeRelFile.isAbsolute()) {
+            // N.b. OpenGrok has a weird convention that
+            // source-root "relative" paths must start with a '/' as they are
+            // elsewhere directly appended to env.getSourceRootPath() and also
+            // stored as such.
+            maybeRelPath = File.separator + maybeRelPath;
+            return maybeRelPath.substring(stripCount);
         }
-        for (String allowedSymlink : getAllowedSymlinks()) {
-            String allowedTarget = new File(allowedSymlink).getCanonicalPath();
-            if (canonicalPath.startsWith(allowedTarget)) {
-                return canonicalPath.substring(allowedTarget.length()
-                        + stripCount);
-            }
-        }
-        throw new FileNotFoundException("Failed to resolve [" + canonicalPath
+
+        throw new FileNotFoundException("Failed to resolve [" + file.getPath()
                 + "] relative to source root [" + sourceRoot + "]");
     }
 
@@ -1707,7 +1708,7 @@ public final class RuntimeEnvironment {
         try {
             config = makeXMLStringAsConfiguration(m.getText());
         } catch (IOException ex) {
-            LOGGER.log(Level.WARNING, "Configuration decoding failed" + ex);
+            LOGGER.log(Level.WARNING, "Configuration decoding failed", ex);
             return;
         }
 

--- a/src/org/opensolaris/opengrok/configuration/messages/ProjectMessage.java
+++ b/src/org/opensolaris/opengrok/configuration/messages/ProjectMessage.java
@@ -199,9 +199,12 @@ public class ProjectMessage extends Message {
                                 return env.getPathRelativeToSourceRoot(
                                         new File((x).getDirectoryName())
                                 );
-                            } catch (IOException|ForbiddenSymlinkException e) {
+                            } catch (ForbiddenSymlinkException e) {
+                                LOGGER.log(Level.FINER, e.getMessage());
+                                return "";
+                            } catch (IOException e) {
                                 LOGGER.log(Level.INFO,
-                                    "cannot remove files for repository " +
+                                    "cannot remove files for repository {0}",
                                     x.getDirectoryName());
                                 // Empty output should not cause any harm
                                 // since {@code getReposFromString()} inside

--- a/src/org/opensolaris/opengrok/configuration/messages/ProjectMessage.java
+++ b/src/org/opensolaris/opengrok/configuration/messages/ProjectMessage.java
@@ -43,6 +43,7 @@ import static org.opensolaris.opengrok.history.RepositoryFactory.getRepository;
 import org.opensolaris.opengrok.history.RepositoryInfo;
 import org.opensolaris.opengrok.index.IndexDatabase;
 import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 import org.opensolaris.opengrok.util.IOUtils;
 
 
@@ -198,7 +199,7 @@ public class ProjectMessage extends Message {
                                 return env.getPathRelativeToSourceRoot(
                                         new File((x).getDirectoryName())
                                 );
-                            } catch (IOException e) {
+                            } catch (IOException|ForbiddenSymlinkException e) {
                                 LOGGER.log(Level.INFO,
                                     "cannot remove files for repository " +
                                     x.getDirectoryName());

--- a/src/org/opensolaris/opengrok/history/BazaarHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/BazaarHistoryParser.java
@@ -173,7 +173,8 @@ class BazaarHistoryParser implements Executor.StreamHandler {
                             String name = env.getPathRelativeToSourceRoot(f);
                             entry.addFile(name.intern());
                         } catch (ForbiddenSymlinkException e) {
-                            // ignored (and already logged by PathUtils)
+                            LOGGER.log(Level.FINER, e.getMessage());
+                            // ignored
                         }
                     }
                     break;

--- a/src/org/opensolaris/opengrok/history/BazaarHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/BazaarHistoryParser.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 
 /**
  * Parse a stream of Bazaar log comments.
@@ -168,8 +169,12 @@ class BazaarHistoryParser implements Executor.StreamHandler {
                         }
 
                         File f = new File(myDir, s);
-                        String name = env.getPathRelativeToSourceRoot(f);
-                        entry.addFile(name.intern());
+                        try {
+                            String name = env.getPathRelativeToSourceRoot(f);
+                            entry.addFile(name.intern());
+                        } catch (ForbiddenSymlinkException e) {
+                            // ignored (and already logged by PathUtils)
+                        }
                     }
                     break;
                 default:

--- a/src/org/opensolaris/opengrok/history/BazaarRepository.java
+++ b/src/org/opensolaris/opengrok/history/BazaarRepository.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -80,11 +81,7 @@ public class BazaarRepository extends Repository {
      */
     Executor getHistoryLogExecutor(final File file, final String sinceRevision)
             throws IOException {
-        String abs = file.getCanonicalPath();
-        String filename = "";
-        if (abs.length() > getDirectoryName().length()) {
-            filename = abs.substring(getDirectoryName().length() + 1);
-        }
+        String filename = getRepoRelativePath(file);
 
         List<String> cmd = new ArrayList<String>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);

--- a/src/org/opensolaris/opengrok/history/CVSRepository.java
+++ b/src/org/opensolaris/opengrok/history/CVSRepository.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -96,8 +97,8 @@ public class CVSRepository extends RCSRepository {
     }
 
     @Override
-    public void setDirectoryName(String directoryName) {
-        super.setDirectoryName(directoryName);
+    public void setDirectoryName(File directory) {
+        super.setDirectoryName(directory);
 
         if (isWorking()) {
             File rootFile = new File(getDirectoryName() + File.separatorChar
@@ -195,11 +196,7 @@ public class CVSRepository extends RCSRepository {
      * @return An Executor ready to be started
      */
     Executor getHistoryLogExecutor(final File file) throws IOException {
-        String abs = file.getCanonicalPath();
-        String filename = "";
-        if (abs.length() > getDirectoryName().length()) {
-            filename = abs.substring(getDirectoryName().length() + 1);
-        }
+        String filename = getRepoRelativePath(file);
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);

--- a/src/org/opensolaris/opengrok/history/ClearCaseRepository.java
+++ b/src/org/opensolaris/opengrok/history/ClearCaseRepository.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -93,11 +94,7 @@ public class ClearCaseRepository extends Repository {
      * @return An Executor ready to be started
      */
     Executor getHistoryLogExecutor(final File file) throws IOException {
-        String abs = file.getCanonicalPath();
-        String filename = "";
-        if (abs.length() > getDirectoryName().length()) {
-            filename = abs.substring(getDirectoryName().length() + 1);
-        }
+        String filename = getRepoRelativePath(file);
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);

--- a/src/org/opensolaris/opengrok/history/FileHistoryCache.java
+++ b/src/org/opensolaris/opengrok/history/FileHistoryCache.java
@@ -631,6 +631,11 @@ class FileHistoryCache implements HistoryCache {
         return dir.exists();
     }
 
+    @Override
+    public boolean hasCacheForFile(File file) throws HistoryException {
+        return getCachedFile(file).exists();
+    }
+
     public String getRepositoryHistDataDirname(Repository repository) {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         String repoDirBasename;
@@ -645,7 +650,7 @@ class FileHistoryCache implements HistoryCache {
         }
 
         return env.getDataRootPath() + File.separatorChar
-            + this.historyCacheDirName
+            + FileHistoryCache.historyCacheDirName
             + repoDirBasename;
     }
 

--- a/src/org/opensolaris/opengrok/history/FileHistoryCache.java
+++ b/src/org/opensolaris/opengrok/history/FileHistoryCache.java
@@ -54,6 +54,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 import org.opensolaris.opengrok.util.IOUtils;
 
 /*
@@ -146,8 +147,14 @@ class FileHistoryCache implements HistoryCache {
             RuntimeEnvironment env,
             Repository repository, History history) throws IOException {
 
-        String repodir = env.getPathRelativeToSourceRoot(
-            new File(repository.getDirectoryName()));
+        String repodir;
+        try {
+            repodir = env.getPathRelativeToSourceRoot(
+                new File(repository.getDirectoryName()));
+        } catch (ForbiddenSymlinkException e) {
+            // already logged by PathUtils
+            return false;
+        }
         String shortestfile = filename.substring(repodir.length() + 1);
 
         return (history.isRenamed(shortestfile));
@@ -203,7 +210,7 @@ class FileHistoryCache implements HistoryCache {
                 sb.append(DIRECTORY_FILE_PREFIX);
             }
             sb.append(".gz");
-        } catch (IOException e) {
+        } catch (IOException|ForbiddenSymlinkException e) {
             throw new HistoryException("Failed to get path relative to " +
                     "source root for " + file, e);
         }
@@ -364,17 +371,17 @@ class FileHistoryCache implements HistoryCache {
     }
 
     private void finishStore(Repository repository, String latestRev) {
-        File file = new File(getRepositoryHistDataDirname(repository));
-        // If the history was not created for some reason (e.g. temporary
-        // failure), do not create the CachedRevision file as this would
-        // create confusion (once it starts working again).
-        if (file.isDirectory()) {
+        String histDir = getRepositoryHistDataDirname(repository);
+        if (histDir == null || !(new File(histDir)).isDirectory()) {
+            LOGGER.log(Level.WARNING,
+                "Could not store history for repo {0}",
+                repository.getDirectoryName());
+        } else {
             storeLatestCachedRevision(repository, latestRev);
+            LOGGER.log(Level.FINE,
+                "Done storing history for repo {0}",
+                repository.getDirectoryName());
         }
-
-        LOGGER.log(Level.FINE,
-            "Done storing history for repo {0}",
-            new Object[] {repository.getDirectoryName()});
     }
 
     /**
@@ -620,11 +627,11 @@ class FileHistoryCache implements HistoryCache {
         }
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         File dir = env.getDataRootFile();
-        dir = new File(dir, this.historyCacheDirName);
+        dir = new File(dir, FileHistoryCache.historyCacheDirName);
         try {
             dir = new File(dir, env.getPathRelativeToSourceRoot(
                 new File(repos.getDirectoryName())));
-        } catch (IOException e) {
+        } catch (IOException|ForbiddenSymlinkException e) {
             throw new HistoryException("Could not resolve " +
                     repos.getDirectoryName()+" relative to source root", e);
         }
@@ -647,6 +654,9 @@ class FileHistoryCache implements HistoryCache {
             LOGGER.log(Level.WARNING, "Could not resolve " +
                 repository.getDirectoryName()+" relative to source root", ex);
             return null;
+        } catch (ForbiddenSymlinkException ex) {
+            LOGGER.log(Level.FINE, "forbidden symbolic link", ex);
+            return null;
         }
 
         return env.getDataRootPath() + File.separatorChar
@@ -655,8 +665,9 @@ class FileHistoryCache implements HistoryCache {
     }
 
     private String getRepositoryCachedRevPath(Repository repository) {
-        return getRepositoryHistDataDirname(repository)
-            + File.separatorChar + latestRevFileName;
+        String histDir = getRepositoryHistDataDirname(repository);
+        if (histDir == null) return null;
+        return histDir + File.separatorChar + latestRevFileName;
     }
 
     /**
@@ -690,8 +701,15 @@ class FileHistoryCache implements HistoryCache {
         String rev = null;
         BufferedReader input;
 
+        String revPath = getRepositoryCachedRevPath(repository);
+        if (revPath == null) {
+            LOGGER.log(Level.WARNING, "no rev path for {0}",
+                repository.getDirectoryName());
+            return null;
+        }
+
         try {
-            input = new BufferedReader(new FileReader(getRepositoryCachedRevPath(repository)));
+            input = new BufferedReader(new FileReader(revPath));
             try {
                 rev = input.readLine();
             } catch (java.io.IOException e) {
@@ -705,8 +723,8 @@ class FileHistoryCache implements HistoryCache {
                 }
             }
         } catch (java.io.FileNotFoundException e) {
-            LOGGER.log(Level.FINE, "not loading latest cached revision file from {0}",
-                getRepositoryCachedRevPath(repository));
+            LOGGER.log(Level.FINE,
+                "not loading latest cached revision file from {0}", revPath);
             return null;
         }
 
@@ -724,16 +742,22 @@ class FileHistoryCache implements HistoryCache {
 
     @Override
     public void clear(Repository repository) {
-        // remove the file cached last revision (done separately in case
-        // it gets ever moved outside of the hierarchy)
-        File cachedRevFile = new File(getRepositoryCachedRevPath(repository));
-        cachedRevFile.delete();
+        String revPath = getRepositoryCachedRevPath(repository);
+        if (revPath != null) {
+            // remove the file cached last revision (done separately in case
+            // it gets ever moved outside of the hierarchy)
+            File cachedRevFile = new File(revPath);
+            cachedRevFile.delete();
+        }
 
-        // Remove all files which constitute the history cache.
-        try {
-            IOUtils.removeRecursive(Paths.get(getRepositoryHistDataDirname(repository)));
-        } catch (IOException ex) {
-            LOGGER.log(Level.SEVERE, null, ex);
+        String histDir = getRepositoryHistDataDirname(repository);
+        if (histDir != null) {
+            // Remove all files which constitute the history cache.
+            try {
+                IOUtils.removeRecursive(Paths.get(histDir));
+            } catch (IOException ex) {
+                LOGGER.log(Level.SEVERE, "tried removeRecursive()", ex);
+            }
         }
     }
 

--- a/src/org/opensolaris/opengrok/history/GitHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/GitHistoryParser.java
@@ -34,6 +34,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
@@ -132,8 +133,10 @@ class GitHistoryParser implements Executor.StreamHandler {
                         File f = new File(myDir, s);
                         String path = env.getPathRelativeToSourceRoot(f);
                         entry.addFile(path.intern());
-                    } catch (FileNotFoundException|
-                        ForbiddenSymlinkException e) { //NOPMD
+                    } catch (ForbiddenSymlinkException e) {
+                        LOGGER.log(Level.FINER, e.getMessage());
+                        // ignore
+                    } catch (FileNotFoundException e) { //NOPMD
                         // If the file is not located under the source root,
                         // ignore it (bug #11664).
                     }

--- a/src/org/opensolaris/opengrok/history/GitHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/GitHistoryParser.java
@@ -39,6 +39,7 @@ import java.util.regex.Pattern;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 import org.opensolaris.opengrok.util.StringUtils;
 
 /**
@@ -131,7 +132,8 @@ class GitHistoryParser implements Executor.StreamHandler {
                         File f = new File(myDir, s);
                         String path = env.getPathRelativeToSourceRoot(f);
                         entry.addFile(path.intern());
-                    } catch (FileNotFoundException e) { //NOPMD
+                    } catch (FileNotFoundException|
+                        ForbiddenSymlinkException e) { //NOPMD
                         // If the file is not located under the source root,
                         // ignore it (bug #11664).
                     }

--- a/src/org/opensolaris/opengrok/history/GitRepository.java
+++ b/src/org/opensolaris/opengrok/history/GitRepository.java
@@ -17,8 +17,9 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -31,7 +32,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedList;
@@ -116,11 +116,7 @@ public class GitRepository extends Repository {
     Executor getHistoryLogExecutor(final File file, String sinceRevision)
             throws IOException {
 
-        String abs = file.getCanonicalPath();
-        String filename = "";
-        if (abs.length() > getDirectoryName().length()) {
-            filename = abs.substring(getDirectoryName().length() + 1);
-        }
+        String filename = getRepoRelativePath(file);
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);

--- a/src/org/opensolaris/opengrok/history/HistoryCache.java
+++ b/src/org/opensolaris/opengrok/history/HistoryCache.java
@@ -25,6 +25,7 @@ package org.opensolaris.opengrok.history;
 import java.io.File;
 import java.util.Date;
 import java.util.Map;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 
 interface HistoryCache {
     /**
@@ -58,9 +59,11 @@ interface HistoryCache {
      * the implementation is allowed to skip the file list, but it doesn't
      * have to.
      * @throws HistoryException if the history cannot be fetched
+     * @throws ForbiddenSymlinkException if symbolic-link checking encounters
+     * an ineligible link
      */
     History get(File file, Repository repository, boolean withFiles)
-            throws HistoryException;
+            throws HistoryException, ForbiddenSymlinkException;
 
     /**
      * Store the history for a repository.

--- a/src/org/opensolaris/opengrok/history/HistoryCache.java
+++ b/src/org/opensolaris/opengrok/history/HistoryCache.java
@@ -95,6 +95,14 @@ interface HistoryCache {
             throws HistoryException;
 
     /**
+     * Check if the specified file is present in the cache.
+     * @param file the file to check
+     * @return {@code true} if the file is in the cache, {@code false}
+     * otherwise
+     */
+    boolean hasCacheForFile(File file) throws HistoryException;
+
+    /**
      * Get the revision identifier for the latest cached revision in a
      * repository.
      *

--- a/src/org/opensolaris/opengrok/history/HistoryGuru.java
+++ b/src/org/opensolaris/opengrok/history/HistoryGuru.java
@@ -296,6 +296,23 @@ public final class HistoryGuru {
     }
 
     /**
+     * Does the history cache contain entry for this directory ?
+     * @param file
+     * @return true if there is cache, false otherwise
+     */
+    public boolean hasCacheForFile(File file) {
+        if (!useCache()) {
+            return false;
+        }
+
+        try {
+            return historyCache.hasCacheForFile(file);
+        } catch (HistoryException ex) {
+            return false;
+        }
+    }
+
+    /**
      * Check if we can annotate the specified file.
      *
      * @param file the file to check
@@ -392,7 +409,6 @@ public final class HistoryGuru {
                         }
                     }
                 } else {
-                    repository.setDirectoryName(path);
                     if (RuntimeEnvironment.getInstance().isVerbose()) {
                         LOGGER.log(Level.CONFIG, "Adding <{0}> repository: <{1}>",
                                 new Object[]{repository.getClass().getName(), path});
@@ -812,14 +828,7 @@ public final class HistoryGuru {
     }
 
     protected Repository getRepository(File path) {
-        File file;
-
-        try {
-            file = path.getCanonicalFile();
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to get canonical path for " + path, e);
-            return null;
-        }
+        File file = path;
 
         while (file != null) {
             Repository r = repositories.get(file.getAbsolutePath());

--- a/src/org/opensolaris/opengrok/history/HistoryGuru.java
+++ b/src/org/opensolaris/opengrok/history/HistoryGuru.java
@@ -427,11 +427,7 @@ public final class HistoryGuru {
                     }
 
                     repoList.add(new RepositoryInfo(repository));
-                    String repoDirectoryName = repository.getDirectoryName();
-                    File repoDirectoryFile = new File(repoDirectoryName);
-                    String repoDirParent = repoDirectoryFile.getParent();
-                    repositoryRoots.put(repoDirParent, "");
-                    repositories.put(repoDirectoryName, repository);
+                    putRepository(repository);
 
                     // @TODO: Search only for one type of repository - the one found here
                     if (recursiveSearch && repository.supportsSubRepositories()) {
@@ -882,6 +878,11 @@ public final class HistoryGuru {
         for (String repo : repos) {
             repositories.remove(repo);
         }
+
+        // Re-map the repository roots.
+        repositoryRoots.clear();
+        List<Repository> ccopy = new ArrayList<>(repositories.values());
+        ccopy.forEach((repo) -> { putRepository(repo); });
     }
 
     /**set
@@ -923,6 +924,7 @@ public final class HistoryGuru {
      */
     public void invalidateRepositories(Collection<? extends RepositoryInfo> repos) {
         if (repos == null || repos.isEmpty()) {
+            repositoryRoots.clear();
             repositories.clear();
             return;
         }
@@ -985,11 +987,25 @@ public final class HistoryGuru {
         }
         executor.shutdown();
 
+        repositoryRoots.clear();
         repositories.clear();
-        repositories.putAll(newrepos);
+        newrepos.forEach((_key, repo) -> { putRepository(repo); });
 
         if (verbose) {
             elapsed.report(LOGGER, "done invalidating repositories");
         }
+    }
+
+    /**
+     * Adds the specified {@code repository} to this instance's repository map
+     * and repository-root map (if not already there).
+     * @param repository a defined instance
+     */
+    private void putRepository(Repository repository) {
+        String repoDirectoryName = repository.getDirectoryName();
+        File repoDirectoryFile = new File(repoDirectoryName);
+        String repoDirParent = repoDirectoryFile.getParent();
+        repositoryRoots.put(repoDirParent, "");
+        repositories.put(repoDirectoryName, repository);
     }
 }

--- a/src/org/opensolaris/opengrok/history/MercurialHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/MercurialHistoryParser.java
@@ -144,8 +144,10 @@ class MercurialHistoryParser implements Executor.StreamHandler {
                         try {
                             String path = env.getPathRelativeToSourceRoot(f);
                             entry.addFile(path.intern());
-                        } catch (FileNotFoundException|
-                            ForbiddenSymlinkException e) { // NOPMD
+                        } catch (ForbiddenSymlinkException e) {
+                            LOGGER.log(Level.FINER, e.getMessage());
+                            // ignore
+                        } catch (FileNotFoundException e) { // NOPMD
                             // If the file is not located under the source root,
                             // ignore it (bug #11664).
                         }

--- a/src/org/opensolaris/opengrok/history/MercurialHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/MercurialHistoryParser.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 
 /**
  * Parse a stream of mercurial log comments.
@@ -143,7 +144,8 @@ class MercurialHistoryParser implements Executor.StreamHandler {
                         try {
                             String path = env.getPathRelativeToSourceRoot(f);
                             entry.addFile(path.intern());
-                        } catch (FileNotFoundException e) { // NOPMD
+                        } catch (FileNotFoundException|
+                            ForbiddenSymlinkException e) { // NOPMD
                             // If the file is not located under the source root,
                             // ignore it (bug #11664).
                         }

--- a/src/org/opensolaris/opengrok/history/MercurialRepository.java
+++ b/src/org/opensolaris/opengrok/history/MercurialRepository.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -152,13 +153,8 @@ public class MercurialRepository extends Repository {
      */
     Executor getHistoryLogExecutor(File file, String sinceRevision)
             throws HistoryException, IOException {
-        String abs = file.getCanonicalPath();
-        String filename = "";
+        String filename = getRepoRelativePath(file);
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-
-        if (abs.length() > getDirectoryName().length()) {
-            filename = abs.substring(getDirectoryName().length() + 1);
-        }
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);

--- a/src/org/opensolaris/opengrok/history/MonotoneHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/MonotoneHistoryParser.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 
 /**
  * Class used to parse the history log from Monotone
@@ -168,7 +169,8 @@ class MonotoneHistoryParser implements Executor.StreamHandler {
                                 String path = env.getPathRelativeToSourceRoot(
                                     file);
                                 entry.addFile(path.intern());
-                            } catch (FileNotFoundException e) { // NOPMD
+                            } catch (FileNotFoundException|
+                                ForbiddenSymlinkException e) { // NOPMD
                                 // If the file is not located under the source root, ignore it
                             }
                         }

--- a/src/org/opensolaris/opengrok/history/MonotoneHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/MonotoneHistoryParser.java
@@ -169,8 +169,10 @@ class MonotoneHistoryParser implements Executor.StreamHandler {
                                 String path = env.getPathRelativeToSourceRoot(
                                     file);
                                 entry.addFile(path.intern());
-                            } catch (FileNotFoundException|
-                                ForbiddenSymlinkException e) { // NOPMD
+                            } catch (ForbiddenSymlinkException e) {
+                                LOGGER.log(Level.FINER, e.getMessage());
+                                // ignore
+                            } catch (FileNotFoundException e) { // NOPMD
                                 // If the file is not located under the source root, ignore it
                             }
                         }

--- a/src/org/opensolaris/opengrok/history/MonotoneRepository.java
+++ b/src/org/opensolaris/opengrok/history/MonotoneRepository.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -124,11 +125,7 @@ public class MonotoneRepository extends Repository {
      */
     Executor getHistoryLogExecutor(File file, String sinceRevision)
             throws IOException {
-        String abs = file.getCanonicalPath();
-        String filename = "";
-        if (abs.length() > getDirectoryName().length()) {
-            filename = abs.substring(getDirectoryName().length() + 1);
-        }
+        String filename = getRepoRelativePath(file);
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);

--- a/src/org/opensolaris/opengrok/history/RazorRepository.java
+++ b/src/org/opensolaris/opengrok/history/RazorRepository.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 /* Portions Copyright 2008 Peter Bray */
 package org.opensolaris.opengrok.history;
@@ -157,13 +158,12 @@ public class RazorRepository extends Repository {
     }
 
     @Override
-    public void setDirectoryName(String directoryName) {
-        super.setDirectoryName(directoryName);
-        File opengrokBaseDirectory = new File(directoryName);
+    public void setDirectoryName(File directory) {
+        super.setDirectoryName(directory);
         opengrokSourceRootDirectoryPath
-                = opengrokBaseDirectory.getParentFile().getAbsolutePath();
+                = directory.getParentFile().getAbsolutePath();
         razorGroupBaseDirectoryPath
-                = new File(directoryName, RAZOR_DIR).getAbsolutePath();
+                = new File(directory, RAZOR_DIR).getAbsolutePath();
     }
 
     public String getOpengrokSourceRootDirectoryPath() {

--- a/src/org/opensolaris/opengrok/history/Repository.java
+++ b/src/org/opensolaris/opengrok/history/Repository.java
@@ -522,4 +522,25 @@ public abstract class Repository extends RepositoryInfo {
         }
         return RepoCommand;
     }
+
+    protected String getRepoRelativePath(final File file)
+            throws IOException {
+
+        String filename = file.getPath();
+        String repoDirName = getDirectoryName();
+
+        String abs = file.getCanonicalPath();
+        if (abs.startsWith(repoDirName)) {
+            if (abs.length() > repoDirName.length()) {
+                filename = abs.substring(repoDirName.length() + 1);
+            }
+        } else {
+            abs = file.getAbsolutePath();
+            if (abs.startsWith(repoDirName) && abs.length() >
+                repoDirName.length()) {
+                filename = abs.substring(repoDirName.length() + 1);
+            }
+        }
+        return filename;
+    }
 }

--- a/src/org/opensolaris/opengrok/history/RepositoryFactory.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryFactory.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -102,13 +103,7 @@ public final class RepositoryFactory {
         for (Repository rep : repositories) {
             if (rep.isRepositoryFor(file)) {
                 repo = rep.getClass().getDeclaredConstructor().newInstance();
-                try {
-                    repo.setDirectoryName(file.getCanonicalPath());
-                } catch (IOException e) {
-                    LOGGER.log(Level.SEVERE,
-                            "Failed to get canonical path name for "
-                            + file.getAbsolutePath(), e);
-                }
+                repo.setDirectoryName(file);
 
                 if (!repo.isWorking()) {
                     LOGGER.log(Level.WARNING,

--- a/src/org/opensolaris/opengrok/history/SubversionHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/SubversionHistoryParser.java
@@ -154,10 +154,16 @@ class SubversionHistoryParser implements Executor.StreamHandler {
                 RuntimeEnvironment.getInstance().getSourceRootPath().length(),
                 repos.getDateFormat());
 
-        Executor executor = repos.getHistoryLogExecutor(file, sinceRevision,
-                numEntries);
-        int status = executor.exec(true, this);
+        Executor executor;
+        try {
+            executor = repos.getHistoryLogExecutor(file, sinceRevision,
+                    numEntries);
+        } catch (IOException e) {
+            throw new HistoryException("Failed to get history for: \"" +
+                    file.getAbsolutePath() + "\"", e);
+        }
 
+        int status = executor.exec(true, this);
         if (status != 0) {
             throw new HistoryException("Failed to get history for: \"" +
                     file.getAbsolutePath() + "\" Exit code: " + status);

--- a/src/org/opensolaris/opengrok/history/SubversionRepository.java
+++ b/src/org/opensolaris/opengrok/history/SubversionRepository.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -154,8 +155,8 @@ public class SubversionRepository extends Repository {
     }
 
     @Override
-    public void setDirectoryName(String directoryName) {
-        super.setDirectoryName(directoryName);
+    public void setDirectoryName(File directory) {
+        super.setDirectoryName(directory);
 
         if (isWorking()) {
             // set to true if we manage to find the root directory
@@ -198,20 +199,9 @@ public class SubversionRepository extends Repository {
      * @return An Executor ready to be started
      */
     Executor getHistoryLogExecutor(final File file, String sinceRevision,
-            int numEntries) {
+            int numEntries) throws IOException {
 
-        String abs;
-        try {
-            abs = file.getCanonicalPath();
-        } catch (IOException exp) {
-            LOGGER.log(Level.SEVERE,
-                    "Failed to get canonical path: {0}", exp.getClass().toString());
-            return null;
-        }
-        String filename = "";
-        if (abs.length() > getDirectoryName().length()) {
-            filename = abs.substring(getDirectoryName().length() + 1);
-        }
+        String filename = getRepoRelativePath(file);
 
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);

--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -1228,7 +1228,7 @@ public class IndexDatabase {
         try {
             path = env.getPathRelativeToSourceRoot(file);
         } catch (ForbiddenSymlinkException e) {
-            // (already logged by PathUtils)
+            LOGGER.log(Level.FINER, e.getMessage());
             return null;
         }
         //sanitize windows path delimiters

--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -79,6 +79,7 @@ import org.opensolaris.opengrok.history.HistoryException;
 import org.opensolaris.opengrok.history.HistoryGuru;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.search.QueryBuilder;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 import org.opensolaris.opengrok.util.IOUtils;
 import org.opensolaris.opengrok.web.Util;
 
@@ -1219,7 +1220,13 @@ public class IndexDatabase {
     public static Definitions getDefinitions(File file)
             throws IOException, ParseException, ClassNotFoundException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        String path = env.getPathRelativeToSourceRoot(file);
+        String path;
+        try {
+            path = env.getPathRelativeToSourceRoot(file);
+        } catch (ForbiddenSymlinkException e) {
+            // (already logged by PathUtils)
+            return null;
+        }
         //sanitize windows path delimiters
         //in order not to conflict with Lucene escape character
         path=path.replace("\\", "/");

--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -666,6 +666,10 @@ public class IndexDatabase {
         Document doc = new Document();
         try (Writer xrefOut = getXrefWriter(fa, path)) {
             analyzerGuru.populateDocument(doc, file, path, fa, xrefOut);
+        } catch (ForbiddenSymlinkException e) {
+            LOGGER.log(Level.FINER, e.getMessage());
+            cleanupResources(doc);
+            return;
         } catch (Exception e) {
             LOGGER.log(Level.INFO,
                     "Skipped file ''{0}'' because the analyzer didn''t "

--- a/src/org/opensolaris/opengrok/search/context/HistoryContext.java
+++ b/src/org/opensolaris/opengrok/search/context/HistoryContext.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.search.context;
@@ -127,6 +128,9 @@ public class HistoryContext {
      */
     private boolean getHistoryContext(
             History in, String path, Writer out, List<Hit> hits, String wcontext) {
+        if (in == null) {
+            throw new IllegalArgumentException("`in' is null");
+        }
         if ((out == null) == (hits == null)) {
             // There should be exactly one destination for the output. If
             // none or both are specified, it's a bug.

--- a/src/org/opensolaris/opengrok/util/ForbiddenSymlinkException.java
+++ b/src/org/opensolaris/opengrok/util/ForbiddenSymlinkException.java
@@ -1,0 +1,37 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+ /*
+ * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.util;
+
+/**
+ * Represents an exception that occurs when an ineligible symbolic link is
+ * encountered while evaluating a file system path.
+ */
+public class ForbiddenSymlinkException extends Exception {
+      public ForbiddenSymlinkException() { super(); }
+      public ForbiddenSymlinkException(String message) { super(message); }
+      public ForbiddenSymlinkException(String message, Throwable cause) {
+          super(message, cause);
+      }
+      public ForbiddenSymlinkException(Throwable cause) { super(cause); }
+}

--- a/src/org/opensolaris/opengrok/util/ForbiddenSymlinkException.java
+++ b/src/org/opensolaris/opengrok/util/ForbiddenSymlinkException.java
@@ -17,7 +17,7 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 

--- a/src/org/opensolaris/opengrok/util/PathUtils.java
+++ b/src/org/opensolaris/opengrok/util/PathUtils.java
@@ -172,7 +172,7 @@ public class PathUtils {
         return false;
     }
 
-    /** private to enforce singleton */
+    /** private to enforce static */
     private PathUtils() {
     }
 }

--- a/src/org/opensolaris/opengrok/util/PathUtils.java
+++ b/src/org/opensolaris/opengrok/util/PathUtils.java
@@ -101,13 +101,20 @@ public class PathUtils {
 
         if (path.equals(canonical)) return "";
 
-        String path0 = path.replace('\\', '/');
-        String normCanonical0 = canonical.replace('\\', File.separatorChar);
-        String normCanonical = normCanonical0.endsWith(File.separator) ?
-            normCanonical0 : normCanonical0 + File.separator;
+        // The following fixup of \\ is really to allow
+        // IndexDatabaseTest.testGetDefinitions() to succeed on Linux or macOS.
+        // That test has an assertion that operation is the "same for windows
+        // delimiters" and passes a path with backslashes. On Windows, the
+        // following fixup would not be needed, since File and Paths recognize
+        // backslash as a delimiter. On Linux and macOS, any backslash needs to
+        // be normalized.
+        path = path.replace('\\', File.separatorChar);
+        canonical = canonical.replace('\\', File.separatorChar);
+        String normCanonical = canonical.endsWith(File.separator) ?
+            canonical : canonical + File.separator;
         Deque<String> tail = null;
 
-        File iterPath = new File(path0);
+        File iterPath = new File(path);
         while (iterPath != null) {
             String iterCanon = iterPath.getCanonicalPath();
 

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -65,6 +65,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.opensolaris.opengrok.util.FileUtilities;
+import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 import org.opensolaris.opengrok.util.IOUtils;
 
 /**
@@ -1076,7 +1077,8 @@ public class RuntimeEnvironmentTest {
      * @throws java.io.IOException
      */
     @Test
-    public void testGetPathRelativeToSourceRoot() throws IOException {
+    public void testGetPathRelativeToSourceRoot() throws IOException,
+            ForbiddenSymlinkException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
         // Create and set source root.
@@ -1102,14 +1104,14 @@ public class RuntimeEnvironmentTest {
                 Paths.get(realDir.getPath()));
         assertTrue(symlink.exists());
         env.setAllowedSymlinks(new HashSet<>());
-        IOException exexp = null;
+        ForbiddenSymlinkException expex = null;
         try {
             env.getPathRelativeToSourceRoot(symlink);
-        } catch (IOException e) {
-            exexp = e;
+        } catch (ForbiddenSymlinkException e) {
+            expex = e;
         }
         assertTrue("getPathRelativeToSourceRoot() should have thrown " +
-            "IOexception for symlink that is not allowed", exexp != null);
+            "IOexception for symlink that is not allowed", expex != null);
 
         // Allow the symlink and retest.
         env.setAllowedSymlinks(new HashSet<>(Arrays.asList(symlink.getPath())));

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -31,8 +31,12 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -60,6 +64,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import org.opensolaris.opengrok.util.FileUtilities;
+import org.opensolaris.opengrok.util.IOUtils;
 
 /**
  * Test the RuntimeEnvironment class
@@ -1062,5 +1068,56 @@ public class RuntimeEnvironmentTest {
     @Test(expected = IOException.class)
     public void testLoadNullStatisticsFile() throws IOException, ParseException {
         RuntimeEnvironment.getInstance().loadStatistics((File) null);
+    }
+
+    /**
+     * Verify that getPathRelativeToSourceRoot() returns path relative to
+     * source root for both directories and symbolic links.
+     * @throws java.io.IOException
+     */
+    @Test
+    public void testGetPathRelativeToSourceRoot() throws IOException {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+        // Create and set source root.
+        File sourceRoot = FileUtilities.createTemporaryDirectory("src");
+        assertTrue(sourceRoot.exists());
+        assertTrue(sourceRoot.isDirectory());
+        env.setSourceRoot(sourceRoot.getPath());
+
+        // Create directory underneath source root and check.
+        String filename = "foo";
+        File file = new File(env.getSourceRootFile(), filename);
+        file.createNewFile();
+        assertTrue(file.exists());
+        assertEquals(File.separator + filename,
+                env.getPathRelativeToSourceRoot(file));
+
+        // Create symlink underneath source root.
+        String symlinkName = "symlink";
+        File realDir = FileUtilities.createTemporaryDirectory("realdir");
+        File symlink = new File(sourceRoot, symlinkName);
+        Files.createSymbolicLink(
+                Paths.get(symlink.getPath()),
+                Paths.get(realDir.getPath()));
+        assertTrue(symlink.exists());
+        env.setAllowedSymlinks(new HashSet<>());
+        IOException exexp = null;
+        try {
+            env.getPathRelativeToSourceRoot(symlink);
+        } catch (IOException e) {
+            exexp = e;
+        }
+        assertTrue("getPathRelativeToSourceRoot() should have thrown " +
+            "IOexception for symlink that is not allowed", exexp != null);
+
+        // Allow the symlink and retest.
+        env.setAllowedSymlinks(new HashSet<>(Arrays.asList(symlink.getPath())));
+        assertEquals(File.separator + symlinkName,
+                env.getPathRelativeToSourceRoot(symlink));
+
+        // cleanup
+        IOUtils.removeRecursive(sourceRoot.toPath());
+        IOUtils.removeRecursive(realDir.toPath());
     }
 }

--- a/test/org/opensolaris/opengrok/history/MercurialRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/MercurialRepositoryTest.java
@@ -161,17 +161,16 @@ public class MercurialRepositoryTest {
     /**
      * Run Mercurial command.
      *
-     * @param command hg command to run
      * @param reposRoot directory of the repository root
-     * @param arg argument to use for the command
+     * @param args {@code hg} command arguments
      */
     static public void runHgCommand(File reposRoot, String ... args) {
         List<String> cmdargs = new ArrayList<>();
         MercurialRepository repo = new MercurialRepository();
+
         cmdargs.add(repo.getRepoCommand());
-        for (String arg: args) {
-            cmdargs.add(arg);
-        }
+        cmdargs.addAll(Arrays.asList(args));
+
         Executor exec = new Executor(cmdargs, reposRoot);
         int exitCode = exec.exec();
         if (exitCode != 0) {

--- a/test/org/opensolaris/opengrok/history/PerforceRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/PerforceRepositoryTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -78,7 +79,7 @@ public class PerforceRepositoryTest {
             return;
         }
         PerforceRepository instance = new PerforceRepository();
-        instance.setDirectoryName(root.getAbsolutePath());
+        instance.setDirectoryName(new File(root.getAbsolutePath()));
         instance.update();
     }
 
@@ -89,7 +90,7 @@ public class PerforceRepositoryTest {
         }
 
         PerforceRepository instance = new PerforceRepository();
-        instance.setDirectoryName(root.getAbsolutePath());
+        instance.setDirectoryName(new File(root.getAbsolutePath()));
 
         for (File f : files) {
             if (instance.fileHasHistory(f)) {

--- a/test/org/opensolaris/opengrok/history/RepositoryInfoTest.java
+++ b/test/org/opensolaris/opengrok/history/RepositoryInfoTest.java
@@ -19,9 +19,11 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
+import java.io.File;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import org.junit.Before;
@@ -43,13 +45,13 @@ public class RepositoryInfoTest {
         String repoDirectory = "/src/foo";
         
         RepositoryInfo ri1 = new RepositoryInfo();
-        ri1.setDirectoryName(repoDirectory);
+        ri1.setDirectoryName(new File(repoDirectory));
         ri1.setBranch("branch1");
         
         RepositoryInfo ri2 = new RepositoryInfo();
         assertNotEquals(ri1, ri2);
         
-        ri2.setDirectoryName(repoDirectory);
+        ri2.setDirectoryName(new File(repoDirectory));
         assertEquals(ri1, ri2);
     }
 }

--- a/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
@@ -22,19 +22,36 @@
  */
 package org.opensolaris.opengrok.index;
 
+import java.io.File;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensolaris.opengrok.condition.ConditionalRun;
+import org.opensolaris.opengrok.condition.RepositoryInstalled;
+import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.history.HistoryGuru;
+import org.opensolaris.opengrok.history.MercurialRepositoryTest;
+import org.opensolaris.opengrok.history.RepositoryInfo;
+import org.opensolaris.opengrok.util.FileUtilities;
 import org.opensolaris.opengrok.util.TestRepository;
+import org.opensolaris.opengrok.util.IOUtils;
 
 /**
- * Test cleanup of renamed thread pool after indexing.
+ * Test indexer w.r.t. repositories.
  *
  * @author Vladimir Kotal
  */
@@ -73,6 +90,76 @@ public class IndexerRepoTest {
         }
     }
 
+    /**
+     * Test that symlinked directories from source root get their relative
+     * path set correctly in RepositoryInfo objects.
+     * @throws org.opensolaris.opengrok.index.IndexerException
+     * @throws java.io.IOException
+     */
+    @ConditionalRun(condition = RepositoryInstalled.MercurialInstalled.class)
+    @Test
+    public void testSymlinks() throws IndexerException, IOException {
+
+        final String symlink = "symlink";
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+        // Set source root to pristine directory so that there is only one
+        // repository to deal with (which makes this faster and easier to write)
+        // and clone the mercurial repository outside of the source root.
+        File realSource = FileUtilities.createTemporaryDirectory("real");
+        File sourceRoot = FileUtilities.createTemporaryDirectory("src");
+        MercurialRepositoryTest.runHgCommand(sourceRoot,
+                "clone", repository.getSourceRoot() + File.separator + "mercurial",
+                realSource.getPath());
+
+        // Create symlink from source root to the real repository.
+        String symlinkPath = sourceRoot.toString() + File.separator + symlink;
+        Files.createSymbolicLink(Paths.get(symlinkPath), Paths.get(realSource.getPath()));
+
+        env.setSourceRoot(sourceRoot.toString());
+        env.setDataRoot(repository.getDataRoot());
+        // Need to have history cache enabled in order to perform scan of repositories.
+        env.setHistoryEnabled(true);
+        // Normally the Indexer would add the symlink automatically.
+        env.setAllowedSymlinks(new HashSet<String>(Arrays.asList(symlinkPath)));
+
+        // Do a rescan of the projects, and only that (we don't care about
+        // the other aspects of indexing in this test case).
+        Indexer.getInstance().prepareIndexer(
+                env,
+                true, // search for repositories
+                true, // scan and add projects
+                null, // no default project
+                false, // don't list files
+                false, // don't create dictionary
+                null, // subFiles - not needed since we don't list files
+                null, // repositories - not needed when not refreshing history
+                new ArrayList<>(), // don't zap cache
+                false); // don't list repos
+
+        // Check the respository paths.
+        List<RepositoryInfo> repos = env.getRepositories();
+        assertEquals(repos.size(), 1);
+        RepositoryInfo repo = repos.get(0);
+        assertEquals("/" + symlink, repo.getDirectoryNameRelative());
+        assertEquals(sourceRoot.toString() + File.separator + "symlink",
+                repo.getDirectoryName());
+
+        // Check that history exists for a file in the repository.
+        File repoRoot = new File(env.getSourceRootFile(), symlink);
+        File fileInRepo = new File(repoRoot, "main.c");
+        assertTrue(fileInRepo.exists());
+        assertTrue(HistoryGuru.getInstance().hasHistory(fileInRepo));
+        assertTrue(HistoryGuru.getInstance().hasCacheForFile(fileInRepo));
+
+        // cleanup
+        IOUtils.removeRecursive(realSource.toPath());
+        IOUtils.removeRecursive(sourceRoot.toPath());
+    }
+
+    /**
+     * Test cleanup of renamed thread pool after indexing with -H.
+     */
     @Test
     public void testMainWithH() throws IOException {
         System.out.println("Generate index by using command line options with -H");
@@ -88,6 +175,9 @@ public class IndexerRepoTest {
         }
     }
 
+    /**
+     * Test cleanup of renamed thread pool after indexing without -H.
+     */
     @Test
     public void testMainWithoutH() throws IOException {
         System.out.println("Generate index by using command line options without -H");

--- a/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.index;
 
@@ -100,7 +101,7 @@ public class IndexerRepoTest {
     @Test
     public void testSymlinks() throws IndexerException, IOException {
 
-        final String symlink = "symlink";
+        final String SYMLINK = "symlink";
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
         // Set source root to pristine directory so that there is only one
@@ -113,7 +114,7 @@ public class IndexerRepoTest {
                 realSource.getPath());
 
         // Create symlink from source root to the real repository.
-        String symlinkPath = sourceRoot.toString() + File.separator + symlink;
+        String symlinkPath = sourceRoot.toString() + File.separator + SYMLINK;
         Files.createSymbolicLink(Paths.get(symlinkPath), Paths.get(realSource.getPath()));
 
         env.setSourceRoot(sourceRoot.toString());
@@ -141,12 +142,14 @@ public class IndexerRepoTest {
         List<RepositoryInfo> repos = env.getRepositories();
         assertEquals(repos.size(), 1);
         RepositoryInfo repo = repos.get(0);
-        assertEquals("/" + symlink, repo.getDirectoryNameRelative());
-        assertEquals(sourceRoot.toString() + File.separator + "symlink",
-                repo.getDirectoryName());
+        assertEquals("/" + SYMLINK, repo.getDirectoryNameRelative());
+        String epath = sourceRoot.toString() + File.separator + SYMLINK;
+        String apath = repo.getDirectoryName();
+        assertTrue("Should match (with macOS leeway):\n" + epath + "\nv.\n" +
+            apath, epath.equals(apath) || apath.equals("/private" + epath));
 
         // Check that history exists for a file in the repository.
-        File repoRoot = new File(env.getSourceRootFile(), symlink);
+        File repoRoot = new File(env.getSourceRootFile(), SYMLINK);
         File fileInRepo = new File(repoRoot, "main.c");
         assertTrue(fileInRepo.exists());
         assertTrue(HistoryGuru.getInstance().hasHistory(fileInRepo));

--- a/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.After;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensolaris.opengrok.condition.ConditionalRun;

--- a/test/org/opensolaris/opengrok/util/PathUtilsTest.java
+++ b/test/org/opensolaris/opengrok/util/PathUtilsTest.java
@@ -1,0 +1,162 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opensolaris.opengrok.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Represents a container for tests of {@link PathUtils}.
+ */
+public class PathUtilsTest {
+
+    private final List<File> tempDirs = new ArrayList<>();
+
+    @After
+    public void tearDown() throws IOException {
+        try {
+            tempDirs.forEach((tempDir) -> {
+                try {
+                    IOUtils.removeRecursive(tempDir.toPath());
+                } catch (IOException e) {
+                    // ignore
+                }
+            });
+        } finally {
+            tempDirs.clear();
+        }
+    }
+
+    @Test
+    public void shouldHandleSameInputs() throws IOException {
+        final String USR_BIN = "/usr/bin";
+        String rel = PathUtils.getRelativeToCanonical(USR_BIN, USR_BIN);
+        Assert.assertEquals("/usr/bin rel to itself", "", rel);
+    }
+
+    @Test
+    public void shouldHandleEffectivelySameInputs() throws IOException {
+        final String USR_BIN = "/usr/bin";
+        String rel = PathUtils.getRelativeToCanonical(USR_BIN + "/", USR_BIN);
+        Assert.assertEquals("/usr/bin rel to ~itself", "", rel);
+    }
+
+    @Test
+    public void shouldHandleLinksOfArbitraryDepthWithValidation()
+            throws IOException {
+        // Create real directories
+        File sourceRoot = createTemporaryDirectory("srcroot");
+        assertTrue("sourceRoot.isDirectory()", sourceRoot.isDirectory());
+
+        File realDir1 = createTemporaryDirectory("realdir1");
+        assertTrue("realDir1.isDirectory()", realDir1.isDirectory());
+        File realDir1b = new File(realDir1, "b");
+        realDir1b.mkdir();
+        assertTrue("realDir1b.isDirectory()", realDir1b.isDirectory());
+
+        File realDir2 = createTemporaryDirectory("realdir2");
+        assertTrue("realDir2.isDirectory()", realDir2.isDirectory());
+
+        // Create symlink #1 underneath source root.
+        final String SYMLINK1 = "symlink1";
+        File symlink1 = new File(sourceRoot, SYMLINK1);
+        Files.createSymbolicLink(Paths.get(symlink1.getPath()),
+            Paths.get(realDir1.getPath()));
+        assertTrue("symlink1.exists()", symlink1.exists());
+
+        // Create symlink #2 underneath realdir1/b.
+        final String SYMLINK2 = "symlink2";
+        File symlink2 = new File(realDir1b, SYMLINK2);
+        Files.createSymbolicLink(Paths.get(symlink2.getPath()),
+            Paths.get(realDir2.getPath()));
+        assertTrue("symlink2.exists()", symlink2.exists());
+
+        // Assert symbolic path
+        Path sympath = Paths.get(sourceRoot.getPath(), SYMLINK1, "b",
+            SYMLINK2);
+        assertTrue("2-link path exists", Files.exists(sympath));
+
+        // Test v. realDir1 canonical
+        String realDir1Canon = realDir1.getCanonicalPath();
+        String rel = PathUtils.getRelativeToCanonical(sympath.toString(),
+            realDir1Canon);
+        assertEquals("because links aren't validated", "b/" + SYMLINK2, rel);
+
+        // Test v. realDir1 canonical with validation and no allowed links
+        Set<String> allowedSymLinks = new HashSet<>();
+        rel = PathUtils.getRelativeToCanonical(sympath.toString(),
+            realDir1Canon, allowedSymLinks);
+        assertEquals("because no links allowed, arg1 is returned fully",
+            sympath.toString(), rel);
+
+        // Test v. realDir1 canonical with validation and an allowed link
+        allowedSymLinks.add(symlink2.getPath());
+        rel = PathUtils.getRelativeToCanonical(sympath.toString(),
+            realDir1Canon, allowedSymLinks);
+        assertEquals("because link is OKed", "b/" + SYMLINK2, rel);
+    }
+
+    @Ignore("macOS has /var symlink, and I also made a second link, `myhome'.")
+    @Test
+    public void shouldResolvePrivateVarOnMacOS() throws IOException {
+        final String MY_VAR_FOLDERS =
+            "/var/folders/58/546k9lk08xl56t0059bln0_h0000gp/T/tilde/Documents";
+        final String EXPECTED_REL = MY_VAR_FOLDERS.substring("/var/".length());
+        String rel = PathUtils.getRelativeToCanonical(MY_VAR_FOLDERS,
+            "/private/var");
+        Assert.assertEquals("/var/run rel to /private/var", EXPECTED_REL, rel);
+    }
+
+    @Ignore("For ad-hoc testing with \\ in paths.")
+    @Test
+    public void mightResolveBackslashesToo() throws IOException {
+        final String MY_VAR_FOLDERS =
+            "\\var\\folders\\58\\546k9lk08xl56t0059bln0_h0000gp\\T";
+        final String EXPECTED_REL = MY_VAR_FOLDERS.substring("/var/".length()).
+            replace('\\', '/');
+        String rel = PathUtils.getRelativeToCanonical(MY_VAR_FOLDERS,
+            "/private/var");
+        Assert.assertEquals("/var/run rel to /private/var", EXPECTED_REL, rel);
+    }
+
+    private File createTemporaryDirectory(String name) throws IOException {
+        File f = FileUtilities.createTemporaryDirectory(name);
+        tempDirs.add(f);
+        return f;
+    }
+}

--- a/test/org/opensolaris/opengrok/util/PathUtilsTest.java
+++ b/test/org/opensolaris/opengrok/util/PathUtilsTest.java
@@ -78,7 +78,7 @@ public class PathUtilsTest {
 
     @Test
     public void shouldHandleLinksOfArbitraryDepthWithValidation()
-            throws IOException {
+            throws IOException, ForbiddenSymlinkException {
         // Create real directories
         File sourceRoot = createTemporaryDirectory("srcroot");
         assertTrue("sourceRoot.isDirectory()", sourceRoot.isDirectory());
@@ -119,10 +119,15 @@ public class PathUtilsTest {
 
         // Test v. realDir1 canonical with validation and no allowed links
         Set<String> allowedSymLinks = new HashSet<>();
-        rel = PathUtils.getRelativeToCanonical(sympath.toString(),
-            realDir1Canon, allowedSymLinks);
-        assertEquals("because no links allowed, arg1 is returned fully",
-            sympath.toString(), rel);
+        ForbiddenSymlinkException expex = null;
+        try {
+            PathUtils.getRelativeToCanonical(sympath.toString(), realDir1Canon,
+                allowedSymLinks);
+        } catch (ForbiddenSymlinkException e) {
+            expex = e;
+        }
+        Assert.assertNotNull("because no links allowed, arg1 is returned fully",
+            expex);
 
         // Test v. realDir1 canonical with validation and an allowed link
         allowedSymLinks.add(symlink2.getPath());

--- a/test/org/opensolaris/opengrok/web/ProjectHelperTest.java
+++ b/test/org/opensolaris/opengrok/web/ProjectHelperTest.java
@@ -17,11 +17,13 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.web;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -90,7 +92,7 @@ public class ProjectHelperTest extends ProjectHelperTestBase {
 
         RepositoryInfo info = new RepoRepository();
         info.setParent(repo.getName());
-        info.setDirectoryName("/foo");
+        info.setDirectoryName(new File("/foo"));
 
         List<RepositoryInfo> infos = getRepositoriesMap().get(repo);
         if (infos == null) {


### PR DESCRIPTION
(This is just reopening PR #1911 rebased on `master`.)

Hello,

Please consider for integration this patch with fixes for symbolic link handling.

The principle addition is `PathUtils.getRelativeToCanonical(...)` and a new explicit `ForbiddenSymlinkException`.

I know PR #1846 is in progress, but my testing showed it still had problems with history processing and also could not support nested symbolic links. I first cherry-picked most of #1846's contents but then revised its versions of `RuntimeEnvironment.getPathRelativeToSourceRoot(...)` and `HistoryGuru.getRepository(...)` to instead use the new `PathUtils`.

I also kept #1846's new tests and added some more.

This patch also contains a new method, `Repository.getRepoRelativePath(...)`, to replace (pre-existing) problematic logic in the various repository implementations (e.g., Git, Mercurial, SVN, etc.) that was lopping off the front of paths assuming they started with "source root". E.g., on macOS, /var is a symlink to /private/var, and the logic was chopping off the number of characters in "/private/var/..." from "/var/...", resulting in paths mangled in the middle of segments.

(I detected the problem while testing scenarios of symbolic-linked project layouts, but unit tests otherwise did not detect this bug.)

TESTING SCENARIOS:

1) Basic case with no symlinks under SRC_ROOT — this behaves as before.
2) Direct symlinks under SRC_ROOT. Here of course `Indexer` "automatically allow symlinks that are directly in source root". `HistoryGuru` and history classes, though, are now fixed to properly work in this case.
3) Add another symlink inside a directory referenced by a symlink under SRC_ROOT. `Indexer` will not have allowed this second symlink, so the new logic properly detects this as disallowed. This repo will not be indexed and will not show up in the UI.
4) Build on the previous test by adding an OPENGROK_READ_XML_CONFIGURATION file with the secondary symlink added to allowedSymlinks. `Indexer` will now allow this repo; it is handled by `HistoryGuru` et al; and the repo will show up in the UI.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
