### PR TITLE
Fix #431 : option -w should die

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -125,10 +125,6 @@ Supported Environment Variables for configuring the default setup:
                                 (by default 3 directories from SRC_ROOT)
   - OPENGROK_WEBAPP_CFGADDR     Web app address to send configuration to
                                 (use "none" to avoid sending it to web app)
-  - OPENGROK_WEBAPP_CONTEXT     Context URL of the OpenGrok webapp
-                                (by default /source)
-                                - FULL reindex is needed once this is used
-                                (old already indexed files won't be refreshed)
   - OPENGROK_WPREFIX            Disable wildcard prefix search query
                                 support (*)
   - OPENGROK_TAG                Enable parsing of revision tags into the History
@@ -374,13 +370,6 @@ DefaultInstanceConfiguration()
 
     if [ -n "${WEBAPP_CONFIG_ADDRESS}" ]; then
         WEBAPP_CONFIG="-U ${WEBAPP_CONFIG_ADDRESS}"
-    fi
-
-    # OPTIONAL: Context URL of the OpenGrok webapp
-    #           (default is /source)
-    WEBAPP_CONTEXT=""
-    if [ -n "${OPENGROK_WEBAPP_CONTEXT}" ]; then
-        WEBAPP_CONTEXT="-w ${OPENGROK_WEBAPP_CONTEXT}"
     fi
 
     # OPTIONAL: JVM Options
@@ -880,7 +869,6 @@ CommonInvocation()
         ${OPENGROK_PARALLELISM:+--threads} ${OPENGROK_PARALLELISM}	\
         ${READ_XML_CONF}                                        	\
         ${WEBAPP_CONFIG}						\
-        ${WEBAPP_CONTEXT}						\
         ${OPENGROK_PROFILER:+--profiler}				\
         "${@}"
 }

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
-Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
 
 -->
 <project name="OpenGrok" default="jar" basedir="." xmlns:jacoco="antlib:org.jacoco.ant"
@@ -371,6 +371,9 @@ Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
         <property name="gen.context.dir" value="/org/opensolaris/opengrok/search/context"/>
         <run-jflex dir="${gen.context.dir}" name="HistoryLineTokenizer"/>
         <run-jflex dir="${gen.context.dir}" name="PlainLineTokenizer"/>
+
+        <property name="gen.web.dir" value="/org/opensolaris/opengrok/web"/>
+        <run-jflex dir="${gen.web.dir}" name="XrefSourceTransformer"/>
     </target>
 
     <property name="git" value="git"/>

