### PR TITLE
run Jacoco and publish the results to Coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
 script: "mvn -B -V verify"
 
 after_success:
- - mvn clean test jacoco:report coveralls:report
+ - mvn clean test jacoco:report org.eluder.coveralls:coveralls-maven-plugin:report
 
 addons:
   coverity_scan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,8 @@ env:
 # in 'script' no matter if an individual command fails or not. This kludgy
 # looking shell incantation takes care of that.
 #
-script: "mvn -B -V verify"
-
-after_success:
- - mvn clean test jacoco:report org.eluder.coveralls:coveralls-maven-plugin:report
+script:
+ - mvn -B -V verify jacoco:report org.eluder.coveralls:coveralls-maven-plugin:report
 
 addons:
   coverity_scan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ env:
 #
 script: "mvn -B -V verify"
 
+after_success:
+ - mvn clean test jacoco:report coveralls:report
+
 addons:
   coverity_scan:
     project:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 
-Copyright (c) 2006, 2017 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
 
 
-# OpenGrok - a wicked fast source browser [![Build Status](https://travis-ci.org/oracle/opengrok.svg?branch=master)](https://travis-ci.org/oracle/opengrok)
+# OpenGrok - a wicked fast source browser
+[![Build Status](https://travis-ci.org/oracle/opengrok.svg?branch=master)](https://travis-ci.org/oracle/opengrok)
+[![Coverage Status](https://coveralls.io/repos/oracle/opengrok/badge.svg?branch=master)](https://coveralls.io/r/oracle/opengrok?branch=master)
 
 1.  [Introduction](#1-introduction)
 2.  [Requirements](#2-requirements)

--- a/doc/release.txt
+++ b/doc/release.txt
@@ -4,7 +4,7 @@ Release criteria
 Ideally, the following minimum criteria should be fulfilled before a new
 final (i.e. non-prerelease) version is released:
 
-  - The code coverage for blocks must be at least 80%
+  - The overall code coverage must be at least 70%
   - No findbugs warnings
   - No stoppers
   - All bugs and enhancements must be evaluated
@@ -19,7 +19,7 @@ Checklist for releasing OpenGrok:
 
 1) sanity check:
 
-   - index
+   - index fairly large code base, ideally multiple projects
    - deploy webapp
    - check UI:
      - history view
@@ -30,13 +30,9 @@ Checklist for releasing OpenGrok:
        - check sorting using multiple criteria
      - perform search using multiple fields across multiple projects
 
-2) check all tests, tests code coverage:
-   junit, pmd, findbugs, checkstyle, emma, jdepend
+2) check all tests pass, test code coverage is above given threshold
 
-   emma reports should be based according to what is set for the release,
-   usually it's overall coverage above 80%.
-
-   Jenkins can help here.
+   Additional tools to use: pmd, findbugs, checkstyle, jdepend
 
    The release is OK, once above is fulfilled to our satisfaction.
 
@@ -60,4 +56,5 @@ Checklist for releasing OpenGrok:
    of the release, e.g. adding list of issues fixed, whether complete reindex
    is necessary etc.
 
-5) Send announcement to opengrok-users@yahoogroups.com, Slack channel etc.
+5) Send announcement to opengrok-users@yahoogroups.com,
+   the #opengrok Slack channel etc.

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -435,6 +435,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                         <!-- Test helper class with name that confuses surefire -->
                         <exclude>**/TestRepository.java</exclude>
                     </excludes>
+		    <argLine>${surefireArgLine}</argLine>
                 </configuration>
             </plugin>
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -58,6 +58,7 @@ Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
                   <systemPropertyVariables>
                       <junit-force-all>true</junit-force-all>
                   </systemPropertyVariables>
+	          <argLine>${surefireArgLine}</argLine>
               </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                 <version>3.6.1</version>
             </plugin>
             <plugin>
+		<!-- UNIT TEST RUNNER -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
@@ -166,6 +167,14 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                         <reuseForks>false</reuseForks>
                 </configuration>
                 <version>2.20</version>
+		<executions>
+			<execution>
+				<id>run-unit-tests</id>
+				<goals>
+					<goal>test</goal>
+				</goals>
+			</execution>
+		</executions>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -277,21 +286,12 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                 </reportSets>
             </plugin>
             <plugin>
-		<!-- UNIT TEST RUNNER -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>2.20</version>
 		<configuration>
 			<argLine>${surefireArgLine}</argLine>
 		</configuration>
-		<executions>
-			<execution>
-				<id>run-unit-tests</id>
-				<goals>
-					<goal>test</goal>
-				</goals>
-			</execution>
-		</executions>
             </plugin>
 	    <!-- CODE COVERAGE PUBLISHER -->
 	    <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,26 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.7.9</version>
+                <executions>
+			<!-- Prepare execution with Surefire -->
+			<execution>
+				<id>pre-unit-test</id>
+				<goals>
+					<goal>prepare-agent</goal>
+				</goals>
+				<configuration>
+					<propertyName>surefireArgLine</propertyName>
+				</configuration>
+			</execution>
+			<!-- Generate report after tests are run -->
+			<execution>
+				<id>post-unit-test</id>
+				<phase>test</phase>
+				<goals>
+					<goal>report</goal>
+				</goals>
+			</execution>
+                </executions>
             </plugin>
 	    <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -257,10 +277,28 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                 </reportSets>
             </plugin>
             <plugin>
+		<!-- UNIT TEST RUNNER -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>2.20</version>
+		<configuration>
+			<argLine>${surefireArgLine}</argLine>
+		</configuration>
+		<executions>
+			<execution>
+				<id>run-unit-tests</id>
+				<goals>
+					<goal>test</goal>
+				</goals>
+			</execution>
+		</executions>
             </plugin>
+	    <!-- CODE COVERAGE PUBLISHER -->
+	    <plugin>
+		<groupId>org.eluder.coveralls</groupId>
+		<artifactId>coveralls-maven-plugin</artifactId>
+		<version>3.1.0</version>
+	    </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>


### PR DESCRIPTION
Enables Jacoco proper, publishes results to [Coveralls.io](https://coveralls.io/repos) (I enabled the oracle/opengrok repo there).

Used resources:
  - https://angus.nyc/2015/continuous-integration-for-java-github
  - https://stackoverflow.com/questions/12269558/maven-jacoco-plugin-error
  - https://github.com/onelogin/java-saml/issues/74
