### PR TITLE
Fix PowerShell break|continue <label> handling

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/powershell/PowershellSymbolTokenizer.lex
+++ b/src/org/opensolaris/opengrok/analysis/powershell/PowershellSymbolTokenizer.lex
@@ -103,7 +103,7 @@ import java.util.regex.Matcher;
     Matcher m = PoshUtils.GOTO_LABEL.matcher(capture);
     if (m.find()) {
         String label   = m.group(3);
-        onCertainlyPublish(label, yychar + yylength() - label.length());
+        onCertainlyPublish(label, m.start(3));
         return yystate();
     }
  }

--- a/test/org/opensolaris/opengrok/analysis/powershell/sample.psm1
+++ b/test/org/opensolaris/opengrok/analysis/powershell/sample.psm1
@@ -474,3 +474,7 @@ function Install-LabCAMachine
 Write-Debug `$`{`}
 Write-Debug $false.$true.$param
 $(Write-Debug $true)
+
+:OuterLoop while ($true) {
+    while ($true) { break OuterLoop }
+}

--- a/test/org/opensolaris/opengrok/analysis/powershell/sample_xref.html
+++ b/test/org/opensolaris/opengrok/analysis/powershell/sample_xref.html
@@ -482,5 +482,9 @@ function get_sym_list(){return [["Variable","xv",[["ALBoundParameters.Add",177],
 <a class="l" name="474" href="#474">474</a><span class='fold-space'>&nbsp;</span><b>Write-Debug</b> `$`{`}
 <a class="l" name="475" href="#475">475</a><span class='fold-space'>&nbsp;</span><b>Write-Debug</b> $<b>false</b>.$<b>true</b>.$<b>param</b>
 <a class="l" name="476" href="#476">476</a><span class='fold-space'>&nbsp;</span>$(<b>Write-Debug</b> $<b>true</b>)
-<a class="l" name="477" href="#477">477</a><span class='fold-space'>&nbsp;</span></body>
+<a class="l" name="477" href="#477">477</a><span class='fold-space'>&nbsp;</span>
+<a class="l" name="478" href="#478">478</a><span class='fold-space'>&nbsp;</span><a class="xlbl" name="OuterLoop">:OuterLoop</a> <b>while</b> ($<b>true</b>) &#123;
+<a class="l" name="479" href="#479">479</a><span class='fold-space'>&nbsp;</span>    <b>while</b> ($<b>true</b>) &#123; <b>break</b> <a class="d intelliWindow-symbol" href="#OuterLoop" data-definition-place="defined-in-file">OuterLoop</a> &#125;
+<a class="hl" name="480" href="#480">480</a><span class='fold-space'>&nbsp;</span>&#125;
+<a class="l" name="481" href="#481">481</a><span class='fold-space'>&nbsp;</span></body>
 </html>

--- a/test/org/opensolaris/opengrok/analysis/powershell/samplesymbols.txt
+++ b/test/org/opensolaris/opengrok/analysis/powershell/samplesymbols.txt
@@ -562,3 +562,5 @@ CRLOverlapUnitsHours
 CRLOverlapUnits
 CRLOverlapUnitsHours
 CRLOverlapUnits
+:OuterLoop
+OuterLoop


### PR DESCRIPTION
Hello,

Please consider for integration this fix for PowerShell label handling broken in `feature/symbol_matcher`. I added a `break <label>` statement to sample.psm1.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
