### PR TITLE
Fix not to add out-of-order tokens for Jar, JavaClass

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/executables/JavaClassAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/executables/JavaClassAnalyzer.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.executables;
 
@@ -60,6 +61,7 @@ import org.opensolaris.opengrok.analysis.IteratorReader;
 import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.search.QueryBuilder;
 import org.opensolaris.opengrok.web.Util;
 
 /**
@@ -95,12 +97,23 @@ public class JavaClassAnalyzer extends FileAnalyzer {
         List<String> refs = new ArrayList<>();
         List<String> full = new ArrayList<>();
 
-        ClassParser classparser = new ClassParser(in, doc.get("path"));
-        StringWriter out = new StringWriter();
+        StringWriter dout = new StringWriter();
+        StringWriter rout = new StringWriter();
         StringWriter fout = new StringWriter();
-        getContent(out, fout, classparser.parse(), defs, refs, full);
-        String fullt = fout.toString();
-        String xref = out.toString();
+
+        /**
+         * The JarAnalyzer uses JavaClassAnalyzer, so if a DEFS, REFS, or FULL
+         * field exists already, then append to it.
+         */
+        useExtantValue(dout, doc, QueryBuilder.DEFS);
+        useExtantValue(rout, doc, QueryBuilder.REFS);
+        useExtantValue(fout, doc, QueryBuilder.FULL);
+
+        ClassParser classparser = new ClassParser(in,
+            doc.get(QueryBuilder.PATH));
+        StringWriter xout = new StringWriter();
+        getContent(xout, fout, classparser.parse(), defs, refs, full);
+        String xref = xout.toString();
 
         if (xrefOut != null) {
             xrefOut.append(xref);
@@ -110,21 +123,26 @@ public class JavaClassAnalyzer extends FileAnalyzer {
                 LOGGER.log(Level.WARNING, "Couldn't flush xref, will retry once added to doc", ex);
             }
         }        
-        xref = null; //flush the xref        
 
-        StringWriter cout=new StringWriter();
-        for (String fl : full) {
-            cout.write(fl);
-            cout.write('\n');
-        }
-        String constants = cout.toString();
-        
-        StringReader fullout=new StringReader(fullt);
+        appendValues(dout, defs, "");
+        appendValues(rout, refs, "");
+        appendValues(fout, full, "// ");
 
-        doc.add(new TextField("defs", new IteratorReader(defs)));
-        doc.add(new TextField("refs", new IteratorReader(refs)));
-        doc.add(new TextField("full", fullout));
-        doc.add(new TextField("full", constants, Store.NO));
+        /**
+         * Unlike other analyzers, which rely on the full content existing to be
+         * accessed at a file system location identified by PATH, *.class and
+         * *.jar files have virtual content which is stored here (Store.YES) for
+         * analyzer convenience.
+         */
+
+        String dstr = dout.toString();
+        doc.add(new TextField(QueryBuilder.DEFS, dstr, Store.YES));
+
+        String rstr = rout.toString();
+        doc.add(new TextField(QueryBuilder.REFS, rstr, Store.YES));
+
+        String fstr = fout.toString();
+        doc.add(new TextField(QueryBuilder.FULL, fstr, Store.YES));
     }
 
     
@@ -466,5 +484,23 @@ private static final String RCBREOL="}\n";
                 throw new ClassFormatException("Unknown constant type " + tag);
         }
         return str;
+    }
+
+    private static void useExtantValue(StringWriter accum, Document doc,
+        String field) {
+        String extantValue = doc.get(field);
+        if (extantValue != null) {
+            doc.removeFields(field);
+            accum.append(extantValue);
+        }
+    }
+
+    private static void appendValues(StringWriter accum, List<String> full,
+        String lede) {
+        for (String fl : full) {
+            accum.write(lede);
+            accum.write(fl);
+            accum.write(EOL);
+        }
     }
 }

--- a/src/org/opensolaris/opengrok/index/DefaultIndexChangedListener.java
+++ b/src/org/opensolaris/opengrok/index/DefaultIndexChangedListener.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.index;
 
@@ -34,7 +35,7 @@ import java.util.logging.Logger;
  * @author Trond Norbye
  */
 @SuppressWarnings("PMD.SystemPrintln")
-class DefaultIndexChangedListener implements IndexChangedListener {
+public class DefaultIndexChangedListener implements IndexChangedListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultIndexChangedListener.class);
 

