### PR TITLE
Close stream. Buffer directly from File. Fix arg.

### DIFF
--- a/src/org/opensolaris/opengrok/history/FileHistoryCache.java
+++ b/src/org/opensolaris/opengrok/history/FileHistoryCache.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.history;
@@ -223,13 +224,10 @@ class FileHistoryCache implements HistoryCache {
      * Read history from a file.
      */
     private static History readCache(File file) throws IOException {
-        try {
-            FileInputStream in = new FileInputStream(file);
-            XMLDecoder d = new XMLDecoder(
-                new BufferedInputStream(new GZIPInputStream(in)));
+        try (FileInputStream in = new FileInputStream(file);
+            XMLDecoder d = new XMLDecoder(new GZIPInputStream(
+                new BufferedInputStream(in)))) {
             return (History) d.readObject();
-        } catch (IOException e) {
-            throw e;
         }
     }
 
@@ -253,9 +251,8 @@ class FileHistoryCache implements HistoryCache {
         try {
             output = File.createTempFile("oghist", null, dir);
             try (FileOutputStream out = new FileOutputStream(output);
-                    XMLEncoder e = new XMLEncoder(
-                            new BufferedOutputStream(
-                                    new GZIPOutputStream(out)))) {
+                XMLEncoder e = new XMLEncoder(new GZIPOutputStream(
+                    new BufferedOutputStream(out)))) {
                 e.setPersistenceDelegate(File.class,
                         new FilePersistenceDelegate());
                 e.writeObject(history);

--- a/src/org/opensolaris/opengrok/history/HistoryGuru.java
+++ b/src/org/opensolaris/opengrok/history/HistoryGuru.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -215,7 +215,7 @@ public final class HistoryGuru {
     }
 
     public History getHistory(File file, boolean withFiles) throws HistoryException {
-        return getHistory(file, true, false);
+        return getHistory(file, withFiles, false);
     }
 
     /**


### PR DESCRIPTION
Hello,

Please consider for integration this patch to use try-with-resources for a `FileInputStream` in `FileHistoryCache`, to revise so `Buffered...` objects are directly above `File`, and to fix a wrong arg.

For the "wrong arg", the fix has no true effect because the argument is ignored anyway by `FileHistoryCache.getHistory(File, boolean, boolean)`, but it was counterintuitive without the fix.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
