### PR TITLE
DEFS stores true offsets from enhanced CtagsReader

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/CtagsReader.java
+++ b/src/org/opensolaris/opengrok/analysis/CtagsReader.java
@@ -285,8 +285,8 @@ public class CtagsReader {
 
         String[] args;
         if (signature != null && !signature.equals("()") &&
-            !signature.startsWith("() ") && (args =
-            splitSignature(signature)) != null) {
+                !signature.startsWith("() ") && (args =
+                splitSignature(signature)) != null) {
             for (String arg : args) {
                 //TODO this algorithm assumes that data types occur to
                 //     the left of the argument name, so it will not
@@ -312,7 +312,9 @@ public class CtagsReader {
                     arg = a[0];  // throws away assigned value
                 }
                 arg = arg.trim();
-                if (arg.length() < 1) continue;
+                if (arg.length() < 1) {
+                    continue;
+                }
 
                 cidx = bestIndexOfArg(lineno, whole, arg);
 
@@ -398,7 +400,9 @@ public class CtagsReader {
     private CpatIndex bestIndexOfTag(int lineno, String whole,
         String str) {
 
-        if (whole.length() < 1) return new CpatIndex(lineno, 0, 1, true);
+        if (whole.length() < 1) {
+            return new CpatIndex(lineno, 0, 1, true);
+        }
         String origWhole = whole;
 
         int t = tabSize;
@@ -456,14 +460,18 @@ public class CtagsReader {
      * @return a defined instance
      */
     private CpatIndex bestIndexOfArg(int lineno, String whole, String arg) {
-        if (whole.length() < 1) return new CpatIndex(lineno, 0, 1, true);
+        if (whole.length() < 1) {
+            return new CpatIndex(lineno, 0, 1, true);
+        }
 
         int t = tabSize;
         int s, e;
 
         // First search arg as-is in the current `whole' -- strict then lax.
         int woff = strictIndexOf(whole, arg);
-        if (woff < 0) woff = whole.indexOf(arg);
+        if (woff < 0) {
+            woff = whole.indexOf(arg);
+        }
         if (woff >= 0) {
             s = ExpandTabsReader.translate(whole, woff, t);
             e = ExpandTabsReader.translate(whole, woff + arg.length(), t);
@@ -532,7 +540,9 @@ public class CtagsReader {
             }
         } else {
             pr = bestMatch(cut, arg, argpat);
-            if (pr.start >= 0) return bestLineOfMatch(lineno, pr, cut);
+            if (pr.start >= 0) {
+                return bestLineOfMatch(lineno, pr, cut);
+            }
         }
 
         /**
@@ -549,7 +559,9 @@ public class CtagsReader {
      */
     private PatResult bestMatch(String whole, String arg, Pattern argpat) {
         PatResult m = strictMatch(whole, arg, argpat);
-        if (m.start >= 0) return m;
+        if (m.start >= 0) {
+            return m;
+        }
         Matcher marg = argpat.matcher(whole);
         if (marg.find()) {
             return new PatResult(marg.start(), marg.end(), marg.group());
@@ -573,7 +585,9 @@ public class CtagsReader {
         int spos = 0;
         do {
             int woff = whole.indexOf(substr, spos);
-            if (woff < 0) return -1;
+            if (woff < 0) {
+                return -1;
+            }
 
             spos = woff + 1;
             String onechar;
@@ -718,11 +732,11 @@ public class CtagsReader {
 
         // Trim outer punctuation if it exists.
         while (soff < signature.length() && (signature.charAt(soff) == '(' ||
-            signature.charAt(soff) == '{')) {
+                signature.charAt(soff) == '{')) {
             ++soff;
         }
         while (eoff - 1 > soff && (signature.charAt(eoff - 1) == ')' ||
-            signature.charAt(eoff - 1) == '}')) {
+                signature.charAt(eoff - 1) == '}')) {
             --eoff;
         }
         if (soff > off0 || eoff < offz) {
@@ -738,15 +752,19 @@ public class CtagsReader {
      */
     private String trySplitterCut(int lineOffset, int maxLines) {
         if (splitter == null) {
-            if (splitterSupplier == null || triedSplitterSupplier) return null;
+            if (splitterSupplier == null || triedSplitterSupplier) {
+                return null;
+            }
             triedSplitterSupplier = true;
             splitter = splitterSupplier.get();
-            if (splitter == null) return null;
+            if (splitter == null) {
+                return null;
+            }
         }
 
         StringBuilder cutbld = new StringBuilder();
         for (int i = lineOffset; i < lineOffset + maxLines &&
-            i < splitter.count(); ++i) {
+                i < splitter.count(); ++i) {
             cutbld.append(splitter.getLine(i));
         }
         return cutbld.toString();

--- a/src/org/opensolaris/opengrok/analysis/CtagsReader.java
+++ b/src/org/opensolaris/opengrok/analysis/CtagsReader.java
@@ -19,38 +19,79 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis;
 
 import java.util.EnumMap;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.SourceSplitter;
 
 /**
  * Represents a reader of output from runs of ctags.
  */
 public class CtagsReader {
 
+    /**
+     * Matches the Unicode word that occurs last in a string, ignoring any
+     * trailing whitespace or non-word characters, and makes it accessible as
+     * the first capture, {@code mtch.groups(1)}:
+     * <pre>
+     * {@code
+     * (?U)(\w+)[\W\s]*$
+     * }
+     * </pre>
+     * (Edit above and paste below [in NetBeans] for easy String escaping.)
+     */
+    private static final Pattern LAST_UWORD = Pattern.compile(
+        "(?U)(\\w+)[\\W\\s]*$");
+
+    /**
+     * Matches a Unicode word character:
+     * <pre>
+     * {@code
+     * (?U)\w
+     * }
+     * </pre>
+     * (Edit above and paste below [in NetBeans] for easy String escaping.)
+     */
+    private static final Pattern WORD_CHAR = Pattern.compile("(?U)\\w");
+
     private static final Logger LOGGER = LoggerFactory.getLogger(
         CtagsReader.class);
 
     /** A value indicating empty method body in tags, so skip it */
-    private final int MIN_METHOD_LINE_LENGTH = 6;
+    private static final int MIN_METHOD_LINE_LENGTH = 6;
 
     /**
      * 96 is used by universal ctags for some lines, but it's too low,
      * OpenGrok can theoretically handle 50000 with 8G heap. Also this might
      * break scopes functionality, if set too low.
      */
-    private final int MAX_METHOD_LINE_LENGTH = 1030;
+    private static final int MAX_METHOD_LINE_LENGTH = 1030;
+
+    /**
+     * E.g. krb5 src/kdc/kdc_authdata.c has a signature for handle_authdata()
+     * split across twelve lines, so use double that number.
+     */
+    private static final int MAX_CUT_LINES = 24;
 
     private final EnumMap<tagFields, String> fields = new EnumMap<>(
         tagFields.class);
 
     private final Definitions defs = new Definitions();
+
+    private Supplier<SourceSplitter> splitterSupplier;
+    private boolean triedSplitterSupplier;
+    private SourceSplitter splitter;
+
+    private int tabSize;
 
     /**
      * This should mimic
@@ -126,12 +167,34 @@ public class CtagsReader {
         }
     }
 
+    public int getTabSize() {
+        return tabSize;
+    }
+
+    public void setTabSize(int tabSize) {
+        this.tabSize = tabSize;
+    }
+
     /**
      * Gets the instance's definitions.
      * @return a defined instance
      */
     public Definitions getDefinitions() {
         return defs;
+    }
+
+    /**
+     * Sets the supplier of a {@link SourceSplitter} to use when ctags pattern
+     * is insufficient, and the reader could use the source data.
+     * <p>
+     * N.b. because an I/O exception can occur, the supplier may return
+     * {@code null}, which the {@link CtagsReader} handles.
+     * @param obj defined instance or {@code null}
+     */
+    public void setSplitterSupplier(Supplier<SourceSplitter> obj) {
+        splitter = null;
+        triedSplitterSupplier = false;
+        splitterSupplier = obj;
     }
 
     /**
@@ -182,20 +245,20 @@ public class CtagsReader {
         String signature = fields.get(tagFields.SIGNATURE);
         String classInher = fields.get(tagFields.CLASS);
 
+        final String whole;
         final String match;
         int mlength = p - mstart;
         if ((p > 0) && (mlength > MIN_METHOD_LINE_LENGTH)) {
+            whole = cutPattern(tagLine, mstart, p);
             if (mlength < MAX_METHOD_LINE_LENGTH) {
-                match = tagLine.substring(mstart + 3, p - 4).
-                    replace("\\/", "/").replaceAll("[ \t]+", " ");
-                //TODO per format we should also recognize \r and \n and \\
+                match = whole.replaceAll("[ \t]+", " ");
+                //TODO per format we should also recognize \r and \n
             } else {
                 LOGGER.log(Level.FINEST, "Ctags: stripping method" +
                     " body for def {0} line {1}(scopes/highlight" +
                     " might break)", new Object[]{def, lnum});
-                match = tagLine.substring(mstart + 3, mstart +
-                    MAX_METHOD_LINE_LENGTH - 1). // +3 - 4 = -1
-                    replace("\\/", "/").replaceAll("[ \t]+", " ");
+                match = whole.substring(0, MAX_METHOD_LINE_LENGTH).replaceAll(
+                    "[ \t]+", " ");
             }
         } else { //tag is wrong format; cannot extract tagaddress from it; skip
             return;
@@ -206,11 +269,24 @@ public class CtagsReader {
 
         final String type = classInher == null ? kind : kind + " in " +
             classInher;
-        addTag(defs, lnum, def, type, match, classInher, signature);
-        if (signature != null) {
-            // TODO if some languages use different character for separating
-            // arguments, below needs to be adjusted
-            String[] args = signature.split(",");
+
+        int lineno;
+        try {
+            lineno = Integer.parseUnsignedInt(lnum);
+        } catch (NumberFormatException e) {
+            lineno = 0;
+            LOGGER.log(Level.WARNING, "CTags line number parsing problem(but" +
+                " I will continue with line # 0) for symbol {0}", def);
+        }
+
+        CpatIndex cidx = bestIndexOfTag(lineno, whole, def);
+        addTag(defs, cidx.lineno, def, type, match, classInher, signature,
+            cidx.lineStart, cidx.lineEnd);
+
+        String[] args;
+        if (signature != null && !signature.equals("()") &&
+            !signature.startsWith("() ") && (args =
+            splitSignature(signature)) != null) {
             for (String arg : args) {
                 //TODO this algorithm assumes that data types occur to
                 //     the left of the argument name, so it will not
@@ -235,21 +311,27 @@ public class CtagsReader {
                     String[] a = arg.split("=");
                     arg = a[0];  // throws away assigned value
                 }
+                arg = arg.trim();
+                if (arg.length() < 1) continue;
 
-                // Strip out all non 'word' class symbols
-                // which leaves just names intact.
-                String[] names = arg.trim().split("[\\W]");
-                String name;
+                cidx = bestIndexOfArg(lineno, whole, arg);
 
-                // Walk the array backwards from the end and
-                // the parameter name should always be the first
-                // non-empty element encountered.
-                for (int ii = names.length - 1; ii >= 0; ii--) {
-                    name = names[ii];
-                    if (name.length() > 0) {
-                        addTag(defs, lnum, name, "argument", def.trim() +
-                            signature.trim(), null, signature);
-                        break;
+                String name = null;
+                Matcher mname = LAST_UWORD.matcher(arg);
+                if (mname.find()) {
+                    name = mname.group(1);
+                } else if (arg.equals("...")) {
+                    name = arg;
+                }
+                if (name != null) {
+                    addTag(defs, cidx.lineno, name, "argument", def.trim() +
+                        signature.trim(), null, signature, cidx.lineStart,
+                        cidx.lineEnd);
+                } else {
+                    if (LOGGER.isLoggable(Level.FINEST)) {
+                        LOGGER.log(Level.FINEST,
+                            "Not matched arg:{0}|sig:{1}",
+                            new Object[]{arg, signature});
                     }
                 }
             }
@@ -260,23 +342,454 @@ public class CtagsReader {
     }
 
     /**
+     * Cuts the ctags TAG FILE FORMAT search pattern from the specified
+     * {@code tagLine} between the specified tab positions, and un-escapes
+     * {@code \\} and {@code \/}.
+     * @return a defined string
+     */
+    private static String cutPattern(String tagLine, int startTab, int endTab) {
+        // Three lead character represents "\t/^".
+        String cut = tagLine.substring(startTab + 3, endTab);
+
+        /**
+         * Formerly this class cut four characters from the end, but my testing
+         * revealed a bug for short lines in files with macOS endings (e.g.
+         * cyrus-sasl mac/libdes/src/des_enc.c) where the pattern-ending $ is
+         * not present. Now, inspect the end of the pattern to determine the
+         * true cut -- which is appropriate for all content anyway.
+         */
+        if (cut.endsWith("$/;\"")) {
+            cut = cut.substring(0, cut.length() - 4);
+        } else if (cut.endsWith("/;\"")) {
+            cut = cut.substring(0, cut.length() - 3);
+        } else {
+            /**
+             * The former logic did the following without the inspections above.
+             * Leaving this here as a fallback.
+             */
+            cut = cut.substring(0, cut.length() - 4);
+        }
+        return cut.replace("\\\\", "\\").replace("\\/", "/");
+    }
+
+    /**
      * Adds a tag to a {@code Definitions} instance.
      */
-    private void addTag(Definitions defs, String lnum, String symbol,
-        String type, String text, String namespace, String signature) {
+    private void addTag(Definitions defs, int lineno, String symbol,
+        String type, String text, String namespace, String signature,
+        int lineStart, int lineEnd) {
         // The strings are frequently repeated (a symbol can be used in
         // multiple definitions, multiple definitions can have the same type,
         // one line can contain multiple definitions). Intern them to minimize
         // the space consumed by them (see bug #809).
-        int lineno = 0;
-        try {
-            lineno = Integer.parseInt(lnum);
-        } catch (NumberFormatException nfe) {
-            LOGGER.log(Level.WARNING, "CTags line number parsing problem(but" +
-                " I will continue with line # 0) for symbol {0}", symbol);
-        }
         defs.addTag(lineno, symbol.trim().intern(), type.trim().intern(),
             text.trim().intern(), namespace == null ? null :
-            namespace.trim().intern(), signature);
+            namespace.trim().intern(), signature, lineStart, lineEnd);
+    }
+
+    /**
+     * Searches for the index of the best match of {@code str} in {@code whole}
+     * in a multi-stage algorithm that first starts strictly to disfavor
+     * abutting words and then relaxes -- and also works around ctags's possibly
+     * having returned a partial line or only one line of a multi-line language
+     * syntax.
+     * @return a defined instance
+     */
+    private CpatIndex bestIndexOfTag(int lineno, String whole,
+        String str) {
+
+        if (whole.length() < 1) return new CpatIndex(lineno, 0, 1, true);
+        String origWhole = whole;
+
+        int t = tabSize;
+        int s, e;
+
+        int woff = strictIndexOf(whole, str);
+        if (woff < 0) {
+            /**
+             * When a splitter is available, search the entire line.
+             * (N.b. use 0-offset vs ctags's 1-offset.)
+             */
+            String cut = trySplitterCut(lineno - 1, 1);
+            if (cut == null || !cut.startsWith(whole)) {
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    String readablecut = cut != null ? cut : "null\n";
+                    LOGGER.log(Level.FINE,
+                        "Bad cut:{0}|versus:{1}|line {2}",
+                        new Object[]{readablecut, whole, lineno});
+                }
+            } else {
+                whole = cut;
+                woff = strictIndexOf(whole, str);
+            }
+
+            if (woff < 0) {
+                /** At this point, do a lax search of the substring. */
+                woff = whole.indexOf(str);
+            }
+        }
+
+        if (woff >= 0) {
+            s = ExpandTabsReader.translate(whole, woff, t);
+            e = ExpandTabsReader.translate(whole, woff + str.length(), t);
+            return new CpatIndex(lineno, s, e);
+        }
+        /**
+         * When ctags has truncated a pattern, or when it spans multiple lines,
+         * then `str' might not be found in `whole'. In that case, return an
+         * imprecise index for the last character as the best we can do.
+         */
+        s = ExpandTabsReader.translate(origWhole, origWhole.length() - 1, t);
+        e = ExpandTabsReader.translate(origWhole, origWhole.length(), t);
+        return new CpatIndex(lineno, s, e, true);
+    }
+
+    /**
+     * Searches for the index of the best match of {@code arg} in {@code whole}
+     * in a multi-stage algorithm that first starts strictly to disfavor
+     * abutting words and then relaxes -- and also works around ctags's possibly
+     * having returned a partial line or only one line of a multi-line language
+     * syntax or where ctags has transformed syntax.
+     * <p>
+     * E.g., the true source might read {@code const fru_regdef_t *d} with the
+     * ctags signature reading {@code const fru_regdef_t * d}
+     * @return a defined instance
+     */
+    private CpatIndex bestIndexOfArg(int lineno, String whole, String arg) {
+        if (whole.length() < 1) return new CpatIndex(lineno, 0, 1, true);
+
+        int t = tabSize;
+        int s, e;
+
+        // First search arg as-is in the current `whole' -- strict then lax.
+        int woff = strictIndexOf(whole, arg);
+        if (woff < 0) woff = whole.indexOf(arg);
+        if (woff >= 0) {
+            s = ExpandTabsReader.translate(whole, woff, t);
+            e = ExpandTabsReader.translate(whole, woff + arg.length(), t);
+            return new CpatIndex(lineno, s, e);
+        }
+
+        // Build a pattern from `arg' with looseness around whitespace.
+        StringBuilder bld = new StringBuilder();
+        int spos = 0;
+        boolean lastWhitespace = false;
+        boolean firstNonWhitespace = false;
+        for (int i = 0; i < arg.length(); ++i) {
+            char c = arg.charAt(i);
+            if (Character.isWhitespace(c)) {
+                if (!firstNonWhitespace) {
+                    ++spos;
+                } else if (!lastWhitespace) {
+                    lastWhitespace = true;
+                    if (spos < i) {
+                        bld.append(Pattern.quote(arg.substring(spos, i)));
+                    }
+                    // m`\s*`
+                    bld.append("\\s*");
+                }
+            } else {
+                firstNonWhitespace = true;
+                if (lastWhitespace) {
+                    lastWhitespace = false;
+                    spos = i;
+                }
+            }
+        }
+        if (spos < arg.length()) {
+            bld.append(Pattern.quote(arg.substring(spos)));
+        }
+        if (bld.length() < 1) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.log(Level.FINE, "Odd arg:{0}|versus:{1}|line {2}",
+                    new Object[]{arg, whole, lineno});
+            }
+            /**
+             * When no fuzzy match can be generated, return an imprecise index
+             * for the first character as the best we can do.
+             */
+            return new CpatIndex(lineno, 0, 1, true);
+        }
+
+        Pattern argpat = Pattern.compile(bld.toString());
+        PatResult pr = bestMatch(whole, arg, argpat);
+        if (pr.start >= 0) {
+            s = ExpandTabsReader.translate(whole, pr.start, t);
+            e = ExpandTabsReader.translate(whole, pr.end, t);
+            return new CpatIndex(lineno, s, e);
+        }
+
+        /**
+         * When a splitter is available, search the next several lines.
+         * (N.b. use 0-offset vs ctags's 1-offset.)
+         */
+        String cut = trySplitterCut(lineno - 1, MAX_CUT_LINES);
+        if (cut == null || !cut.startsWith(whole)) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                String readablecut = cut != null ? cut : "null\n";
+                LOGGER.log(Level.FINE, "Bad cut:{0}|versus:{1}|line {2}",
+                    new Object[]{readablecut, whole, lineno});
+            }
+        } else {
+            pr = bestMatch(cut, arg, argpat);
+            if (pr.start >= 0) return bestLineOfMatch(lineno, pr, cut);
+        }
+
+        /**
+         * When no match is found, return an imprecise index for the last
+         * character as the best we can do.
+         */
+        s = ExpandTabsReader.translate(whole, whole.length() - 1, t);
+        e = ExpandTabsReader.translate(whole, whole.length(), t);
+        return new CpatIndex(lineno, s, e, true);
+    }
+
+    /**
+     * Searches strictly then laxly.
+     */
+    private PatResult bestMatch(String whole, String arg, Pattern argpat) {
+        PatResult m = strictMatch(whole, arg, argpat);
+        if (m.start >= 0) return m;
+        Matcher marg = argpat.matcher(whole);
+        if (marg.find()) {
+            return new PatResult(marg.start(), marg.end(), marg.group());
+        }
+        // Return m, which was invalid if we got to here.
+        return m;
+    }
+
+    /**
+     * Like {@link String#indexOf(java.lang.String)} but strict that a
+     * {@code substr} starting with a word character cannot abut another word
+     * character on its left and likewise on the right for a {@code substr}
+     * ending with a word character.
+     */
+    private int strictIndexOf(String whole, String substr) {
+        boolean strictLeft = substr.length() > 0 && WORD_CHAR.matcher(
+            String.valueOf(substr.charAt(0))).matches();
+        boolean strictRight = substr.length() > 0 && WORD_CHAR.matcher(
+            String.valueOf(substr.charAt(substr.length() - 1))).matches();
+
+        int spos = 0;
+        do {
+            int woff = whole.indexOf(substr, spos);
+            if (woff < 0) return -1;
+
+            spos = woff + 1;
+            String onechar;
+            /**
+             * Reject if the previous character is a word character, as that
+             * would not accord with a clean symbol break
+             */
+            if (strictLeft && woff > 0) {
+                onechar = String.valueOf(whole.charAt(woff - 1));
+                if (WORD_CHAR.matcher(onechar).matches()) {
+                    continue;
+                }
+            }
+            /**
+             * Reject if the following character is a word character, as that
+             * would not accord with a clean symbol break
+             */
+            if (strictRight && woff + substr.length() < whole.length()) {
+                onechar = String.valueOf(whole.charAt(woff + substr.length()));
+                if (WORD_CHAR.matcher(onechar).matches()) {
+                    continue;
+                }
+            }
+            return woff;
+        } while (spos < whole.length());
+        return -1;
+    }
+
+    /**
+     * Like {@link #strictIndexOf(java.lang.String, java.lang.String)} but using
+     * a pattern.
+     */
+    private PatResult strictMatch(String whole, String substr, Pattern pat) {
+        boolean strictLeft = substr.length() > 0 && WORD_CHAR.matcher(
+            String.valueOf(substr.charAt(0))).matches();
+        boolean strictRight = substr.length() > 0 && WORD_CHAR.matcher(
+            String.valueOf(substr.charAt(substr.length() - 1))).matches();
+
+        Matcher m = pat.matcher(whole);
+        while (m.find()) {
+            String onechar;
+            /**
+             * Reject if the previous character is a word character, as that
+             * would not accord with a clean symbol break
+             */
+            if (strictLeft && m.start() > 0) {
+                onechar = String.valueOf(whole.charAt(m.start() - 1));
+                if (WORD_CHAR.matcher(onechar).matches()) {
+                    continue;
+                }
+            }
+            /**
+             * Reject if the following character is a word character, as that
+             * would not accord with a clean symbol break
+             */
+            if (strictRight && m.end() < whole.length()) {
+                onechar = String.valueOf(whole.charAt(m.end()));
+                if (WORD_CHAR.matcher(onechar).matches()) {
+                    continue;
+                }
+            }
+            return new PatResult(m.start(), m.end(), m.group());
+        }
+        return new PatResult(-1, -1, null);
+    }
+
+    /**
+     * Finds the line with the longest content from {@code midx}.
+     * <p>
+     * The {@link Definitions} tag model is based on a match within a line.
+     * "signature" fields, however, can be condensed from multiple lines; and a
+     * fuzzy match can therefore span multiple lines.
+     */
+    private CpatIndex bestLineOfMatch(int lineno, PatResult pr, String cut) {
+        // (N.b. use 0-offset vs ctags's 1-offset.)
+        int lpos = splitter.getPosition(lineno - 1);
+        int mpos = lpos + pr.start;
+        int moff = splitter.findLineOffset(mpos);
+        int zpos = lpos + pr.end - 1;
+        int zoff = splitter.findLineOffset(zpos);
+
+        int t = tabSize;
+        int resoff = moff;
+        int contentLength = 0;
+        /**
+         * Initialize the following just to silence warnings but with values
+         * that will be detected as "bad fuzzy" later.
+         */
+        String whole = "";
+        int s = 0;
+        int e = 1;
+        /**
+         * Iterate to determine the length of the portion of `midx' that
+         * is contained within each line.
+         */
+        for (int ioff = moff; ioff <= zoff; ++ioff) {
+            String iwhole = splitter.getLine(ioff);
+            int ioffpos = splitter.getPosition(ioff);
+            int iendpos = ioffpos + iwhole.length();
+            int i_s = pr.start + lpos < ioffpos ? ioffpos : pr.start + lpos;
+            int i_e = pr.end + lpos > iendpos ? iendpos : pr.end + lpos;
+            if (i_e - i_s > contentLength) {
+                contentLength = i_e - i_s;
+                resoff = ioff;
+                whole = iwhole;
+                // (The following are not yet adjusted for tabs.)
+                s = i_s - ioffpos;
+                e = i_e - ioffpos;
+            }
+        }
+
+        if (s >= 0 && s < whole.length() && e >= 0 && e <= whole.length()) {
+            s = ExpandTabsReader.translate(whole, s, t);
+            e = ExpandTabsReader.translate(whole, e, t);
+            // (N.b. use ctags's 1-offset.)
+            return new CpatIndex(resoff + 1, s, e);
+        }
+
+        /**
+         * This should not happen -- but if it does, log it and return an
+         * imprecise index for the first character as the best we can do.
+         */
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE,
+                "Bad fuzzy:{0}|versus:{1}|line {2} pos {3}-{4}|{5}|",
+                new Object[]{pr.capture, cut, lineno, s, e, whole});
+        }
+        return new CpatIndex(lineno, 0, 1, true);
+    }
+
+    /**
+     * TODO if some languages use different character for separating arguments,
+     * below needs to be adjusted.
+     * @return a defined instance or null
+     */
+    private static String[] splitSignature(String signature) {
+        int off0 = 0;
+        int offz = signature.length();
+        int soff = off0;
+        int eoff = offz;
+        if (soff >= eoff) return null;
+
+        // Trim outer punctuation if it exists.
+        while (soff < signature.length() && (signature.charAt(soff) == '(' ||
+            signature.charAt(soff) == '{')) {
+            ++soff;
+        }
+        while (eoff - 1 > soff && (signature.charAt(eoff - 1) == ')' ||
+            signature.charAt(eoff - 1) == '}')) {
+            --eoff;
+        }
+        if (soff > off0 || eoff < offz) {
+            signature = signature.substring(soff, eoff);
+        }
+        return signature.split(",");
+    }
+
+    /**
+     * Tries to cut lines from a splitter provided by {@code splitterSupplier}.
+     * @return a defined instance if a successful cut is made or else
+     * {@code null}
+     */
+    private String trySplitterCut(int lineOffset, int maxLines) {
+        if (splitter == null) {
+            if (splitterSupplier == null || triedSplitterSupplier) return null;
+            triedSplitterSupplier = true;
+            splitter = splitterSupplier.get();
+            if (splitter == null) return null;
+        }
+
+        StringBuilder cutbld = new StringBuilder();
+        for (int i = lineOffset; i < lineOffset + maxLines &&
+            i < splitter.count(); ++i) {
+            cutbld.append(splitter.getLine(i));
+        }
+        return cutbld.toString();
+    }
+
+    /**
+     * Represents an index into ctags pattern entries.
+     */
+    private static class CpatIndex {
+        public final int lineno;
+        public final int lineStart;
+        public final int lineEnd;
+        public final boolean imprecise;
+
+        public CpatIndex(int lineno, int lineStart, int lineEnd) {
+            this.lineno = lineno;
+            this.lineStart = lineStart;
+            this.lineEnd = lineEnd;
+            this.imprecise = false;
+        }
+
+        public CpatIndex(int lineno, int lineStart, int lineEnd,
+            boolean imprecise) {
+            this.lineno = lineno;
+            this.lineStart = lineStart;
+            this.lineEnd = lineEnd;
+            this.imprecise = imprecise;
+        }
+    }
+
+    /**
+     * Represents a result from a pattern match -- valid if lineStart is greater
+     * than or equal to zero.
+     */
+    private static class PatResult {
+        public final int start;
+        public final int end;
+        public final String capture;
+
+        public PatResult(int start, int end, String capture) {
+            this.start = start;
+            this.end = end;
+            this.capture = capture;
+        }
     }
 }

--- a/src/org/opensolaris/opengrok/analysis/Definitions.java
+++ b/src/org/opensolaris/opengrok/analysis/Definitions.java
@@ -228,7 +228,8 @@ public class Definitions implements Serializable {
         public transient boolean used;
 
         protected Tag(int line, String symbol, String type, String text,
-            String namespace, String signature, int lineStart, int lineEnd) {
+                String namespace, String signature, int lineStart,
+                int lineEnd) {
             this.line = line;
             this.symbol = symbol;
             this.type = type;
@@ -241,12 +242,12 @@ public class Definitions implements Serializable {
     }
 
     public void addTag(int line, String symbol, String type, String text,
-        int lineStart, int lineEnd) {
+            int lineStart, int lineEnd) {
         addTag(line, symbol, type, text, null, null, lineStart, lineEnd);
     }
 
     public void addTag(int line, String symbol, String type, String text,
-        String namespace, String signature, int lineStart, int lineEnd) {
+            String namespace, String signature, int lineStart, int lineEnd) {
         Tag new_tag = new Tag(line, symbol, type, text, namespace, signature,
             lineStart, lineEnd);
         tags.add(new_tag);

--- a/src/org/opensolaris/opengrok/analysis/Definitions.java
+++ b/src/org/opensolaris/opengrok/analysis/Definitions.java
@@ -211,28 +211,44 @@ public class Definitions implements Serializable {
          * Scope of tag definition
          */
         public final String signature;
+        /**
+         * The starting offset (possibly approximate) of {@link #symbol} from
+         * the start of the line
+         */
+        public final int lineStart;
+        /**
+         * The ending offset (possibly approximate) of {@link #symbol} from
+         * the start of the line
+         */
+        public final int lineEnd;
 
         /**
          * A non-serialized marker for marking a tag to avoid its reuse.
          */
         public transient boolean used;
 
-        protected Tag(int line, String symbol, String type, String text, String namespace, String signature) {
+        protected Tag(int line, String symbol, String type, String text,
+            String namespace, String signature, int lineStart, int lineEnd) {
             this.line = line;
             this.symbol = symbol;
             this.type = type;
             this.text = text;
             this.namespace = namespace;
             this.signature = signature;
+            this.lineStart = lineStart;
+            this.lineEnd = lineEnd;
         }
     }
 
-    public void addTag(int line, String symbol, String type, String text) {
-        addTag(line, symbol, type, text, null, null);
+    public void addTag(int line, String symbol, String type, String text,
+        int lineStart, int lineEnd) {
+        addTag(line, symbol, type, text, null, null, lineStart, lineEnd);
     }
 
-    public void addTag(int line, String symbol, String type, String text, String namespace, String signature) {
-        Tag new_tag = new Tag(line, symbol, type, text, namespace, signature);
+    public void addTag(int line, String symbol, String type, String text,
+        String namespace, String signature, int lineStart, int lineEnd) {
+        Tag new_tag = new Tag(line, symbol, type, text, namespace, signature,
+            lineStart, lineEnd);
         tags.add(new_tag);
         Set<Integer> lines = symbols.get(symbol);
         if (lines == null) {

--- a/src/org/opensolaris/opengrok/analysis/ExpandTabsReader.java
+++ b/src/org/opensolaris/opengrok/analysis/ExpandTabsReader.java
@@ -110,7 +110,9 @@ public class ExpandTabsReader extends FilterReader {
         if (column > line.length()) {
             throw new IllegalArgumentException("`column' is out of bounds");
         }
-        if (tabSize < 1) return column;
+        if (tabSize < 1) {
+            return column;
+        }
 
         int newColumn = 0;
         for (int i = 0; i < column; ++i) {

--- a/src/org/opensolaris/opengrok/analysis/PendingToken.java
+++ b/src/org/opensolaris/opengrok/analysis/PendingToken.java
@@ -1,0 +1,93 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.analysis;
+
+import java.util.Objects;
+
+/**
+ * Represents an almost-wholly immutable tuple whose field data are used by
+ * {@link JFlexTokenizer} to set attributes to be read while iterating a
+ * token stream.
+ */
+public class PendingToken {
+
+    public final String str;
+    public final int start;
+    public final int end;
+    /**
+     * When tokenizers allow overlapping tokens, the following field is set to
+     * {@code true} for tokens that should not increment the position attribute.
+     */
+    public boolean nonpos;
+
+    /**
+     * Initializes an instance with immutable fields for the specified
+     * arguments.
+     * @param str
+     * @param start
+     * @param end
+     */
+    public PendingToken(String str, int start, int end) {
+        this.str = str;
+        this.start = start;
+        this.end = end;
+    }
+
+    /**
+     * Compares this instance's immutable fields to the other.
+     * @param o
+     * @return {@code true} if the objects are equal
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof PendingToken)) {
+            return false;
+        }
+        PendingToken other = (PendingToken) o;
+        return start == other.start && end == other.end &&
+            str.equals(other.str);
+    }
+
+    /**
+     * Calculates a hash code from the instance's immutable fields.
+     * @return a hash value
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(str, start, end);
+    }
+
+    /**
+     * Gets a readable representation for debugging.
+     * @return a defined instance
+     */
+    @Override
+    public String toString() {
+        return "PendingToken{" + str + "<<< start=" + start + ",end=" + end +
+            ",nonpos=" + nonpos + '}';
+    }
+}

--- a/src/org/opensolaris/opengrok/analysis/PendingTokenOffsetsComparator.java
+++ b/src/org/opensolaris/opengrok/analysis/PendingTokenOffsetsComparator.java
@@ -1,0 +1,55 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.analysis;
+
+import java.util.Comparator;
+
+/**
+ * Represents a comparator for {@link PendingToken} that just compares the
+ * instances' offsets.
+ */
+public class PendingTokenOffsetsComparator implements Comparator<PendingToken> {
+
+    /**
+     * Singleton instance.
+     */
+    public static final PendingTokenOffsetsComparator INSTANCE =
+        new PendingTokenOffsetsComparator();
+
+    @Override
+    public int compare(PendingToken o1, PendingToken o2) {
+        // ASC by starting offset.
+        int cmp = Integer.compare(o1.start, o2.start);
+        if (cmp != 0) {
+            return cmp;
+        }
+        // ASC by ending offset
+        cmp = Integer.compare(o1.end, o2.end);
+        return cmp;
+    }
+
+    /** private to enforce singleton */
+    private PendingTokenOffsetsComparator() {
+    }
+}

--- a/src/org/opensolaris/opengrok/analysis/StreamSource.java
+++ b/src/org/opensolaris/opengrok/analysis/StreamSource.java
@@ -19,14 +19,17 @@
 
 /*
  * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This class lets you create {@code InputStream}s that read data from a
@@ -61,6 +64,23 @@ public abstract class StreamSource {
             @Override
             public InputStream getStream() throws IOException {
                 return new BufferedInputStream(new FileInputStream(file));
+            }
+        };
+    }
+
+    /**
+     * Helper method that creates a {@code StreamSource} instance that
+     * reads data from a String.
+     * @param str the source string
+     * @return a stream source that reads from {@code str}
+     */
+    public static StreamSource fromString(final String str) {
+        return new StreamSource() {
+            private final byte[] sbuf = str.getBytes(StandardCharsets.UTF_8);
+
+            @Override
+            public InputStream getStream() throws IOException {
+                return new ByteArrayInputStream(sbuf);
             }
         };
     }

--- a/src/org/opensolaris/opengrok/analysis/plain/DefinitionsTokenStream.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/DefinitionsTokenStream.java
@@ -116,7 +116,7 @@ public class DefinitionsTokenStream extends TokenStream {
             int lineno = tag.line - 1;
 
             if (lineno >= 0 && lineno < brk.count() && tag.symbol != null &&
-                tag.text != null) {
+                    tag.text != null) {
                 int lineoff = brk.getPosition(lineno);
                 if (tag.lineStart >= 0) {
                     PendingToken tok = new PendingToken(tag.symbol, lineoff +

--- a/src/org/opensolaris/opengrok/analysis/plain/DefinitionsTokenStream.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/DefinitionsTokenStream.java
@@ -1,0 +1,131 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.analysis.plain;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.opensolaris.opengrok.analysis.Definitions;
+import org.opensolaris.opengrok.analysis.PendingToken;
+import org.opensolaris.opengrok.analysis.PendingTokenOffsetsComparator;
+import org.opensolaris.opengrok.analysis.StreamSource;
+import org.opensolaris.opengrok.util.LineBreaker;
+import org.opensolaris.opengrok.util.ReaderWrapper;
+
+/**
+ * Represents a token stream from {@link Definitions}.
+ */
+public class DefinitionsTokenStream extends TokenStream {
+
+    /**
+     * Defines the ultimate queue of tokens to be produced by
+     * {@link #incrementToken()}.
+     */
+    private final List<PendingToken> events = new ArrayList<>();
+
+    private final CharTermAttribute termAtt = addAttribute(
+        CharTermAttribute.class);
+    private final OffsetAttribute offsetAtt = addAttribute(
+        OffsetAttribute.class);
+    private final PositionIncrementAttribute posIncrAtt = addAttribute(
+        PositionIncrementAttribute.class);
+
+    private int offset;
+
+    /**
+     * Initializes the stream by merging {@code defs} with cross-referenced
+     * line offsets read from {@code src}.
+     * @param defs a defined instance
+     * @param src a defined instance
+     * @param wrapper an optional instance
+     * @throws IOException if I/O error occurs
+     */
+    public void initialize(Definitions defs, StreamSource src,
+        ReaderWrapper wrapper) throws IOException {
+        if (defs == null) {
+            throw new IllegalArgumentException("`defs' is null");
+        }
+        if (src == null) {
+            throw new IllegalArgumentException("`src' is null");
+        }
+
+        events.clear();
+        offset = 0;
+
+        LineBreaker brk = new LineBreaker();
+        brk.reset(src, wrapper);
+        createTokens(defs, brk);
+    }
+
+    /**
+     * Publishes the next, pending token from
+     * {@link #initialize(org.opensolaris.opengrok.analysis.Definitions, org.opensolaris.opengrok.analysis.StreamSource, org.opensolaris.opengrok.util.ReaderWrapper)},
+     * if one is available.
+     * @return false if no more tokens; otherwise true
+     * @throws IOException in case of I/O error
+     */
+    @Override
+    public final boolean incrementToken() throws IOException {
+        if (offset < events.size()) {
+            PendingToken tok = events.get(offset++);
+            setAttribs(tok);
+            return true;
+        }
+
+        clearAttributes();
+        return false;
+    }
+
+    private void setAttribs(PendingToken tok) {
+        clearAttributes();
+
+        this.posIncrAtt.setPositionIncrement(tok.nonpos ? 0 : 1);
+        this.termAtt.setEmpty();
+        this.termAtt.append(tok.str);
+        this.offsetAtt.setOffset(tok.start, tok.end);
+    }
+
+    private void createTokens(Definitions defs, LineBreaker brk) {
+        for (Definitions.Tag tag : defs.getTags()) {
+            // Shift from ctags's convention.
+            int lineno = tag.line - 1;
+
+            if (lineno >= 0 && lineno < brk.count() && tag.symbol != null &&
+                tag.text != null) {
+                int lineoff = brk.getPosition(lineno);
+                if (tag.lineStart >= 0) {
+                    PendingToken tok = new PendingToken(tag.symbol, lineoff +
+                        tag.lineStart, lineoff + tag.lineEnd);
+                    events.add(tok);
+                }
+            }
+        }
+
+        events.sort(PendingTokenOffsetsComparator.INSTANCE);
+    }
+}

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.plain;
 
@@ -33,7 +33,6 @@ import org.apache.lucene.document.TextField;
 import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.ExpandTabsReader;
 import org.opensolaris.opengrok.analysis.FileAnalyzerFactory;
-import org.opensolaris.opengrok.analysis.IteratorReader;
 import org.opensolaris.opengrok.analysis.JFlexTokenizer;
 import org.opensolaris.opengrok.analysis.JFlexXref;
 import org.opensolaris.opengrok.analysis.Scopes;
@@ -92,9 +91,11 @@ public class PlainAnalyzer extends TextAnalyzer {
         doc.add(new TextField(QueryBuilder.FULL, getReader(src.getStream())));
         String fullpath = doc.get(QueryBuilder.FULLPATH);
         if (fullpath != null && ctags != null) {
-            defs = ctags.doCtags(fullpath + "\n");
+            defs = ctags.doCtags(fullpath);
             if (defs != null && defs.numberOfSymbols() > 0) {
-                doc.add(new TextField(QueryBuilder.DEFS, new IteratorReader(defs.getSymbols())));
+                DefinitionsTokenStream defstream = new DefinitionsTokenStream();
+                defstream.initialize(defs, src, null);
+                doc.add(new TextField(QueryBuilder.DEFS, defstream));
                 //this is to explicitly use appropriate analyzers tokenstream to workaround #1376 symbols search works like full text search 
                 TextField ref = new TextField(QueryBuilder.REFS,
                     this.symbolTokenizer);

--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -683,6 +683,8 @@ public class IndexDatabase {
         for (IndexChangedListener listener : listeners) {
             listener.fileAdd(path, fa.getClass().getSimpleName());
         }
+
+        ctags.setTabSize(project != null ? project.getTabSize() : 0);
         if (ctags.getBinary() != null) fa.setCtags(ctags);
         fa.setProject(Project.getProject(path));
         fa.setScopesEnabled(RuntimeEnvironment.getInstance().isScopesEnabled());
@@ -1040,8 +1042,8 @@ public class IndexDatabase {
                             ret = false;
                         } finally {
                             if (pctags != null) {
+                                pctags.reset();
                                 ctagsPool.release(pctags);
-                                pctags = null;
                             }
                         }
 

--- a/src/org/opensolaris/opengrok/util/IOUtils.java
+++ b/src/org/opensolaris/opengrok/util/IOUtils.java
@@ -20,12 +20,11 @@
 /*
  * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Trond Norbye 
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.util;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FilenameFilter;

--- a/src/org/opensolaris/opengrok/util/LineBreaker.java
+++ b/src/org/opensolaris/opengrok/util/LineBreaker.java
@@ -1,0 +1,162 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.opensolaris.opengrok.analysis.StreamSource;
+
+/**
+ * Represents a reader of source text to find end-of-line tokens -- in
+ * accordance with {@link StringUtils#STANDARD_EOL} -- in order to determine
+ * line offsets but discarding line content.
+ */
+public class LineBreaker {
+
+    private int length;
+    private int[] lineOffsets;
+
+    /**
+     * Calls
+     * {@link #reset(org.opensolaris.opengrok.analysis.StreamSource, org.opensolaris.opengrok.util.ReaderWrapper)}
+     * with {@code src} and {@code null}.
+     * @param src a defined instance
+     * @throws java.io.IOException if an I/O error occurs
+     */
+    public void reset(StreamSource src) throws IOException {
+        reset(src, null);
+    }
+
+    /**
+     * Resets the breaker using the specified inputs.
+     * @param src a defined instance
+     * @param wrapper an optional instance
+     * @throws java.io.IOException if an I/O error occurs
+     */
+    public void reset(StreamSource src, ReaderWrapper wrapper)
+            throws IOException {
+        if (src == null) {
+            throw new IllegalArgumentException("`src' is null");
+        }
+
+        length = 0;
+        lineOffsets = null;
+
+        try (InputStream in = src.getStream();
+            Reader rdr = IOUtils.createBOMStrippedReader(in,
+                StandardCharsets.UTF_8.name())) {
+            Reader intermediate = null;
+            if (wrapper != null) intermediate = wrapper.get(rdr);
+
+            try (BufferedReader brdr = new BufferedReader(
+                intermediate != null ? intermediate : rdr)) {
+                reset(brdr);
+            } finally {
+                if (intermediate != null) intermediate.close();
+            }
+        }
+    }
+
+    private void reset(Reader reader) throws IOException {
+        List<Integer> newOffsets = new ArrayList<>();
+        newOffsets.add(0);
+
+        int c;
+        while ((c = reader.read()) != -1) {
+            ++length;
+            switch (c) {
+                case '\r':
+                    c = reader.read();
+                    if (c == -1) {
+                        newOffsets.add(length);
+                        break;
+                    } else {
+                        ++length;
+                        switch (c) {
+                            case '\n':
+                                newOffsets.add(length);
+                                break;
+                            case '\r':
+                                newOffsets.add(length - 1);
+                                newOffsets.add(length);
+                                break;
+                            default:
+                                newOffsets.add(length - 1);
+                                break;
+                        }
+                    }
+                    break;
+                case '\n':
+                    newOffsets.add(length);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        lineOffsets = new int[newOffsets.size()];
+        for (int i = 0; i < lineOffsets.length; ++i) {
+            lineOffsets[i] = newOffsets.get(i);
+        }
+    }
+
+    /**
+     * Gets the number of characters in the original source document.
+     * @return value
+     */
+    public int originalLength() {
+        return length;
+    }
+
+    /**
+     * Gets the number of broken lines.
+     * @return value
+     */
+    public int count() {
+        if (lineOffsets == null) {
+            throw new IllegalStateException("reset() did not succeed");
+        }
+        return lineOffsets.length;
+    }
+
+    /**
+     * Gets the starting document character position of the line at the
+     * specified offset.
+     * @param offset greater than or equal to zero and less than or equal to
+     * {@link #count()}
+     * @return line length, including the end-of-line token
+     * @throws IllegalArgumentException if {@code offset} is out of bounds
+     */
+    public int getPosition(int offset) {
+        if (offset < 0 || lineOffsets == null || offset >= lineOffsets.length) {
+            throw new IllegalArgumentException("`offset' is out of bounds");
+        }
+        return lineOffsets[offset];
+    }
+}

--- a/src/org/opensolaris/opengrok/util/LineBreaker.java
+++ b/src/org/opensolaris/opengrok/util/LineBreaker.java
@@ -72,13 +72,17 @@ public class LineBreaker {
             Reader rdr = IOUtils.createBOMStrippedReader(in,
                 StandardCharsets.UTF_8.name())) {
             Reader intermediate = null;
-            if (wrapper != null) intermediate = wrapper.get(rdr);
+            if (wrapper != null) {
+                intermediate = wrapper.get(rdr);
+            }
 
             try (BufferedReader brdr = new BufferedReader(
-                intermediate != null ? intermediate : rdr)) {
+                    intermediate != null ? intermediate : rdr)) {
                 reset(brdr);
             } finally {
-                if (intermediate != null) intermediate.close();
+                if (intermediate != null) {
+                    intermediate.close();
+                }
             }
         }
     }

--- a/src/org/opensolaris/opengrok/util/ReaderWrapper.java
+++ b/src/org/opensolaris/opengrok/util/ReaderWrapper.java
@@ -1,0 +1,33 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.util;
+
+import java.io.Reader;
+
+/**
+ * Represents an API for overlaying a reader with another reader.
+ */
+public interface ReaderWrapper {
+    Reader get(Reader reader);
+}

--- a/src/org/opensolaris/opengrok/util/SourceSplitter.java
+++ b/src/org/opensolaris/opengrok/util/SourceSplitter.java
@@ -109,7 +109,9 @@ public class SourceSplitter {
         if (lineOffsets == null) {
             throw new IllegalStateException("reset() has not succeeded");
         }
-        if (position < 0 || position > length) return -1;
+        if (position < 0 || position > length) {
+            return -1;
+        }
 
         int lo = 0;
         int hi = lineOffsets.length - 1;
@@ -195,13 +197,17 @@ public class SourceSplitter {
             Reader rdr = IOUtils.createBOMStrippedReader(in,
                 StandardCharsets.UTF_8.name())) {
             Reader intermediate = null;
-            if (wrapper != null) intermediate = wrapper.get(rdr);
+            if (wrapper != null) {
+                intermediate = wrapper.get(rdr);
+            }
 
             try (BufferedReader brdr = new BufferedReader(
-                intermediate != null ? intermediate : rdr)) {
+                    intermediate != null ? intermediate : rdr)) {
                 reset(brdr);
             } finally {
-                if (intermediate != null) intermediate.close();
+                if (intermediate != null) {
+                    intermediate.close();
+                }
             }
         }
     }
@@ -277,7 +283,9 @@ public class SourceSplitter {
         int position = 0;
         for (int i = 0; i < lineOffsets.length; ++i) {
             lineOffsets[i] = position;
-            if (i < lines.length) position += lines[i].length();
+            if (i < lines.length) {
+                position += lines[i].length();
+            }
         }
     }
 }

--- a/src/org/opensolaris/opengrok/util/SourceSplitter.java
+++ b/src/org/opensolaris/opengrok/util/SourceSplitter.java
@@ -1,0 +1,283 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import org.opensolaris.opengrok.analysis.StreamSource;
+
+/**
+ * Represents a splitter of source text into lines where end-of-line tokens --
+ * identified by {@link StringUtils#STANDARD_EOL} -- are maintained instead of
+ * being stripped.
+ */
+public class SourceSplitter {
+
+    private int length;
+    private String[] lines;
+    private int[] lineOffsets;
+
+    /**
+     * Gets the number of characters in the original source document.
+     * @return value
+     */
+    public int originalLength() {
+        return length;
+    }
+
+    /**
+     * Gets the number of split lines.
+     * @return value
+     */
+    public int count() {
+        if (lines == null) {
+            throw new IllegalStateException("reset() has not succeeded");
+        }
+        return lines.length;
+    }
+
+    /**
+     * Gets the lines at the specified offset.
+     * @param offset greater than or equal to zero and less than
+     * {@link #count()}
+     * @return defined instance
+     * @throws IllegalArgumentException if {@code offset} is out of bounds
+     */
+    public String getLine(int offset) {
+        if (lines == null) {
+            throw new IllegalStateException("reset() has not succeeded");
+        }
+        if (offset < 0 || offset >= lines.length) {
+            throw new IllegalArgumentException("`offset' is out of bounds");
+        }
+        return lines[offset];
+    }
+
+    /**
+     * Gets the starting document character position of the line at the
+     * specified offset.
+     * @param offset greater than or equal to zero and less than or equal to
+     * {@link #count()}
+     * @return line length, including the end-of-line token
+     * @throws IllegalArgumentException if {@code offset} is out of bounds
+     */
+    public int getPosition(int offset) {
+        if (lineOffsets == null) {
+            throw new IllegalStateException("reset() has not succeeded");
+        }
+        if (offset < 0 || offset >= lineOffsets.length) {
+            throw new IllegalArgumentException("`offset' is out of bounds");
+        }
+        return lineOffsets[offset];
+    }
+
+    /**
+     * Find the line offset for the specified document position.
+     * @param position greater than or equal to zero and less than
+     * {@link #originalLength()}.
+     * @return -1 if {@code position} is beyond the document bounds; otherwise,
+     * a valid offset
+     */
+    public int findLineOffset(int position) {
+        if (lineOffsets == null) {
+            throw new IllegalStateException("reset() has not succeeded");
+        }
+        if (position < 0 || position > length) return -1;
+
+        int lo = 0;
+        int hi = lineOffsets.length - 1;
+        int mid;
+        while (lo <= hi) {
+            mid = lo + (hi - lo) / 2;
+            int linelen = mid < lines.length ? lines[mid].length() : 0;
+            if (position < lineOffsets[mid]) {
+                hi = mid - 1;
+            } else if (linelen == 0 && position == lineOffsets[mid]) {
+                return mid;
+            } else if (position >= lineOffsets[mid] + linelen) {
+                lo = mid + 1;
+            } else {
+                return mid;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Reset the splitter to use the specified content.
+     * @param original a defined instance
+     */
+    public void reset(String original) {
+        if (original == null) {
+            throw new IllegalArgumentException("`original' is null");
+        }
+
+        length = original.length();
+        lines = null;
+        lineOffsets = null;
+
+        List<String> slist = new ArrayList<>();
+        int position = 0;
+        Matcher eolm = StringUtils.STANDARD_EOL.matcher(original);
+        while (eolm.find()) {
+            slist.add(original.substring(position, eolm.end()));
+            position = eolm.end();
+        }
+        if (position < original.length()) {
+            slist.add(original.substring(position));
+        } else {
+            /*
+             * Following JFlexXref's custom, an empty file or a file ending
+             * with LF produces an additional line of length zero.
+             */
+            slist.add("");
+        }
+
+        lines = slist.stream().toArray(String[]::new);
+        setLineOffsets();
+    }
+
+    /**
+     * Calls
+     * {@link #reset(org.opensolaris.opengrok.analysis.StreamSource, org.opensolaris.opengrok.util.ReaderWrapper)}
+     * with {@code src} and {@code null}.
+     * @param src a defined instance
+     * @throws java.io.IOException if an I/O error occurs
+     */
+    public void reset(StreamSource src) throws IOException {
+        reset(src, null);
+    }
+
+    /**
+     * Reset the splitter to use the specified inputs.
+     * @param src a defined instance
+     * @param wrapper an optional instance
+     * @throws java.io.IOException if an I/O error occurs
+     */
+    public void reset(StreamSource src, ReaderWrapper wrapper)
+            throws IOException {
+        if (src == null) {
+            throw new IllegalArgumentException("`src' is null");
+        }
+
+        length = 0;
+        lines = null;
+        lineOffsets = null;
+
+        try (InputStream in = src.getStream();
+            Reader rdr = IOUtils.createBOMStrippedReader(in,
+                StandardCharsets.UTF_8.name())) {
+            Reader intermediate = null;
+            if (wrapper != null) intermediate = wrapper.get(rdr);
+
+            try (BufferedReader brdr = new BufferedReader(
+                intermediate != null ? intermediate : rdr)) {
+                reset(brdr);
+            } finally {
+                if (intermediate != null) intermediate.close();
+            }
+        }
+    }
+
+    private void reset(Reader reader) throws IOException {
+        List<String> slist = new ArrayList<>();
+        StringBuilder bld = new StringBuilder();
+        int c;
+        while ((c = reader.read()) != -1) {
+            ++length;
+            bld.append((char)c);
+            switch (c) {
+                case '\r':
+                    c = reader.read();
+                    if (c == -1) {
+                        slist.add(bld.toString());
+                        bld.setLength(0);
+                        break;
+                    } else {
+                        ++length;
+                        switch (c) {
+                            case '\n':
+                                bld.append((char)c);
+                                slist.add(bld.toString());
+                                bld.setLength(0);
+                                break;
+                            case '\r':
+                                slist.add(bld.toString());
+                                bld.setLength(0);
+
+                                bld.append((char)c);
+                                slist.add(bld.toString());
+                                bld.setLength(0);
+                                break;
+                            default:
+                                slist.add(bld.toString());
+                                bld.setLength(0);
+
+                                bld.append((char)c);
+                                break;
+                        }
+                    }
+                    break;
+                case '\n':
+                    slist.add(bld.toString());
+                    bld.setLength(0);
+                    break;
+                default:
+                    break;
+            }
+        }
+        if (bld.length() > 0) {
+            slist.add(bld.toString());
+            bld.setLength(0);
+        } else {
+            /*
+             * Following JFlexXref's custom, an empty file or a file ending
+             * with LF produces an additional line of length zero.
+             */
+            slist.add("");
+        }
+
+        lines = slist.stream().toArray(String[]::new);
+        setLineOffsets();
+    }
+
+    private void setLineOffsets() {
+        /**
+         * Add one more entry for lineOffsets so that findLineOffset() can
+         * easily work on the last line.
+         */
+        lineOffsets = new int[lines.length + 1];
+        int position = 0;
+        for (int i = 0; i < lineOffsets.length; ++i) {
+            lineOffsets[i] = position;
+            if (i < lines.length) position += lines[i].length();
+        }
+    }
+}

--- a/src/org/opensolaris/opengrok/util/StringUtils.java
+++ b/src/org/opensolaris/opengrok/util/StringUtils.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.util;
@@ -33,6 +33,18 @@ import java.util.regex.Pattern;
  * @author austvik
  */
 public final class StringUtils {
+
+    /**
+     * Matches a standard end-of-line indicator, identical to Common.lexh's
+     * {EOL}
+     * <pre>
+     * {@code
+     * \r?\n|\r
+     * }
+     * </pre>
+     * (Edit above and paste below [in NetBeans] for easy String escaping.)
+     */
+    public static final Pattern STANDARD_EOL = Pattern.compile("\\r?\\n|\\r");
 
     /**
      * Matches an apostrophe not following a backslash escape or following an

--- a/test/org/opensolaris/opengrok/analysis/CtagsTest.java
+++ b/test/org/opensolaris/opengrok/analysis/CtagsTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis;
@@ -94,7 +94,7 @@ public class CtagsTest {
     private static Definitions getDefs(String fileName) throws Exception {
         String path = repository.getSourceRoot() + File.separator
                 + fileName.replace('/', File.separatorChar);
-        return ctags.doCtags(new File(path).getAbsolutePath() + "\n");
+        return ctags.doCtags(new File(path).getAbsolutePath());
     }
 
     /**

--- a/test/org/opensolaris/opengrok/analysis/DefinitionsTest.java
+++ b/test/org/opensolaris/opengrok/analysis/DefinitionsTest.java
@@ -20,6 +20,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis;
@@ -66,7 +67,7 @@ public class DefinitionsTest {
         Set<String> result = instance.getSymbols();
         assertNotNull(result);
         assertEquals(result.size(), 0);
-        instance.addTag(1, "found", "", "");
+        instance.addTag(1, "found", "", "", 0, 0);
         result = instance.getSymbols();
         assertNotNull(result);
         assertEquals(result.size(), 1);
@@ -78,7 +79,7 @@ public class DefinitionsTest {
     @Test
     public void hasSymbol() {
         Definitions instance = new Definitions();
-        instance.addTag(1, "found", "", "");
+        instance.addTag(1, "found", "", "", 0, 0);
         assertEquals(instance.hasSymbol("notFound"), false);
         assertEquals(instance.hasSymbol("found"), true);
     }
@@ -91,7 +92,7 @@ public class DefinitionsTest {
         Definitions instance = new Definitions();
         String[] type= new String[1];
         type[0]="";
-        instance.addTag(1, "found", "", "");
+        instance.addTag(1, "found", "", "", 0, 0);
         assertEquals(instance.hasDefinitionAt("found", 0, type), false);
         assertEquals(instance.hasDefinitionAt("found", 1, type), true);
         assertEquals(instance.hasDefinitionAt("found", 2, type), false);
@@ -105,9 +106,9 @@ public class DefinitionsTest {
     @Test
     public void occurrences() {
         Definitions instance = new Definitions();
-        instance.addTag(1, "one", "", "");
-        instance.addTag(1, "two", "", "");
-        instance.addTag(3, "two", "", "");
+        instance.addTag(1, "one", "", "", 0, 0);
+        instance.addTag(1, "two", "", "", 0, 0);
+        instance.addTag(3, "two", "", "", 0, 0);
         assertEquals(instance.occurrences("one"), 1);
         assertEquals(instance.occurrences("two"), 2);
         assertEquals(instance.occurrences("notFound"), 0);
@@ -120,10 +121,10 @@ public class DefinitionsTest {
     public void numberOfSymbols() {
         Definitions instance = new Definitions();
         assertEquals(instance.numberOfSymbols(), 0);
-        instance.addTag(1, "one", "", "");
+        instance.addTag(1, "one", "", "", 0, 0);
         assertEquals(instance.numberOfSymbols(), 1);
-        instance.addTag(1, "two", "", "");
-        instance.addTag(3, "two", "", "");
+        instance.addTag(1, "two", "", "", 0, 0);
+        instance.addTag(3, "two", "", "", 0, 0);
         assertEquals(instance.numberOfSymbols(), 2);
     }
 
@@ -134,11 +135,11 @@ public class DefinitionsTest {
     public void getTags() {
         Definitions instance = new Definitions();
         assertEquals(instance.getTags().size(), 0);
-        instance.addTag(1, "one", "", "");
+        instance.addTag(1, "one", "", "", 0, 0);
         assertEquals(instance.getTags().size(), 1);
-        instance.addTag(1, "two", "", "");
+        instance.addTag(1, "two", "", "", 0, 0);
         assertEquals(instance.getTags().size(), 2);
-        instance.addTag(3, "two", "", "");
+        instance.addTag(3, "two", "", "", 0, 0);
         assertEquals(instance.getTags().size(), 3);
     }
 
@@ -149,7 +150,7 @@ public class DefinitionsTest {
     public void addTag() {
         Definitions instance = new Definitions();
         assertEquals(instance.getTags().size(), 0);
-        instance.addTag(1, "one", "", "");
+        instance.addTag(1, "one", "", "", 0, 0);
         assertEquals(instance.getTags().size(), 1);
     }
 
@@ -159,7 +160,7 @@ public class DefinitionsTest {
     @Test
     public void serialize() throws Exception {
         Definitions instance = new Definitions();
-        instance.addTag(1, "one", "", "");
+        instance.addTag(1, "one", "", "", 0, 0);
         byte serial[] = instance.serialize();
         Definitions instance2 = Definitions.deserialize(serial);
         assertEquals(instance.getTags().size(), instance2.getTags().size());

--- a/test/org/opensolaris/opengrok/analysis/ExpandTabsReaderTest.java
+++ b/test/org/opensolaris/opengrok/analysis/ExpandTabsReaderTest.java
@@ -20,6 +20,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis;
@@ -28,8 +29,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
  * Unit tests for the ExpandTabsReader class.
@@ -92,4 +95,29 @@ public class ExpandTabsReaderTest {
         assertEquals("    xyz", sb.toString());
     }
 
+    /**
+     * Tests that line offsets are translated as expected.
+     */
+    @Test
+    public void testTranslate() {
+        final String INPUT = "abc\tdef\t\t12345678\t1\t1234567\tabc";
+
+        int tbsz = 8;
+        assertEquals(0,  ExpandTabsReader.translate(INPUT, 0,  tbsz)); // a
+        assertEquals(2,  ExpandTabsReader.translate(INPUT, 2,  tbsz)); // c
+        assertEquals(3,  ExpandTabsReader.translate(INPUT, 3,  tbsz)); // \t
+        assertEquals(8,  ExpandTabsReader.translate(INPUT, 4,  tbsz)); // d
+        assertEquals(10, ExpandTabsReader.translate(INPUT, 6,  tbsz)); // f
+        assertEquals(11, ExpandTabsReader.translate(INPUT, 7,  tbsz)); // \t
+        assertEquals(16, ExpandTabsReader.translate(INPUT, 8,  tbsz)); // \t
+        assertEquals(24, ExpandTabsReader.translate(INPUT, 9,  tbsz)); // 1
+        assertEquals(31, ExpandTabsReader.translate(INPUT, 16, tbsz)); // 8
+        assertEquals(32, ExpandTabsReader.translate(INPUT, 17, tbsz)); // \t
+        assertEquals(40, ExpandTabsReader.translate(INPUT, 18, tbsz)); // 1
+        assertEquals(41, ExpandTabsReader.translate(INPUT, 19, tbsz)); // \t
+        assertEquals(48, ExpandTabsReader.translate(INPUT, 20, tbsz)); // 1
+        assertEquals(54, ExpandTabsReader.translate(INPUT, 26, tbsz)); // 7
+        assertEquals(55, ExpandTabsReader.translate(INPUT, 27, tbsz)); // \t
+        assertEquals(56, ExpandTabsReader.translate(INPUT, 28, tbsz)); // a
+    }
 }

--- a/test/org/opensolaris/opengrok/analysis/JFlexXrefTest.java
+++ b/test/org/opensolaris/opengrok/analysis/JFlexXrefTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis;
@@ -177,7 +177,7 @@ public class JFlexXrefTest {
     private void bug15890Anchor(Class<? extends JFlexSymbolMatcher> klass,
         String path) throws Exception {
         File file = new File(repository.getSourceRoot() + File.separator + path);
-        Definitions defs = ctags.doCtags(file.getAbsolutePath() + "\n");
+        Definitions defs = ctags.doCtags(file.getAbsolutePath());
 
         // Input files contain non-ascii characters and are encoded in UTF-8
         Reader in = new InputStreamReader(new FileInputStream(file), "UTF-8");
@@ -381,7 +381,7 @@ public class JFlexXrefTest {
         String filename = repository.getSourceRoot() + "/sql/bug18586.sql";
         Reader in = new InputStreamReader(new FileInputStream(filename), "UTF-8");
         JFlexXref xref = new JFlexXref(new SQLXref(in));
-        xref.setDefs(ctags.doCtags(filename + "\n"));
+        xref.setDefs(ctags.doCtags(filename));
         // The next call used to fail with an ArrayIndexOutOfBoundsException.
         xref.write(new StringWriter());
     }

--- a/test/org/opensolaris/opengrok/analysis/haskell/HaskellXrefTest.java
+++ b/test/org/opensolaris/opengrok/analysis/haskell/HaskellXrefTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.haskell;
 
@@ -93,7 +93,8 @@ public class HaskellXrefTest {
         ByteArrayOutputStream sampleOutputStream = new ByteArrayOutputStream();
 
         Definitions defs = new Definitions();
-        defs.addTag(6, "x'y'", "functions", "x'y' = let f' = 1; g'h = 2 in f' + g'h");
+        defs.addTag(6, "x'y'", "functions",
+            "x'y' = let f' = 1; g'h = 2 in f' + g'h", 0, 0);
         int actLOC;
         try {
             actLOC = writeHaskellXref(sampleInputStream,

--- a/test/org/opensolaris/opengrok/analysis/plain/DefinitionsTokenStreamTest.java
+++ b/test/org/opensolaris/opengrok/analysis/plain/DefinitionsTokenStreamTest.java
@@ -1,0 +1,179 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.analysis.plain;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.opensolaris.opengrok.analysis.Definitions;
+import org.opensolaris.opengrok.analysis.ExpandTabsReader;
+import org.opensolaris.opengrok.analysis.StreamSource;
+import org.opensolaris.opengrok.util.IOUtils;
+import org.opensolaris.opengrok.util.StreamUtils;
+
+/**
+ * Represents a container for tests of {@link DefinitionsTokenStream}.
+ */
+public class DefinitionsTokenStreamTest {
+
+    /**
+     * Tests sampleplain.cc v. sampletags_cc with no expand-tabs and
+     * no supplement when ctags's pattern excerpt is insufficient w.r.t.
+     * `signature'.
+     * @throws java.io.IOException
+     */
+    @Test
+    public void testCppDefinitionsForRawContentUnsupplemented()
+            throws IOException {
+        Map<Integer, SimpleEntry<String, String>> overrides = new TreeMap<>();
+        overrides.put(44, new SimpleEntry<>(",", "parent_def"));
+        overrides.put(45, new SimpleEntry<>(",", "element"));
+        overrides.put(46, new SimpleEntry<>(",", "offset"));
+        overrides.put(47, new SimpleEntry<>(",", "ant"));
+        overrides.put(48, new SimpleEntry<>(",", "path"));
+
+        testDefinitionsVsContent(false,
+            "org/opensolaris/opengrok/analysis/c/sample.cc",
+            "org/opensolaris/opengrok/analysis/c/sampletags_cc", 65, false,
+            overrides);
+    }
+
+    /**
+     * Tests sampleplain.cc v. sampletags_cc with no expand-tabs but
+     * supplementing when ctags's pattern excerpt is insufficient w.r.t.
+     * `signature'.
+     * @throws java.io.IOException
+     */
+    @Test
+    public void testCppDefinitionsWithRawContent1() throws IOException {
+        testDefinitionsVsContent(false,
+            "org/opensolaris/opengrok/analysis/c/sample.cc",
+            "org/opensolaris/opengrok/analysis/c/sampletags_cc", 65, true,
+            null);
+    }
+
+    /**
+     * Tests sampleplain.cc v. sampletags_cc with expand-tabs and
+     * supplementing when ctags's pattern excerpt is insufficient w.r.t.
+     * `signature'.
+     * @throws java.io.IOException
+     */
+    @Test
+    public void testCppDefinitionsWithRawContent2() throws IOException {
+        testDefinitionsVsContent(true,
+            "org/opensolaris/opengrok/analysis/c/sample.cc",
+            "org/opensolaris/opengrok/analysis/c/sampletags_cc", 65, true,
+            null);
+    }
+
+    private void testDefinitionsVsContent(boolean expandTabs,
+        String sourceResource, String tagsResource, int expectedCount,
+        boolean doSupplement,
+        Map<Integer, SimpleEntry<String, String>> overrides)
+            throws IOException {
+
+        StreamSource src = getSourceFromResource(sourceResource);
+
+        // Deserialize the ctags.
+        int tabSize = expandTabs ? 8 : 0;
+        String suppResource = doSupplement ? sourceResource : null;
+        Definitions defs = StreamUtils.readTagsFromResource(tagsResource,
+            suppResource, tabSize);
+
+        // Read the whole input.
+        StringBuilder bld = new StringBuilder();
+        String source;
+        try (Reader rdr = ExpandTabsReader.wrap(
+            IOUtils.createBOMStrippedReader(src.getStream(),
+            StandardCharsets.UTF_8.name()), tabSize)) {
+            int c;
+            while ((c = rdr.read()) != -1) {
+                bld.append((char)c);
+            }
+            source = bld.toString();
+        }
+
+        // Deserialize the token stream.
+        DefinitionsTokenStream tokstream = new DefinitionsTokenStream();
+        tokstream.initialize(defs, src, (in) -> {
+            return ExpandTabsReader.wrap(in, tabSize);
+        });
+
+        // Iterate through stream.
+        CharTermAttribute term = tokstream.getAttribute(
+            CharTermAttribute.class);
+        assertNotNull("CharTermAttribute", term);
+
+        OffsetAttribute offs = tokstream.getAttribute(OffsetAttribute.class);
+        assertNotNull("OffsetAttribute", offs);
+
+        int count = 0;
+        while (tokstream.incrementToken()) {
+            ++count;
+            String termValue = term.toString();
+
+            String cutValue = source.substring(offs.startOffset(),
+                offs.endOffset());
+
+            // If an override exists, test it specially.
+            if (overrides != null && overrides.containsKey(count)) {
+                SimpleEntry<String, String> overkv = overrides.get(count);
+                assertEquals("cut term override" + count, overkv.getKey(),
+                    cutValue);
+                assertEquals("cut term w.r.t. term override" + count,
+                    overkv.getValue(), termValue);
+                continue;
+            }
+
+            boolean cutContainsTerm = cutValue.endsWith(termValue);
+            assertTrue("cut term" + count + " at " +
+                (offs.startOffset()) + "-" + (offs.endOffset()) + "["
+                + cutValue + "] vs [" + termValue + "]", cutContainsTerm);
+        }
+
+        assertEquals("token count", expectedCount, count);
+    }
+
+    private static StreamSource getSourceFromResource(String name) {
+        return new StreamSource() {
+            @Override
+            public InputStream getStream() throws IOException {
+                InputStream srcres = getClass().getClassLoader().
+                    getResourceAsStream(name);
+                assertNotNull(name + " as resource,", srcres);
+                return srcres;
+            }
+        };
+    }
+}

--- a/test/org/opensolaris/opengrok/analysis/plain/DefinitionsTokenStreamTest.java
+++ b/test/org/opensolaris/opengrok/analysis/plain/DefinitionsTokenStreamTest.java
@@ -115,8 +115,8 @@ public class DefinitionsTokenStreamTest {
         StringBuilder bld = new StringBuilder();
         String source;
         try (Reader rdr = ExpandTabsReader.wrap(
-            IOUtils.createBOMStrippedReader(src.getStream(),
-            StandardCharsets.UTF_8.name()), tabSize)) {
+                IOUtils.createBOMStrippedReader(src.getStream(),
+                StandardCharsets.UTF_8.name()), tabSize)) {
             int c;
             while ((c = rdr.read()) != -1) {
                 bld.append((char)c);

--- a/test/org/opensolaris/opengrok/search/context/ContextTest.java
+++ b/test/org/opensolaris/opengrok/search/context/ContextTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.search.context;
 
@@ -160,7 +161,7 @@ public class ContextTest {
 
         // Search with definitions
         Definitions defs = new Definitions();
-        defs.addTag(1, "def", "type", "text");
+        defs.addTag(1, "def", "type", "text", 0, 0);
         in = new StringReader("abc def ghi\n");
         out = hitList ? null : new StringWriter();
         hits = hitList ? new ArrayList<>() : null;
@@ -215,7 +216,7 @@ public class ContextTest {
         assertEquals(expectedOutput, actualOutput);
 
         defs = new Definitions();
-        defs.addTag(2, "def", "type", "text");
+        defs.addTag(2, "def", "type", "text", 0, 0);
         in = new StringReader("abc1 def ghi\nabc def ghi\nabc3 def ghi\n");
         out = hitList ? null : new StringWriter();
         hits = hitList ? new ArrayList<>() : null;
@@ -461,8 +462,8 @@ public class ContextTest {
 
         StringReader in = new StringReader("abc\nbug17582\nBug17582\n");
         Definitions defs = new Definitions();
-        defs.addTag(2, "bug17582", "type1", "text1");
-        defs.addTag(3, "Bug17582", "type2", "text2");
+        defs.addTag(2, "bug17582", "type1", "text1", 0, 0);
+        defs.addTag(3, "Bug17582", "type2", "text2", 0, 0);
 
         Context context = new Context(builder.build(), builder.getQueries());
         ArrayList<Hit> hits = new ArrayList<>();

--- a/test/org/opensolaris/opengrok/util/LineBreakerTest.java
+++ b/test/org/opensolaris/opengrok/util/LineBreakerTest.java
@@ -1,0 +1,87 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.util;
+
+import java.io.IOException;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensolaris.opengrok.analysis.StreamSource;
+
+/**
+ * Represents a container for tests of {@link LineBreaker}.
+ */
+public class LineBreakerTest {
+
+    private static LineBreaker brkr;
+
+    @BeforeClass
+    public static void setUpClass() {
+        brkr = new LineBreaker();
+    }
+
+    @Test
+    public void shouldSplitEmptyStringIntoOneLine() throws IOException {
+        StreamSource src = StreamSource.fromString("");
+        brkr.reset(src);
+        assertEquals("split count", 1, brkr.count());
+        assertEquals("split position", 0, brkr.getPosition(0));
+    }
+
+    @Test
+    public void shouldSplitEndingLFsIntoOneMoreLine() throws IOException {
+        StreamSource src = StreamSource.fromString("abc\ndef\n");
+        brkr.reset(src);
+        assertEquals("split count", 3, brkr.count());
+        assertEquals("split position", 0, brkr.getPosition(0));
+        assertEquals("split position", 4, brkr.getPosition(1));
+        assertEquals("split position", 8, brkr.getPosition(2));
+    }
+
+    @Test
+    public void shouldSplitDocsWithNoLastLF() throws IOException {
+        StreamSource src = StreamSource.fromString("abc\r\ndef");
+        brkr.reset(src);
+        assertEquals("split count", 2, brkr.count());
+        assertEquals("split position", 0, brkr.getPosition(0));
+        assertEquals("split position", 5, brkr.getPosition(1));
+    }
+
+    @Test
+    public void shouldHandleDocsOfLongerLength() throws IOException {
+        //                                  0             0
+        //                    0-- -  5-- - -1--- - 5--- - 2-
+        final String INPUT = "ab\r\ncde\r\nefgh\r\nijk\r\nlm";
+        StreamSource src = StreamSource.fromString(INPUT);
+
+        brkr.reset(src);
+        assertEquals("split count", 5, brkr.count());
+        assertEquals("split position", 0, brkr.getPosition(0));
+        assertEquals("split position", 4, brkr.getPosition(1));
+        assertEquals("split position", 9, brkr.getPosition(2));
+        assertEquals("split position", 15, brkr.getPosition(3));
+        assertEquals("split position", 20, brkr.getPosition(4));
+    }
+}

--- a/test/org/opensolaris/opengrok/util/SourceSplitterTest.java
+++ b/test/org/opensolaris/opengrok/util/SourceSplitterTest.java
@@ -1,0 +1,136 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.util;
+
+import java.io.IOException;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.opensolaris.opengrok.analysis.StreamSource;
+
+/**
+ * Represents a container for tests of {@link SourceSplitter}.
+ */
+public class SourceSplitterTest {
+
+    @Test
+    public void shouldSplitEmptyStringIntoOneLine() {
+        SourceSplitter splitter = new SourceSplitter();
+        splitter.reset("");
+        assertEquals("split count", 1, splitter.count());
+        assertEquals("split position", 0, splitter.getPosition(0));
+        assertEquals("split position", 0, splitter.getPosition(1));
+
+        assertEquals("split find-offset", 0, splitter.findLineOffset(0));
+        assertEquals("split find-offset", -1, splitter.findLineOffset(1));
+    }
+
+    @Test
+    public void shouldSplitEndingLFsIntoOneMoreLine() {
+        SourceSplitter splitter = new SourceSplitter();
+        splitter.reset("abc\ndef\n");
+        assertEquals("split count", 3, splitter.count());
+        assertEquals("split position", 0, splitter.getPosition(0));
+        assertEquals("split position", 4, splitter.getPosition(1));
+        assertEquals("split position", 8, splitter.getPosition(2));
+        assertEquals("split position", 8, splitter.getPosition(3));
+    }
+
+    @Test
+    public void shouldSplitDocsWithNoLastLF() {
+        SourceSplitter splitter = new SourceSplitter();
+        splitter.reset("abc\r\ndef");
+        assertEquals("split count", 2, splitter.count());
+        assertEquals("split position", 0, splitter.getPosition(0));
+        assertEquals("split position", 5, splitter.getPosition(1));
+        assertEquals("split position", 8, splitter.getPosition(2));
+
+        assertEquals("split find-offset", 0, splitter.findLineOffset(0));
+        assertEquals("split find-offset", 0, splitter.findLineOffset(1));
+        assertEquals("split find-offset", 0, splitter.findLineOffset(4));
+        assertEquals("split find-offset", 1, splitter.findLineOffset(5));
+        assertEquals("split find-offset", 1, splitter.findLineOffset(6));
+    }
+
+    @Test
+    public void shouldHandleDocsOfLongerLength() {
+        //                                  0             0
+        //                    0-- -  5-- - -1--- - 5--- - 2-
+        final String INPUT = "ab\r\ncde\r\nefgh\r\nijk\r\nlm";
+
+        SourceSplitter splitter = new SourceSplitter();
+        splitter.reset(INPUT);
+        assertEquals("split count", 5, splitter.count());
+        assertEquals("split position", 0, splitter.getPosition(0));
+        assertEquals("split position", 4, splitter.getPosition(1));
+        assertEquals("split position", 9, splitter.getPosition(2));
+        assertEquals("split position", 15, splitter.getPosition(3));
+        assertEquals("split position", 20, splitter.getPosition(4));
+        assertEquals("split position", 22, splitter.getPosition(5));
+
+        /*
+         * Test findLineOffset() for every character with an alternate
+         * computation that counts every LFs.
+         */
+        for (int i = 0; i < splitter.originalLength(); ++i) {
+            char c = INPUT.charAt(i);
+            int off = splitter.findLineOffset(i);
+            long numLF = INPUT.substring(0, i + 1).chars().filter(ch ->
+                ch == '\n').count();
+            long exp = numLF - (c == '\n' ? 1 : 0);
+            assertEquals("split find-offset of " + i, exp, off);
+        }
+    }
+
+    @Test
+    public void shouldHandleStreamedDocsOfLongerLength() throws IOException {
+        //                                  0             0
+        //                    0-- -  5-- - -1--- - 5--- - 2-
+        final String INPUT = "ab\r\ncde\r\nefgh\r\nijk\r\nlm";
+        StreamSource src = StreamSource.fromString(INPUT);
+
+        SourceSplitter splitter = new SourceSplitter();
+        splitter.reset(src);
+        assertEquals("split count", 5, splitter.count());
+        assertEquals("split position", 0, splitter.getPosition(0));
+        assertEquals("split position", 4, splitter.getPosition(1));
+        assertEquals("split position", 9, splitter.getPosition(2));
+        assertEquals("split position", 15, splitter.getPosition(3));
+        assertEquals("split position", 20, splitter.getPosition(4));
+        assertEquals("split position", 22, splitter.getPosition(5));
+
+        /*
+         * Test findLineOffset() for every character with an alternate
+         * computation that counts every LFs.
+         */
+        for (int i = 0; i < splitter.originalLength(); ++i) {
+            char c = INPUT.charAt(i);
+            int off = splitter.findLineOffset(i);
+            long numLF = INPUT.substring(0, i + 1).chars().filter(ch ->
+                ch == '\n').count();
+            long exp = numLF - (c == '\n' ? 1 : 0);
+            assertEquals("split find-offset of " + i, exp, off);
+        }
+    }
+}

--- a/test/org/opensolaris/opengrok/util/StreamUtils.java
+++ b/test/org/opensolaris/opengrok/util/StreamUtils.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import static org.junit.Assert.assertNotNull;
-import org.openide.util.Exceptions;
 import org.opensolaris.opengrok.analysis.CtagsReader;
 import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.analysis.StreamSource;

--- a/test/org/opensolaris/opengrok/util/StreamUtils.java
+++ b/test/org/opensolaris/opengrok/util/StreamUtils.java
@@ -19,13 +19,22 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.util;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import static org.junit.Assert.assertNotNull;
+import org.openide.util.Exceptions;
+import org.opensolaris.opengrok.analysis.CtagsReader;
+import org.opensolaris.opengrok.analysis.Definitions;
+import org.opensolaris.opengrok.analysis.StreamSource;
 
 /**
  * Represents a container for stream utility methods
@@ -37,8 +46,7 @@ public class StreamUtils {
      * @return a defined instance
      * @throws IOException if I/O fails
      */
-    public static byte[] copyStream(InputStream iss)
-        throws IOException {
+    public static byte[] copyStream(InputStream iss) throws IOException {
 
         ByteArrayOutputStream baosExp = new ByteArrayOutputStream();
         byte[] buffer = new byte[8192];
@@ -52,6 +60,71 @@ public class StreamUtils {
 
         baosExp.close();
         return baosExp.toByteArray();
+    }
+
+    public static Definitions readTagsFromResource(String tagsResourceName)
+        throws IOException {
+        return readTagsFromResource(tagsResourceName, null);
+    }
+
+    public static Definitions readTagsFromResource(String tagsResourceName,
+        String rawResourceName) throws IOException {
+        return readTagsFromResource(tagsResourceName, rawResourceName, 0);
+    }
+
+    public static Definitions readTagsFromResource(String tagsResourceName,
+        String rawResourceName, int tabSize) throws IOException {
+
+        InputStream res = StreamUtils.class.getClassLoader().
+            getResourceAsStream(tagsResourceName);
+        assertNotNull(tagsResourceName + " as resource", res);
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(
+            res, "UTF-8"));
+
+        CtagsReader rdr = new CtagsReader();
+        rdr.setTabSize(tabSize);
+        if (rawResourceName != null) {
+            rdr.setSplitterSupplier(() -> {
+                /**
+                 * This should return truly raw content, as the CtagsReader will
+                 * expand tabs according to its setting.
+                 */
+                SourceSplitter splitter = new SourceSplitter();
+                StreamSource src = sourceFromEmbedded(rawResourceName);
+                try {
+                    splitter.reset(src);
+                } catch (IOException ex) {
+                    Exceptions.printStackTrace(ex);
+                    return null;
+                }
+                return splitter;
+            });
+        }
+
+        String line;
+        while ((line = in.readLine()) != null) {
+            rdr.readLine(line);
+        }
+        return rdr.getDefinitions();
+    }
+
+    /**
+     * Creates a {@code StreamSource} instance that reads data from an
+     * embedded resource.
+     * @param resourceName a required resource name
+     * @return a stream source that reads from {@code name}
+     */
+    public static StreamSource sourceFromEmbedded(String resourceName) {
+        return new StreamSource() {
+            @Override
+            public InputStream getStream() throws IOException {
+                InputStream res = StreamUtils.class.getClassLoader().
+                    getResourceAsStream(resourceName);
+                assertNotNull("resource " + resourceName, res);
+                return new BufferedInputStream(res);
+            }
+        };
     }
 
     /** private to enforce static */

--- a/test/org/opensolaris/opengrok/util/StreamUtils.java
+++ b/test/org/opensolaris/opengrok/util/StreamUtils.java
@@ -94,7 +94,7 @@ public class StreamUtils {
                 try {
                     splitter.reset(src);
                 } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
+                    System.err.println(ex.toString());
                     return null;
                 }
                 return splitter;

--- a/test/org/opensolaris/opengrok/util/StreamUtils.java
+++ b/test/org/opensolaris/opengrok/util/StreamUtils.java
@@ -62,12 +62,12 @@ public class StreamUtils {
     }
 
     public static Definitions readTagsFromResource(String tagsResourceName)
-        throws IOException {
+            throws IOException {
         return readTagsFromResource(tagsResourceName, null);
     }
 
     public static Definitions readTagsFromResource(String tagsResourceName,
-        String rawResourceName) throws IOException {
+            String rawResourceName) throws IOException {
         return readTagsFromResource(tagsResourceName, rawResourceName, 0);
     }
 


### PR DESCRIPTION
Hello,

Please consider for integration this patch to enhance `CtagsReader` to store true posting for `DEFS` for use by the `UnifiedHighlighter` — i.e. so that a document is not required to be re-analyzed to present `DEFS` search matches.

Because of limitations in ctags results (e.g. partial patterns or truncated patterns) and limitations in the ctags format itself (e.g., having line numbering but no character offsets as required for Lucene postings), `CtagsReader` is enhanced to supplement the tags *when necessary* with additional analysis of the source text.

E.g., in `sample.cc`/`sampletags_cc`, the function definition (excluding body) for `definitionContains()` spans seven lines in source code:
```
int
Ancestor::definitionContains(const fru_regdef_t *def,
				const fru_regdef_t *parent_def,
				Str element,
				uint32_t offset,
				Ancestor *ant,
				Str path)
```
 but Universal Ctags only produces a pattern for one line of the definition:
```
/^Ancestor::definitionContains(const fru_regdef_t *def,$/;"
```
and ctags presents a `signature` with modified cstyle (note the different whitespace around asterisks and commas):
```
(const fru_regdef_t * def,const fru_regdef_t * parent_def,Str element,uint32_t offset,Ancestor * ant,Str path)
```

`CtagsReader` is enhanced to analyze the text in various ways to arrive at the best Lucene postings given the ctags variances.

`CtagsReader` is also enhanced to be project tabsize-aware or else postings would be mistakenly shifted when a non-zero project tab size is defined.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
