### PR TITLE
Store and verify AnalyzerGuru and Analyzer versions

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -120,6 +120,14 @@ Supported Environment Variables for configuring the default setup:
                                   OPENGROK_IGNORE_PATTERNS="-i d:dummy"
                                   Multiple entries can be joined together:
                                     "-i dummy -i d:tmp -i f:dummy"
+  - OPENGROK_ASSIGNMENTS        Assign/Unassign specialized analyzers using
+                                  (.ext|prefix.):(-|Analyzer) syntax. E.g.,
+                                  .lib:Ignorant,Makefile.:- to set files ending
+                                  with .LIB (case-insensitive) to use the
+                                  IgnorantAnalyzerFactory (case-sensitive due to
+                                  Java limitation), and to clear special
+                                  handling for files starting with MAKEFILE
+                                  (case-insensitive and no full-stop)
   - OPENGROK_SCAN_REPOS         Disable Scan for repositories (*)
   - OPENGROK_SCAN_DEPTH         how deep should scanning for repos go
                                 (by default 3 directories from SRC_ROOT)
@@ -444,6 +452,11 @@ ${BZR:+-Dorg.opensolaris.opengrok.history.Bazaar=$BZR} \
     if [ -n "${OPENGROK_PROGRESS}" ]
     then
         PROGRESS="--progress"
+    fi
+
+    if [ "$OPENGROK_ASSIGNMENTS" != "" ]; then
+        ASSIGNMENTS="`echo $OPENGROK_ASSIGNMENTS | sed 's/[:space:]+/_/g'`"
+        ASSIGNMENTS="-A `echo $ASSIGNMENTS | sed 's/,/ -A /g'`"
     fi
 }
 
@@ -878,6 +891,7 @@ CommonInvocation()
         ${CTAGS_OPTIONS_FILE:+-o} ${CTAGS_OPTIONS_FILE}         	\
         ${OPENGROK_FLUSH_RAM_BUFFER_SIZE} ${SKIN} ${LEADING_WILDCARD}	\
         ${OPENGROK_PARALLELISM:+--threads} ${OPENGROK_PARALLELISM}	\
+        ${ASSIGNMENTS}							\
         ${READ_XML_CONF}                                        	\
         ${WEBAPP_CONFIG}						\
         ${WEBAPP_CONTEXT}						\

--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -54,7 +54,6 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedDocValuesField;
-import org.apache.lucene.document.StoredField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.util.BytesRef;
@@ -354,6 +353,10 @@ public class AnalyzerGuru {
         return ANALYZER_VERSIONS.getOrDefault(fileTypeName, Long.MIN_VALUE);
     }
 
+    public static Map<String, Long> getAnalyzersVersionNos() {
+        return Collections.unmodifiableMap(ANALYZER_VERSIONS);
+    }
+
     public static Map<String, FileAnalyzerFactory> getExtensionsMap() {
         return Collections.unmodifiableMap(ext);
     }
@@ -571,8 +574,6 @@ public class AnalyzerGuru {
 
             String type = fa.getFileTypeName();
             doc.add(new StringField(QueryBuilder.TYPE, type, Store.YES));
-
-            doc.add(new StoredField(QueryBuilder.ZVER, fa.getVersionNo()));
         }
     }
 

--- a/src/org/opensolaris/opengrok/analysis/FileAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/FileAnalyzer.java
@@ -63,6 +63,7 @@ public class FileAnalyzer extends Analyzer {
     private static final Logger LOGGER = LoggerFactory.getLogger(FileAnalyzer.class);
 
     protected Project project;
+    protected Ctags ctags;
     protected boolean scopesEnabled;
     protected boolean foldingEnabled;
     private final FileAnalyzerFactory factory;
@@ -126,7 +127,31 @@ public class FileAnalyzer extends Analyzer {
             return null;
         }
     }
