### PR TITLE
Fix to ignore IOException from mandoc errstream

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/document/MandocRunner.java
+++ b/src/org/opensolaris/opengrok/analysis/document/MandocRunner.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  * (derived from Ctags.java).
  */
 package org.opensolaris.opengrok.analysis.document;
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.nio.channels.ClosedByInterruptException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -122,24 +121,15 @@ public class MandocRunner {
         mandoc = starting;
 
         errThread = new Thread(() -> {
-            StringBuilder sb1 = new StringBuilder();
             // implicitly capture `errorStream' for the InputStreamReader
             try (final BufferedReader error = new BufferedReader(
                 new InputStreamReader(errorStream, StandardCharsets.UTF_8))) {
                 String s;
                 while ((s = error.readLine()) != null) {
-                    sb1.append(s);
-                    sb1.append('\n');
+                    LOGGER.log(Level.WARNING, "Error from mandoc: {0}", s);
                 }
-            } catch (ClosedByInterruptException ex) {
-                // ignore
             } catch (IOException ex) {
-                LOGGER.log(Level.WARNING,
-                    "Got an exception reading mandoc error stream: ", ex);
-            }
-            if (sb1.length() > 0) {
-                LOGGER.log(Level.WARNING, "Error from mandoc: {0}",
-                    sb1.toString());
+                // ignore
             }
         });
         errThread.setDaemon(true);


### PR DESCRIPTION
Hello,

Please consider for integration this patch to silence an unhelpful mandoc error regarding its normally-closed error stream.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
