### PR TITLE
add the OPENGROK_DEFAULT_PROJECTS env var

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -111,6 +111,9 @@ Supported Environment Variables for configuring the default setup:
   - OPENGROK_ENABLE_PROJECTS    Enable projects, where every directory in
                                   SRC_ROOT is considered a separate project.
                                   on|off (default on) (^)
+  - OPENGROK_DEFAULT_PROJECTS   List of projects (relative to source root,
+                                starting with slash) separated with comma to be
+				selected by default in the UI.
   - OPENGROK_IGNORE_PATTERNS    Set ignored patterns for indexer to skip.
                                   OPENGROK_IGNORE_PATTERNS="-i dummy"
                                   OPENGROK_IGNORE_PATTERNS="-i f:dummy"
@@ -310,6 +313,15 @@ DefaultInstanceConfiguration()
         off|false|0) ENABLE_PROJECTS="" ;;
         *) ENABLE_PROJECTS="-P" ;;
     esac
+
+    if [ -n "${ENABLE_PROJECTS}" ]
+    then
+        DEFAULT_PROJECTS=""
+        for proj in $( IFS=","; echo ${OPENGROK_DEFAULT_PROJECTS} )
+	do
+            DEFAULT_PROJECTS="-p $proj ${DEFAULT_PROJECTS}"
+        done
+    fi
 
     # OPTIONAL: Scanning Options (for Mercurial repositories)
     SCAN_FOR_REPOSITORY="-S"
@@ -883,6 +895,7 @@ StdInvocation()
         -W ${XML_CONFIGURATION}	\
 	${SCAN_FOR_REPOSITORY}	\
 	${ENABLE_PROJECTS}	\
+	${DEFAULT_PROJECTS}	\
         -s "${SRC_ROOT}"	\
 	-d "${DATA_ROOT}"	\
 	"${@}"


### PR DESCRIPTION
passthru for the -p option. I don't like that the shell script is a filter to `Indexer` however until it is rewritten such changes need to happen.