### PR TITLE
Enable conditional test runs by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,10 @@ env:
    #   via the "travis encrypt" command using the project repo's public key
    - secure: "O_cda5pWDBAP-O3_0nG5RQ"
 
-script:     "mvn -DskipTests=true -Dmaven.javadoc.skip=false -B -V compile && cd opengrok-indexer && mvn javadoc:javadoc && cd ../opengrok-web && mvn javadoc:javadoc && cd .. && mvn verify -B"
+script: "mvn -DskipTests=true -Dmaven.javadoc.skip=false -B -V compile \
+            && cd opengrok-indexer && mvn javadoc:javadoc \
+            && cd ../opengrok-web && mvn javadoc:javadoc \
+            && cd .. && mvn verify -B -Djunit-force-all=true"
 
 addons:
   coverity_scan:

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -431,9 +431,6 @@ Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <systemPropertyVariables>
-                        <junit-force-all>true</junit-force-all>
-                    </systemPropertyVariables>
                     <excludes>
                         <!-- Test helper class with name that confuses surefire -->
                         <exclude>**/TestRepository.java</exclude>


### PR DESCRIPTION
I think it might be counterintuitive if `mvn clean test` command fails on a completely correct repository just because some SCM tools are not installed. User can skip uninstalled SCM tools by adding `-Djunit-force-all=false` but this option is mentioned at the very bottom of the `README.md` file which makes it very easy to miss. (I for one installed BitKeeper and CVS to make the tests working and did not know about this option until I started to investigate it further...)

Therefore, I think it might be wise to skip some of those tests by default and check them all via Travis.

Thanks for considering this PR :)