### PR TITLE
Fix search matching first line has a line number 0

### DIFF
--- a/src/org/opensolaris/opengrok/search/context/PlainLineTokenizer.lex
+++ b/src/org/opensolaris/opengrok/search/context/PlainLineTokenizer.lex
@@ -54,11 +54,11 @@ import org.opensolaris.opengrok.analysis.Scopes.Scope;
    * first line part of the matching region.
    */
   private final StringBuilder markedContents = new StringBuilder();
-  int markedPos=0;
-  int curLinePos=0;
-  int matchStart=-1;
-  int markedLine=0;
-  int rest=0;
+  int markedPos = 0;
+  int curLinePos = 0;
+  int matchStart = -1;
+  int markedLine = 1; // lines are indexed from 1
+  int rest = 0;
   boolean wait = false;
   boolean dumpRest = false;
   Writer out;
@@ -115,10 +115,10 @@ import org.opensolaris.opengrok.analysis.Scopes.Scope;
         wait = false;
         dumpRest = false;
         rest = 0;
-        markedPos=0;
-        curLinePos=0;
-        matchStart=-1;
-        markedLine=0;
+        markedPos = 0;
+        curLinePos = 0;
+        matchStart = -1;
+        markedLine = 1;
         yyline = 1;
         this.out = out;
         this.url = url;

--- a/test/org/opensolaris/opengrok/search/context/ContextTest.java
+++ b/test/org/opensolaris/opengrok/search/context/ContextTest.java
@@ -409,7 +409,7 @@ public class ContextTest {
         QueryBuilder qb = new QueryBuilder().setFreetext("mixed");
         Context c = new Context(qb.build(), qb.getQueries());
         assertTrue(c.getContext(in, out, "", "", "", null, false, qb.isDefSearch(), null));
-        assertEquals("<a class=\"s\" href=\"#0\"><span class=\"l\">0</span> "
+        assertEquals("<a class=\"s\" href=\"#1\"><span class=\"l\">1</span> "
                 + "<b>Mixed</b> case: abc AbC dEf</a><br/>",
                 out.toString());
     }


### PR DESCRIPTION
fixes #2033 

Testing done: manual verification

Other lines were working correctly because they were repaired by this line: `markedLine = yyline+1;`

I hope I did not break anything else.

Thanks for review :) 