### PR TITLE
fix a bug in getPathRelativeToSourceRoot when there is symlink

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -403,7 +403,8 @@ public final class RuntimeEnvironment {
         for (String allowedSymlink : getAllowedSymlinks()) {
             String allowedTarget = new File(allowedSymlink).getCanonicalPath();
             if (canonicalPath.startsWith(allowedTarget)) {
-                return canonicalPath.substring(allowedTarget.length()
+                return allowedSymlink.substring(sourceRoot.length()) +
+                       canonicalPath.substring(allowedTarget.length()
                         + stripCount);
             }
         }


### PR DESCRIPTION
Problem: When there is a symlink, getPathRelativeToSourceRoot will return the path relative to symlink.

Expected: The path relative to source root is returned.
Solution: Add the missing part.

Example:
/var/opengrok/src/project1 -> /root/project1
getPathRelativeToSourceRoot("/root/project1/web") => "/web"
It should be "/project1/web" instead.
