### PR TITLE
Optimize for a single listener. Support --profiler.

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -115,13 +115,15 @@
 #   - OPENGROK_SUBVERSION_PASSWORD password of the user that should be used for
 #                                 fetching the history from subversion
 #
+#   - OPENGROK_PROFILER           Pause to await user input for profiling.
+#
 # Notes:
 #   (*) Any Non-Empty String will enable these options
 #
 
 #
 # Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
-# Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+# Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
 #
 
 #
@@ -866,6 +868,7 @@ CommonInvocation()
         ${READ_XML_CONF}                                        	\
         ${WEBAPP_CONFIG}						\
         ${WEBAPP_CONTEXT}						\
+        ${OPENGROK_PROFILER:+--profiler}				\
         "${@}"
 }
 

--- a/src/org/opensolaris/opengrok/analysis/JFlexSymbolMatcher.java
+++ b/src/org/opensolaris/opengrok/analysis/JFlexSymbolMatcher.java
@@ -18,14 +18,12 @@
  */
 
 /*
- * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis;
 
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import org.opensolaris.opengrok.util.StringUtils;
 
@@ -36,32 +34,48 @@ import org.opensolaris.opengrok.util.StringUtils;
 public abstract class JFlexSymbolMatcher extends JFlexStateStacker
         implements ScanningSymbolMatcher {
 
-    private final CopyOnWriteArrayList<SymbolMatchedListener> symbolListeners =
-        new CopyOnWriteArrayList<>();
-
-    private final CopyOnWriteArrayList<NonSymbolMatchedListener>
-        nonSymbolListeners = new CopyOnWriteArrayList<>();
-
+    private SymbolMatchedListener symbolListener;
+    private NonSymbolMatchedListener nonSymbolListener;
     private String disjointSpanClassName;
 
+    /**
+     * Associates the specified listener, replacing the former one.
+     * @param l defined instance
+     */
     @Override
