### PR TITLE
Mirror timeout

### DIFF
--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -95,7 +95,7 @@ class Command:
                         self.logger.info("Terminating command {} with PID {} "
                                          "after timeout of {} seconds".
                                          format(p.args, p.pid, self.timeout))
-                        self.popen.terminate()
+                        p.terminate()
                         self.exception = TimeoutException("Command {} with pid"
                                                           " {} timed out".
                                                           format(p.args,

--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -93,8 +93,8 @@ class Command:
                     if not self.condition.wait(self.timeout):
                         p = self.popen
                         self.logger.info("Terminating command {} with PID {} "
-                                         "after timeout".
-                                         format(p.args, p.pid))
+                                         "after timeout of {} seconds".
+                                         format(p.args, p.pid, self.timeout))
                         self.popen.terminate()
                         self.exception = TimeoutException("Command {} with pid"
                                                           " {} timed out".

--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -199,7 +199,7 @@ class Command:
             self.logger.error("Got OS error", exc_info=True)
             self.state = Command.ERRORED
         except TimeoutException as e:
-            self.logger.error("Timed out", exc_info=True)
+            self.logger.error("Timed out")
             self.state = Command.TIMEDOUT
         else:
             self.state = Command.FINISHED

--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -33,6 +33,7 @@ class TimeoutException(Exception):
     """
     Exception returned when command exceeded its timeout.
     """
+    pass
 
 
 class Command:
@@ -103,7 +104,7 @@ class Command:
                     else:
                         return None
 
-            def getexception(self):
+            def get_exception(self):
                 return self.exception
 
         class OutputThread(threading.Thread):
@@ -188,7 +189,7 @@ class Command:
             p.wait()
 
             if self.timeout:
-                e = timeout_thread.getexception()
+                e = timeout_thread.get_exception()
                 if e:
                     raise e
         except KeyboardInterrupt as e:

--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -26,6 +26,13 @@ import logging
 import subprocess
 import string
 import threading
+import time
+
+
+class TimeoutException(Exception):
+    """
+    Exception returned when command exceeded its timeout.
+    """
 
 
 class Command:
@@ -38,14 +45,17 @@ class Command:
     FINISHED = "finished"
     INTERRUPTED = "interrupted"
     ERRORED = "errored"
+    TIMEDOUT = "timed out"
 
     def __init__(self, cmd, args_subst=None, args_append=None, logger=None,
-                 excl_subst=False, work_dir=None, env_vars=None):
+                 excl_subst=False, work_dir=None, env_vars=None, timeout=None):
         self.cmd = cmd
         self.state = "notrun"
         self.excl_subst = excl_subst
         self.work_dir = work_dir
         self.env_vars = env_vars
+        self.timeout = timeout
+        self.pid = None
 
         self.logger = logger or logging.getLogger(__name__)
         logging.basicConfig()
@@ -60,6 +70,41 @@ class Command:
         """
         Execute the command and capture its output and return code.
         """
+
+        class TimeoutThread(threading.Thread):
+            """
+            Wait until the timeout specified in seconds expires and kill
+            the process specified by the Popen object after that.
+            If timeout expires, TimeoutException is stored in the object
+            and can be retrieved by the caller.
+            """
+
+            def __init__(self, logger, timeout, condition, p):
+                super(TimeoutThread, self).__init__()
+                self.timeout = timeout
+                self.popen = p
+                self.condition = condition
+                self.logger = logger
+                self.start()
+                self.exception = None
+
+            def run(self):
+                with self.condition:
+                    if not self.condition.wait(self.timeout):
+                        p = self.popen
+                        self.logger.info("Terminating command {} with PID {} "
+                                         "after timeout".
+                                         format(p.args, p.pid))
+                        self.popen.terminate()
+                        self.exception = TimeoutException("Command {} with pid"
+                                                          " {} timed out".
+                                                          format(p.args,
+                                                                 p.pid))
+                    else:
+                        return None
+
+            def getexception(self):
+                return self.exception
 
         class OutputThread(threading.Thread):
             """
@@ -116,19 +161,36 @@ class Command:
                                   format(self.work_dir), exc_info=True)
                 return
 
-        othr = OutputThread()
+        timeout_thread = None
+        output_thread = OutputThread()
         try:
+            start_time = time.time()
             self.logger.debug("working directory = {}".format(os.getcwd()))
             self.logger.debug("command = {}".format(self.cmd))
             if self.env_vars:
                 my_env = os.environ.copy()
                 my_env.update(self.env_vars)
                 p = subprocess.Popen(self.cmd, stderr=subprocess.STDOUT,
-                                     stdout=othr, env=my_env)
+                                     stdout=output_thread, env=my_env)
             else:
                 p = subprocess.Popen(self.cmd, stderr=subprocess.STDOUT,
-                                     stdout=othr)
+                                     stdout=output_thread)
+
+            self.pid = p.pid
+
+            if self.timeout:
+                condition = threading.Condition()
+                self.logger.debug("Setting timeout to {}".format(self.timeout))
+                timeout_thread = TimeoutThread(self.logger, self.timeout,
+                                               condition, p)
+
+            self.logger.debug("Waiting for process with PID {}".format(p.pid))
             p.wait()
+
+            if self.timeout:
+                e = timeout_thread.getexception()
+                if e:
+                    raise e
         except KeyboardInterrupt as e:
             self.logger.info("Got KeyboardException while processing ",
                              exc_info=True)
@@ -136,13 +198,22 @@ class Command:
         except OSError as e:
             self.logger.error("Got OS error", exc_info=True)
             self.state = Command.ERRORED
+        except TimeoutException as e:
+            self.logger.error("Timed out", exc_info=True)
+            self.state = Command.TIMEDOUT
         else:
             self.state = Command.FINISHED
             self.returncode = int(p.returncode)
             self.logger.debug("{} -> {}".format(self.cmd, self.getretcode()))
         finally:
-            othr.close()
-            self.out = othr.getoutput()
+            if self.timeout != 0 and timeout_thread:
+                with condition:
+                    condition.notifyAll()
+            output_thread.close()
+            self.out = output_thread.getoutput()
+            elapsed_time = time.time() - start_time
+            self.logger.debug("Command {} took {} seconds".
+                              format(self.cmd, int(elapsed_time)))
 
         if orig_work_dir:
             try:
@@ -199,3 +270,6 @@ class Command:
 
     def getstate(self):
         return self.state
+
+    def getpid(self):
+        return self.pid

--- a/tools/sync/cvs.py
+++ b/tools/sync/cvs.py
@@ -27,9 +27,9 @@ from shutil import which
 
 
 class CVSRepository(Repository):
-    def __init__(self, logger, path, project, command, env, hooks):
+    def __init__(self, logger, path, project, command, env, hooks, timeout):
 
-        super().__init__(logger, path, project, command, env, hooks)
+        super().__init__(logger, path, project, command, env, hooks, timeout)
 
         if command:
             self.command = command
@@ -42,7 +42,8 @@ class CVSRepository(Repository):
 
     def reposync(self):
         hg_command = [self.command, "update", "-dP"]
-        cmd = Command(hg_command, work_dir=self.path, env_vars=self.env)
+        cmd = self.getCommand(hg_command, work_dir=self.path,
+                              env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info(cmd.getoutputstr())
         if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:

--- a/tools/sync/git.py
+++ b/tools/sync/git.py
@@ -27,9 +27,9 @@ from shutil import which
 
 
 class GitRepository(Repository):
-    def __init__(self, logger, path, project, command, env, hooks):
+    def __init__(self, logger, path, project, command, env, hooks, timeout):
 
-        super().__init__(logger, path, project, command, env, hooks)
+        super().__init__(logger, path, project, command, env, hooks, timeout)
 
         if command:
             self.command = command
@@ -42,7 +42,8 @@ class GitRepository(Repository):
 
     def reposync(self):
         hg_command = [self.command, "pull", "--ff-only"]
-        cmd = Command(hg_command, work_dir=self.path, env_vars=self.env)
+        cmd = self.getCommand(hg_command, work_dir=self.path,
+                              env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info(cmd.getoutputstr())
         if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:

--- a/tools/sync/hook.py
+++ b/tools/sync/hook.py
@@ -26,7 +26,7 @@ from command import Command
 import logging
 
 
-def run_hook(logger, script, path, env):
+def run_hook(logger, script, path, env, timeout):
     """
     Change a working directory to specified path, run a command
     and change the working directory back to its original value.
@@ -37,7 +37,8 @@ def run_hook(logger, script, path, env):
     ret = 0
     logger.debug("Running hook '{}' in directory {}".
                  format(script, path))
-    cmd = Command([script], work_dir=path, env_vars=env)
+    cmd = Command([script], logger=logger, work_dir=path, env_vars=env,
+                  timeout=timeout)
     cmd.execute()
     if cmd.state is not "finished" or cmd.getretcode() != 0:
         logger.error("command failed: {} -> {}".format(cmd, cmd.getretcode()))

--- a/tools/sync/mercurial.py
+++ b/tools/sync/mercurial.py
@@ -27,9 +27,9 @@ from shutil import which
 
 
 class MercurialRepository(Repository):
-    def __init__(self, logger, path, project, command, env, hooks):
+    def __init__(self, logger, path, project, command, env, hooks, timeout):
 
-        super().__init__(logger, path, project, command, env, hooks)
+        super().__init__(logger, path, project, command, env, hooks, timeout)
 
         if command:
             self.command = command
@@ -42,7 +42,8 @@ class MercurialRepository(Repository):
 
     def get_branch(self):
         hg_command = [self.command, "branch"]
-        cmd = Command(hg_command, work_dir=self.path, env_vars=self.env)
+        cmd = self.getCommand(hg_command, work_dir=self.path,
+                              env_vars=self.env, logger=self.logger)
         cmd.execute()
         if cmd.getstate() != Command.FINISHED:
             self.logger.debug(cmd.getoutput())
@@ -66,7 +67,8 @@ class MercurialRepository(Repository):
         if branch != "default":
             hg_command.append("-b")
             hg_command.append(branch)
-        cmd = Command(hg_command, work_dir=self.path, env_vars=self.env)
+        cmd = self.getCommand(hg_command, work_dir=self.path,
+                              env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info(cmd.getoutputstr())
         #
@@ -81,7 +83,8 @@ class MercurialRepository(Repository):
         if branch != "default":
             hg_command.append("-b")
             hg_command.append(branch)
-        cmd = Command(hg_command, work_dir=self.path, env_vars=self.env)
+        cmd = self.getCommand(hg_command, work_dir=self.path,
+                              env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info(cmd.getoutputstr())
         if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
@@ -93,7 +96,8 @@ class MercurialRepository(Repository):
         # some servers do not support it.
         if branch == "default":
             hg_command.append("--check")
-        cmd = Command(hg_command, work_dir=self.path, env_vars=self.env)
+        cmd = self.getCommand(hg_command, work_dir=self.path,
+                              env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info(cmd.getoutputstr())
         if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:

--- a/tools/sync/mirror.py
+++ b/tools/sync/mirror.py
@@ -139,7 +139,7 @@ if __name__ == '__main__':
                     try:
                         pattern = re.compile(proj)
                     except re.error:
-                        logger.error("Not a valid regular exception: {}".
+                        logger.error("Not a valid regular expression: {}".
                                      format(proj))
                         continue
 

--- a/tools/sync/mirror.py
+++ b/tools/sync/mirror.py
@@ -278,7 +278,7 @@ if __name__ == '__main__':
                 logger.info("Running pre hook")
                 if run_hook(logger, prehook,
                             os.path.join(source_root, args.project),
-                            config.get['proxy'] if use_proxy else None,
+                            config['proxy'] if use_proxy else None,
                             hook_timeout) != 0:
                     logger.error("pre hook failed")
                     logging.shutdown()

--- a/tools/sync/mirror.py
+++ b/tools/sync/mirror.py
@@ -69,6 +69,10 @@ if __name__ == '__main__':
     output = []
     dirs_to_process = []
 
+    # "constants"
+    HOOK_TIMEOUT_PROPERTY = 'hook_timeout'
+    CMD_TIMEOUT_PROPERTY = 'command_timeout'
+
     parser = argparse.ArgumentParser(description='project mirroring')
 
     parser.add_argument('project')
@@ -152,6 +156,14 @@ if __name__ == '__main__':
     if hookdir:
         logger.debug("Hook directory = {}".format(hookdir))
 
+    command_timeout = config.get(CMD_TIMEOUT_PROPERTY)
+    if command_timeout:
+        logger.debug("Global command timeout = {}".format(command_timeout))
+
+    hook_timeout = config.get(HOOK_TIMEOUT_PROPERTY)
+    if hook_timeout:
+        logger.debug("Global hook timeout = {}".format(hook_timeout))
+
     prehook = None
     posthook = None
     ignored_repos = []
@@ -159,6 +171,18 @@ if __name__ == '__main__':
     if project_config:
         logger.debug("Project '{}' has specific (non-default) config".
                      format(args.project))
+
+        project_command_timeout = project_config.get(CMD_TIMEOUT_PROPERTY)
+        if project_command_timeout:
+            command_timeout = project_command_timeout
+            logger.debug("Project command timeout = {}".
+                         format(command_timeout))
+
+        project_hook_timeout = project_config.get(HOOK_TIMEOUT_PROPERTY)
+        if project_hook_timeout:
+            hook_timeout = project_hook_timeout
+            logger.debug("Project hook timeout = {}".
+                         format(hook_timeout))
 
         if project_config.get('ignored_repos'):
             ignored_repos = project_config.get('ignored_repos')
@@ -242,13 +266,15 @@ if __name__ == '__main__':
                              args.project + "-mirror.lock"))
     try:
         with lock.acquire(timeout=0):
-            if prehook and run_hook(logger, prehook,
-                                    os.path.join(source_root, args.project),
-                                    config['proxy'] if use_proxy else None
-                                    ) != 0:
-                logger.error("pre hook failed")
-                logging.shutdown()
-                sys.exit(1)
+            if prehook:
+                logger.info("Running pre hook")
+                if run_hook(logger, prehook,
+                            os.path.join(source_root, args.project),
+                            config.get['proxy'] if use_proxy else None,
+                            hook_timeout) != 0:
+                    logger.error("pre hook failed")
+                    logging.shutdown()
+                    sys.exit(1)
 
             #
             # If one of the repositories fails to sync, the whole project sync
@@ -258,7 +284,7 @@ if __name__ == '__main__':
                 logger.debug("Repository path = {}".format(repo_path))
 
                 if repo_path in ignored_repos:
-                    logger.debug("repository {} ignored".format(repo_path))
+                    logger.info("repository {} ignored".format(repo_path))
                     continue
 
                 repo_type = get_repo_type(logger, repo_path, messages_file)
@@ -275,24 +301,29 @@ if __name__ == '__main__':
                                       args.project,
                                       config.get('commands'),
                                       config['proxy'] if use_proxy else None,
-                                      None)
+                                      None,
+                                      command_timeout)
                 if not repo:
                     logger.error("Cannot get repository for {}".
                                  format(repo_path))
                     ret = 1
                 else:
+                    logger.info("Synchronizing repository {}".
+                                format(repo_path))
                     if repo.sync() != 0:
                         logger.error("failed to sync repository {}".
                                      format(repo_path))
                         ret = 1
 
-            if posthook and run_hook(logger, posthook,
-                                     os.path.join(source_root, args.project),
-                                     config['proxy'] if use_proxy else None
-                                     ) != 0:
-                logger.error("post hook failed")
-                logging.shutdown()
-                sys.exit(1)
+            if posthook:
+                logger.info("Running post hook")
+                if run_hook(logger, posthook,
+                            os.path.join(source_root, args.project),
+                            config['proxy'] if use_proxy else None,
+                            hook_timeout) != 0:
+                    logger.error("post hook failed")
+                    logging.shutdown()
+                    sys.exit(1)
     except Timeout:
         logger.warning("Already running, exiting.")
         sys.exit(1)

--- a/tools/sync/mirror.py
+++ b/tools/sync/mirror.py
@@ -48,7 +48,7 @@ from commands import Commands, CommandsBase
 from repository import Repository
 from mercurial import MercurialRepository
 from repofactory import get_repository
-from utils import is_exe, check_create_dir
+from utils import is_exe, check_create_dir, get_int
 from hook import run_hook
 from readconfig import read_config
 from opengrok import get_repos, get_config_value, get_repo_type
@@ -156,11 +156,13 @@ if __name__ == '__main__':
     if hookdir:
         logger.debug("Hook directory = {}".format(hookdir))
 
-    command_timeout = config.get(CMD_TIMEOUT_PROPERTY)
+    command_timeout = get_int(logger, "command timeout",
+                              config.get(CMD_TIMEOUT_PROPERTY))
     if command_timeout:
         logger.debug("Global command timeout = {}".format(command_timeout))
 
-    hook_timeout = config.get(HOOK_TIMEOUT_PROPERTY)
+    hook_timeout = get_int(logger, "hook timeout",
+                           config.get(HOOK_TIMEOUT_PROPERTY))
     if hook_timeout:
         logger.debug("Global hook timeout = {}".format(hook_timeout))
 
@@ -172,13 +174,19 @@ if __name__ == '__main__':
         logger.debug("Project '{}' has specific (non-default) config".
                      format(args.project))
 
-        project_command_timeout = project_config.get(CMD_TIMEOUT_PROPERTY)
+        project_command_timeout = get_int(logger, "command timeout for "
+                                          "project {}".format(args.project),
+                                          project_config.
+                                          get(CMD_TIMEOUT_PROPERTY))
         if project_command_timeout:
             command_timeout = project_command_timeout
             logger.debug("Project command timeout = {}".
                          format(command_timeout))
 
-        project_hook_timeout = project_config.get(HOOK_TIMEOUT_PROPERTY)
+        project_hook_timeout = get_int(logger, "hook timeout for "
+                                       "project {}".format(args.project),
+                                       project_config.
+                                       get(HOOK_TIMEOUT_PROPERTY))
         if project_hook_timeout:
             hook_timeout = project_hook_timeout
             logger.debug("Project hook timeout = {}".

--- a/tools/sync/repofactory.py
+++ b/tools/sync/repofactory.py
@@ -28,7 +28,8 @@ from svn import SubversionRepository
 from git import GitRepository
 
 
-def get_repository(logger, path, repo_type, project, commands, env, hooks):
+def get_repository(logger, path, repo_type, project, commands, env, hooks,
+                   timeout):
     """
     Repository factory. Returns a Repository derived object according
     to the type specified or None if given repository type cannot
@@ -41,22 +42,22 @@ def get_repository(logger, path, repo_type, project, commands, env, hooks):
     if repo_lower in ["mercurial", "hg"]:
         return MercurialRepository(logger, path, project,
                                    commands.get("hg"),
-                                   env, hooks)
+                                   env, hooks, timeout)
     elif repo_lower in ["teamware", "sccs"]:
         return TeamwareRepository(logger, path, project,
                                   commands.get("teamware"),
-                                  env, hooks)
+                                  env, hooks, timeout)
     elif repo_lower.lower() == "cvs":
         return CVSRepository(logger, path, project,
                              commands.get("cvs"),
-                             env, hooks)
+                             env, hooks, timeout)
     elif repo_lower in ["svn", "subversion"]:
         return SubversionRepository(logger, path, project,
                                     commands.get("svn"),
-                                    env, hooks)
+                                    env, hooks, timeout)
     elif repo_lower == "git":
         return GitRepository(logger, path, project,
                              commands.get("git"),
-                             env, hooks)
+                             env, hooks, timeout)
     else:
         return None

--- a/tools/sync/repository.py
+++ b/tools/sync/repository.py
@@ -22,6 +22,7 @@
 #
 
 import abc
+from command import Command
 
 
 class Repository:
@@ -31,10 +32,12 @@ class Repository:
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, logger, path, project, command, env, hooks):
+    def __init__(self, logger, path, project, command, env, hooks,
+                 timeout):
         self.logger = logger
         self.path = path
         self.project = project
+        self.timeout = timeout
         if env:
             self.env = env
         else:
@@ -42,6 +45,10 @@ class Repository:
 
     def __str__(self):
         return self.path
+
+    def getCommand(self, cmd, **kwargs):
+        kwargs['timeout'] = self.timeout
+        return Command(cmd, **kwargs)
 
     def sync(self):
         # Eventually, there might be per-repository hooks added here.

--- a/tools/sync/svn.py
+++ b/tools/sync/svn.py
@@ -27,9 +27,9 @@ from shutil import which
 
 
 class SubversionRepository(Repository):
-    def __init__(self, logger, path, project, command, env, hooks):
+    def __init__(self, logger, path, project, command, env, hooks, timeout):
 
-        super().__init__(logger, path, project, command, env, hooks)
+        super().__init__(logger, path, project, command, env, hooks, timeout)
 
         if command:
             self.command = command
@@ -67,7 +67,8 @@ class SubversionRepository(Repository):
                                no_proxy)
 
         svn_command.append("update")
-        cmd = Command(svn_command, work_dir=self.path, env_vars=self.env)
+        cmd = self.getCommand(svn_command, work_dir=self.path,
+                              env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info(cmd.getoutputstr())
         if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:

--- a/tools/sync/teamware.py
+++ b/tools/sync/teamware.py
@@ -28,9 +28,9 @@ import os
 
 
 class TeamwareRepository(Repository):
-    def __init__(self, logger, path, project, command, env, hooks):
+    def __init__(self, logger, path, project, command, env, hooks, timeout):
 
-        super().__init__(logger, path, project, command, env, hooks)
+        super().__init__(logger, path, project, command, env, hooks, timeout)
 
         #
         # Teamware is different than the rest of the repositories.
@@ -69,7 +69,8 @@ class TeamwareRepository(Repository):
             return 0
 
         bringover_command = ["bringover"]
-        cmd = Command(bringover_command, work_dir=self.path, env_vars=self.env)
+        cmd = self.getCommand(bringover_command, work_dir=self.path,
+                              env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info(cmd.getoutputstr())
         if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:

--- a/tools/sync/utils.py
+++ b/tools/sync/utils.py
@@ -71,3 +71,17 @@ def get_command(logger, path, name):
     logger.debug("{} = {}".format(name, cmd_file))
 
     return cmd_file
+
+
+def get_int(logger, name, value):
+    """
+    If the supplied value is integer, return it. Otherwise return None.
+    """
+    if not value:
+        return None
+
+    try:
+        return int(value)
+    except ValueError:
+        logger.error("'{}' is not a number: {}".format(name, value))
+        return None

--- a/tools/sync/utils.py
+++ b/tools/sync/utils.py
@@ -26,6 +26,7 @@ from shutil import which
 import logging
 import sys
 
+
 def is_exe(fpath):
     return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
 

--- a/tools/sync/utils.py
+++ b/tools/sync/utils.py
@@ -24,7 +24,7 @@
 import os
 from shutil import which
 import logging
-
+import sys
 
 def is_exe(fpath):
     return os.path.isfile(fpath) and os.access(fpath, os.X_OK)


### PR DESCRIPTION
Some of the internal repositories recently started exhibiting strange traffic patterns (either connect was lagging or the data was painfully slow to receive from the other side. For Mercurial for instance this means that commands like `hg incoming` were hanging for hours) which made me realize there is no timeout mechanism in the mirroring scripts.

Also, this fixes bunch of places where logger is not properly passed onto the created objects so some logging was missing.