### PR TITLE
add pep8 checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ cache:
   - $HOME/.m2
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq exuberant-ctags cvs git mercurial cssc bzr subversion monotone rcs
+ - sudo apt-get install -qq exuberant-ctags cvs git mercurial cssc bzr subversion monotone rcs pep8
  - sudo ./scripts/install-bitkeeper.sh
+install: true
 
 before_script:
  - bk --version
@@ -26,7 +27,7 @@ env:
    #   via the "travis encrypt" command using the project repo's public key
    - secure: "O_cda5pWDBAP-O3_0nG5RQ"
 
-script:     "mvn -DskipTests=true -Dmaven.javadoc.skip=false -B -V compile && cd opengrok-indexer && mvn javadoc:javadoc && cd ../opengrok-web && mvn javadoc:javadoc && cd .. && mvn test -B"
+script:     "mvn -DskipTests=true -Dmaven.javadoc.skip=false -B -V compile && cd opengrok-indexer && mvn javadoc:javadoc && cd ../opengrok-web && mvn javadoc:javadoc && cd .. && mvn verify -B"
 
 addons:
   coverity_scan:

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -434,6 +434,27 @@ Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
                 </configuration>
             </plugin>
 
+           <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                  <execution>
+                    <phase>verify</phase>
+                    <goals>
+                      <goal>exec</goal>
+                    </goals>
+                  </execution>
+                </executions>
+                <configuration>
+                  <executable>pep8</executable>
+                  <arguments>
+		    <argument>-v</argument>
+		    <argument>--exclude=filelock.py,test_command.py</argument>
+                    <argument>${project.basedir}/../tools/sync</argument>
+                  </arguments>
+                </configuration>
+           </plugin>
 
         </plugins>
     </build>


### PR DESCRIPTION
On Travis this currently passes because the Ubuntu there has much older pep8 version. On my Ubuntu laptop this fails on `tools/sync/test/test_commands.py`. I will leave it there as a canary.

This also disables the `install` phase that triggered `./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V` in Travis which is most probably not needed as everything is done in the `script:` section (the `mvnw` is good candidate for removal anyway).