### PR TITLE
Log some additional places where !accept()ed

### DIFF
--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -757,13 +757,14 @@ public class IndexDatabase {
      */
     private boolean accept(File file) {
 
+        String absolutePath = file.getAbsolutePath();
+
         if (!includedNames.isEmpty()
                 && // the filter should not affect directory names
                 (!(file.isDirectory() || includedNames.match(file)))) {
+            LOGGER.log(Level.FINER, "not including {0}", absolutePath);
             return false;
         }
-
-        String absolutePath = file.getAbsolutePath();
 
         if (ignoredNames.ignore(file)) {
             LOGGER.log(Level.FINER, "ignoring {0}", absolutePath);
@@ -807,7 +808,13 @@ public class IndexDatabase {
         }
 
         // this is an unversioned file, check if it should be indexed
-        return !RuntimeEnvironment.getInstance().isIndexVersionedFilesOnly();
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        boolean res = !env.isIndexVersionedFilesOnly();
+        if (!res) {
+            LOGGER.log(Level.FINER, "not accepting unversioned {0}",
+                absolutePath);
+        }
+        return res;
     }
 
     private boolean accept(File parent, File file) {


### PR DESCRIPTION
Hello,

Please consider for integration this patch with a minor, FINER logging of some files that aren't `accept()`ed.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
