### PR TITLE
Store a SHA-256 digest with all documents

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -52,6 +52,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.util.BytesRef;
@@ -465,13 +466,24 @@ public class AnalyzerGuru {
             doc.add(npstring);
         }
 
+        StreamSource src = StreamSource.fromFile(file);
+        byte[] digest;
+        try (DigestedInputStream digestStream = src.getSHA256stream()) {
+            digest = digestStream.digestAll();
+        } catch (IOException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IOException("DigestedInputStream close()");
+        }
+        doc.add(new StoredField(QueryBuilder.SHA256, digest));
+
         if (fa != null) {
             Genre g = fa.getGenre();
             if (g == Genre.PLAIN || g == Genre.XREFABLE || g == Genre.HTML) {
                 doc.add(new Field(QueryBuilder.T, g.typeName(),
 		        string_ft_stored_nanalyzed_norms));
             }
-            fa.analyze(doc, StreamSource.fromFile(file), xrefOut);
+            fa.analyze(doc, src, xrefOut);
 
             String type = fa.getFileTypeName();
             doc.add(new StringField(QueryBuilder.TYPE, type, Store.YES));

--- a/src/org/opensolaris/opengrok/analysis/DigestedInputStream.java
+++ b/src/org/opensolaris/opengrok/analysis/DigestedInputStream.java
@@ -1,0 +1,39 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.analysis;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+
+/**
+ * Represents an API to allow associating a {@link MessageDigest} with an input
+ * stream where OpenGrok can re-wrap the stream while carrying forward the
+ * digest of the underlying data.
+ */
+public interface DigestedInputStream extends AutoCloseable {
+    InputStream getStream();
+    MessageDigest getMessageDigest();
+    byte[] digestAll() throws IOException;
+}

--- a/src/org/opensolaris/opengrok/analysis/archive/BZip2Analyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/archive/BZip2Analyzer.java
@@ -93,8 +93,10 @@ public class BZip2Analyzer extends FileAnalyzer {
 
     /**
      * Wrap the raw stream source in one that returns the uncompressed stream.
+     * @param src a defined instance
+     * @return a defined instance
      */
-    private static StreamSource wrap(final StreamSource src) {
+    public static StreamSource wrap(final StreamSource src) {
         return new StreamSource() {
             @Override
             public InputStream getStream() throws IOException {

--- a/src/org/opensolaris/opengrok/analysis/archive/GZIPAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/archive/GZIPAnalyzer.java
@@ -102,8 +102,10 @@ public class GZIPAnalyzer extends FileAnalyzer {
 
     /**
      * Wrap the raw stream source in one that returns the uncompressed stream.
+     * @param src a defined instance
+     * @return a defined instance
      */
-    private static StreamSource wrap(final StreamSource src) {
+    public static StreamSource wrap(final StreamSource src) {
         return new StreamSource() {
             @Override
             public InputStream getStream() throws IOException {

--- a/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.document;
 
@@ -31,7 +31,6 @@ import org.apache.lucene.document.TextField;
 import org.opensolaris.opengrok.analysis.FileAnalyzer;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
 import org.opensolaris.opengrok.analysis.JFlexTokenizer;
-import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.analysis.TextAnalyzer;
 import org.opensolaris.opengrok.analysis.WriteXrefArgs;

--- a/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.plain;
 
@@ -34,6 +34,7 @@ import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.analysis.TextAnalyzer;
 import org.opensolaris.opengrok.analysis.WriteXrefArgs;
 import org.opensolaris.opengrok.analysis.Xrefer;
+import org.opensolaris.opengrok.search.QueryBuilder;
 
 /**
  * Analyzes HTML files Created on September 30, 2005
@@ -52,7 +53,7 @@ public class XMLAnalyzer extends TextAnalyzer {
 
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
-        doc.add(new TextField("full", getReader(src.getStream())));
+        doc.add(new TextField(QueryBuilder.FULL, getReader(src.getStream())));
 
         if (xrefOut != null) {
             try (Reader in = getReader(src.getStream())) {

--- a/src/org/opensolaris/opengrok/search/QueryBuilder.java
+++ b/src/org/opensolaris/opengrok/search/QueryBuilder.java
@@ -20,7 +20,7 @@
 /* 
  * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.search;
 
@@ -66,6 +66,7 @@ public class QueryBuilder {
     public static final String DIRPATH = "dirpath";
     public static final String PROJECT = "project";
     public static final String DATE = "date";
+    public static final String SHA256 = "sha256";
 
     /** Used for paths, so SHA-1 is completely sufficient */
     private static final String DIRPATH_HASH_ALGORITHM = "SHA-1";

--- a/test/org/opensolaris/opengrok/analysis/DigestedInputStreamTest.java
+++ b/test/org/opensolaris/opengrok/analysis/DigestedInputStreamTest.java
@@ -1,0 +1,161 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.analysis;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.MessageDigest;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensolaris.opengrok.analysis.archive.BZip2Analyzer;
+import org.opensolaris.opengrok.analysis.archive.GZIPAnalyzer;
+import org.opensolaris.opengrok.history.RepositoryTest;
+import org.opensolaris.opengrok.util.TestRepository;
+
+/**
+ * Represents a container for tests of {@link DigestedInputStream}.
+ */
+public class DigestedInputStreamTest {
+    private static TestRepository repository;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        repository = new TestRepository();
+        repository.create(RepositoryTest.class.getResourceAsStream(
+            "repositories.zip"));
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        repository.destroy();
+        repository = null;
+    }
+
+    @Test
+    public void shouldDigestTextFileTwoWays() throws IOException {
+        File sample = new File(repository.getSourceRoot(), "git/Makefile");
+        assertTrue("git/Makefile exists", sample.exists());
+
+        StreamSource src = StreamSource.fromFile(sample);
+        assertNotNull("StreamSource.fromFile() result", src);
+
+        // Digest the entire file at once.
+        DigestedInputStream dis = src.getSHA256stream();
+        assertNotNull("src.getSHA256stream() result", dis);
+        byte[] digest1 = dis.digestAll();
+        assertNotNull("dis.digestAll() result", digest1);
+
+        // Digest the entire file implicitly while reading a stream.
+        dis = src.getSHA256stream();
+        while (dis.getStream().read() != -1) { /* noop */ }
+        MessageDigest messageDigest = dis.getMessageDigest();
+        assertNotNull("dis.getMessageDigest() result", messageDigest);
+        byte[] digest2 = messageDigest.digest();
+
+        assertArrayEquals("digestAll() v. read/digest()", digest1, digest2);
+    }
+
+    @Test
+    public void shouldDigestGzipFileThreeWays() throws IOException {
+        File sample = new File(repository.getSourceRoot(),
+            "svn/archives/tarfile.tar.gz");
+        assertTrue("svn/archives/tarfile.tar.gz exists", sample.exists());
+
+        StreamSource src1 = StreamSource.fromFile(sample);
+        assertNotNull("StreamSource.fromFile() result", src1);
+
+        // Digest the entire file at once.
+        DigestedInputStream dis = src1.getSHA256stream();
+        assertNotNull("src.getSHA256stream() result", dis);
+        byte[] digest1 = dis.digestAll();
+        assertNotNull("dis.digestAll() result", digest1);
+
+        // Digest the entire file implicitly while reading a raw stream.
+        dis = src1.getSHA256stream();
+        int rawcount = 0;
+        while (dis.getStream().read() != -1) { ++rawcount; }
+        MessageDigest messageDigest = dis.getMessageDigest();
+        assertNotNull("dis.getMessageDigest() result", messageDigest);
+        byte[] digest2 = messageDigest.digest();
+
+        // Digest the entire file implicitly while reading a gunzip stream.
+        StreamSource src2 = GZIPAnalyzer.wrap(src1);
+        assertNotNull("GZIPAnalyzer.wrap() result", src2);
+        dis = src2.getSHA256stream();
+        int cookedcount = 0;
+        while (dis.getStream().read() != -1) { ++cookedcount; }
+        messageDigest = dis.getMessageDigest();
+        assertNotNull("dis.getMessageDigest() result", messageDigest);
+        byte[] digest3 = messageDigest.digest();
+
+        assertArrayEquals("digestAll() v. read #1/digest()", digest1, digest2);
+        assertArrayEquals("digestAll() v. read #2/digest()", digest1, digest3);
+        assertTrue("some bytes read", rawcount > 0 && cookedcount > 0);
+        assertNotEquals("raw byte# vs unzipped byte#", rawcount, cookedcount);
+    }
+
+    @Test
+    public void shouldDigestBzip2FileThreeWays() throws IOException {
+        File sample = new File(repository.getSourceRoot(),
+            "svn/archives/tarfile.tar.bz2");
+        assertTrue("svn/archives/tarfile.tar.bz2 exists", sample.exists());
+
+        StreamSource src1 = StreamSource.fromFile(sample);
+        assertNotNull("StreamSource.fromFile() result", src1);
+
+        // Digest the entire file at once.
+        DigestedInputStream dis = src1.getSHA256stream();
+        assertNotNull("src.getSHA256stream() result", dis);
+        byte[] digest1 = dis.digestAll();
+        assertNotNull("dis.digestAll() result", digest1);
+
+        // Digest the entire file implicitly while reading a raw stream.
+        dis = src1.getSHA256stream();
+        int rawcount = 0;
+        while (dis.getStream().read() != -1) { ++rawcount; }
+        MessageDigest messageDigest = dis.getMessageDigest();
+        assertNotNull("dis.getMessageDigest() result", messageDigest);
+        byte[] digest2 = messageDigest.digest();
+
+        // Digest the entire file implicitly while reading a bzip2 stream.
+        StreamSource src2 = BZip2Analyzer.wrap(src1);
+        assertNotNull("BZip2Analyzer.wrap() result", src2);
+        dis = src2.getSHA256stream();
+        int cookedcount = 0;
+        while (dis.getStream().read() != -1) { ++cookedcount; }
+        messageDigest = dis.getMessageDigest();
+        assertNotNull("dis.getMessageDigest() result", messageDigest);
+        byte[] digest3 = messageDigest.digest();
+
+        assertArrayEquals("digestAll() v. read #1/digest()", digest1, digest2);
+        assertArrayEquals("digestAll() v. read #2/digest()", digest1, digest3);
+        assertTrue("some bytes read", rawcount > 0 && cookedcount > 0);
+        assertNotEquals("raw byte# vs unzipped byte#", rawcount, cookedcount);
+    }
+}

--- a/test/org/opensolaris/opengrok/analysis/JFlexXrefTest.java
+++ b/test/org/opensolaris/opengrok/analysis/JFlexXrefTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis;
@@ -505,6 +505,11 @@ public class JFlexXrefTest {
                     StringWriter.class.getName().replace('.', '/') +
                     ".class";
                 return StringWriter.class.getResourceAsStream(path);
+            }
+
+            @Override
+            public DigestedInputStream getSHA256stream() throws IOException {
+                return StreamSource.getSHA256stream(getStream());
             }
         };
         Document doc = new Document();

--- a/test/org/opensolaris/opengrok/analysis/TextAnalyzerTest.java
+++ b/test/org/opensolaris/opengrok/analysis/TextAnalyzerTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -49,6 +49,11 @@ public class TextAnalyzerTest {
             @Override
             public InputStream getStream() throws IOException {
                 return new ByteArrayInputStream(bytes);
+            }
+
+            @Override
+            public DigestedInputStream getSHA256stream() throws IOException {
+                return StreamSource.getSHA256stream(getStream());
             }
         };
     }

--- a/test/org/opensolaris/opengrok/analysis/c/CAnalyzerFactoryTest.java
+++ b/test/org/opensolaris/opengrok/analysis/c/CAnalyzerFactoryTest.java
@@ -30,9 +30,6 @@ import static org.junit.Assert.fail;
 import static org.opensolaris.opengrok.analysis.AnalyzerGuru.string_ft_nstored_nanalyzed_norms;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
 
 import org.apache.lucene.document.Document;
@@ -61,12 +58,7 @@ public class CAnalyzerFactoryTest {
     private static FileAnalyzer analyzer;
 
     private static StreamSource getStreamSource(final String fname) {
-        return new StreamSource() {
-            @Override
-            public InputStream getStream() throws IOException {
-                return new FileInputStream(fname);
-            }
-        };
+        return StreamSource.fromFile(new File(fname));
     }
 
     @BeforeClass

--- a/test/org/opensolaris/opengrok/analysis/c/CxxAnalyzerFactoryTest.java
+++ b/test/org/opensolaris/opengrok/analysis/c/CxxAnalyzerFactoryTest.java
@@ -30,9 +30,6 @@ import static org.junit.Assert.fail;
 import static org.opensolaris.opengrok.analysis.AnalyzerGuru.string_ft_nstored_nanalyzed_norms;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
 
 import org.apache.lucene.document.Document;
@@ -61,12 +58,7 @@ public class CxxAnalyzerFactoryTest {
     private static FileAnalyzer analyzer;
 
     private static StreamSource getStreamSource(final String fname) {
-        return new StreamSource() {
-            @Override
-            public InputStream getStream() throws IOException {
-                return new FileInputStream(fname);
-            }
-        };
+        return StreamSource.fromFile(new File(fname));
     }
 
     @BeforeClass

--- a/test/org/opensolaris/opengrok/analysis/clojure/ClojureAnalyzerFactoryTest.java
+++ b/test/org/opensolaris/opengrok/analysis/clojure/ClojureAnalyzerFactoryTest.java
@@ -37,9 +37,6 @@ import org.opensolaris.opengrok.search.QueryBuilder;
 import org.opensolaris.opengrok.util.TestRepository;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -59,12 +56,7 @@ public class ClojureAnalyzerFactoryTest {
     private static FileAnalyzer analyzer;
 
     private static StreamSource getStreamSource(final String fname) {
-        return new StreamSource() {
-            @Override
-            public InputStream getStream() throws IOException {
-                return new FileInputStream(fname);
-            }
-        };
+        return StreamSource.fromFile(new File(fname));
     }
 
     @BeforeClass

--- a/test/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzerFactoryTest.java
+++ b/test/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzerFactoryTest.java
@@ -24,11 +24,8 @@
 package org.opensolaris.opengrok.analysis.csharp;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexableField;
-import java.io.InputStream;
 import java.io.StringWriter;
 import org.apache.lucene.document.Field;
 import org.junit.AfterClass;
@@ -56,12 +53,7 @@ public class CSharpAnalyzerFactoryTest {
     private static FileAnalyzer analyzer;
 
     private static StreamSource getStreamSource(final String fname) {
-        return new StreamSource() {
-            @Override
-            public InputStream getStream() throws IOException {
-                return new FileInputStream(fname);
-            }
-        };
+        return StreamSource.fromFile(new File(fname));
     }
 
     @BeforeClass

--- a/test/org/opensolaris/opengrok/analysis/document/TroffAnalyzerTest.java
+++ b/test/org/opensolaris/opengrok/analysis/document/TroffAnalyzerTest.java
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
  * Portions copyright 2009 - 2011 Jens Elkner. 
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.document;
 
@@ -40,6 +41,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.opensolaris.opengrok.analysis.DigestedInputStream;
 import org.opensolaris.opengrok.analysis.StreamSource;
 import org.opensolaris.opengrok.util.TestRepository;
 import org.opensolaris.opengrok.web.Util;
@@ -123,6 +125,11 @@ public class TroffAnalyzerTest {
             @Override
             public InputStream getStream() throws IOException {
                 return new ByteArrayInputStream(content.getBytes());
+            }
+
+            @Override
+            public DigestedInputStream getSHA256stream() throws IOException {
+                return StreamSource.getSHA256stream(getStream());
             }
         }, xrefOut);
     }

--- a/test/org/opensolaris/opengrok/analysis/java/JavaAnalyzerFactoryTest.java
+++ b/test/org/opensolaris/opengrok/analysis/java/JavaAnalyzerFactoryTest.java
@@ -30,9 +30,6 @@ import static org.junit.Assert.fail;
 import static org.opensolaris.opengrok.analysis.AnalyzerGuru.string_ft_nstored_nanalyzed_norms;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
 
 import org.apache.lucene.document.Document;
@@ -61,12 +58,7 @@ public class JavaAnalyzerFactoryTest {
     private static FileAnalyzer analyzer;
 
     private static StreamSource getStreamSource(final String fname) {
-        return new StreamSource() {
-            @Override
-            public InputStream getStream() throws IOException {
-                return new FileInputStream(fname);
-            }
-        };
+        return StreamSource.fromFile(new File(fname));
     }
 
     @BeforeClass

--- a/test/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzerFactoryTest.java
+++ b/test/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzerFactoryTest.java
@@ -24,9 +24,6 @@
 package org.opensolaris.opengrok.analysis.pascal;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -58,12 +55,7 @@ public class PascalAnalyzerFactoryTest {
     private static FileAnalyzer analyzer;
     
     private static StreamSource getStreamSource(final String fname) {
-        return new StreamSource() {
-            @Override
-            public InputStream getStream() throws IOException {
-                return new FileInputStream(fname);
-            }
-        };
+        return StreamSource.fromFile(new File(fname));
     }
     
     @BeforeClass


### PR DESCRIPTION
Hello,

Please consider for integration this patch to store a SHA hash for documents.

This is a prerequisite for including the Lucene `UnifiedHighlighter` as that highlighter requires strictly affirming that a Lucene `Document` and the underlying source text are in accordance. I.e., since OpenGrok rightly does not store full, original source text in the Lucene index, a SHA hash will allow `Context` to affirm that the source text is either unchanged (so that `UnifiedHighlighter` can be used) or that a temporary fallback to the old `PlainLineTokenizer` method should be done.

(This latter fallback could happen transiently e.g. when `git update` has been executed but before `OpenGrok index` has completed.)

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