--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -19,12 +19,13 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -511,6 +512,34 @@ public class AnalyzerGuru {
 
         FileAnalyzer analyzer = factory.getAnalyzer();
         analyzer.writeXref(args);
+    }
+
+    /**
+     * Writes a browse-able version of the file transformed for immediate
+     * serving to a web client.
+     * @param contextPath the web context path for
+     * {@link Util#dumpXref(java.io.Writer, java.io.Reader, java.lang.String)}
+     * @param factory the analyzer factory for this file type
+     * @param in the input stream containing the data
+     * @param out a defined instance to write
+     * @param defs definitions for the source file, if available
+     * @param annotation annotation information for the file
+     * @param project project the file belongs to
+     * @throws java.io.IOException if an error occurs while creating the output
+     */
+    public static void writeDumpedXref(String contextPath,
+        FileAnalyzerFactory factory, Reader in, Writer out, Definitions defs,
+        Annotation annotation, Project project) throws IOException {
+
+        File xrefTemp = File.createTempFile("ogxref", ".html");
+        try {
+            try (FileWriter tmpout = new FileWriter(xrefTemp)) {
+                writeXref(factory, in, tmpout, defs, annotation, project);
+            }
+            Util.dumpXref(out, xrefTemp, false, contextPath);
+        } finally {
+            xrefTemp.delete();
+        }
     }
 
     /**

--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -137,6 +137,14 @@ public final class Configuration {
     private String sourceRoot;
     private String dataRoot;
     private List<RepositoryInfo> repositories;
+    /**
+     * @deprecated This is kept around so not to break object deserialization
+     * but it is ignored and cannot be truly set. This should mean that the
+     * configuration is written leaving out this deprecated property; so after
+     * some time it can be retired with the expectation that zero or a
+     * miniscule number of production configurations still have this deprecated
+     * property.
+     */
     private String urlPrefix;
     private boolean generateHtml;
     /**
@@ -430,8 +438,7 @@ public final class Configuration {
         setStatisticsFilePath(null);
         //setTabSize(4);
         setTagsEnabled(false);
-        setUrlPrefix("/source/s?");
-        //setUrlPrefix("../s?"); // TODO generate relative search paths, get rid of -w <webapp> option to indexer !
+        //urlPrefix's constant value is moved to RuntimeEnvironment.
         //setUserPage("http://www.myserver.org/viewProfile.jspa?username=");
         // Set to empty string so we can append it to the URL
         // unconditionally later.
@@ -735,15 +742,16 @@ public final class Configuration {
     }
 
     /**
-     * Set the URL prefix to be used by the {@link
-     * org.opensolaris.opengrok.analysis.executables.JavaClassAnalyzer} as well
-     * as lexers (see {@link org.opensolaris.opengrok.analysis.JFlexXref}) when
-     * they create output with html links.
-     *
-     * @param urlPrefix prefix to use.
+     * Formerly this allowed setting the URL prefix to be used for the Java
+     * class analyzer and for language cross-referencing (xref) when they
+     * created HTML links. Now, a static value is used and transformed as
+     * necessary to the servlet {@code contextPath} so that users can deploy
+     * OpenGrok as they like.
+     * @param urlPrefix ignored
      */
