### PR TITLE
Fix to also check for boolean-"is" methods for Help

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/ConfigurationHelp.java
+++ b/src/org/opensolaris/opengrok/configuration/ConfigurationHelp.java
@@ -261,13 +261,17 @@ public class ConfigurationHelp {
     private static Object getDefaultValue(Class<?> klass, Method setter,
         Configuration cinst) {
 
-        String gname = setter.getName();
-        gname = gname.replaceFirst("^set", "get");
+        String gname = setter.getName().replaceFirst("^set", "get");
         Method getter;
         try {
             getter = klass.getDeclaredMethod(gname);
         } catch (NoSuchMethodException|SecurityException ex) {
-            return null;
+            gname = setter.getName().replaceFirst("^set", "is");
+            try {
+                getter = klass.getDeclaredMethod(gname);
+            } catch (NoSuchMethodException|SecurityException ex2) {
+                return null;
+            }
         }
 
         try {


### PR DESCRIPTION
Hello,

Please consider for integration this fix so that `ConfigurationHelp` also checks for "is" methods.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
