### PR TITLE
Fix #1477, fix #2080 : Handle symlink loop. Xref symlink dir.

### DIFF
--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -34,9 +34,13 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.ConnectException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -109,6 +113,9 @@ public class IndexDatabase {
         (File p1, File p2) -> p1.getName().compareTo(p2.getName());
 
     private final Object INSTANCE_LOCK = new Object();
+
+    /** Key is canonical path; Value is the first accepted, absolute path. */
+    private final Map<String, String> acceptedNonlocalSymlinks = new HashMap<>();
 
     private Project project;
     private FSDirectory indexDirectory;
@@ -390,6 +397,7 @@ public class IndexDatabase {
         writer = null;
         settings = null;
         uidIter = null;
+        acceptedNonlocalSymlinks.clear();
 
         IOException finishingException = null;
         try {
@@ -775,9 +783,15 @@ public class IndexDatabase {
      * Check if I should accept this file into the index database
      *
      * @param file the file to check
+     * @param outLocalRelPath optional output array whose 0-th element is set
+     * to a relative path if and only if the {@code file} is a symlink targeting
+     * a local directory (N.b. method will return {@code false})
      * @return true if the file should be included, false otherwise
      */
-    private boolean accept(File file) {
+    private boolean accept(File file, String[] outLocalRelPath) {
+        if (outLocalRelPath != null) {
+            outLocalRelPath[0] = null;
+        }
 
         String absolutePath = file.getAbsolutePath();
 
@@ -799,13 +813,16 @@ public class IndexDatabase {
         }
 
         try {
-            String canonicalPath = file.getCanonicalPath();
-            if (!absolutePath.equals(canonicalPath)
-                && !acceptSymlink(absolutePath, canonicalPath)) {
-
-                LOGGER.log(Level.FINE, "Skipped symlink ''{0}'' -> ''{1}''",
-                    new Object[]{absolutePath, canonicalPath});
-                return false;
+            Path absolute = Paths.get(absolutePath);
+            if (Files.isSymbolicLink(absolute)) {
+                File canonical = file.getCanonicalFile();
+                if (!absolutePath.equals(canonical.getPath())
+                        && !acceptSymlink(absolute, canonical,
+                                outLocalRelPath)) {
+                    LOGGER.log(Level.FINE, "Skipped symlink ''{0}'' -> ''{1}''",
+                        new Object[]{absolutePath, canonical});
+                    return false;
+                }
             }
             //below will only let go files and directories, anything else is considered special and is not added
             if (!file.isFile() && !file.isDirectory()) {
@@ -839,7 +856,20 @@ public class IndexDatabase {
         return res;
     }
 
-    private boolean accept(File parent, File file) {
+    /**
+     * Determines if {@code file} should be accepted into the index database.
+     * @param parent parent of {@code file}
+     * @param file directory object under consideration
+     * @param outLocalRelPath optional output array whose 0-th element is set
+     * to a relative path if and only if the {@code file} is a symlink targeting
+     * a local directory (N.b. method will return {@code false})
+     * @return {@code true} if the file should be included; else {@code false}
+     */
+    private boolean accept(File parent, File file, String[] outLocalRelPath) {
+        if (outLocalRelPath != null) {
+            outLocalRelPath[0] = null;
+        }
+
         try {
             File f1 = parent.getCanonicalFile();
             File f2 = file.getCanonicalFile();
@@ -859,7 +889,7 @@ public class IndexDatabase {
                 }
             }
 
-            return accept(file);
+            return accept(file, outLocalRelPath);
         } catch (IOException ex) {
             LOGGER.log(Level.WARNING, "Failed to resolve name: {0} {1}",
                     new Object[]{parent.getAbsolutePath(), file.getAbsolutePath()});
@@ -870,21 +900,53 @@ public class IndexDatabase {
     /**
      * Check if I should accept the path containing a symlink
      *
-     * @param absolutePath the path with a symlink to check
-     * @param canonicalPath the canonical path to the file
-     * @return true if the file should be accepted, false otherwise
+     * @param absolute the path with a symlink to check
+     * @param canonical the canonical file object
+     * @param outLocalRelPath optional output array whose 0-th element is set
+     * to a relative path if and only if {@code absolute} is a symlink targeting
+     * a local directory, {@code canonical} (N.b. method will return
+     * {@code false})
+     * @return {@code true} if the file should be accepted; else {@code false}
      */
-    private boolean acceptSymlink(String absolutePath, String canonicalPath) throws IOException {
-        // Always accept local symlinks
-        if (isLocal(canonicalPath)) {
-            return true;
+    private boolean acceptSymlink(Path absolute, File canonical,
+            String[] outLocalRelPath) throws IOException {
+        if (outLocalRelPath != null) {
+            outLocalRelPath[0] = null;
         }
 
+        if (isLocal(canonical.getPath())) {
+            if (!canonical.isDirectory()) {
+                // Always accept symlinks to local non-directories.
+                return true;
+            } else {
+                /**
+                 * Do not accept symlinks to local directories, because the
+                 * canonical target will be indexed on its own -- but
+                 * relativize() a path to be returned in outLocalRelPath so that
+                 * a symlink can be replicated in xref/.
+                 **/
+                if (outLocalRelPath != null) {
+                    outLocalRelPath[0] = absolute.getParent().relativize(
+                            canonical.toPath()).toString();
+                }
+                return false;
+            }
+        }
+
+        // No need to synchronize, as indexDown() runs on one thread.
+        if (acceptedNonlocalSymlinks.containsKey(canonical.getPath())) {
+            return false;
+        }
+
+        String absolstr = absolute.toString();
         for (String allowedSymlink : RuntimeEnvironment.getInstance().getAllowedSymlinks()) {
-            if (absolutePath.startsWith(allowedSymlink)) {
+            if (absolstr.startsWith(allowedSymlink)) {
                 String allowedTarget = new File(allowedSymlink).getCanonicalPath();
-                if (canonicalPath.startsWith(allowedTarget)
-                        && absolutePath.substring(allowedSymlink.length()).equals(canonicalPath.substring(allowedTarget.length()))) {
+                String canonstr = canonical.getPath();
+                if (canonstr.startsWith(allowedTarget)
+                        && absolstr.substring(allowedSymlink.length()).equals(
+                                canonstr.substring(allowedTarget.length()))) {
+                    acceptedNonlocalSymlinks.put(canonstr, absolstr);
                     return true;
                 }
             }
@@ -949,7 +1011,20 @@ public class IndexDatabase {
             return;
         }
 
-        if (!accept(dir)) {
+        String[] outLocalRelPath = new String[1];
+        if (!accept(dir, outLocalRelPath)) {
+            /**
+             * If outLocalRelPath[0] is defined, then a local symlink was
+             * detected but not "accepted" to avoid redundancy with its
+             * canonical target. Set up for a deferred recreation of the symlink
+             * for xref/.
+             */
+            if (outLocalRelPath[0] != null) {
+                File xrefPath = new File(xrefDir, parent);
+                PendingSymlinkage psym = new PendingSymlinkage(
+                        xrefPath.getAbsolutePath(), outLocalRelPath[0]);
+                completer.add(psym);
+            }
             return;
         }
 
@@ -962,9 +1037,15 @@ public class IndexDatabase {
         Arrays.sort(files, FILENAME_COMPARATOR);
 
         for (File file : files) {
-            if (accept(dir, file)) {
-                String path = parent + '/' + file.getName();
-
+            String path = parent + '/' + file.getName();
+            if (!accept(dir, file, outLocalRelPath)) {
+                if (outLocalRelPath[0] != null) {
+                    File xrefPath = new File(xrefDir, path);
+                    PendingSymlinkage psym = new PendingSymlinkage(
+                            xrefPath.getAbsolutePath(), outLocalRelPath[0]);
+                    completer.add(psym);
+                }
+            } else {
                 if (file.isDirectory()) {
                     indexDown(file, path, args);
                 } else {
@@ -1510,7 +1591,7 @@ public class IndexDatabase {
             hasPendingCommit = true;
 
             int n = completer.complete();
-            LOGGER.log(Level.FINE, "completed {0} file(s)", n);
+            LOGGER.log(Level.FINE, "completed {0} object(s)", n);
 
             // Just before commit(), reset the `hasPendingCommit' flag,
             // since after commit() is called, there is no need for

--- a/src/org/opensolaris/opengrok/index/PendingSymlinkage.java
+++ b/src/org/opensolaris/opengrok/index/PendingSymlinkage.java
@@ -24,46 +24,48 @@
 package org.opensolaris.opengrok.index;
 
 /**
- * Represents the metadata for a pending file renaming.
+ * Represents the metadata for a pending symbolic linkage.
  */
-public final class PendingFileRenaming {
-    private final String absolutePath;
-    private final String transientPath;
+public final class PendingSymlinkage {
+    private final String sourcePath;
+    private final String targetRelPath;
 
-    public PendingFileRenaming(String absolutePath, String transientPath) {
-        this.absolutePath = absolutePath;
-        this.transientPath = transientPath;
+    public PendingSymlinkage(String sourcePath, String targetRelPath) {
+        this.sourcePath = sourcePath;
+        this.targetRelPath = targetRelPath;
     }
 
     /**
-     * @return the final, absolute path
+     * @return the source, absolute path
      */
-    public String getAbsolutePath() {
-        return absolutePath;
+    public String getSourcePath() {
+        return sourcePath;
     }
 
     /**
-     * @return the transient, absolute path
+     * @return the target, relative path
      */
-    public String getTransientPath() {
-        return transientPath;
+    public String getTargetRelPath() {
+        return targetRelPath;
     }
 
     /**
-     * Compares {@code absolutePath} to the other object's value.
+     * Compares {@code sourcePath} to the other object's value.
      * @param o other object for comparison
      * @return {@code true} if the two compared objects are identical;
      * otherwise false
      */
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof PendingFileRenaming)) return false;
-        PendingFileRenaming other = (PendingFileRenaming)o;
-        return this.absolutePath.equals(other.absolutePath);
+        if (!(o instanceof PendingSymlinkage)) {
+            return false;
+        }
+        PendingSymlinkage other = (PendingSymlinkage)o;
+        return this.sourcePath.equals(other.sourcePath);
     }
 
     @Override
     public int hashCode() {
-        return this.absolutePath.hashCode();
+        return this.sourcePath.hashCode();
     }
 }


### PR DESCRIPTION
Hello,

Please consider for integration this patch to account for loops in symlinked directories.

I tested with the [openshift-ansible](https://github.com/openshift/openshift-ansible) repository and also with the problematic sample layout provided by @ChristopheBordieu.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