--- a/test/org/opensolaris/opengrok/analysis/executables/JarAnalyzerTest.java
+++ b/test/org/opensolaris/opengrok/analysis/executables/JarAnalyzerTest.java
@@ -1,0 +1,120 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.analysis.executables;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.TreeSet;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensolaris.opengrok.authorization.AuthorizationFrameworkReloadTest;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
+import org.opensolaris.opengrok.index.Indexer;
+import org.opensolaris.opengrok.util.TestRepository;
+import org.opensolaris.opengrok.history.RepositoryFactory;
+import org.opensolaris.opengrok.index.DefaultIndexChangedListener;
+import org.opensolaris.opengrok.index.IndexChangedListener;
+import org.opensolaris.opengrok.search.SearchEngine;
+
+/**
+ * Represents a container for tests of {@link JarAnalyzer} and
+ * {@link SearchEngine}.
+ * <p>
+ * Derived from Trond Norbye's {@code SearchEngineTest}
+ */
+public class JarAnalyzerTest {
+
+    private static final String TESTPLUGINS_JAR = "testplugins.jar";
+
+    private static RuntimeEnvironment env;
+    private static TestRepository repository;
+    private static File configFile;
+    private static boolean skip = false;
+    private static boolean originalProjectsEnabled;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        env = RuntimeEnvironment.getInstance();
+
+        originalProjectsEnabled = env.isProjectsEnabled();
+        env.setProjectsEnabled(false);
+
+        repository = new TestRepository();
+        repository.createEmpty();
+        repository.addAdhocFile(TESTPLUGINS_JAR,
+            AuthorizationFrameworkReloadTest.class.getResourceAsStream(
+            TESTPLUGINS_JAR), null);
+
+        env.setSourceRoot(repository.getSourceRoot());
+        env.setDataRoot(repository.getDataRoot());
+        RepositoryFactory.initializeIgnoredNames(env);
+
+        if (env.validateExuberantCtags()) {
+            env.setVerbose(false);
+            env.setHistoryEnabled(false);
+            IndexChangedListener progress = new DefaultIndexChangedListener();
+            Indexer.getInstance().prepareIndexer(env, true, true,
+                new TreeSet<>(Arrays.asList(new String[]{"/c"})),
+                false, false, null, null, new ArrayList<>(), false);
+
+            Indexer.getInstance().doIndexerExecution(true, null, progress);
+        } else {
+            System.out.println(
+                "Skipping test. Could not find a ctags I could use in path.");
+            skip = true;
+        }
+
+        configFile = File.createTempFile("configuration", ".xml");
+        env.writeConfiguration(configFile);
+        env.readConfiguration(new File(configFile.getAbsolutePath()));
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        env.setProjectsEnabled(originalProjectsEnabled);
+        if (repository != null) repository.destroy();
+        if (configFile != null) configFile.delete();
+        skip = false;
+    }
+
+    @Test
+    public void testSearchForJar() throws IOException {
+        if (skip) return;
+
+        SearchEngine instance;
+        int noHits;
+
+        instance = new SearchEngine();
+        instance.setFile(TESTPLUGINS_JAR);
+        noHits = instance.search();
+        assertTrue("noHits for " + TESTPLUGINS_JAR + " should be positive",
+            noHits > 0);
+        instance.destroy();
+    }
+}

--- a/test/org/opensolaris/opengrok/util/TestRepository.java
+++ b/test/org/opensolaris/opengrok/util/TestRepository.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.util;
 
@@ -42,6 +43,14 @@ public class TestRepository {
 
     private File sourceRoot;
     private File dataRoot;
+
+    public void createEmpty() throws IOException {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        sourceRoot = FileUtilities.createTemporaryDirectory("source");
+        dataRoot = FileUtilities.createTemporaryDirectory("data");
+        env.setSourceRoot(sourceRoot.getAbsolutePath());
+        env.setDataRoot(dataRoot.getAbsolutePath());
+    }
 
     public void create(InputStream inputBundle) throws IOException {
         File sourceBundle = null;
@@ -109,5 +118,31 @@ public class TestRepository {
         File dummy = new File(getSourceRoot() + File.separator + project +
             File.separator + dummyFilename);
         dummy.delete();
+    }
+
+    /**
+     * Add an ad-hoc file of a specified name with contents from the specified
+     * stream.
+     * @param filename a required instance
+     * @param in a required instance
+     * @param project an optional project name
+     * @return
+     * @throws IOException
+     */
+    public File addAdhocFile(String filename, InputStream in, String project)
+            throws IOException {
+
+        String projsep = project != null ? File.separator + project : "";
+        File adhoc = new File(getSourceRoot() + projsep + File.separator +
+            filename);
+
+        byte[] buf = new byte[8192];
+        try (FileOutputStream out = new FileOutputStream(adhoc)) {
+            int r;
+            if ((r = in.read(buf)) != -1) {
+                out.write(buf, 0, r);
+            }
+        }
+        return adhoc;
     }
 }


### PR DESCRIPTION
Hello,

Please consider for integration this patch to fix `JarAnalyzer` and `JavaClassAnalyzer` not to add out-of-order tokens. This is a prerequisite for the upcoming Lucene `UnifiedHighlighter`; and, as Lubos found, for Lucene 7 in PR #1871.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
