### PR TITLE
OpenGrok help uses bashism

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -927,7 +927,7 @@ UpdateDescriptionCache()
 
 OpenGrokUsage()
 {
-    [ "$1" == "--detailed" ] && helpargs=$1
+    [ "$1" = "--detailed" ] && helpargs=$1
     echo "Options for opengrok.jar:" 1>&2
     ${DO} ${JAVA} ${JAVA_OPTS} -jar "${OPENGROK_JAR}" '-?' $helpargs
 }


### PR DESCRIPTION
On systems where /bin/sh is dash (like Debian), invoking OpenGrok help
will print the following error message along with its output:

./OpenGrok: 930: [: unexpected operator

Also, the --detailed option won't print all the detailed help.

This patch replaces a bashism (the == operator) with standard shell
syntax (the = operator).