### PR TITLE
Use en dash for Results count. Fix to specify UTF-8 for jsps.

### DIFF
--- a/web/enoent.jsp
+++ b/web/enoent.jsp
@@ -18,8 +18,11 @@ CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
---%><%@page session="false" errorPage="error.jsp" isErrorPage="true" import="
+--%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@page session="false" errorPage="error.jsp" isErrorPage="true" import="
 org.opensolaris.opengrok.web.Prefix,
 org.opensolaris.opengrok.configuration.RuntimeEnvironment"
  %><%

--- a/web/error.jsp
+++ b/web/error.jsp
@@ -17,10 +17,11 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
-
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 --%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@page import="javax.servlet.http.HttpServletResponse"%>
 <%@ page session="false" isErrorPage="true" import="
 java.io.PrintWriter,

--- a/web/help.jsp
+++ b/web/help.jsp
@@ -17,10 +17,12 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
-
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
---%><%@ page session="false" errorPage="error.jsp" import="
+--%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@page session="false" errorPage="error.jsp" import="
 org.opensolaris.opengrok.web.PageConfig,
 org.opensolaris.opengrok.search.SearchEngine"
 %><%

--- a/web/history.jsp
+++ b/web/history.jsp
@@ -23,6 +23,7 @@ Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 --%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@page import="org.opensolaris.opengrok.web.Util"%>
 <%@page import="org.opensolaris.opengrok.history.HistoryGuru"%>
 <%@page import="java.io.File"%>

--- a/web/index.jsp
+++ b/web/index.jsp
@@ -17,10 +17,12 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
-
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
---%><%@ page session="false" errorPage="error.jsp" %>
+--%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@page session="false" errorPage="error.jsp" %>
 <%
 {
     PageConfig cfg = PageConfig.get(request);

--- a/web/mast.jsp
+++ b/web/mast.jsp
@@ -20,12 +20,14 @@ CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 --%><%--
 
 After include you are here: /body/div#page/div#content/
 
 --%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@page import="org.json.simple.JSONArray"%>
 <%@page import="org.opensolaris.opengrok.configuration.messages.Message"%>
 <%@page import="java.util.SortedSet"%>

--- a/web/search.jsp
+++ b/web/search.jsp
@@ -20,9 +20,10 @@ CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
-Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
 
 --%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@page import="javax.servlet.http.HttpServletResponse"%>
 <%@page session="false" errorPage="error.jsp" import="
 org.opensolaris.opengrok.search.Results,
@@ -207,7 +208,7 @@ include file="menu.jspf"
         %>
         <p class="pagetitle">Searched <b><%
             Util.htmlize(searchHelper.query.toString(), out);
-            %></b> (Results <b> <%= start + 1 %> - <%= thispage + start
+            %></b> (Results <b> <%= start + 1 %> – <%= thispage + start
             %></b> of <b><%= totalHits %></b>) sorted by <%=
             searchHelper.order.getDesc() %></p><%
         if (slider.length() > 0) {

--- a/web/status.jsp
+++ b/web/status.jsp
@@ -19,10 +19,12 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
-
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
---%><%@page session="false" errorPage="error.jsp" import="
+--%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@page session="false" errorPage="error.jsp" import="
 org.opensolaris.opengrok.configuration.RuntimeEnvironment,
 org.opensolaris.opengrok.web.Util"
 %><%


### PR DESCRIPTION
Hello,

Please consider for integration this patch to use an en-dash in the results item range instead of a hyphen.

With this tiny revision, it became apparent that many jsps did not have their encoding set to UTF-8. It's required or else — in the presence of a non-Latin code point — a conversion of content to ISO-8859-1 is warned and then executed. That happens even if a jsp has an `include` of a file specifying UTF-8 (e.g., `web/httpheader.jspf`).

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
