### PR TITLE
Fix to use CVSRepository getRepoCommand() in test

### DIFF
--- a/test/org/opensolaris/opengrok/history/CVSRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/CVSRepositoryTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -33,6 +34,10 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
 import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -40,8 +45,6 @@ import org.junit.Test;
 import org.opensolaris.opengrok.condition.ConditionalRun;
 import org.opensolaris.opengrok.condition.ConditionalRunRule;
 import org.opensolaris.opengrok.condition.RepositoryInstalled;
-
-import static org.junit.Assert.*;
 import org.opensolaris.opengrok.util.Executor;
 import org.opensolaris.opengrok.util.IOUtils;
 import org.opensolaris.opengrok.util.TestRepository;
@@ -113,7 +116,8 @@ public class CVSRepositoryTest {
      */
     private static void runCvsCommand(File reposRoot, String ... args) {
         List<String> cmdargs = new ArrayList<>();
-        cmdargs.add(CVSRepository.CMD_FALLBACK);
+        CVSRepository repo = new CVSRepository();
+        cmdargs.add(repo.getRepoCommand());
         for (String arg: args) {
             cmdargs.add(arg);
         }


### PR DESCRIPTION
Hello,

Please consider for integration this tiny patch to fix `CVSRepositoryTest` to use `CVSRepository getRepoCommand()`, so that the test uses a developer's environment override of `cvs` command.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
