### PR TITLE
Store TABSIZE in a supplementary document for each IndexDatabase

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -52,7 +52,6 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedDocValuesField;
-import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.util.BytesRef;
@@ -470,9 +469,6 @@ public class AnalyzerGuru {
                 normalizedPath, Store.NO);
             doc.add(npstring);
         }
-
-        doc.add(new StoredField(QueryBuilder.TABSIZE, project != null &&
-            project.hasTabSizeSetting() ? project.getTabSize() : 0));
 
         if (fa != null) {
             Genre g = fa.getGenre();

--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -52,6 +52,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.util.BytesRef;
@@ -469,6 +470,9 @@ public class AnalyzerGuru {
                 normalizedPath, Store.NO);
             doc.add(npstring);
         }
+
+        doc.add(new StoredField(QueryBuilder.TABSIZE, project != null &&
+            project.hasTabSizeSetting() ? project.getTabSize() : 0));
 
         if (fa != null) {
             Genre g = fa.getGenre();

--- a/src/org/opensolaris/opengrok/index/IndexAnalysisSettings.java
+++ b/src/org/opensolaris/opengrok/index/IndexAnalysisSettings.java
@@ -1,0 +1,151 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.index;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * Represents a serializable gathering of some top-level metadata concerning the
+ * operation of {@link IndexDatabase} -- and persisted therein too -- which are
+ * re-compared upon each indexing run since changes to them might require
+ * re-indexing particular files or in certain cases all files.
+ */
+public final class IndexAnalysisSettings implements Serializable {
+
+    private static final long serialVersionUID = 1005610724146719938L;
+
+    private String projectName;
+
+    /**
+     * (nullable to allow easing this object into existing OpenGrok indexes
+     * without forcing a re-indexing)
+     * @serial
+     */
+    private Integer tabSize;
+
+    /**
+     * (nullable to allow easing this object into existing OpenGrok indexes
+     * without forcing a re-indexing)
+     * @serial
+     */
+    private Long analyzerGuruVersion;
+
+    /**
+     * Gets the project name to be used to distinguish different instances of
+     * {@link IndexAnalysisSettings} that might be returned by a Lucene
+     * {@code MultiReader} search across projects.
+     * @return projectName
+     */
+    public String getProjectName() {
+        return projectName;
+    }
+
+    /**
+     * Sets the project name to be used to distinguish different instances of
+     * {@link IndexAnalysisSettings} that might be returned by a Lucene
+     * {@code MultiReader} search across projects.
+     * @param value
+     */
+    public void setProjectName(String value) {
+        this.projectName = value;
+    }
+
+    public Integer getTabSize() {
+        return tabSize;
+    }
+
+    public void setTabSize(Integer value) {
+        this.tabSize = value;
+    }
+
+    public Long getAnalyzerGuruVersion() {
+        return analyzerGuruVersion;
+    }
+
+    public void setAnalyzerGuruVersion(Long value) {
+        this.analyzerGuruVersion = value;
+    }
+
+    /**
+     * Creates a binary representation of this object.
+     * @return a byte array representing this object
+     * @throws  IOException Any exception thrown by the underlying
+     * OutputStream.
+     */
+    public byte[] serialize() throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        new ObjectOutputStream(bytes).writeObject(this);
+        return bytes.toByteArray();
+    }
+
+    /**
+     * De-serializes a binary representation of an {@link IndexAnalysisSettings}
+     * object.
+     * @param bytes a byte array containing the serialization
+     * @return a defined instance
+     * @throws IOException Any of the usual Input/Output related exceptions.
+     * @throws ClassNotFoundException Class of a serialized object cannot be
+     * found.
+     * @throws ClassCastException if the array contains an object of another
+     * type than {@code IndexAnalysisSettings}
+     */
+    public static IndexAnalysisSettings deserialize(byte[] bytes)
+            throws IOException, ClassNotFoundException {
+        ObjectInputStream in = new ObjectInputStream(
+            new ByteArrayInputStream(bytes));
+        return (IndexAnalysisSettings)in.readObject();
+    }
+
+    private void readObject(ObjectInputStream in) throws ClassNotFoundException,
+            IOException {
+
+        boolean hasValue = in.readBoolean();
+        String vstring = in.readUTF();
+        projectName = hasValue ? vstring : null;
+
+        hasValue = in.readBoolean();
+        int vint = in.readInt();
+        tabSize = hasValue ? vint : null;
+
+        hasValue = in.readBoolean();
+        long vlong = in.readLong();
+        analyzerGuruVersion = hasValue ? vlong : null;
+    }
+
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.writeBoolean(projectName != null); // hasValue
+        out.writeUTF(projectName == null ? "" : projectName);
+
+        out.writeBoolean(tabSize != null); // hasValue
+        out.writeInt(tabSize == null ? 0 : tabSize);
+
+        out.writeBoolean(analyzerGuruVersion != null); // hasValue
+        out.writeLong(analyzerGuruVersion == null ? 0 : analyzerGuruVersion);
+    }
+}