-    public void addSymbolMatchedListener(SymbolMatchedListener l) {
-        symbolListeners.add(l);
+    public void setSymbolMatchedListener(SymbolMatchedListener l) {
+        if (l == null) {
+            throw new IllegalArgumentException("`l' is null");
+        }
+        symbolListener = l;
     }
 
+    /**
+     * Clears any association to a listener.
+     */
     @Override
-    public void removeSymbolMatchedListener(SymbolMatchedListener l) {
-        symbolListeners.remove(l);
+    public void clearSymbolMatchedListener() {
+        symbolListener = null;
     }
 
+    /**
+     * Associates the specified listener, replacing the former one.
+     * @param l defined instance
+     */
     @Override
-    public void addNonSymbolMatchedListener(NonSymbolMatchedListener l) {
-        nonSymbolListeners.add(l);
+    public void setNonSymbolMatchedListener(NonSymbolMatchedListener l) {
+        if (l == null) {
+            throw new IllegalArgumentException("`l' is null");
+        }
+        nonSymbolListener = l;
     }
 
+    /**
+     * Clears any association to a listener.
+     */
     @Override
-    public void removeNonSymbolMatchedListener(NonSymbolMatchedListener l) {
-        nonSymbolListeners.remove(l);
+    public void clearNonSymbolMatchedListener() {
+        nonSymbolListener = null;
     }
 
     /**
@@ -76,15 +90,16 @@ public abstract class JFlexSymbolMatcher extends JFlexStateStacker
     /**
      * Raises
      * {@link SymbolMatchedListener#symbolMatched(org.opensolaris.opengrok.analysis.SymbolMatchedEvent)}
-     * for all subscribed listeners in turn.
+     * for a subscribed listener.
      * @param str the symbol string
      * @param start the symbol start position
      */
     protected void onSymbolMatched(String str, int start) {
-        if (symbolListeners.size() > 0) {
+        SymbolMatchedListener l = symbolListener;
+        if (l != null) {
             SymbolMatchedEvent evt = new SymbolMatchedEvent(this, str, start,
                 start + str.length());
-            symbolListeners.forEach((l) -> l.symbolMatched(evt));
+            l.symbolMatched(evt);
         }
     }
 
@@ -101,47 +116,50 @@ public abstract class JFlexSymbolMatcher extends JFlexStateStacker
     /**
      * Raises
      * {@link NonSymbolMatchedListener#nonSymbolMatched(org.opensolaris.opengrok.analysis.TextMatchedEvent)}
-     * for all subscribed listeners in turn.
+     * for a subscribed listener.
      * @param str the text string
      * @param start the text start position
      */
     protected void onNonSymbolMatched(String str, int start) {
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             TextMatchedEvent evt = new TextMatchedEvent(this, str, start,
                 start + str.length());
-            onNonSymbolEvent((l) -> l.nonSymbolMatched(evt));
+            l.nonSymbolMatched(evt);
         }
     }
 
     /**
      * Raises
      * {@link NonSymbolMatchedListener#nonSymbolMatched(org.opensolaris.opengrok.analysis.TextMatchedEvent)}
-     * for all subscribed listeners in turn.
+     * for a subscribed listener.
      * @param str the text string
      * @param hint the text hint
      * @param start the text start position
      */
     protected void onNonSymbolMatched(String str, EmphasisHint hint,
         int start) {
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             TextMatchedEvent evt = new TextMatchedEvent(this, str, hint, start,
                 start + str.length());
-            onNonSymbolEvent((l) -> l.nonSymbolMatched(evt));
+            l.nonSymbolMatched(evt);
         }
     }
 
     /**
      * Raises
      * {@link NonSymbolMatchedListener#keywordMatched(org.opensolaris.opengrok.analysis.TextMatchedEvent)}
-     * for all subscribed listeners in turn.
+     * for a subscribed listener.
      * @param str the text string
      * @param start the text start position
      */
     protected void onKeywordMatched(String str, int start) {
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             TextMatchedEvent evt = new TextMatchedEvent(this, str, start,
                 start + str.length());
-            onNonSymbolEvent((l) -> l.keywordMatched(evt));
+            l.keywordMatched(evt);
         }
     }
 
@@ -150,32 +168,34 @@ public abstract class JFlexSymbolMatcher extends JFlexStateStacker
      * {@link #getLineNumber()} and the number of LFs in {@code str}, and then
      * raises
      * {@link NonSymbolMatchedListener#endOfLineMatched(org.opensolaris.opengrok.analysis.TextMatchedEvent)}
-     * for all subscribed listeners in turn.
+     * for a subscribed listener.
      * @param str the text string
      * @param start the text start position
      */
     protected void onEndOfLineMatched(String str, int start) {
         setLineNumber(getLineNumber() + countLFs(str));
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             TextMatchedEvent evt = new TextMatchedEvent(this, str, start,
                 start + str.length());
-            onNonSymbolEvent((l) -> l.endOfLineMatched(evt));
+            l.endOfLineMatched(evt);
         }
     }
 
     /**
      * Raises
      * {@link NonSymbolMatchedListener#disjointSpanChanged(org.opensolaris.opengrok.analysis.DisjointSpanChangedEvent)}
-     * for all subscribed listeners in turn.
+     * for a subscribed listener.
      * @param className the text string
      * @param position the text position
      */
     protected void onDisjointSpanChanged(String className, int position) {
         disjointSpanClassName = className;
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             DisjointSpanChangedEvent evt = new DisjointSpanChangedEvent(this,
                 className, position);
-            onNonSymbolEvent((l) -> l.disjointSpanChanged(evt));
+            l.disjointSpanChanged(evt);
         }
     }
 
@@ -193,7 +213,7 @@ public abstract class JFlexSymbolMatcher extends JFlexStateStacker
     /**
      * Raises
      * {@link NonSymbolMatchedListener#linkageMatched(org.opensolaris.opengrok.analysis.LinkageMatchedEvent)}
-     * of {@link LinkageType#URI} for all subscribed listeners in turn.
+     * of {@link LinkageType#URI} for a subscribed listener.
      * <p>First, the end of {@code uri} is possibly trimmed (with a
      * corresponding call to {@link #yypushback(int)}) based on the result
      * of {@link StringUtils#countURIEndingPushback(java.lang.String)} and
@@ -234,32 +254,34 @@ public abstract class JFlexSymbolMatcher extends JFlexStateStacker
         } while (subn != 0);
         if (n > 0) yypushback(n);
 
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             LinkageMatchedEvent evt = new LinkageMatchedEvent(this, uri,
                 LinkageType.URI, start, start + uri.length());
-            onNonSymbolEvent((l) -> l.linkageMatched(evt));
+            l.linkageMatched(evt);
         }
     }
 
     /**
      * Raises
      * {@link NonSymbolMatchedListener#linkageMatched(org.opensolaris.opengrok.analysis.LinkageMatchedEvent)}
-     * of {@link LinkageType#FILELIKE} for all subscribed listeners in turn.
+     * of {@link LinkageType#FILELIKE} for a subscribed listener.
      * @param str the text string
      * @param start the text start position
      */
     protected void onFilelikeMatched(String str, int start) {
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             LinkageMatchedEvent evt = new LinkageMatchedEvent(this, str,
                 LinkageType.FILELIKE, start, start + str.length());
-            onNonSymbolEvent((l) -> l.linkageMatched(evt));
+            l.linkageMatched(evt);
         }
     }
 
     /**
      * Raises
      * {@link NonSymbolMatchedListener#pathlikeMatched(org.opensolaris.opengrok.analysis.PathlikeMatchedEvent)}
-     * for all subscribed listeners in turn.
+     * for a subscribed listener.
      * @param str the path text string
      * @param sep the path separator
      * @param canonicalize a value indicating whether the path should be
@@ -268,102 +290,109 @@ public abstract class JFlexSymbolMatcher extends JFlexStateStacker
      */
     protected void onPathlikeMatched(String str, char sep,
         boolean canonicalize, int start) {
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             PathlikeMatchedEvent  evt = new PathlikeMatchedEvent(this, str,
                 sep, canonicalize, start, start + str.length());
-            onNonSymbolEvent((l) -> l.pathlikeMatched(evt));
+            l.pathlikeMatched(evt);
         }
     }
 
     /**
      * Raises
      * {@link NonSymbolMatchedListener#linkageMatched(org.opensolaris.opengrok.analysis.LinkageMatchedEvent)}
-     * of {@link LinkageType#EMAIL} for all subscribed listeners in turn.
+     * of {@link LinkageType#EMAIL} for a subscribed listener.
      * @param str the text string
      * @param start the text start position
      */
     protected void onEmailAddressMatched(String str, int start) {
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             LinkageMatchedEvent evt = new LinkageMatchedEvent(this, str,
                 LinkageType.EMAIL, start, start + str.length());
-            onNonSymbolEvent((l) -> l.linkageMatched(evt));
+            l.linkageMatched(evt);
         }
     }
 
     /**
      * Raises
      * {@link NonSymbolMatchedListener#linkageMatched(org.opensolaris.opengrok.analysis.LinkageMatchedEvent)}
-     * of {@link LinkageType#LABEL} for all subscribed listeners in turn.
+     * of {@link LinkageType#LABEL} for a subscribed listener.
      * @param str the text string (literal capture)
      * @param start the text start position
      * @param lstr the text link string
      */
     protected void onLabelMatched(String str, int start, String lstr) {
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             LinkageMatchedEvent evt = new LinkageMatchedEvent(this, str,
                 LinkageType.LABEL, start, start + str.length(), lstr);
-            onNonSymbolEvent((l) -> l.linkageMatched(evt));
+            l.linkageMatched(evt);
         }
     }
 
     /**
      * Raises
      * {@link NonSymbolMatchedListener#linkageMatched(org.opensolaris.opengrok.analysis.LinkageMatchedEvent)}
-     * of {@link LinkageType#LABELDEF} for all subscribed listeners in turn.
+     * of {@link LinkageType#LABELDEF} for a subscribed listener.
      * @param str the text string (literal capture)
      * @param start the text start position
      */
     protected void onLabelDefMatched(String str, int start) {
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             LinkageMatchedEvent evt = new LinkageMatchedEvent(this, str,
                 LinkageType.LABELDEF, start, start + str.length());
-            onNonSymbolEvent((l) -> l.linkageMatched(evt));
+            l.linkageMatched(evt);
         }
     }
 
     /**
      * Raises
      * {@link NonSymbolMatchedListener#linkageMatched(org.opensolaris.opengrok.analysis.LinkageMatchedEvent)}
-     * of {@link LinkageType#QUERY} for all subscribed listeners in turn.
+     * of {@link LinkageType#QUERY} for a subscribed listener.
      * @param str the text string
      * @param start the text start position
      */
     protected void onQueryTermMatched(String str, int start) {
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             LinkageMatchedEvent evt = new LinkageMatchedEvent(this, str,
                 LinkageType.QUERY, start, start + str.length());
-            onNonSymbolEvent((l) -> l.linkageMatched(evt));
+            l.linkageMatched(evt);
         }
     }
 
     /**
      * Raises
      * {@link NonSymbolMatchedListener#linkageMatched(org.opensolaris.opengrok.analysis.LinkageMatchedEvent)}
-     * of {@link LinkageType#REFS} for all subscribed listeners in turn.
+     * of {@link LinkageType#REFS} for a subscribed listener.
      * @param str the text string
      * @param start the text start position
      */
     protected void onRefsTermMatched(String str, int start) {
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             LinkageMatchedEvent evt = new LinkageMatchedEvent(this, str,
                 LinkageType.REFS, start, start + str.length());
-            onNonSymbolEvent((l) -> l.linkageMatched(evt));
+            l.linkageMatched(evt);
         }
     }
 
     /**
      * Raises
      * {@link NonSymbolMatchedListener#scopeChanged(org.opensolaris.opengrok.analysis.ScopeChangedEvent)}
-     * for all subscribed listeners in turn.
+     * for a subscribed listener.
      * @param action the scope change action
      * @param str the text string
      * @param start the text start position
      */
     protected void onScopeChanged(ScopeAction action, String str, int start) {
-        if (nonSymbolListeners.size() > 0) {
+        NonSymbolMatchedListener l = nonSymbolListener;
+        if (l != null) {
             ScopeChangedEvent evt = new ScopeChangedEvent(this, action, str,
                 start, start + str.length());
-            nonSymbolListeners.forEach((l) -> l.scopeChanged(evt));
+            l.scopeChanged(evt);
         }
     }
 
@@ -410,10 +439,6 @@ public abstract class JFlexSymbolMatcher extends JFlexStateStacker
         }
         onSymbolMatched(str, start);
         return true;