-    protected Ctags ctags;
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * <p>
+     * The value is the union of a {@link FileAnalyzer} root version and the
+     * value from {@link #getSpecializedVersionNo()}. Changing the root version
+     * affects all analyzers simultaneously; while subclasses can override
+     * {@link #getSpecializedVersionNo()} to allow changes that affect a few.
+     * @return (20061115_01 &lt;&lt; 32) | {@link #getSpecializedVersionNo()}
+     */
+    public final long getVersionNo() {
+        final int rootVersionNo = 20061115_01; // Edit comment above too!
+        return ((long)rootVersionNo << 32) | getSpecializedVersionNo();
+    }
+
+    /**
+     * Subclasses should override to produce a value relevant for the evolution
+     * of their analysis in each release.
+     * @return 0
+     */
+    protected int getSpecializedVersionNo() {
+        return 0; // FileAnalyzer is not specialized.
+    }
 
     public void setCtags(Ctags ctags) {
         this.ctags = ctags;

--- a/src/org/opensolaris/opengrok/analysis/FileAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/FileAnalyzer.java
@@ -20,7 +20,7 @@
  /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
  * Use is subject to license terms.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 

--- a/src/org/opensolaris/opengrok/analysis/TextAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/TextAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
 
@@ -47,6 +47,17 @@ public abstract class TextAnalyzer extends FileAnalyzer {
     protected TextAnalyzer(FileAnalyzerFactory factory,
         JFlexTokenizer symbolTokenizer) {
         super(factory, symbolTokenizer);
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171223_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171223_00; // Edit comment above too!
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/ada/AdaAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/ada/AdaAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.ada;
 
@@ -45,6 +45,17 @@ public class AdaAnalyzer extends AbstractSourceCodeAnalyzer {
     protected AdaAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new AdaSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
     
     /**

--- a/src/org/opensolaris/opengrok/analysis/archive/BZip2Analyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/archive/BZip2Analyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.archive;
 
@@ -55,11 +55,23 @@ public class BZip2Analyzer extends FileAnalyzer {
     protected BZip2Analyzer(FileAnalyzerFactory factory) {
         super(factory);
     }
-    private FileAnalyzer fa;
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180111_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180111_00; // Edit comment above too!
+    }
 
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut)
             throws IOException, InterruptedException {
+        FileAnalyzer fa;
+
         StreamSource bzSrc = wrap(src);
         String path = doc.get("path");
         if (path != null
@@ -69,9 +81,7 @@ public class BZip2Analyzer extends FileAnalyzer {
             try (InputStream in = bzSrc.getStream()) {
                 fa = AnalyzerGuru.getAnalyzer(in, newname);
             }
-            if (fa instanceof BZip2Analyzer) {
-                fa = null;
-            } else {
+            if (!(fa instanceof BZip2Analyzer)) {
                 if (fa.getGenre() == Genre.PLAIN || fa.getGenre() == Genre.XREFABLE) {
                     this.g = Genre.XREFABLE;
                 } else {

--- a/src/org/opensolaris/opengrok/analysis/archive/GZIPAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/archive/GZIPAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.archive;
 
@@ -61,11 +61,23 @@ public class GZIPAnalyzer extends FileAnalyzer {
     protected GZIPAnalyzer(FileAnalyzerFactory factory) {
         super(factory);
     }
-    private FileAnalyzer fa;
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180111_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180111_00; // Edit comment above too!
+    }
 
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut)
             throws IOException, InterruptedException {
+        FileAnalyzer fa;
+
         StreamSource gzSrc = wrap(src);
         String path = doc.get("path");
         if (path != null

--- a/src/org/opensolaris/opengrok/analysis/archive/TarAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/archive/TarAnalyzer.java
@@ -48,6 +48,17 @@ public class TarAnalyzer extends FileAnalyzer {
         super(factory);
     }
 
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180112_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180112_00; // Edit comment above too!
+    }
+
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
         ArrayList<String> names = new ArrayList<>();

--- a/src/org/opensolaris/opengrok/analysis/archive/ZipAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/archive/ZipAnalyzer.java
@@ -48,6 +48,17 @@ public class ZipAnalyzer extends FileAnalyzer {
         super(factory);
     }
 
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180112_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180112_00; // Edit comment above too!
+    }
+
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
         ArrayList<String> names = new ArrayList<>();

--- a/src/org/opensolaris/opengrok/analysis/c/CAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/c/CAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.c;
 
@@ -46,6 +46,17 @@ public class CAnalyzer extends AbstractSourceCodeAnalyzer {
     protected CAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new CSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
         
     /**

--- a/src/org/opensolaris/opengrok/analysis/c/CxxAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/c/CxxAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.c;
 
@@ -45,6 +45,17 @@ public class CxxAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new CxxSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }      
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link CxxXref} instance.

--- a/src/org/opensolaris/opengrok/analysis/clojure/ClojureAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/clojure/ClojureAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.clojure;
 
@@ -35,6 +35,17 @@ public class ClojureAnalyzer extends AbstractSourceCodeAnalyzer {
     protected ClojureAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new ClojureSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
     
     /**

--- a/src/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/csharp/CSharpAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.csharp;
 
@@ -39,6 +39,17 @@ public class CSharpAnalyzer extends AbstractSourceCodeAnalyzer {
     protected CSharpAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new CSharpSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
    
     /**

--- a/src/org/opensolaris/opengrok/analysis/document/MandocAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/document/MandocAnalyzer.java
@@ -51,6 +51,17 @@ public class MandocAnalyzer extends TextAnalyzer {
             FileAnalyzer.dummyReader)));
     }
 
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
+
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut)
         throws IOException {

--- a/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/document/TroffAnalyzer.java
@@ -53,6 +53,17 @@ public class TroffAnalyzer extends TextAnalyzer {
         super(factory, new JFlexTokenizer(new TroffFullTokenizer(
             FileAnalyzer.dummyReader)));
     }    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180112_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180112_00; // Edit comment above too!
+    }
     
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {        

--- a/src/org/opensolaris/opengrok/analysis/eiffel/EiffelAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/eiffel/EiffelAnalyzer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.eiffel;
@@ -42,6 +42,17 @@ public class EiffelAnalyzer extends AbstractSourceCodeAnalyzer {
     protected EiffelAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new EiffelSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/erlang/ErlangAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/erlang/ErlangAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.erlang;
@@ -40,6 +40,17 @@ public class ErlangAnalyzer extends AbstractSourceCodeAnalyzer {
     protected ErlangAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new ErlangSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/executables/ELFAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/executables/ELFAnalyzer.java
@@ -75,6 +75,17 @@ public class ELFAnalyzer extends FileAnalyzer {
         super(factory);
     }
 
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180112_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180112_00; // Edit comment above too!
+    }
+
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
         String fullpath = doc.get("fullpath");

--- a/src/org/opensolaris/opengrok/analysis/executables/JarAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/executables/JarAnalyzer.java
@@ -49,6 +49,17 @@ public class JarAnalyzer extends FileAnalyzer {
         super(factory);
     }
 
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180112_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180112_00; // Edit comment above too!
+    }
+
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
         StringBuilder fout = new StringBuilder();

--- a/src/org/opensolaris/opengrok/analysis/executables/JavaClassAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/executables/JavaClassAnalyzer.java
@@ -90,6 +90,17 @@ public class JavaClassAnalyzer extends FileAnalyzer {
         super(factory);
     }
 
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180112_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180112_00; // Edit comment above too!
+    }
+
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
         try (InputStream in = src.getStream()) {

--- a/src/org/opensolaris/opengrok/analysis/golang/GolangAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/golang/GolangAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.golang;
@@ -45,6 +45,17 @@ public class GolangAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new GolangSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }   
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link GolangXref} instance.

--- a/src/org/opensolaris/opengrok/analysis/haskell/HaskellAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/haskell/HaskellAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.haskell;
@@ -45,6 +45,17 @@ public class HaskellAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new HaskellSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link HaskellXref} instance.

--- a/src/org/opensolaris/opengrok/analysis/java/JavaAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/java/JavaAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.java;
 
@@ -43,6 +43,17 @@ public class JavaAnalyzer extends AbstractSourceCodeAnalyzer {
     protected JavaAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new JavaSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/javascript/JavaScriptAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.javascript;
 
@@ -45,6 +45,17 @@ public class JavaScriptAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new JavaScriptSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180118_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180118_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link JavaScriptXref} instance.

--- a/src/org/opensolaris/opengrok/analysis/json/JsonAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/json/JsonAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.json;
 
@@ -45,6 +45,17 @@ public class JsonAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new JsonSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link JsonXref} instance.

--- a/src/org/opensolaris/opengrok/analysis/kotlin/KotlinAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/kotlin/KotlinAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.kotlin;
 
@@ -43,6 +43,17 @@ public class KotlinAnalyzer extends AbstractSourceCodeAnalyzer {
     protected KotlinAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new KotlinSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/lisp/LispAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/lisp/LispAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.lisp;
 
@@ -39,6 +39,17 @@ public class LispAnalyzer extends AbstractSourceCodeAnalyzer {
     protected LispAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new LispSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
     
     /**

--- a/src/org/opensolaris/opengrok/analysis/lua/LuaAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/lua/LuaAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.lua;
@@ -45,6 +45,17 @@ public class LuaAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new LuaSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link LuaXref} instance.

--- a/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/pascal/PascalAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.pascal;
 
@@ -44,6 +44,17 @@ public class PascalAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new PascalSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }       
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180125_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180125_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link PascalXref} instance.

--- a/src/org/opensolaris/opengrok/analysis/perl/PerlAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/perl/PerlAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.perl;
 
@@ -43,6 +43,17 @@ public class PerlAnalyzer extends AbstractSourceCodeAnalyzer {
     protected PerlAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new PerlSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
     
     /**

--- a/src/org/opensolaris/opengrok/analysis/php/PhpAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/php/PhpAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.php;
 
@@ -44,6 +44,17 @@ public class PhpAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new PhpSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link PhpXref} instance.

--- a/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/PlainAnalyzer.java
@@ -72,6 +72,17 @@ public class PlainAnalyzer extends TextAnalyzer {
     }
 
     /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180112_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180112_00; // Edit comment above too!
+    }
+
+    /**
      * Creates a wrapped {@link PlainXref} instance.
      * @param reader the data to produce xref for
      * @return an xref instance

--- a/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/plain/XMLAnalyzer.java
@@ -51,6 +51,17 @@ public class XMLAnalyzer extends TextAnalyzer {
         super(factory);
     }
 
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180112_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180112_00; // Edit comment above too!
+    }
+
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
         doc.add(new OGKTextField(QueryBuilder.FULL,

--- a/src/org/opensolaris/opengrok/analysis/powershell/PowershellAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/powershell/PowershellAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.powershell;
 
@@ -45,6 +45,17 @@ public class PowershellAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new PoshSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
 
     @Override
     protected boolean supportsScopes() {

--- a/src/org/opensolaris/opengrok/analysis/python/PythonAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/python/PythonAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.python;
 
@@ -43,6 +43,17 @@ public class PythonAnalyzer extends AbstractSourceCodeAnalyzer {
     protected PythonAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new PythonSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
     
     /**

--- a/src/org/opensolaris/opengrok/analysis/ruby/RubyAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/ruby/RubyAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.ruby;
@@ -44,6 +44,17 @@ public class RubyAnalyzer extends AbstractSourceCodeAnalyzer {
     protected RubyAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new RubySymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/rust/RustAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/rust/RustAnalyzer.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2016 Nikolay Denev.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opensolaris.opengrok.analysis.rust;
@@ -47,6 +47,17 @@ public class RustAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new RustSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link RustXref} instance.

--- a/src/org/opensolaris/opengrok/analysis/scala/ScalaAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/scala/ScalaAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.scala;
 
@@ -43,6 +43,17 @@ public class ScalaAnalyzer extends AbstractSourceCodeAnalyzer {
     protected ScalaAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new ScalaSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
     
     /**

--- a/src/org/opensolaris/opengrok/analysis/sh/ShAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/sh/ShAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.sh;
 
@@ -45,6 +45,17 @@ public class ShAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new ShSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link ShXref} instance.

--- a/src/org/opensolaris/opengrok/analysis/sql/PLSQLAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/sql/PLSQLAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.sql;
 
@@ -32,6 +32,17 @@ public class PLSQLAnalyzer extends PlainAnalyzer {
 
     public PLSQLAnalyzer(FileAnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/sql/SQLAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/sql/SQLAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.sql;
 
@@ -32,6 +32,17 @@ public class SQLAnalyzer extends PlainAnalyzer {
 
     public SQLAnalyzer(FileAnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/swift/SwiftAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/swift/SwiftAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.swift;
 
@@ -43,6 +43,17 @@ public class SwiftAnalyzer extends AbstractSourceCodeAnalyzer {
     protected SwiftAnalyzer(FileAnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new SwiftSymbolTokenizer(
             FileAnalyzer.dummyReader)));
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
     }
 
     /**

--- a/src/org/opensolaris/opengrok/analysis/tcl/TclAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/tcl/TclAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.tcl;
 
@@ -40,6 +40,17 @@ public class TclAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new TclSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link TclXref} instance.

--- a/src/org/opensolaris/opengrok/analysis/uue/UuencodeAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/uue/UuencodeAnalyzer.java
@@ -53,6 +53,17 @@ public class UuencodeAnalyzer extends TextAnalyzer {
             FileAnalyzer.dummyReader)));
     }
 
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180112_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180112_00; // Edit comment above too!
+    }
+
     @Override
     public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {        
         //this is to explicitly use appropriate analyzers tokenstream to workaround #1376 symbols search works like full text search 

--- a/src/org/opensolaris/opengrok/analysis/vb/VBAnalyzer.java
+++ b/src/org/opensolaris/opengrok/analysis/vb/VBAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis.vb;
 
@@ -44,6 +44,17 @@ public class VBAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new VBSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20171218_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20171218_00; // Edit comment above too!
+    }
 
     /**
      * Creates a wrapped {@link VBXref} instance.

--- a/src/org/opensolaris/opengrok/index/IndexAnalysisSettingsUpgrader.java
+++ b/src/org/opensolaris/opengrok/index/IndexAnalysisSettingsUpgrader.java
@@ -1,0 +1,67 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.index;
+
+import java.io.IOException;
+
+/**
+ * Represents a converter to upgrade earlier binary representations of
+ * index-analysis-settings to the latest version.
+ */
+public class IndexAnalysisSettingsUpgrader {
+
+    /**
+     * De-serialize the specified {@code bytes}, and upgrade if necessary from
+     * an older version to the current object version which is
+     * {@link IndexAnalysisSettings2}.
+     * @param bytes a defined instance
+     * @param objver a value greater than or equal to 1
+     * @return a defined instance
+     * @throws ClassNotFoundException if class of a serialized object cannot be
+     * found
+     * @throws IOException if any of the usual Input/Output related exceptions
+     */
+    public IndexAnalysisSettings2 upgrade(byte[] bytes, int objver)
+            throws ClassNotFoundException, IOException {
+        switch (objver) {
+            case 1:
+                IndexAnalysisSettings old1 = IndexAnalysisSettings.deserialize(
+                        bytes);
+                return convertFromV1(old1);
+            case 2:
+                return IndexAnalysisSettings2.deserialize(bytes);
+            default:
+                throw new IllegalArgumentException("Unknown version " + objver);
+        }
+    }
+
+    private IndexAnalysisSettings2 convertFromV1(IndexAnalysisSettings old1) {
+        IndexAnalysisSettings2 res = new IndexAnalysisSettings2();
+        res.setAnalyzerGuruVersion(old1.getAnalyzerGuruVersion());
+        res.setProjectName(old1.getProjectName());
+        res.setTabSize(old1.getTabSize());
+        // Version 1 has no analyzersVersions, so nothing more to do.
+        return res;
+    }
+}

--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -63,10 +63,12 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
@@ -108,6 +110,8 @@ public class IndexDatabase {
     private static final Comparator<File> FILENAME_COMPARATOR =
         (File p1, File p2) -> p1.getName().compareTo(p2.getName());
 
+    private static final Set<String> CHECK_FIELDS;
+
     private final Object INSTANCE_LOCK = new Object();
 
     private Project project;
@@ -117,6 +121,7 @@ public class IndexDatabase {
     private IndexAnalysisSettings settings;
     private PendingFileCompleter completer;
     private TermsEnum uidIter;
+    private PostingsEnum postsIter;
     private IgnoredNames ignoredNames;
     private Filter includedNames;
     private AnalyzerGuru analyzerGuru;
@@ -157,6 +162,12 @@ public class IndexDatabase {
         this.project = project;
         lockfact = NoLockFactory.INSTANCE;
         initialize();
+    }
+
+    static {
+        CHECK_FIELDS = new HashSet<>();
+        CHECK_FIELDS.add(QueryBuilder.ZVER);
+        CHECK_FIELDS.add(QueryBuilder.TYPE);
     }
 
     /**
@@ -390,6 +401,7 @@ public class IndexDatabase {
         writer = null;
         settings = null;
         uidIter = null;
+        postsIter = null;
 
         IOException finishingException = null;
         try {
@@ -695,10 +707,7 @@ public class IndexDatabase {
      */
     private void addFile(File file, String path, Ctags ctags)
             throws IOException, InterruptedException {
-        FileAnalyzer fa;
-        try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
-            fa = AnalyzerGuru.getAnalyzer(in, path);
-        }
+        FileAnalyzer fa = getAnalyzerFor(file, path);
 
         for (IndexChangedListener listener : listeners) {
             listener.fileAdd(path, fa.getClass().getSimpleName());
@@ -747,6 +756,15 @@ public class IndexDatabase {
         setDirty();
         for (IndexChangedListener listener : listeners) {
             listener.fileAdded(path, fa.getClass().getSimpleName());
+        }
+    }
+
+    private FileAnalyzer getAnalyzerFor(File file, String path)
+            throws IOException {
+        FileAnalyzer fa;
+        try (InputStream in = new BufferedInputStream(
+                new FileInputStream(file))) {
+            return AnalyzerGuru.getAnalyzer(in, path);
         }
     }
 
@@ -1004,7 +1022,7 @@ public class IndexDatabase {
                          */
                         if (uidIter != null && uidIter.term() != null
                                 && uidIter.term().bytesEquals(buid)) {
-                            boolean chkres = chkSettings(path);
+                            boolean chkres = chkSettings(file, path);
                             if (!chkres) {
                                 removeFile(false);
                             }
@@ -1526,11 +1544,13 @@ public class IndexDatabase {
     }
 
     /**
-     * Verify TABSIZE, or return a value to indicate mismatch.
+     * Verify TABSIZE, and evaluate AnalyzerGuru version together with ZVER --
+     * or return a value to indicate mismatch.
+     * @param file the source file object
      * @param path the source file path
      * @return {@code false} if a mismatch is detected
      */
-    private boolean chkSettings(String path) {
+    private boolean chkSettings(File file, String path) throws IOException {
         int reqTabSize = project != null && project.hasTabSizeSetting() ?
             project.getTabSize() : 0;
         Integer actTabSize = settings.getTabSize();
@@ -1539,7 +1559,76 @@ public class IndexDatabase {
             return false;
         }
 
-        // TODO: verify ANALYZER_GURU_VERSION and ANALYZER_VERSION.
+        int n = 0;
+        postsIter = uidIter.postings(postsIter);
+        while (postsIter.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
+            ++n;
+            // Read a limited-fields version of the document.
+            Document doc = reader.document(postsIter.docID(), CHECK_FIELDS);
+            if (doc == null) {
+                LOGGER.log(Level.FINER, "No Document: {0}", path);
+                continue;
+            }
+
+            long reqGuruVersion = AnalyzerGuru.getVersionNo();
+            Long actGuruVersion = settings.getAnalyzerGuruVersion();
+            /**
+             * For an older OpenGrok index that does not yet have a defined,
+             * stored analyzerGuruVersion, break so that no extra work is done.
+             * After a re-index, the guru version check will be active.
+             */
+            if (actGuruVersion == null) {
+                break;
+            }
+
+            String fileTypeName;
+            if (actGuruVersion.equals(reqGuruVersion)) {
+                fileTypeName = doc.get(QueryBuilder.TYPE);
+                if (fileTypeName == null) {
+                    // (Should not get here, but break just in case.)
+                    LOGGER.log(Level.FINEST, "Missing TYPE field: {0}", path);
+                    break;
+                }
+            } else {
+                /**
+                 * If the stored guru version does not match, re-verify the
+                 * selection of analyzer or return a value to indicate the
+                 * analyzer is now mis-matched.
+                 */
+                LOGGER.log(Level.FINER, "Guru version mismatch: {0}", path);
+
+                FileAnalyzer fa = getAnalyzerFor(file, path);
+                fileTypeName = fa.getFileTypeName();
+                String oldTypeName = doc.get(QueryBuilder.TYPE);
+                if (!fileTypeName.equals(oldTypeName)) {
+                    if (LOGGER.isLoggable(Level.FINE)) {
+                        LOGGER.log(Level.FINE, "Changed {0} to {1}: {2}",
+                            new Object[]{oldTypeName, fileTypeName, path});
+                    }
+                    return false;
+                }
+            }
+
+            // Verify ZVER, or return a value to indicate mismatch.
+            long reqVersion = AnalyzerGuru.getAnalyzerVersionNo(fileTypeName);
+            IndexableField zver = doc.getField(QueryBuilder.ZVER);
+            Long actVersion = zver == null ? null :
+                zver.numericValue().longValue();
+            if (actVersion == null || !actVersion.equals(reqVersion)) {
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE, "{0} version mismatch: {1}",
+                        new Object[]{fileTypeName, path});
+                }
+                return false;
+            }
+
+            // The versions checks have passed.
+            break;
+        }
+        if (n < 1) {
+            LOGGER.log(Level.FINER, "Missing index Documents: {0}", path);
+            return false;
+        }
 
         // Assume "true" if otherwise no discrepancies were observed.
         return true;

--- a/src/org/opensolaris/opengrok/index/Indexer.java
+++ b/src/org/opensolaris/opengrok/index/Indexer.java
@@ -406,14 +406,15 @@ public final class Indexer {
                 "-A (.ext|prefix.):(-|analyzer)", "--analyzer", "/(\\.\\w+|\\w+\\.):(-|[a-zA-Z_0-9.]+)/",
                     "Files with the named prefix/extension should be analyzed",
                     "with the given analyzer, where 'analyzer' may be specified",
-                    "using a simple class name (CAnalyzer) or language name (C)",
+                    "using a simple class name (RubyAnalyzer) or language name (C)",
                     "(Note, analyzer specification is case sensitive)",
                     "  Ex: -A .foo:CAnalyzer",
-                    "      will use the C analyzer for all files ending with .foo",
-                    "  Ex: -A bar.:C",
-                    "      will use the C analyzer for all files starting with bar.",
+                    "      will use the C analyzer for all files ending with .FOO",
+                    "  Ex: -A bar.:Perl",
+                    "      will use the Perl analyzer for all files starting",
+                    "      with \"BAR\" (no full-stop)",
                     "  Ex: -A .c:-",
-                    "      will disable the C analyzer for for all files ending with .c").
+                    "      will disable specialized analyzers for all files ending with .c").
                 Do( analyzerSpec -> {
                     String[] arg = ((String)analyzerSpec).split(":");
                     String fileSpec = arg[0];

--- a/src/org/opensolaris/opengrok/search/QueryBuilder.java
+++ b/src/org/opensolaris/opengrok/search/QueryBuilder.java
@@ -69,6 +69,7 @@ public class QueryBuilder {
     public static final String DATE = "date";
     public static final String OBJUID = "objuid"; // object UID
     public static final String OBJSER = "objser"; // object serialized
+    public static final String ZVER = "zver"; // analyzer version
 
     /** Used for paths, so SHA-1 is completely sufficient */
     private static final String DIRPATH_HASH_ALGORITHM = "SHA-1";

--- a/src/org/opensolaris/opengrok/search/QueryBuilder.java
+++ b/src/org/opensolaris/opengrok/search/QueryBuilder.java
@@ -69,7 +69,7 @@ public class QueryBuilder {
     public static final String DATE = "date";
     public static final String OBJUID = "objuid"; // object UID
     public static final String OBJSER = "objser"; // object serialized
-    public static final String ZVER = "zver"; // analyzer version
+    public static final String OBJVER = "objver"; // object version
 
     /** Used for paths, so SHA-1 is completely sufficient */
     private static final String DIRPATH_HASH_ALGORITHM = "SHA-1";

--- a/src/org/opensolaris/opengrok/search/context/Context.java
+++ b/src/org/opensolaris/opengrok/search/context/Context.java
@@ -131,7 +131,8 @@ public class Context {
      * the {@code limit} argument will not be interpreted w.r.t.
      * {@link RuntimeEnvironment#isQuickContextScan()}.
      * @param tabSize optional positive tab size that must accord with the value
-     * used when indexing
+     * used when indexing or else postings may be wrongly shifted until
+     * re-indexing
      * @return Did it get any matching context?
      */
     public boolean getContext2(RuntimeEnvironment env, IndexSearcher searcher,

--- a/src/org/opensolaris/opengrok/web/SearchHelper.java
+++ b/src/org/opensolaris/opengrok/web/SearchHelper.java
@@ -62,7 +62,7 @@ import org.opensolaris.opengrok.analysis.Definitions;
 import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.configuration.SuperIndexSearcher;
-import org.opensolaris.opengrok.index.IndexAnalysisSettings;
+import org.opensolaris.opengrok.index.IndexAnalysisSettings2;
 import org.opensolaris.opengrok.index.IndexAnalysisSettingsAccessor;
 import org.opensolaris.opengrok.index.IndexDatabase;
 import org.opensolaris.opengrok.logger.LoggerFactory;
@@ -217,7 +217,7 @@ public class SearchHelper {
     /**
      * Key is Project name or empty string for null Project
      */
-    private Map<String, IndexAnalysisSettings> mappedAnalysisSettings;
+    private Map<String, IndexAnalysisSettings2> mappedAnalysisSettings;
 
     /**
      * User readable description for file types. Only those listed in
@@ -621,7 +621,7 @@ public class SearchHelper {
      */
     public int getTabSize(Project proj) throws IOException {
         String projectName = proj != null ? proj.getName() : null;
-        IndexAnalysisSettings settings = getSettings(projectName);
+        IndexAnalysisSettings2 settings = getSettings(projectName);
         int tabSize;
         if (settings != null && settings.getTabSize() != null) {
             tabSize = settings.getTabSize();
@@ -639,12 +639,12 @@ public class SearchHelper {
      * @return a defined instance or {@code null} if none is found
      * @throws IOException if an I/O error occurs querying the active reader
      */
-    public IndexAnalysisSettings getSettings(String projectName)
+    public IndexAnalysisSettings2 getSettings(String projectName)
             throws IOException {
         if (mappedAnalysisSettings == null) {
             IndexAnalysisSettingsAccessor dao =
                 new IndexAnalysisSettingsAccessor();
-            IndexAnalysisSettings[] setts = dao.read(reader, Short.MAX_VALUE);
+            IndexAnalysisSettings2[] setts = dao.read(reader, Short.MAX_VALUE);
             mappedAnalysisSettings = map(setts);
         }
 
@@ -652,12 +652,12 @@ public class SearchHelper {
         return mappedAnalysisSettings.get(k);
     }
 
-    private Map<String, IndexAnalysisSettings> map(
-        IndexAnalysisSettings[] setts) {
+    private Map<String, IndexAnalysisSettings2> map(
+        IndexAnalysisSettings2[] setts) {
 
-        Map<String, IndexAnalysisSettings> res = new HashMap<>();
+        Map<String, IndexAnalysisSettings2> res = new HashMap<>();
         for (int i = 0; i < setts.length; ++i) {
-            IndexAnalysisSettings settings = setts[i];
+            IndexAnalysisSettings2 settings = setts[i];
             String k = settings.getProjectName() != null ?
                 settings.getProjectName() : "";
             res.put(k, settings);

--- a/test/org/opensolaris/opengrok/index/IndexAnalysisSettings2Test.java
+++ b/test/org/opensolaris/opengrok/index/IndexAnalysisSettings2Test.java
@@ -24,19 +24,30 @@
 package org.opensolaris.opengrok.index;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opensolaris.opengrok.search.QueryBuilder;
 
 /**
- * Represents a test class for {@link IndexAnalysisSettings}.
+ * Represents a test class for {@link IndexAnalysisSettings2}.
  */
-public class IndexAnalysisSettingsTest {
+public class IndexAnalysisSettings2Test {
 
     private static final String PROJECT_NAME = "foo-1-2-3";
     private static final long ANALYZER_GURU_VERSION = 3;
     private static final int TABSIZE = 17;
+    private static final Map<String, Long> ANALYZER_VERSIONS = new HashMap<>();
+
+    @BeforeClass
+    public static void setUpClass() {
+        ANALYZER_VERSIONS.put("abc", 6L);
+        ANALYZER_VERSIONS.put("ABC", 45L);
+        ANALYZER_VERSIONS.put("d e", Long.MAX_VALUE - 19);
+    }
 
     @Test
     public void shouldAffirmINDEX_ANALYSIS_SETTINGS_OBJUID() {
@@ -49,10 +60,10 @@ public class IndexAnalysisSettingsTest {
     @Test
     public void shouldRoundTripANullObject() throws IOException,
             ClassNotFoundException {
-        IndexAnalysisSettings obj = new IndexAnalysisSettings();
+        IndexAnalysisSettings2 obj = new IndexAnalysisSettings2();
         byte[] bin = obj.serialize();
 
-        IndexAnalysisSettings res = IndexAnalysisSettings.deserialize(bin);
+        IndexAnalysisSettings2 res = IndexAnalysisSettings2.deserialize(bin);
         assertNotNull(res);
         assertEquals("projectName", null, res.getProjectName());
         assertEquals("tabSize", null, res.getTabSize());
@@ -62,13 +73,13 @@ public class IndexAnalysisSettingsTest {
     @Test
     public void shouldRoundTripADefinedObject() throws IOException,
             ClassNotFoundException {
-        IndexAnalysisSettings obj = new IndexAnalysisSettings();
+        IndexAnalysisSettings2 obj = new IndexAnalysisSettings2();
         obj.setProjectName(PROJECT_NAME);
         obj.setAnalyzerGuruVersion(ANALYZER_GURU_VERSION);
         obj.setTabSize(TABSIZE);
         byte[] bin = obj.serialize();
 
-        IndexAnalysisSettings res = IndexAnalysisSettings.deserialize(bin);
+        IndexAnalysisSettings2 res = IndexAnalysisSettings2.deserialize(bin);
         assertNotNull(res);
         assertEquals("projectName", PROJECT_NAME, res.getProjectName());
         assertEquals("tabSize", TABSIZE, (int)res.getTabSize());

--- a/test/org/opensolaris/opengrok/index/IndexAnalysisSettingsUpgraderTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexAnalysisSettingsUpgraderTest.java
@@ -1,0 +1,117 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.index;
+
+import java.io.IOException;
+import java.util.Map;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.opensolaris.opengrok.analysis.AnalyzerGuru;
+
+/**
+ * Represents a test container for {@link IndexAnalysisSettingsUpgrader}.
+ */
+public class IndexAnalysisSettingsUpgraderTest {
+
+    private static final String PROJECT_NAME = "foo-1-2-3";
+    private static final long ANALYZER_GURU_VERSION = 3;
+    private static final int TABSIZE = 17;
+
+    @Test
+    public void shouldHandleLatest() throws IOException,
+            ClassNotFoundException {
+        IndexAnalysisSettings2 obj = new IndexAnalysisSettings2();
+        obj.setAnalyzerGuruVersion(ANALYZER_GURU_VERSION);
+        Map<String, Long> actAnalyzersVersionNos =
+                AnalyzerGuru.getAnalyzersVersionNos();
+        obj.setAnalyzersVersions(actAnalyzersVersionNos);
+        obj.setProjectName(PROJECT_NAME);
+        obj.setTabSize(TABSIZE);
+        byte[] bin = obj.serialize();
+
+        IndexAnalysisSettingsUpgrader upgrader =
+                new IndexAnalysisSettingsUpgrader();
+        IndexAnalysisSettings2 vlatest = upgrader.upgrade(bin, 2);
+        assertNotNull(vlatest);
+        assertEquals("projectName", PROJECT_NAME, vlatest.getProjectName());
+        assertEquals("tabSize", TABSIZE, (int)vlatest.getTabSize());
+        assertEquals("analyzerGuruVersion", ANALYZER_GURU_VERSION,
+            (long)vlatest.getAnalyzerGuruVersion());
+        assertTrue("should have expected analyzer versions",
+            vlatest.getAnalyzersVersions().size() ==
+            actAnalyzersVersionNos.size());
+        /**
+         * Smelly but I know the underlying Map implementations are the same;
+         * otherwise the following tests might not work.
+         */
+        assertArrayEquals(actAnalyzersVersionNos.keySet().toArray(),
+            vlatest.getAnalyzersVersions().keySet().toArray());
+        assertArrayEquals(actAnalyzersVersionNos.values().toArray(),
+            vlatest.getAnalyzersVersions().values().toArray());
+    }
+
+    @Test
+    public void shouldUpgradeV1() throws IOException, ClassNotFoundException {
+        IndexAnalysisSettings obj = new IndexAnalysisSettings();
+        obj.setAnalyzerGuruVersion(ANALYZER_GURU_VERSION);
+        obj.setProjectName(PROJECT_NAME);
+        obj.setTabSize(TABSIZE);
+        byte[] bin = obj.serialize();
+
+        IndexAnalysisSettingsUpgrader upgrader =
+                new IndexAnalysisSettingsUpgrader();
+        IndexAnalysisSettings2 v2 = upgrader.upgrade(bin, 1);
+        assertNotNull(v2);
+        assertEquals("projectName", PROJECT_NAME, v2.getProjectName());
+        assertEquals("tabSize", TABSIZE, (int)v2.getTabSize());
+        assertEquals("analyzerGuruVersion", ANALYZER_GURU_VERSION,
+            (long)v2.getAnalyzerGuruVersion());
+        assertTrue("should have no analyzer versions",
+            v2.getAnalyzersVersions().isEmpty());
+    }
+
+    @Test
+    public void shouldThrowIfVersionIsMisrepresented() throws IOException,
+            ClassNotFoundException {
+        IndexAnalysisSettings obj = new IndexAnalysisSettings();
+        obj.setAnalyzerGuruVersion(ANALYZER_GURU_VERSION);
+        obj.setProjectName(PROJECT_NAME);
+        obj.setTabSize(TABSIZE);
+        byte[] bin = obj.serialize();
+
+        IndexAnalysisSettingsUpgrader upgrader =
+                new IndexAnalysisSettingsUpgrader();
+        IndexAnalysisSettings2 res = null;
+        try {
+            res = upgrader.upgrade(bin, 2); // wrong objver
+        } catch (ClassCastException e) {
+            // expected
+        }
+        assertNull("should not have produced an instance", res);
+    }
+}


### PR DESCRIPTION
Hello,

Please consider for integration this patch to store and verify version numbers for `AnalyzerGuru`, `FileAnalyzer`, and `FileAnalyzer` subclasses so that re-analysis can be done in a targeted manner as needed upon certain reconfigurations or upon deploying a new OpenGrok release.

`AnalyzerGuru` version number is a 64-bit value composed from:
* a static 32-bit value incremented by developers upon the addition of a new `FileAnalyzer` subclass (as for the patches in queue to support Forth [4be83daf29] and Objective-C [fbd7de4f249d]) or when existing matching logic is altered (e.g., changing a supported suffix for Fortran).
* a dynamic 32-bit value composed deterministically from users' customizing prefix/extension matching by specifying `-A,--analyzer` or by using the new `OPENGROK_ASSIGNMENTS` environment variable.

On finding a mismatch of `AnalyzerGuru` version for a stored `Document`, OpenGrok will re-determine the appropriate analyzer for the file (possibly changing e.g. from `PlainAnalyzer` to `ObjectiveCAnalyzer`) or decide that the existing analyzer is appropriate and do nothing.

`FileAnalyzer` and subclasses' version number is a 64-bit value composed from:
* a static 32-bit value defined in the `FileAnalyzer` base class that applies to all analyzers.
* a static 32-bit value defined for each specific `FileAnalyzer` subclass.

On finding a mismatch of analyzer version, OpenGrok will re-analyze a file. Such a targeted version update might be used e.g. when fixing a specific support for a specific language's syntax.

(Updating the base class `FileAnalyzer` version will be done very rarely when new developments require that all files be re-analyzed but without requiring users to manually delete their own indexes.)

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