--- a/src/org/opensolaris/opengrok/index/IndexAnalysisSettingsAccessor.java
+++ b/src/org/opensolaris/opengrok/index/IndexAnalysisSettingsAccessor.java
@@ -1,0 +1,112 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.index;
+
+import java.io.IOException;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.opensolaris.opengrok.analysis.CompatibleAnalyser;
+import org.opensolaris.opengrok.search.QueryBuilder;
+
+/**
+ * Represents a data-access object for {@link IndexAnalysisSettings}.
+ */
+public class IndexAnalysisSettingsAccessor {
+
+    /**
+     * {@code "uthuslvotkgltggqqjmurqojpjpjjkutkujktnkk"}, the
+     * {@link QueryBuilder}-normalized value for UUID
+     * 58859C75-F941-42E5-8D1A-FAF71DDEBBA7
+     */
+    public static final String INDEX_ANALYSIS_SETTINGS_OBJUID =
+        "uthuslvotkgltggqqjmurqojpjpjjkutkujktnkk";
+
+    /**
+     * Searches for a document with a {@link QueryBuilder#OBJUID} value matching
+     * {@link #INDEX_ANALYSIS_SETTINGS_OBJUID}.
+     * @param reader a defined instance
+     * @return a defined instance or {@code null} if none could be found
+     * @throws IOException if I/O error occurs while searching Lucene
+     */
+    public IndexAnalysisSettings read(IndexReader reader) throws IOException {
+        IndexSearcher searcher = new IndexSearcher(reader);
+        Query q;
+        try {
+            q = new QueryParser(QueryBuilder.OBJUID, new CompatibleAnalyser()).
+                parse(INDEX_ANALYSIS_SETTINGS_OBJUID);
+        } catch (ParseException ex) {
+            // This is not expected, so translate to RuntimeException.
+            throw new RuntimeException(ex);
+        }
+        TopDocs top = searcher.search(q, 1);
+        if (top.totalHits < 1) {
+            return null;
+        }
+
+        Document doc = searcher.doc(top.scoreDocs[0].doc);
+        IndexableField objser = doc.getField(QueryBuilder.OBJSER);
+        try {
+            return objser == null ? null : IndexAnalysisSettings.deserialize(
+                objser.binaryValue().bytes);
+        } catch (ClassNotFoundException ex) {
+            // This is not expected, so translate to RuntimeException.
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Writes a document to contain the serialized version of {@code settings},
+     * with a {@link QueryBuilder#OBJUID} value set to
+     * {@link #INDEX_ANALYSIS_SETTINGS_OBJUID}. An existing version of the
+     * document is first deleted.
+     * @param writer a defined, target instance
+     * @param settings a defined instance
+     * @throws IOException if I/O error occurs while writing Lucene
+     */
+    public void write(IndexWriter writer, IndexAnalysisSettings settings)
+            throws IOException {
+        byte[] objser = settings.serialize();
+
+        writer.deleteDocuments(new Term(QueryBuilder.OBJUID,
+            INDEX_ANALYSIS_SETTINGS_OBJUID));
+
+        Document doc = new Document();
+        StringField uidfield = new StringField(QueryBuilder.OBJUID,
+            INDEX_ANALYSIS_SETTINGS_OBJUID, Field.Store.NO);
+        doc.add(uidfield);
+        doc.add(new StoredField(QueryBuilder.OBJSER, objser));
+        writer.addDocument(doc);
+    }
+}

--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -989,8 +989,8 @@ public class IndexDatabase {
                          * If the file was not modified, probably skip to the
                          * next one.
                          */
-                        if (uidIter != null && uidIter.term() != null &&
-                            uidIter.term().bytesEquals(buid)) {
+                        if (uidIter != null && uidIter.term() != null
+                                && uidIter.term().bytesEquals(buid)) {
                             boolean chkres = chkFields(file, path);
                             if (!chkres) removeFile(false);
 
@@ -1522,8 +1522,8 @@ public class IndexDatabase {
              * ignore the check so that no extra work is done. After a re-index,
              * the TABSIZE check will be active.
              */
-            int reqTabSize = project != null ? project.hasTabSizeSetting() ?
-                project.getTabSize() : 0 : 0;
+            int reqTabSize = project != null && project.hasTabSizeSetting() ?
+                project.getTabSize() : 0;
             IndexableField tbsz = doc.getField(QueryBuilder.TABSIZE);
             int tbszint = tbsz != null ? tbsz.numericValue().intValue(): 0;
             if (tbsz != null && tbszint != reqTabSize) {

--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -61,12 +61,10 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.MultiFields;
-import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.queryparser.classic.ParseException;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
@@ -108,17 +106,15 @@ public class IndexDatabase {
     private static final Comparator<File> FILENAME_COMPARATOR =
         (File p1, File p2) -> p1.getName().compareTo(p2.getName());
 
-    private static final Set<String> CHECK_FIELDS;
-
     private final Object INSTANCE_LOCK = new Object();
 
     private Project project;
     private FSDirectory indexDirectory;
     private IndexReader reader;
     private IndexWriter writer;
+    private IndexAnalysisSettings settings;
     private PendingFileCompleter completer;
     private TermsEnum uidIter;
-    private PostingsEnum postsIter;
     private IgnoredNames ignoredNames;
     private Filter includedNames;
     private AnalyzerGuru analyzerGuru;
@@ -159,11 +155,6 @@ public class IndexDatabase {
         this.project = project;
         lockfact = NoLockFactory.INSTANCE;
         initialize();
-    }
-
-    static {
-        CHECK_FIELDS = new HashSet<>();
-        CHECK_FIELDS.add(QueryBuilder.TABSIZE);
     }
 
     /**
@@ -395,8 +386,8 @@ public class IndexDatabase {
 
         reader = null;
         writer = null;
+        settings = null;
         uidIter = null;
-        postsIter = null;
 
         IOException finishingException = null;
         try {
@@ -439,6 +430,10 @@ public class IndexDatabase {
 
                 String startuid = Util.path2uid(dir, "");
                 reader = DirectoryReader.open(indexDirectory); // open existing index
+                settings = readAnalysisSettings();
+                if (settings == null) {
+                    settings = new IndexAnalysisSettings();
+                }
                 Terms terms = null;
                 int numDocs = reader.numDocs();
                 if (numDocs > 0) {
@@ -991,13 +986,19 @@ public class IndexDatabase {
                          */
                         if (uidIter != null && uidIter.term() != null
                                 && uidIter.term().bytesEquals(buid)) {
-                            boolean chkres = chkFields(file, path);
-                            if (!chkres) removeFile(false);
+                            boolean chkres = chkSettings(path);
+                            if (!chkres) {
+                                removeFile(false);
+                            }
 
                             BytesRef next = uidIter.next();
-                            if (next == null) uidIter = null;
+                            if (next == null) {
+                                uidIter = null;
+                            }
 
-                            if (chkres) continue; // keep matching docs
+                            if (chkres) {
+                                continue; // keep matching docs
+                            }
                         }
                     }
 
@@ -1485,6 +1486,8 @@ public class IndexDatabase {
     private void finishWriting() throws IOException {
         boolean hasPendingCommit = false;
         try {
+            writeAnalysisSettings();
+
             writer.prepareCommit();
             hasPendingCommit = true;
 
@@ -1504,42 +1507,40 @@ public class IndexDatabase {
         }
     }
 
-    private boolean chkFields(File file, String path) throws IOException {
-        int n = 0;
-        postsIter = uidIter.postings(postsIter);
-        while (postsIter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
-            ++n;
-            // Read a limited-fields version of the document.
-            Document doc = reader.document(postsIter.docID(), CHECK_FIELDS);
-            if (doc == null) {
-                LOGGER.log(Level.FINER, "No Document: {0}", path);
-                continue;
-            }
-
-            /**
-             * Verify TABSIZE, or return a value to indicate mismatch.
-             * For an older OpenGrok index that does not yet have TABSIZE,
-             * ignore the check so that no extra work is done. After a re-index,
-             * the TABSIZE check will be active.
-             */
-            int reqTabSize = project != null && project.hasTabSizeSetting() ?
-                project.getTabSize() : 0;
-            IndexableField tbsz = doc.getField(QueryBuilder.TABSIZE);
-            int tbszint = tbsz != null ? tbsz.numericValue().intValue(): 0;
-            if (tbsz != null && tbszint != reqTabSize) {
-                LOGGER.log(Level.FINE, "Tabsize mismatch: {0}", path);
-                return false;
-            }
-
-            break;
-        }
-        if (n < 1) {
-            LOGGER.log(Level.FINER, "Missing index Documents: {0}", path);
+    /**
+     * Verify TABSIZE, or return a value to indicate mismatch.
+     * @param path the source file path
+     * @return {@code false} if a mismatch is detected
+     */
+    private boolean chkSettings(String path) {
+        int reqTabSize = project != null && project.hasTabSizeSetting() ?
+            project.getTabSize() : 0;
+        Integer actTabSize = settings.getTabSize();
+        if (actTabSize != null && !actTabSize.equals(reqTabSize)) {
+            LOGGER.log(Level.FINE, "Tabsize mismatch: {0}", path);
             return false;
         }
 
+        // TODO: verify ANALYZER_GURU_VERSION and ANALYZER_VERSION.
+
         // Assume "true" if otherwise no discrepancies were observed.
         return true;
+    }
+
+    private void writeAnalysisSettings() throws IOException {
+        settings = new IndexAnalysisSettings();
+        settings.setProjectName(project != null ? project.getName() : null);
+        settings.setTabSize(project != null && project.hasTabSizeSetting() ?
+            project.getTabSize() : 0);
+        // TODO: set ANALYZER_GURU and ANALYZER versions.
+
+        IndexAnalysisSettingsAccessor dao = new IndexAnalysisSettingsAccessor();
+        dao.write(writer, settings);
+    }
+
+    private IndexAnalysisSettings readAnalysisSettings() throws IOException {
+        IndexAnalysisSettingsAccessor dao = new IndexAnalysisSettingsAccessor();
+        return dao.read(reader);
     }
 
     private class IndexDownArgs {

--- a/src/org/opensolaris/opengrok/search/QueryBuilder.java
+++ b/src/org/opensolaris/opengrok/search/QueryBuilder.java
@@ -20,7 +20,7 @@
 /* 
  * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.search;
 
@@ -66,6 +66,7 @@ public class QueryBuilder {
     public static final String DIRPATH = "dirpath";
     public static final String PROJECT = "project";
     public static final String DATE = "date";
+    public static final String TABSIZE = "tabsize";
 
     /** Used for paths, so SHA-1 is completely sufficient */
     private static final String DIRPATH_HASH_ALGORITHM = "SHA-1";

--- a/src/org/opensolaris/opengrok/search/QueryBuilder.java
+++ b/src/org/opensolaris/opengrok/search/QueryBuilder.java
@@ -66,7 +66,8 @@ public class QueryBuilder {
     public static final String DIRPATH = "dirpath";
     public static final String PROJECT = "project";
     public static final String DATE = "date";
-    public static final String TABSIZE = "tabsize";
+    public static final String OBJUID = "objuid"; // object UID
+    public static final String OBJSER = "objser"; // object serialized
 
     /** Used for paths, so SHA-1 is completely sufficient */
     private static final String DIRPATH_HASH_ALGORITHM = "SHA-1";

--- a/src/org/opensolaris/opengrok/search/Results.java
+++ b/src/org/opensolaris/opengrok/search/Results.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.search;
@@ -89,7 +89,12 @@ public final class Results {
         for (int i = startIdx; i < stopIdx; i++) {
             int docId = hits[i].doc;
             Document doc = searcher.doc(docId);
+
             String rpath = doc.get(QueryBuilder.PATH);
+            if (rpath == null) {
+                continue;
+            }
+
             String parent = rpath.substring(0, rpath.lastIndexOf('/'));
             ArrayList<Document> dirDocs = dirHash.get(parent);
             if (dirDocs == null) {

--- a/test/org/opensolaris/opengrok/index/IndexAnalysisSettingsTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexAnalysisSettingsTest.java
@@ -1,0 +1,89 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.index;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensolaris.opengrok.search.QueryBuilder;
+
+/**
+ * Represents a test class for {@link IndexAnalysisSettings}.
+ */
+public class IndexAnalysisSettingsTest {
+
+    private static final String PROJECT_NAME = "foo-1-2-3";
+    private static final long ANALYZER_GURU_VERSION = 3;
+    private static final int TABSIZE = 17;
+    private static final Map<String, Long> ANALYZER_VERSIONS = new HashMap<>();
+
+    @BeforeClass
+    public static void setUpClass() {
+        ANALYZER_VERSIONS.put("abc", 6L);
+        ANALYZER_VERSIONS.put("ABC", 45L);
+        ANALYZER_VERSIONS.put("d e", Long.MAX_VALUE - 19);
+    }
+
+    @Test
+    public void shouldAffirmINDEX_ANALYSIS_SETTINGS_OBJUID() {
+        String objuid = QueryBuilder.normalizeDirPath(
+            "58859C75-F941-42E5-8D1A-FAF71DDEBBA7");
+        assertEquals("IndexAnalysisSettingsDao objuid", objuid,
+            IndexAnalysisSettingsAccessor.INDEX_ANALYSIS_SETTINGS_OBJUID);
+    }
+
+    @Test
+    public void shouldRoundTripANullObject() throws IOException,
+            ClassNotFoundException {
+        IndexAnalysisSettings obj = new IndexAnalysisSettings();
+        byte[] bin = obj.serialize();
+
+        IndexAnalysisSettings res = IndexAnalysisSettings.deserialize(bin);
+        assertNotNull(res);
+        assertEquals("projectName", null, res.getProjectName());
+        assertEquals("tabSize", null, res.getTabSize());
+        assertEquals("analyzerGuruVersion", null, res.getAnalyzerGuruVersion());
+    }
+
+    @Test
+    public void shouldRoundTripADefinedObject() throws IOException,
+            ClassNotFoundException {
+        IndexAnalysisSettings obj = new IndexAnalysisSettings();
+        obj.setProjectName(PROJECT_NAME);
+        obj.setAnalyzerGuruVersion(ANALYZER_GURU_VERSION);
+        obj.setTabSize(TABSIZE);
+        byte[] bin = obj.serialize();
+
+        IndexAnalysisSettings res = IndexAnalysisSettings.deserialize(bin);
+        assertNotNull(res);
+        assertEquals("projectName", PROJECT_NAME, res.getProjectName());
+        assertEquals("tabSize", TABSIZE, (int)res.getTabSize());
+        assertEquals("analyzerGuruVersion", ANALYZER_GURU_VERSION,
+            (long)res.getAnalyzerGuruVersion());
+    }
+}

--- a/test/org/opensolaris/opengrok/index/IndexDatabaseTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexDatabaseTest.java
@@ -164,7 +164,7 @@ public class IndexDatabaseTest {
         // Check that the file was indexed successfully in terms of generated data.
         checkDataExistence(projectName + File.separator + fileName, true);
         origNumFiles = idb.getNumFiles();
-        Assert.assertEquals(6, origNumFiles);
+        Assert.assertEquals(7, origNumFiles);
 
         // Remove the file and reindex using IndexDatabase directly.
         File file = new File(repository.getSourceRoot(), projectName + File.separator + fileName);


### PR DESCRIPTION
Hello,

Please consider for integration this patch to store project tabsize (if defined) at the time a document is indexed.

The source text presented to `UnifiedHighlighter` must accord with the text as it was when the indexing occured. A non-zero tab size results in transformed source text via `ExpandTabsReader`, so any change in tab size must be recognized.

In addition to `UnifiedHighlighter` checking tab size, this patch also updates `IndexDatabase` so that it detects a changed tab size in order to reindex files automatically. (This fields-check is augmented in later patches [e16d4b92e351] with additional versioning metadata for analyzers and for `AnalyzerGuru` itself so that re-indexing can occur automatically *as necessary* when OpenGrok is updated.)

Thank you. 

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
