### PR TITLE
Remove redundant changeRequests field from HistoryEntry

### DIFF
--- a/src/org/opensolaris/opengrok/history/HistoryEntry.java
+++ b/src/org/opensolaris/opengrok/history/HistoryEntry.java
@@ -18,16 +18,14 @@
  */
 
 /*
- * Copyright (c) 2006, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Copyright 2006 Trond Norbye.  All rights reserved.
  */
 package org.opensolaris.opengrok.history;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.logging.Level;
@@ -53,13 +51,11 @@ public class HistoryEntry {
 
     private boolean active;
     private SortedSet<String> files;
-    private List<String> changeRequests;
 
     /** Creates a new instance of HistoryEntry */
     public HistoryEntry() {
         message = new StringBuffer();
-        files = new TreeSet<String>();
-        changeRequests = new ArrayList<String>();
+        files = new TreeSet<>();
     }
     
     /**
@@ -74,7 +70,6 @@ public class HistoryEntry {
         this.message = that.message;
         this.active = that.active;
         this.files = that.files;
-        this.changeRequests = that.changeRequests;
     }
 
     public HistoryEntry(String revision, Date date, String author,
@@ -85,8 +80,7 @@ public class HistoryEntry {
         this.tags = tags;
         this.message = new StringBuffer(message);
         this.active = active;
-        this.files = new TreeSet<String>();
-        this.changeRequests = new ArrayList<String>();
+        this.files = new TreeSet<>();
     }
 
     public String getLine() {
@@ -106,12 +100,6 @@ public class HistoryEntry {
         for (String line : lines) {
             LOGGER.log(Level.FINE, "HistoryEntry : message        {0} {1}",
                     new Object[]{separator, line});
-            separator = ">";
-        }
-        separator = "=";
-        for (String cr : changeRequests) {
-            LOGGER.log(Level.FINE, "HistoryEntry : changeRequests {0} {1}",
-                    new Object[]{separator, cr});
             separator = ">";
         }
         separator = "=";
@@ -195,20 +183,6 @@ public class HistoryEntry {
     @Override
     public String toString() {
         return getLine();
-    }
-
-    public void addChangeRequest(String changeRequest) {
-        if (!changeRequests.contains(changeRequest)) {
-            changeRequests.add(changeRequest);
-        }
-    }
-
-    public List<String> getChangeRequests() {
-        return changeRequests;
-    }
-
-    public void setChangeRequests(List<String> changeRequests) {
-        this.changeRequests = changeRequests;
     }
 
     /**

--- a/src/org/opensolaris/opengrok/history/RazorHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/RazorHistoryParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  */
 /* Portions Copyright 2008 Peter Bray */
 package org.opensolaris.opengrok.history;
@@ -124,9 +124,6 @@ class RazorHistoryParser {
                             parseDebug("Setting Message : '" + details + "'");
                             entry.setMessage(details);
                             lastWasTitle = true;
-                        } else if ("ISSUE".equals(infoType)) {
-                            parseDebug("Adding CR : '" + details + "'");
-                            entry.addChangeRequest(details);
                         } else {
                             parseDebug("Ignoring Info Type Line '" + line + "'");
                         }

--- a/test/org/opensolaris/opengrok/history/HistoryEntryTest.java
+++ b/test/org/opensolaris/opengrok/history/HistoryEntryTest.java
@@ -18,15 +18,12 @@
  */
 
 /*
- * Copyright (c) 2008, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  */
-
 package org.opensolaris.opengrok.history;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 import java.util.TreeSet;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -86,8 +83,6 @@ public class HistoryEntryTest {
         instance.setActive(false);
         instance.addFile("testFile1.txt");
         instance.addFile("testFile2.txt");
-        instance.addChangeRequest("CR1");
-        instance.addChangeRequest("CR2");
         instance.dump();
     }
 
@@ -244,30 +239,6 @@ public class HistoryEntryTest {
     public void testToString() {
         assertTrue(instance.toString().contains(historyRevision));
         assertTrue(instance.toString().contains(historyAuthor));
-    }
-
-    /**
-     * Test of addChangeRequest method, of class HistoryEntry.
-     */
-    @Test
-    public void addGetChangeRequest() {
-        String changeRequest = "Change Request";
-        assertEquals(0, instance.getChangeRequests().size());
-        instance.addChangeRequest(changeRequest);
-        assertEquals(1, instance.getChangeRequests().size());
-        assertTrue(instance.getChangeRequests().contains(changeRequest));
-    }
-
-    /**
-     * Test of setChangeRequests method, of class HistoryEntry.
-     */
-    @Test
-    public void setChangeRequests() {
-        List<String> changeRequests = new ArrayList<String>();
-        changeRequests.add("CR1");
-        changeRequests.add("CR2");
-        instance.setChangeRequests(changeRequests);
-        assertEquals(2, instance.getChangeRequests().size());
     }
 
     /**


### PR DESCRIPTION
Removed `changeRequests` field from `HistoryEntry`. This field was not used at all. Some data were inserted from `Razor` SCM but they were not consumed.

Thanks for considering this PR :) 