+    @Deprecated
     public void setUrlPrefix(String urlPrefix) {
-        this.urlPrefix = urlPrefix;
+        // ignore the value
     }
 
     public void setGenerateHtml(boolean generateHtml) {

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -102,6 +102,7 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static org.opensolaris.opengrok.configuration.Configuration.makeXMLStringAsConfiguration;
 import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 import org.opensolaris.opengrok.util.PathUtils;
+import org.opensolaris.opengrok.web.Prefix;
 
 /**
  * The RuntimeEnvironment class is used as a placeholder for the current
@@ -110,6 +111,9 @@ import org.opensolaris.opengrok.util.PathUtils;
 public final class RuntimeEnvironment {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RuntimeEnvironment.class);
+
+    /** {@code "/source"} + {@link Prefix#SEARCH_R} + {@code "?"} */
+    private static final String URL_PREFIX = "/source" + Prefix.SEARCH_R + "?";
 
     private Configuration configuration;
     private final ThreadLocal<Configuration> threadConfig;
@@ -532,21 +536,12 @@ public final class RuntimeEnvironment {
     }
 
     /**
-     * Get the context name of the web application
-     *
-     * @return the web applications context name
+     * Gets a static placeholder for the web application context name that is
+     * translated to the true servlet {@code contextPath} on demand.
+     * @return {@code "/source"} + {@link Prefix#SEARCH_R} + {@code "?"}
      */
     public String getUrlPrefix() {
-        return threadConfig.get().getUrlPrefix();
-    }
-
-    /**
-     * Set the web context name
-     *
-     * @param urlPrefix the web applications context name
-     */
-    public void setUrlPrefix(String urlPrefix) {
-        threadConfig.get().setUrlPrefix(urlPrefix);
+        return URL_PREFIX;
     }
 
     /**

--- a/src/org/opensolaris/opengrok/index/Indexer.java
+++ b/src/org/opensolaris/opengrok/index/Indexer.java
@@ -742,22 +742,6 @@ public final class Indexer {
                 "(so that the web application can use the same configuration)").Do( configFile -> {
                 configFilename = (String)configFile;
             });
-
-            parser.on("-w", "--web", "=webapp-context", 
-                "Context of webapp. Default is /source. If you specify a different",
-                "name, make sure to rename source.war to that name. Also FULL reindex",
-                "is needed if this is changed.").
-                Do( webContext -> {
-                    String webapp = (String)webContext;
-                    if (webapp.charAt(0) != '/' && !webapp.startsWith("http")) {
-                        webapp = "/" + webapp;
-                    }
-                    if (!webapp.endsWith("/")) {
-                        webapp += "/";
-                    }
-                    cfg.setUrlPrefix(webapp + "s?");
-                }
-            );
         });
 
         // Need to read the configuration file first

--- a/src/org/opensolaris/opengrok/web/Util.java
+++ b/src/org/opensolaris/opengrok/web/Util.java
@@ -20,15 +20,16 @@
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.web;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
@@ -1146,10 +1147,10 @@ public final class Util {
         if (!file.exists()) {
             return false;
         }
-        try (Reader in = compressed
-                ? new InputStreamReader(new GZIPInputStream(
-                        new FileInputStream(file)))
-                : new FileReader(file)) {
+        try (InputStream iss = new BufferedInputStream(
+            new FileInputStream(file))) {
+            Reader in = compressed ? new InputStreamReader(new GZIPInputStream(
+                iss)) : new InputStreamReader(iss);
             dump(out, in);
             return true;
         } catch (IOException e) {
@@ -1157,6 +1158,53 @@ public final class Util {
                     "An error occured while piping file " + file + ": ", e);
         }
         return false;
+    }
+
+    /**
+     * Silently dump an xref file to the given destination. All
+     * {@link IOException}s get caught and logged, but not re-thrown.
+     * @param out dump destination
+     * @param file file to dump
+     * @param compressed if {@code true} the denoted file is assumed to be
+     * gzipped
+     * @param contextPath an optional override of "/source/" as the context path
+     * @return {@code true} on success (everything read and written)
+     * @throws NullPointerException if a parameter is {@code null}.
+     */
+    public static boolean dumpXref(Writer out, File file, boolean compressed,
+        String contextPath) {
+        if (!file.exists()) return false;
+        try (InputStream iss = new BufferedInputStream(
+            new FileInputStream(file))) {
+            Reader in = compressed ? new InputStreamReader(new GZIPInputStream(
+                iss)) : new InputStreamReader(iss);
+            dumpXref(out, in, contextPath);
+            return true;
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "An error occured while piping file " +
+                file, e);
+        }
+        return false;
+    }
+
+    /**
+     * Silently dump an xref file to the given destination. All
+     * {@link IOException}s get caught and logged, but not re-thrown.
+     * @param out dump destination
+     * @param in source to read
+     * @param contextPath an optional override of "/source/" as the context path
+     * @throws IOException as defined by the given reader/writer
+     * @throws NullPointerException if a parameter is {@code null}.
+     */
+    public static void dumpXref(Writer out, Reader in, String contextPath)
+            throws IOException {
+        if (in == null || out == null) return;
+        XrefSourceTransformer xform = new XrefSourceTransformer(in);
+        xform.setWriter(out);
+        xform.setContextPath(contextPath);
+        while (xform.yylex()) {
+            // Nothing else to do.
+        }
     }
 
     /**

--- a/src/org/opensolaris/opengrok/web/XrefSourceTransformer.lex
+++ b/src/org/opensolaris/opengrok/web/XrefSourceTransformer.lex
@@ -1,0 +1,98 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.web;
+
+import java.io.Writer;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
+%%
+%public
+%class XrefSourceTransformer
+%unicode
+%type boolean
+%eofval{
+    return false;
+%eofval}
+%{
+    private Writer out;
+
+    /**
+     * If set, this will have a leading and trailing slash (which might be the
+     * same character for the root path). It's intended to substitute the
+     * default {@code "/source/"} from
+     * {@link RuntimeEnvironment#getUrlPrefix()}.
+     */
+    private String contextPath;
+
+    /**
+     * Sets the required target to write.
+     * @param out a required instance
+     */
+    public void setWriter(Writer out) {
+        if (out == null) {
+            throw new IllegalArgumentException("`out' is null");
+        }
+        this.out = out;
+    }
+
+    /**
+     * Sets the optional context path override.
+     * @param path an optional instance
+     */
+    public void setContextPath(String path) {
+        if (path == null || path.equals("source") || path.equals("/source") ||
+            path.equals("/source/")) {
+            this.contextPath = null;
+        } else {
+            StringBuilder pathBuilder = new StringBuilder();
+
+            if (!path.startsWith("/")) pathBuilder.append("/");
+            pathBuilder.append(path);
+            this.contextPath = pathBuilder.toString();
+
+            if (!this.contextPath.endsWith("/")) {
+                pathBuilder.append("/");
+                this.contextPath = pathBuilder.toString();
+            }
+        }
+    }
+%}
+
+%%
+
+/*
+ * Matches a hyperlink to the static OpenGrok urlPrefix for possible
+ * substitution.
+ */
+"href=\"/source/"    {
+    if (contextPath == null) {
+        out.write(yytext());
+    } else {
+        out.write("href=\"");
+        out.write(contextPath);
+    }
+}
+
+[^]    {
+    out.write(yytext());
+}

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -200,9 +200,6 @@ public class RuntimeEnvironmentTest {
     public void testUrlPrefix() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertEquals("/source/s?", instance.getUrlPrefix());
-        String prefix = "/opengrok/s?";
-        instance.setUrlPrefix(prefix);
-        assertEquals(prefix, instance.getUrlPrefix());
     }
 
     @Test

