### PR TITLE
Properly handle result of getRelativeToCanonical()

### DIFF
--- a/src/org/opensolaris/opengrok/history/HistoryGuru.java
+++ b/src/org/opensolaris/opengrok/history/HistoryGuru.java
@@ -855,10 +855,15 @@ public final class HistoryGuru {
                         e);
                     return null;
                 }
-                String inRootPath = Paths.get(rootKey, rel).toString();
-                Repository r = repositories.get(inRootPath);
-                if (r != null) {
-                    return r;
+                Repository repo;
+                if (rel.equals(nextPath)) {
+                    repo = repositories.get(nextPath);
+                } else {
+                    String inRootPath = Paths.get(rootKey, rel).toString();
+                    repo = repositories.get(inRootPath);
+                }
+                if (repo != null) {
+                    return repo;
                 }
             }
 

--- a/src/org/opensolaris/opengrok/history/RepositoryInfo.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryInfo.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
@@ -131,7 +131,9 @@ public class RepositoryInfo implements Serializable {
             // `directoryNameRelative' must start with a '/', as it is
             // elsewhere directly appended to env.getSourceRootPath() and
             // also stored as such.
-            if (!path.equals(originalPath)) path = File.separator + path;
+            if (!path.equals(originalPath)) {
+                path = File.separator + path;
+            }
         } catch (IOException e) {
             path = originalPath;
             LOGGER.log(Level.SEVERE, String.format(


### PR DESCRIPTION
Hello,

Please consider for integration this patch to fix result handling from `getRelativeToCanonical()`. Existing tests cover this change for Linux and Mac. This may or may not be the solution to issue #2069 on Windows, as I could not test on that environment.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
