### PR TITLE
Fix to consistently default to UTF-8 for SRCROOT readers

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -32,6 +32,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -921,7 +922,8 @@ public class AnalyzerGuru {
 
         String encoding = IOUtils.findBOMEncoding(sig);
         if (encoding == null) {
-            encoding = "UTF-8";
+            // SRCROOT is read with UTF-8 as a default.
+            encoding = StandardCharsets.UTF_8.name();
         } else {
             int skipForBOM = IOUtils.skipForBOM(sig);
             if (in.skip(skipForBOM) < skipForBOM) {

--- a/src/org/opensolaris/opengrok/analysis/Ctags.java
+++ b/src/org/opensolaris/opengrok/analysis/Ctags.java
@@ -30,6 +30,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -298,15 +299,22 @@ public class Ctags {
         }
 
         ctags = processBuilder.start();
-        ctagsIn = new OutputStreamWriter(ctags.getOutputStream());
-        ctagsOut = new BufferedReader(new InputStreamReader(ctags.getInputStream()));
+        ctagsIn = env.isUniversalCtags() ? new OutputStreamWriter(
+            ctags.getOutputStream(), StandardCharsets.UTF_8) :
+            new OutputStreamWriter(ctags.getOutputStream());
+        ctagsOut = new BufferedReader(env.isUniversalCtags() ?
+            new InputStreamReader(ctags.getInputStream(),
+            StandardCharsets.UTF_8) : new InputStreamReader(
+            ctags.getInputStream()));
 
         errThread = new Thread(new Runnable() {
 
             @Override
             public void run() {
                 try (BufferedReader error = new BufferedReader(
-                        new InputStreamReader(ctags.getErrorStream()))) {
+                    env.isUniversalCtags() ? new InputStreamReader(
+                    ctags.getErrorStream(), StandardCharsets.UTF_8) :
+                    new InputStreamReader(ctags.getErrorStream()))) {
                     String s;
                     while ((s = error.readLine()) != null) {
                         if (s.length() > 0) {

--- a/src/org/opensolaris/opengrok/analysis/TextAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/TextAnalyzer.java
@@ -26,6 +26,7 @@ package org.opensolaris.opengrok.analysis;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import org.opensolaris.opengrok.util.IOUtils;
 
 public abstract class TextAnalyzer extends FileAnalyzer {
@@ -76,6 +77,8 @@ public abstract class TextAnalyzer extends FileAnalyzer {
     protected abstract Xrefer newXref(Reader reader);
 
     protected Reader getReader(InputStream stream) throws IOException {
-        return IOUtils.createBOMStrippedReader(stream);
+        // SRCROOT is read with UTF-8 as a default.
+        return IOUtils.createBOMStrippedReader(stream,
+            StandardCharsets.UTF_8.name());
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/document/MandocRunner.java
+++ b/src/org/opensolaris/opengrok/analysis/document/MandocRunner.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.channels.ClosedByInterruptException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -110,12 +111,11 @@ public class MandocRunner {
 
         ProcessBuilder processBuilder = new ProcessBuilder(command);
 
-        String utf8 = "UTF-8";
         Process starting = processBuilder.start();
         OutputStreamWriter inn = new OutputStreamWriter(
-            starting.getOutputStream(), utf8);
+            starting.getOutputStream(), StandardCharsets.UTF_8);
         BufferedReader rdr = new BufferedReader(new InputStreamReader(
-            starting.getInputStream(), utf8));
+            starting.getInputStream(), StandardCharsets.UTF_8));
         InputStream errorStream = starting.getErrorStream();
         mandocIn = inn;
         mandocOut = rdr;
@@ -125,7 +125,7 @@ public class MandocRunner {
             StringBuilder sb1 = new StringBuilder();
             // implicitly capture `errorStream' for the InputStreamReader
             try (final BufferedReader error = new BufferedReader(
-                new InputStreamReader(errorStream))) {
+                new InputStreamReader(errorStream, StandardCharsets.UTF_8))) {
                 String s;
                 while ((s = error.readLine()) != null) {
                     sb1.append(s);

--- a/src/org/opensolaris/opengrok/analysis/sql/Consts.java
+++ b/src/org/opensolaris/opengrok/analysis/sql/Consts.java
@@ -25,6 +25,7 @@ package org.opensolaris.opengrok.analysis.sql;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
@@ -54,7 +55,7 @@ public final class Consts {
     {
         String line,lline;
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(
-                    Consts.class.getResourceAsStream(file), "US-ASCII"))) {
+            Consts.class.getResourceAsStream(file), StandardCharsets.UTF_8))) {
             while ((line = reader.readLine()) != null) {
                 line=line.trim();
                 lline = line.toLowerCase(Locale.US);

--- a/src/org/opensolaris/opengrok/analysis/sql/PLSQLConsts.java
+++ b/src/org/opensolaris/opengrok/analysis/sql/PLSQLConsts.java
@@ -25,6 +25,7 @@ package org.opensolaris.opengrok.analysis.sql;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
@@ -55,7 +56,7 @@ public final class PLSQLConsts {
     {
         String line,lline;
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(
-                    Consts.class.getResourceAsStream(file), "US-ASCII"))) {
+            Consts.class.getResourceAsStream(file), StandardCharsets.UTF_8))) {
             while ((line = reader.readLine()) != null) {
                 line=line.trim();
                 lline = line.toLowerCase(Locale.US);

--- a/src/org/opensolaris/opengrok/search/Results.java
+++ b/src/org/opensolaris/opengrok/search/Results.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -119,6 +120,10 @@ public final class Results {
     private static Reader getXrefReader(
                     File basedir, String path, boolean compressed)
             throws IOException {
+        /**
+         * For backward compatibility, read the OpenGrok-produced document
+         * using the system default charset.
+         */
         if (compressed) {
             return new BufferedReader(IOUtils.createBOMStrippedReader(
                     new GZIPInputStream(new FileInputStream(new File(basedir, path + ".gz")))));
@@ -236,9 +241,11 @@ public final class Results {
                         String htags = getTags(sh.sourceRoot, rpath, false);
                         out.write(sh.summarizer.getSummary(htags).toString());
                     } else {
-                        Reader r = genre == Genre.PLAIN
-                                ? IOUtils.createBOMStrippedReader(new FileInputStream(new File(sh.sourceRoot, rpath)))
-                                : null;
+                        // SRCROOT is read with UTF-8 as a default.
+                        Reader r = genre == Genre.PLAIN ?
+                            IOUtils.createBOMStrippedReader(
+                            new FileInputStream(new File(sh.sourceRoot, rpath)),
+                            StandardCharsets.UTF_8.name()) : null;
                         sh.sourceContext.getContext(r, out, xrefPrefix, morePrefix, 
                                 rpath, tags, true, sh.builder.isDefSearch(), null, scopes);
                     }

--- a/src/org/opensolaris/opengrok/search/Search.java
+++ b/src/org/opensolaris/opengrok/search/Search.java
@@ -26,6 +26,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
@@ -140,7 +141,9 @@ final class Search {
                 System.out.println("Collect the rest (y/n) ?");
                 BufferedReader in;
                 try {
-                    in = new BufferedReader(new InputStreamReader(System.in, "UTF-8"));
+                    // SRCROOT is read with UTF-8 as a default.
+                    in = new BufferedReader(new InputStreamReader(System.in,
+                        StandardCharsets.UTF_8));
                     String line = in.readLine();
                     if (null == line || line.length() == 0 || line.charAt(0) == 'n') {
                        return;

--- a/src/org/opensolaris/opengrok/search/SearchEngine.java
+++ b/src/org/opensolaris/opengrok/search/SearchEngine.java
@@ -30,6 +30,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -453,11 +454,19 @@ public class SearchEngine {
                 if (sourceContext != null) {
                     try {
                         if (Genre.PLAIN == genre && (source != null)) {
-                            hasContext = sourceContext.getContext(new InputStreamReader(new FileInputStream(source
-                                    + filename)), null, null, null, filename,
-                                    tags, nhits > 100, false, ret, scopes);
+                            // SRCROOT is read with UTF-8 as a default.
+                            hasContext = sourceContext.getContext(
+                                new InputStreamReader(new FileInputStream(
+                                source + filename), StandardCharsets.UTF_8),
+                                null, null, null, filename, tags, nhits > 100,
+                                false, ret, scopes);
                         } else if (Genre.XREFABLE == genre && data != null && summarizer != null) {
                             int l;
+                            /**
+                             * For backward compatibility, read the
+                             * OpenGrok-produced document using the system
+                             * default charset.
+                             */
                             try (Reader r = RuntimeEnvironment.getInstance().isCompressXref()
                                     ? new HTMLStripCharFilter(new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(data + Prefix.XREF_P + filename + ".gz")))))
                                     : new HTMLStripCharFilter(new BufferedReader(new FileReader(data + Prefix.XREF_P + filename)))) {

--- a/src/org/opensolaris/opengrok/util/IOUtils.java
+++ b/src/org/opensolaris/opengrok/util/IOUtils.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -219,7 +220,7 @@ public final class IOUtils {
                 && head[2] == (byte) 0xBF) {
             // InputStreamReader does not properly discard BOM on UTF8 streams,
             // so don't reset the stream.
-            charset = "UTF-8";
+            charset = StandardCharsets.UTF_8.name();
         }
 
         if (charset == null) {

--- a/src/org/opensolaris/opengrok/web/PageConfig.java
+++ b/src/org/opensolaris/opengrok/web/PageConfig.java
@@ -34,6 +34,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -271,8 +272,10 @@ public final class PageConfig {
                 ArrayList<String> lines = new ArrayList<>();
                 Project p = getProject();
                 for (int i = 0; i < 2; i++) {
+                    // SRCROOT is read with UTF-8 as a default.
                     try (BufferedReader br = new BufferedReader(
-                            ExpandTabsReader.wrap(IOUtils.createBOMStrippedReader(in[i]), p))) {
+                        ExpandTabsReader.wrap(IOUtils.createBOMStrippedReader(
+                        in[i], StandardCharsets.UTF_8.name()), p))) {
                         String line;
                         while ((line = br.readLine()) != null) {
                             lines.add(line);

--- a/src/org/opensolaris/opengrok/web/Util.java
+++ b/src/org/opensolaris/opengrok/web/Util.java
@@ -39,6 +39,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
@@ -77,8 +78,6 @@ import org.opensolaris.opengrok.logger.LoggerFactory;
 public final class Util {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Util.class);
-
-    private static final Charset UTF8 = Charset.forName("UTF-8");
 
     private static final int BOLD_COUNT_THRESHOLD = 1000;
 
@@ -902,7 +901,8 @@ public final class Util {
      */
     public static String URIEncode(String q) {
         try {
-            return q == null ? "" : URLEncoder.encode(q, UTF8.name());
+            return q == null ? "" : URLEncoder.encode(q,
+                StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             // Should not happen. UTF-8 must be supported by JVMs.
             LOGGER.log(
@@ -965,7 +965,7 @@ public final class Util {
         //
         // For now, encode manually the way we want it.
         StringBuilder sb = new StringBuilder(path.length());
-        for (byte b : path.getBytes(UTF8)) {
+        for (byte b : path.getBytes(StandardCharsets.UTF_8)) {
             // URLEncoder's javadoc says a-z, A-Z, ., -, _ and * are safe
             // characters, so we preserve those to make the encoded string
             // shorter and easier to read. We also preserve the separator
@@ -1165,6 +1165,10 @@ public final class Util {
         if (!file.exists()) {
             return false;
         }
+        /**
+         * For backward compatibility, read the OpenGrok-produced document
+         * using the system default charset.
+         */
         try (Reader in = compressed
                 ? new InputStreamReader(new GZIPInputStream(
                         new FileInputStream(file)))

--- a/web/list.jsp
+++ b/web/list.jsp
@@ -32,6 +32,7 @@ java.io.InputStream,
 java.io.InputStreamReader,
 java.io.Reader,
 java.net.URLEncoder,
+java.nio.charset.StandardCharsets,
 java.util.ArrayList,
 java.util.Arrays,
 java.util.List,
@@ -190,6 +191,10 @@ document.pageReady.push(function() { pageReadyList();});
     <img src="<%= rawPath %>"/>
 </div><%
                 } else if ( g == Genre.HTML) {
+                    /**
+                     * For backward compatibility, read the OpenGrok-produced
+                     * document using the system default charset.
+                     */
                     r = new InputStreamReader(bin);
                     Util.dump(out, r);
                 } else if (g == Genre.PLAIN) {
@@ -200,7 +205,9 @@ document.pageReady.push(function() { pageReadyList();});
                     // find the definitions in the index.
                     Definitions defs = IndexDatabase.getDefinitions(resourceFile);
                     Annotation annotation = cfg.getAnnotation();
-                    r = IOUtils.createBOMStrippedReader(bin);
+                    // SRCROOT is read with UTF-8 as a default.
+                    r = IOUtils.createBOMStrippedReader(bin,
+                        StandardCharsets.UTF_8.name());
                     AnalyzerGuru.writeXref(a, r, out, defs, annotation,
                         Project.getProject(resourceFile));
     %></pre>
@@ -269,7 +276,9 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
                                 Annotation annotation = cfg.getAnnotation();
                                 //not needed yet
                                 //annotation.writeTooltipMap(out);
-                                r = IOUtils.createBOMStrippedReader(in);
+                                // SRCROOT is read with UTF-8 as a default.
+                                r = IOUtils.createBOMStrippedReader(in,
+                                    StandardCharsets.UTF_8.name());
                                 AnalyzerGuru.writeXref(a, r, out, defs,
                                     annotation, Project.getProject(resourceFile));
                             } else if (g == Genre.IMAGE) {
@@ -277,6 +286,11 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
         <img src="<%= rawPath %>?r=<%= Util.URIEncode(rev) %>"/>
         <pre><%
                             } else if (g == Genre.HTML) {
+                                /**
+                                 * For backward compatibility, read the
+                                 * OpenGrok-produced document using the system
+                                 * default charset.
+                                 */
                                 r = new InputStreamReader(in);
                                 Util.dump(out, r);
                             } else {

--- a/web/more.jsp
+++ b/web/more.jsp
@@ -25,6 +25,7 @@ Portions Copyright 2011 Jens Elkner.
 --%><%@page errorPage="error.jsp" import="
 java.io.FileInputStream,
 java.io.Reader,
+java.nio.charset.StandardCharsets,
 java.util.logging.Level,
 java.util.logging.Logger,
 
@@ -56,8 +57,9 @@ file="mast.jsp"
 %><p><span class="pagetitle">Lines Matching <b><%= tquery %></b></span></p>
 <div id="more" style="line-height:1.5em;">
     <pre><%
-            Reader r = IOUtils.createBOMStrippedReader(
-                    new FileInputStream(cfg.getResourceFile()));
+            // SRCROOT is read with UTF-8 as a default.
+            Reader r = IOUtils.createBOMStrippedReader(new FileInputStream(
+                cfg.getResourceFile()), StandardCharsets.UTF_8.name());
             sourceContext.getContext(r, out,
                 request.getContextPath() + Prefix.XREF_P, null, cfg.getPath(),
                 null, false, false, null, null);


### PR DESCRIPTION
Hello,

Please consider for integration this patch to consistently use UTF-8 as a fallback for readers against `SRCROOT`. This is a fix that helps to prepare for later integration of the Lucene `UnifiedHighlighter` (a2a76a2).

I encountered problems with inconsistent charsets when testing OpenGrok on JVMs on macOS and on OmniOS. On macOS, the JDK uses UTF-8 by default as the system charset; while on OmniOS, I determined it was Latin-1.

I think UTF-8 is a more sensible default for OpenGrok because it eliminates some unexpected inconsistency and aligns with the default encoding of Universal ctags. I am using `StandardCharsets.UTF_8` instead of a literal `"UTF-8"` as a way of tagging code that I reviewed. If it was decided later to support specifying an explicit, alternate default charset (for OpenGrok and ctags), I think having used `StandardCharsets` will help identify places for revision.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