-    }
-
-    private void onNonSymbolEvent(Consumer<NonSymbolMatchedListener> action) {
-        nonSymbolListeners.forEach(action);
     }
 
     private static int countLFs(String str) {

--- a/src/org/opensolaris/opengrok/analysis/JFlexTokenizer.java
+++ b/src/org/opensolaris/opengrok/analysis/JFlexTokenizer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -49,7 +49,7 @@ public class JFlexTokenizer extends Tokenizer
             throw new IllegalArgumentException("`matcher' is null");
         }
         this.matcher = matcher;
-        matcher.addSymbolMatchedListener(this);
+        matcher.setSymbolMatchedListener(this);
         // The tokenizer will own the matcher, so we won't have to unsubscribe.
     }
 

--- a/src/org/opensolaris/opengrok/analysis/JFlexXref.java
+++ b/src/org/opensolaris/opengrok/analysis/JFlexXref.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -93,8 +93,8 @@ public class JFlexXref implements Xrefer, SymbolMatchedListener,
             throw new IllegalArgumentException("`matcher' is null");
         }
         this.matcher = matcher;
-        matcher.addSymbolMatchedListener(this);
-        matcher.addNonSymbolMatchedListener(this);
+        matcher.setSymbolMatchedListener(this);
+        matcher.setNonSymbolMatchedListener(this);
         // The xrefer will own the matcher, so we won't have to unsubscribe.
 
         userPageLink = RuntimeEnvironment.getInstance().getUserPage();

