### PR TITLE
Fix to call createSlider() with revised signature

### DIFF
--- a/web/history.jsp
+++ b/web/history.jsp
@@ -19,8 +19,8 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
-
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 --%>
 <%@page import="org.opensolaris.opengrok.web.Util"%>
@@ -115,8 +115,8 @@ include file="pageheader.jspf"
 
         int start = cfg.getSearchStart();
         int max = cfg.getSearchMaxItems();
-        int totalHits = hist.getHistoryEntries().size();
-        int thispage = Math.min(totalHits - start, max);
+        long totalHits = hist.getHistoryEntries().size();
+        long thispage = Math.min(totalHits - start, max);
 
         // We have a lots of results to show: create a slider for them
         request.setAttribute("history.jsp-slider", Util.createSlider(start, max, totalHits, request));


### PR DESCRIPTION
Hello,

Please consider for integration this patch to use in `history.jsp` too the revised version of `createSlider()` which was changed in c29e0463794e (Lucene 7).

I'm not sure if it's a Tomcat weirdness, but after deployment I was seeing `NoSuchMethodError` related to `createSlider()` whose `size` parameter was changed from `int` to `long`.

This now matches the change already made to `search.jsp`.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
