### PR TITLE
Properly set LOGGER_CONF_SOURCE for binary distributions

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -221,7 +221,7 @@ DefaultInstanceConfiguration()
         else
             # Handle Binary Distributions
             OPENGROK_DISTRIBUTION_BASE="${SCRIPT_DIRECTORY}/../lib"
-            LOGGER_CONF_SOURCE="${OPENGROK_DISTRIBUTION_BASE}/../doc/"
+            LOGGER_CONF_SOURCE="${OPENGROK_DISTRIBUTION_BASE}/../doc/${LOGGER_CONFIG_FILE}"
         fi
     fi
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
I'm seeing a warning when using the OpenGrok script to start an index run using opengrok 1.1-rc21:

    Loading the default instance configuration ...
      Creating default /tmp/opengrok/logging.properties ...
    WARNING: Can't find distribution logging configuration (/nail/home/sjaensch/pg/services/opengrok/opengrok-1.1-rc21/bin/../lib/../doc/) to install as default logging configuration (/tmp/opengrok/logging.properties)

LOGGER_CONF_SOURCE is supposed to point to the logging.properties file. This simple PR fixes the issue.

I do accept the terms of the OCA.