### PR TITLE
document and handle InvalidPathException in history parsers

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -96,6 +96,7 @@ import org.opensolaris.opengrok.web.Statistics;
 import org.opensolaris.opengrok.web.Util;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
+import java.nio.file.InvalidPathException;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
@@ -408,9 +409,11 @@ public final class RuntimeEnvironment {
      * @throws FileNotFoundException if the file is not relative to source root
      * @throws ForbiddenSymlinkException if symbolic-link checking encounters
      * an ineligible link
+     * @throws InvalidPathException if the path cannot be decoded
      */
     public String getPathRelativeToSourceRoot(File file, int stripCount)
-            throws IOException, ForbiddenSymlinkException {
+            throws IOException, ForbiddenSymlinkException, FileNotFoundException,
+            InvalidPathException {
         String sourceRoot = getSourceRootPath();
         if (sourceRoot == null) {
             throw new FileNotFoundException("Source Root Not Found");

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -44,6 +44,7 @@ import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
@@ -96,7 +97,6 @@ import org.opensolaris.opengrok.web.Statistics;
 import org.opensolaris.opengrok.web.Util;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
-import java.nio.file.InvalidPathException;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;

--- a/src/org/opensolaris/opengrok/history/BazaarHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/BazaarHistoryParser.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.InvalidPathException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -175,6 +176,8 @@ class BazaarHistoryParser implements Executor.StreamHandler {
                         } catch (ForbiddenSymlinkException e) {
                             LOGGER.log(Level.FINER, e.getMessage());
                             // ignored
+                        } catch (InvalidPathException e) {
+                            LOGGER.log(Level.WARNING, e.getMessage());
                         }
                     }
                     break;

--- a/src/org/opensolaris/opengrok/history/GitHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/GitHistoryParser.java
@@ -30,6 +30,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.InvalidPathException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -139,6 +140,8 @@ class GitHistoryParser implements Executor.StreamHandler {
                     } catch (FileNotFoundException e) { //NOPMD
                         // If the file is not located under the source root,
                         // ignore it (bug #11664).
+                    } catch (InvalidPathException e) {
+                        LOGGER.log(Level.WARNING, e.getMessage());
                     }
                 }
             }

--- a/src/org/opensolaris/opengrok/history/MercurialHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/MercurialHistoryParser.java
@@ -29,6 +29,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.InvalidPathException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -150,6 +151,8 @@ class MercurialHistoryParser implements Executor.StreamHandler {
                         } catch (FileNotFoundException e) { // NOPMD
                             // If the file is not located under the source root,
                             // ignore it (bug #11664).
+                        } catch (InvalidPathException e) {
+                            LOGGER.log(Level.WARNING, e.getMessage());
                         }
                     }
                 }

--- a/src/org/opensolaris/opengrok/history/MonotoneHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/MonotoneHistoryParser.java
@@ -29,6 +29,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.InvalidPathException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -174,6 +175,8 @@ class MonotoneHistoryParser implements Executor.StreamHandler {
                                 // ignore
                             } catch (FileNotFoundException e) { // NOPMD
                                 // If the file is not located under the source root, ignore it
+                            } catch (InvalidPathException e) {
+                                LOGGER.log(Level.WARNING, e.getMessage());
                             }
                         }
                     }

--- a/src/org/opensolaris/opengrok/util/PathUtils.java
+++ b/src/org/opensolaris/opengrok/util/PathUtils.java
@@ -26,6 +26,7 @@ package org.opensolaris.opengrok.util;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.util.Deque;
 import java.util.LinkedList;
@@ -94,10 +95,11 @@ public class PathUtils {
      * for portions of {@code path}
      * @throws ForbiddenSymlinkException if symbolic-link checking is active
      * and it encounters an ineligible link
+     * @throws InvalidPathException if path cannot be decoded
      */
     public static String getRelativeToCanonical(String path, String canonical,
         Set<String> allowedSymlinks)
-            throws IOException, ForbiddenSymlinkException {
+            throws IOException, ForbiddenSymlinkException, InvalidPathException {
 
         if (path.equals(canonical)) return "";
 


### PR DESCRIPTION
With this change it is possible to index internal Solaris source code repository (that contains UTF-8 file names) on a system with `LC_ALL="C"` and `LANG=""`.