--- a/src/org/opensolaris/opengrok/analysis/SymbolMatchedPublisher.java
+++ b/src/org/opensolaris/opengrok/analysis/SymbolMatchedPublisher.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis;
@@ -33,26 +33,24 @@ package org.opensolaris.opengrok.analysis;
  */
 public interface SymbolMatchedPublisher {
     /**
-     * Adds a listener for the publisher.
+     * Sets a listener for the publisher.
      * @param l the listener
      */
-    void addSymbolMatchedListener(SymbolMatchedListener l);
+    void setSymbolMatchedListener(SymbolMatchedListener l);
 
     /**
-     * Removes a listener from the publisher.
-     * @param l the listener
+     * Clears any listener from the publisher.
      */
-    void removeSymbolMatchedListener(SymbolMatchedListener l);
+    void clearSymbolMatchedListener();
 
     /**
-     * Adds a listener for the publisher.
+     * Sets a listener for the publisher.
      * @param l the listener
      */
-    void addNonSymbolMatchedListener(NonSymbolMatchedListener l);
+    void setNonSymbolMatchedListener(NonSymbolMatchedListener l);
 
     /**
-     * Removes a listener from the publisher.
-     * @param l the listener
+     * Clears any listener from the publisher.
      */
-    void removeNonSymbolMatchedListener(NonSymbolMatchedListener l);
+    void clearNonSymbolMatchedListener();
 }


### PR DESCRIPTION
Hello,

Please consider for integration this patch to optimize for a single `SymbolMatchedPublisher` listener. (If we possibly do need multiple listeners in the future, I think a new fan-out mediator would suffice.)

I also added a `--profiler` switch to `Indexer` and `OPENGROK_PROFILER` env var support to the `OpenGrok` script — which is a convenience to pause the process in order to allow attaching a profiler or debugger. I used this to profile this optimization in NetBeans.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