--- a/web/enoent.jsp
+++ b/web/enoent.jsp
@@ -18,6 +18,7 @@ CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 --%><%@page session="false" errorPage="error.jsp" isErrorPage="true" import="
 org.opensolaris.opengrok.web.Prefix,
@@ -28,9 +29,6 @@ org.opensolaris.opengrok.configuration.RuntimeEnvironment"
     PageConfig cfg = PageConfig.get(request);
     cfg.checkSourceRootExistence();
     cfg.setTitle("File not found");
-
-    String context = request.getContextPath();
-    cfg.getEnv().setUrlPrefix(context + Prefix.SEARCH_R + "?");
 }
 %><%@
 

--- a/web/mast.jsp
+++ b/web/mast.jsp
@@ -20,6 +20,7 @@ CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 --%><%--
 
@@ -69,9 +70,6 @@ org.opensolaris.opengrok.web.Util"%><%
     // set the default page title
     String path = cfg.getPath();
     cfg.setTitle(cfg.getPathTitle());
-
-    String context = request.getContextPath();
-    cfg.getEnv().setUrlPrefix(context + Prefix.SEARCH_R + "?");
 }
 %>
 <%@

--- a/web/projects.jspf
+++ b/web/projects.jspf
@@ -19,8 +19,8 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
-
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 --%>
 <%@page import="
@@ -39,7 +39,6 @@ org.opensolaris.opengrok.configuration.Project
     }
 
     PageConfig cfg = PageConfig.get(request);
-    cfg.getEnv().setUrlPrefix(request.getContextPath() + Prefix.SEARCH_R + "?");
 
     String projects = cfg.getRequestedProjectsAsString();
     if (projects.length() != 0) {

--- a/web/rss.jsp
+++ b/web/rss.jsp
@@ -19,8 +19,8 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
-
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 --%><%@page import="
 java.io.File,
@@ -49,7 +49,6 @@ org.opensolaris.opengrok.web.PageConfig"
         }
         return;
     }
-    cfg.getEnv().setUrlPrefix(request.getContextPath() + Prefix.SEARCH_R + '?');
     String path = cfg.getPath();
     String dtag = cfg.getDefineTagsIndex();
     String ForwardedHost = request.getHeader("X-Forwarded-Host");


### PR DESCRIPTION
Hello,

Please consider for integration this patch to kill option `-w,--web` and to handle instead a JFlex-powered, dynamic rewriting of `href="/source/` to target `request.getContextPath()`.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
