### PR TITLE
various repository methods should use interactive timeout

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -204,6 +204,7 @@ public final class Configuration {
     private final Map<String, String> cmds;  // repository type -> command
     private int tabSize;
     private int commandTimeout; // in seconds
+    private int interactiveCommandTimeout; // in seconds
     private boolean scopesEnabled;
     private boolean projectsEnabled;
     private boolean foldingEnabled;
@@ -348,6 +349,24 @@ public final class Configuration {
         this.commandTimeout = commandTimeout;
     }
 
+    public int getInteractiveCommandTimeout() {
+        return interactiveCommandTimeout;
+    }
+
+    /**
+     * Set the interactive command timeout to a new value.
+     *
+     * @param commandTimeout the new value
+     * @throws IllegalArgumentException when the timeout is negative
+     */
+    public void setInteractiveCommandTimeout(int commandTimeout) throws IllegalArgumentException {
+        if (commandTimeout < 0) {
+            throw new IllegalArgumentException(
+                    String.format(NEGATIVE_NUMBER_ERROR, "interactiveCommandTimeout", commandTimeout));
+        }
+        this.interactiveCommandTimeout = commandTimeout;
+    }
+    
     public String getStatisticsFilePath() {
         return statisticsFilePath;
     }
@@ -397,6 +416,7 @@ public final class Configuration {
         setBugPattern("\\b([12456789][0-9]{6})\\b");
         setCachePages(5);
         setCommandTimeout(600); // 10 minutes
+        setInteractiveCommandTimeout(30);
         setCompressXref(true);
         setContextLimit((short)10);
         //contextSurround is default(short)

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -311,6 +311,14 @@ public final class RuntimeEnvironment {
         threadConfig.get().setCommandTimeout(timeout);
     }
 
+    public int getInteractiveCommandTimeout() {
+        return threadConfig.get().getInteractiveCommandTimeout();
+    }
+
+    public void setInteractiveCommandTimeout(int timeout) {
+        threadConfig.get().setInteractiveCommandTimeout(timeout);
+    }
+    
     public Statistics getStatistics() {
         return statistics;
     }
@@ -1373,6 +1381,16 @@ public final class RuntimeEnvironment {
     }
 
     /**
+     * Read configuration from a file and put it into effect.
+     * @param file the file to read
+     * @param interactive true if run in interactive mode
+     * @throws IOException 
+     */
+    public void readConfiguration(File file, boolean interactive) throws IOException {
+        setConfiguration(Configuration.read(file), null, interactive);
+    }
+    
+    /**
      * Write the current configuration to a file
      *
      * @param file the file to write the configuration into
@@ -1493,10 +1511,10 @@ public final class RuntimeEnvironment {
      * @param configuration what configuration to use
      */
     public void setConfiguration(Configuration configuration) {
-        setConfiguration(configuration, null);
+        setConfiguration(configuration, null, false);
     }
 
-    public void setConfiguration(Configuration configuration, List<String> subFileList) {
+    public void setConfiguration(Configuration configuration, List<String> subFileList, boolean interactive) {
         this.configuration = configuration;
         // HistoryGuru constructor uses environment properties so register()
         // needs to be called first.
@@ -1516,10 +1534,10 @@ public final class RuntimeEnvironment {
         // Set the working repositories in HistoryGuru.
         if (subFileList != null) {
             histGuru.invalidateRepositories(
-                configuration.getRepositories(), subFileList);
+                configuration.getRepositories(), subFileList, interactive);
         } else {
-            histGuru.invalidateRepositories(
-                configuration.getRepositories());
+            histGuru.invalidateRepositories(configuration.getRepositories(),
+                    interactive);
         }
         // The invalidation of repositories above might have excluded some
         // repositories in HistoryGuru so the configuration needs to reflect that.

--- a/src/org/opensolaris/opengrok/configuration/messages/ProjectMessage.java
+++ b/src/org/opensolaris/opengrok/configuration/messages/ProjectMessage.java
@@ -226,7 +226,7 @@ public class ProjectMessage extends Message {
                         List<RepositoryInfo> riList = env.getProjectRepositoriesMap().get(project);
                         if (riList != null) {
                             for (RepositoryInfo ri : riList) {
-                                Repository repo = getRepository(ri);
+                                Repository repo = getRepository(ri, false);
 
                                 if (repo != null && repo.getCurrentVersion() != null &&
                                     repo.getCurrentVersion().length() > 0) {

--- a/src/org/opensolaris/opengrok/history/AccuRevAnnotationParser.java
+++ b/src/org/opensolaris/opengrok/history/AccuRevAnnotationParser.java
@@ -1,0 +1,99 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.history;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.Executor;
+
+/**
+ * handles parsing the output of the {@code accurev annotate} command
+ * into an annotation object.
+ */
+public class AccuRevAnnotationParser implements Executor.StreamHandler {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(AccuRevAnnotationParser.class);
+    
+    private static final Pattern ANNOTATION_PATTERN
+            = Pattern.compile("^\\s+(\\d+.\\d+)\\s+(\\w+)");   // version, user
+    
+    /**
+     * Store annotation created by processStream.
+     */
+    private final Annotation annotation;
+
+    /**
+     * @param fileName the name of the file being annotated
+     */
+    public AccuRevAnnotationParser(String fileName) {
+        annotation = new Annotation(fileName);
+    }
+    
+    /**
+     * Returns the annotation that has been created.
+     *
+     * @return annotation an annotation object
+     */
+    public Annotation getAnnotation() {
+        return annotation;
+    }
+    
+    @Override
+    public void processStream(InputStream input) throws IOException {
+        try (BufferedReader reader
+                = new BufferedReader(new InputStreamReader(input))) {
+            String line;
+            int lineno = 0;
+            try {
+                while ((line = reader.readLine()) != null) {
+                    ++lineno;
+                    Matcher matcher = ANNOTATION_PATTERN.matcher(line);
+
+                    if (matcher.find()) {
+                        // On Windows machines version shows up as
+                        // <number>\<number>. To get search annotation
+                        // to work properly, need to flip '\' to '/'.
+                        // This is a noop on Unix boxes.
+                        String version = matcher.group(1).replace('\\', '/');
+                        String author  = matcher.group(2);
+                        annotation.addLine(version, author, true);
+                    } else {
+                        LOGGER.log(Level.SEVERE,
+                                "Did not find annotation in line {0}: [{1}]",
+                                new Object[]{lineno, line});
+                    }
+                }
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE,
+                        "Could not read annotations for " + annotation.getFilename(), e);
+            }
+        }
+    }
+}

--- a/src/org/opensolaris/opengrok/history/Annotation.java
+++ b/src/org/opensolaris/opengrok/history/Annotation.java
@@ -49,9 +49,9 @@ public class Annotation {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Annotation.class);
 
-    private final List<Line> lines = new ArrayList<Line>();
-    private final Map<String, String> desc = new HashMap<String, String>();
-    private final Map<String, Integer> fileVersions = new HashMap<String, Integer>(); //maps revision to file version
+    private final List<Line> lines = new ArrayList<>();
+    private final Map<String, String> desc = new HashMap<>();
+    private final Map<String, Integer> fileVersions = new HashMap<>(); // maps revision to file version
     private int widestRevision;
     private int widestAuthor;
     private final String filename;

--- a/src/org/opensolaris/opengrok/history/BazaarAnnotationParser.java
+++ b/src/org/opensolaris/opengrok/history/BazaarAnnotationParser.java
@@ -17,40 +17,49 @@
  * CDDL HEADER END
  */
 
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ */
 package org.opensolaris.opengrok.history;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
 
 /**
- * handles parsing the output of the {@code bk annotate} command
- * into an annotation object.
- *
- * @author James Service  {@literal <jas2701@googlemail.com>}
+ * BazaarAnnotationParser handles parsing the output of the {@code bzr blame}
+ * command into an annotation object.
  */
-public class BitKeeperAnnotationParser implements Executor.StreamHandler {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(BitKeeperAnnotationParser.class);
-
+public class BazaarAnnotationParser implements Executor.StreamHandler {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(BazaarAnnotationParser.class);
+    
     /**
      * Store annotation created by processStream.
      */
     private final Annotation annotation;
-
+    
+    /**
+     * Pattern used to extract author/revision
+     */
+    private static final Pattern BLAME_PATTERN
+            = Pattern.compile("^\\W*(\\S+)\\W+(\\S+).*$");
+    
     /**
      * @param fileName the name of the file being annotated
      */
-    public BitKeeperAnnotationParser(String fileName) {
+    public BazaarAnnotationParser(String fileName) {
         annotation = new Annotation(fileName);
     }
-
+    
     /**
      * Returns the annotation that has been created.
      *
@@ -60,26 +69,24 @@ public class BitKeeperAnnotationParser implements Executor.StreamHandler {
         return annotation;
     }
 
-    /**
-     * Process the output of a {@code bk annotate} command.
-     *
-     * Each input line should be in the following format:
-     *   USER\tREVISION\tTEXT
-     *
-     * @param input the executor input stream
-     * @throws IOException if the stream reader throws an IOException
-     */
     @Override
     public void processStream(InputStream input) throws IOException {
-        final BufferedReader in = new BufferedReader(new InputStreamReader(input));
-        for (String line = in.readLine(); line != null; line = in.readLine()) {
-            final String fields[] = line.split("\t");
-            if (fields.length >= 2) {
-                final String author = fields[0];
-                final String rev = fields[1];
-                annotation.addLine(rev, author, true);
-            } else {
-                LOGGER.log(Level.SEVERE, "Error: malformed BitKeeper annotate output {0}", line);
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(input))) {
+            String line = "";
+            int lineno = 0;
+            Matcher matcher = BLAME_PATTERN.matcher(line);
+            while ((line = in.readLine()) != null) {
+                ++lineno;
+                matcher.reset(line);
+                if (matcher.find()) {
+                    String rev = matcher.group(1);
+                    String author = matcher.group(2).trim();
+                    annotation.addLine(rev, author, true);
+                } else {
+                    LOGGER.log(Level.SEVERE,
+                            "Error: did not find annotation in line {0}: [{1}]",
+                            new Object[]{String.valueOf(lineno), line});
+                }
             }
         }
     }

--- a/src/org/opensolaris/opengrok/history/BazaarTagParser.java
+++ b/src/org/opensolaris/opengrok/history/BazaarTagParser.java
@@ -1,0 +1,79 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.history;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.TreeSet;
+import org.opensolaris.opengrok.util.Executor;
+
+/**
+ * handles parsing the output of the {@code bzr tags} command
+ * into a set of tag entries.
+ */
+public class BazaarTagParser implements Executor.StreamHandler {
+    
+    /**
+     * Store tag entries created by processStream.
+     */
+    private final TreeSet<TagEntry> entries = new TreeSet<>();
+    
+    /**
+     * Returns the set of entries that has been created.
+     *
+     * @return entries a set of tag entries
+     */
+    public TreeSet<TagEntry> getEntries() {
+        return entries;
+    }
+    
+    @Override
+    public void processStream(InputStream input) throws IOException {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(input))) {
+            String line;
+            while ((line = in.readLine()) != null) {
+                String parts[] = line.split("  *");
+                if (parts.length < 2) {
+                    throw new IOException("Tag line contains more than 2 columns: " + line);
+                }
+                // Grrr, how to parse tags with spaces inside?
+                // This solution will loose multiple spaces;-/
+                String tag = parts[0];
+                for (int i = 1; i < parts.length - 1; ++i) {
+                    tag += " " + parts[i];
+                }
+                TagEntry tagEntry = new BazaarTagEntry(Integer.parseInt(parts[parts.length - 1]), tag);
+                // Bazaar lists multiple tags on more lines. We need to merge those into single TagEntry
+                TagEntry higher = entries.ceiling(tagEntry);
+                if (higher != null && higher.equals(tagEntry)) {
+                    // Found in the tree, merge tags
+                    entries.remove(higher);
+                    tagEntry.setTags(higher.getTags() + ", " + tag);
+                }
+                entries.add(tagEntry);
+            }
+        }
+    }
+}

--- a/src/org/opensolaris/opengrok/history/BitKeeperTagParser.java
+++ b/src/org/opensolaris/opengrok/history/BitKeeperTagParser.java
@@ -33,7 +33,8 @@ import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
 
 /**
- * BitKeeperTagParser handles parsing the output of `bk tags` into a set of tag entries.
+ * handles parsing the output of the {@code bk tags} command
+ * into a set of tag entries.
  *
  * @author James Service  {@literal <jas2701@googlemail.com>}
  */
@@ -46,9 +47,9 @@ public class BitKeeperTagParser implements Executor.StreamHandler {
      */
     private final SimpleDateFormat dateFormat;
     /**
-     * Store tag entries created by processStream.
+     * Store tag entries created by {@link processStream()}.
      */
-    private final TreeSet<TagEntry> entries = new TreeSet<TagEntry>();
+    private final TreeSet<TagEntry> entries = new TreeSet<>();
 
     /**
      * Constructor to construct the thing to be constructed.
@@ -69,13 +70,13 @@ public class BitKeeperTagParser implements Executor.StreamHandler {
     }
 
     /**
-     * Process the output of a `bk tags` command.
+     * Process the output of the {@code bk tags} command.
      *
      * Each input line should be in the following format:
      * either
-     *   D REVISION\tDATE
+     *   {@code D REVISION\tDATE}
      * or
-     *   T TAG
+     *   {@code T TAG}
      *
      * @param input the executor input stream
      * @throws IOException if the stream reader throws an IOException

--- a/src/org/opensolaris/opengrok/history/CVSRepository.java
+++ b/src/org/opensolaris/opengrok/history/CVSRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
@@ -30,13 +30,12 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
 
@@ -57,12 +56,6 @@ public class CVSRepository extends RCSRepository {
      * The command to use to access the repository if none was given explicitly
      */
     public static final String CMD_FALLBACK = "cvs";
-
-    /**
-     * Pattern used to extract author/revision from 'cvs annotate'.
-     */
-    private static final Pattern ANNOTATE_PATTERN
-            = Pattern.compile("([\\.\\d]+)\\W+\\((\\w+)");
 
     public CVSRepository() {
         /**
@@ -141,7 +134,7 @@ public class CVSRepository extends RCSRepository {
     }
 
     @Override
-    public boolean isRepositoryFor(File file) {
+    public boolean isRepositoryFor(File file, boolean interactive) {
         if (file.isDirectory()) {
             File cvsDir = new File(file, "CVS");
             return cvsDir.isDirectory();
@@ -164,7 +157,7 @@ public class CVSRepository extends RCSRepository {
     }
 
     @Override
-    String determineBranch() throws IOException {
+    String determineBranch(boolean interactive) throws IOException {
         String branch = null;
 
         File tagFile = new File(getDirectoryName(), "CVS/Tag");
@@ -232,11 +225,13 @@ public class CVSRepository extends RCSRepository {
         try {
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
             String argv[] = {RepoCommand, "up", "-p", "-r", revision, basename};
-            process = Runtime.getRuntime().exec(argv, null, new File(parent));
+            Executor executor = new Executor(Arrays.asList(argv), new File(parent),
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+            executor.exec();
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             byte[] buffer = new byte[32 * 1024];
-            try (InputStream in = process.getInputStream()) {
+            try (InputStream in = executor.getOutputStream()) {
                 int len;
 
                 while ((len = in.read(buffer)) != -1) {
@@ -248,18 +243,8 @@ public class CVSRepository extends RCSRepository {
 
             ret = new ByteArrayInputStream(out.toByteArray());
         } catch (Exception exp) {
-            LOGGER.log(Level.SEVERE,
+            LOGGER.log(Level.WARNING,
                     "Failed to get history: {0}", exp.getClass().toString());
-        } finally {
-            // Clean up zombie-processes...
-            if (process != null) {
-                try {
-                    process.exitValue();
-                } catch (IllegalThreadStateException exp) {
-                    // the process is still running??? just kill it..
-                    process.destroy();
-                }
-            }
         }
 
         return ret;
@@ -298,8 +283,10 @@ public class CVSRepository extends RCSRepository {
         }
         cmd.add(file.getName());
 
-        Executor exec = new Executor(cmd, file.getParentFile());
-        int status = exec.exec();
+        Executor exec = new Executor(cmd, file.getParentFile(),
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+        CVSAnnotationParser parser = new CVSAnnotationParser(file.getName());
+        int status = exec.exec(true, parser);
 
         if (status != 0) {
             LOGGER.log(Level.WARNING,
@@ -307,43 +294,11 @@ public class CVSRepository extends RCSRepository {
                     new Object[]{file.getAbsolutePath(), String.valueOf(status)});
         }
 
-        return parseAnnotation(exec.getOutputReader(), file.getName());
-    }
-
-    protected Annotation parseAnnotation(Reader input, String fileName)
-            throws IOException {
-        BufferedReader in = new BufferedReader(input);
-        Annotation ret = new Annotation(fileName);
-        String line = "";
-        int lineno = 0;
-        boolean hasStarted = false;
-        Matcher matcher = ANNOTATE_PATTERN.matcher(line);
-        while ((line = in.readLine()) != null) {
-            // Skip header
-            if (!hasStarted && (line.length() == 0
-                    || !Character.isDigit(line.charAt(0)))) {
-                continue;
-            }
-            hasStarted = true;
-
-            // Start parsing
-            ++lineno;
-            matcher.reset(line);
-            if (matcher.find()) {
-                String rev = matcher.group(1);
-                String author = matcher.group(2).trim();
-                ret.addLine(rev, author, true);
-            } else {
-                LOGGER.log(Level.SEVERE,
-                        "Error: did not find annotation in line {0}: [{1}]",
-                        new Object[]{String.valueOf(lineno), line});
-            }
-        }
-        return ret;
+        return parser.getAnnotation();
     }
 
     @Override
-    String determineParent() throws IOException {
+    String determineParent(boolean interactive) throws IOException {
         File rootFile = new File(getDirectoryName() + File.separator + "CVS"
                 + File.separator + "Root");
         String parent = null;

--- a/src/org/opensolaris/opengrok/history/ClearCaseRepository.java
+++ b/src/org/opensolaris/opengrok/history/ClearCaseRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
@@ -36,9 +36,9 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
-import org.opensolaris.opengrok.util.IOUtils;
 
 /**
  * Access to a ClearCase repository.
@@ -116,7 +116,6 @@ public class ClearCaseRepository extends Repository {
 
         File directory = new File(getDirectoryName());
 
-        Process process = null;
         try {
             String filename = (new File(parent, basename)).getCanonicalPath()
                     .substring(getDirectoryName().length() + 1);
@@ -132,14 +131,15 @@ public class ClearCaseRepository extends Repository {
             String decorated = filename + "@@" + rev;
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
             String argv[] = {RepoCommand, "get", "-to", tmpName, decorated};
-            process = Runtime.getRuntime().exec(argv, null, directory);
-
-            drainStream(process.getInputStream());
-
-            if (waitFor(process) != 0) {
+            Executor executor = new Executor(Arrays.asList(argv), directory,
+                    RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+            int status = executor.exec();
+            if (status != 0) {
+                LOGGER.log(Level.SEVERE, "Failed to get history: {0}",
+                        executor.getErrorString());
                 return null;
             }
-
+            
             ret = new BufferedInputStream(new FileInputStream(tmp)) {
 
                 @Override
@@ -154,46 +154,11 @@ public class ClearCaseRepository extends Repository {
                 }
             };
         } catch (Exception exp) {
-            LOGGER.log(Level.SEVERE,
+            LOGGER.log(Level.WARNING,
                     "Failed to get history: " + exp.getClass().toString(), exp);
-        } finally {
-            // Clean up zombie-processes...
-            if (process != null) {
-                try {
-                    process.exitValue();
-                } catch (IllegalThreadStateException exp) {
-                    // the process is still running??? just kill it..
-                    process.destroy();
-                }
-            }
         }
 
         return ret;
-    }
-
-    /**
-     * Drain all data from a stream and close it.
-     *
-     * @param in the stream to drain
-     * @throws IOException if an I/O error occurs
-     */
-    private static void drainStream(InputStream in) throws IOException {
-        while (true) {
-            long skipped = 0;
-            try {
-                skipped = in.skip(32768L);
-            } catch (IOException ioe) {
-                // ignored - stream isn't seekable, but skipped variable still
-                // has correct value.
-                LOGGER.log(Level.FINEST,
-                        "Stream not seekable", ioe);
-            }
-            if (skipped == 0 && in.read() == -1) {
-                // No bytes skipped, checked that we've reached EOF with read()
-                break;
-            }
-        }
-        IOUtils.close(in);
     }
 
     /**
@@ -222,34 +187,13 @@ public class ClearCaseRepository extends Repository {
             argv.add(revision);
         }
         argv.add(file.getName());
-        ProcessBuilder pb = new ProcessBuilder(argv);
-        pb.directory(file.getParentFile());
-        Process process = null;
-        try {
-            process = pb.start();
-            Annotation a = new Annotation(file.getName());
-            String line;
-            try (BufferedReader in = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()))) {
-                while ((line = in.readLine()) != null) {
-                    String parts[] = line.split("\\|");
-                    String aAuthor = parts[0];
-                    String aRevision = parts[1];
-                    aRevision = aRevision.replace('\\', '/');
-
-                    a.addLine(aRevision, aAuthor, true);
-                }
-            }
-            return a;
-        } finally {
-            if (process != null) {
-                try {
-                    process.exitValue();
-                } catch (IllegalThreadStateException e) {
-                    process.destroy();
-                }
-            }
-        }
+        
+        Executor executor = new Executor(argv, file.getParentFile(),
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+        ClearCaseAnnotationParser parser = new ClearCaseAnnotationParser(file.getName());
+        executor.exec(true, parser);
+        
+        return parser.getAnnotation();
     }
 
     @Override
@@ -257,60 +201,39 @@ public class ClearCaseRepository extends Repository {
         return true;
     }
 
-    private int waitFor(Process process) {
-
-        do {
-            try {
-                return process.waitFor();
-            } catch (InterruptedException exp) {
-            }
-        } while (true);
-    }
-
     @SuppressWarnings("PMD.EmptyWhileStmt")
     @Override
     public void update() throws IOException {
-        Process process = null;
-        try {
-            File directory = new File(getDirectoryName());
+        File directory = new File(getDirectoryName());
 
-            // Check if this is a snapshot view
+        // Check if this is a snapshot view
+        ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
+        String[] argv = {RepoCommand, "catcs"};
+        Executor executor = new Executor(Arrays.asList(argv), directory);
+        int status = executor.exec();
+        if (status != 0) {
+            LOGGER.log(Level.WARNING, "Failed to determine if {0} is snapshot view",
+                    directory);
+            return;
+        }
+        boolean snapshot = false;
+        String line;
+        try (BufferedReader in = new BufferedReader(
+                new InputStreamReader(executor.getOutputStream()))) {
+            while (!snapshot && (line = in.readLine()) != null) {
+                snapshot = line.startsWith("load");
+            }
+        }
+
+        if (snapshot) {
+            // It is a snapshot view, we need to update it manually
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
-            String[] argv = {RepoCommand, "catcs"};
-            process = Runtime.getRuntime().exec(argv, null, directory);
-            boolean snapshot = false;
-            String line;
+            argv = new String[]{RepoCommand, "update", "-overwrite", "-f"};
+            executor = new Executor(Arrays.asList(argv), directory);
             try (BufferedReader in = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()))) {
-                while (!snapshot && (line = in.readLine()) != null) {
-                    snapshot = line.startsWith("load");
-                }
-                if (waitFor(process) != 0) {
-                    return;
-                }
-            }
-            if (snapshot) {
-                // It is a snapshot view, we need to update it manually
-                ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
-                argv = new String[]{RepoCommand, "update", "-overwrite", "-f"};
-                process = Runtime.getRuntime().exec(argv, null, directory);
-                try (BufferedReader in = new BufferedReader(
-                        new InputStreamReader(process.getInputStream()))) {
-                    while ((line = in.readLine()) != null) {
-                        // do nothing
-                    }
-                }
-
-                if (waitFor(process) != 0) {
-                    return;
-                }
-            }
-        } finally {
-            if (process != null) {
-                try {
-                    process.exitValue();
-                } catch (IllegalThreadStateException e) {
-                    process.destroy();
+                    new InputStreamReader(executor.getOutputStream()))) {
+                while ((line = in.readLine()) != null) {
+                    // do nothing
                 }
             }
         }
@@ -335,7 +258,7 @@ public class ClearCaseRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file) {
+    boolean isRepositoryFor(File file, boolean interactive) {
         // if the parent contains a file named "view.dat" or
         // the parent is named "vobs" or the canonical path
         // is found in "cleartool lsvob -s"
@@ -358,6 +281,11 @@ public class ClearCaseRepository extends Repository {
             }
         }
         return false;
+    }
+
+    @Override
+    String determineCurrentVersion(boolean interactive) throws IOException {
+        return null;
     }
 
     private static class VobsHolder {
@@ -408,12 +336,12 @@ public class ClearCaseRepository extends Repository {
     }
 
     @Override
-    String determineParent() throws IOException {
+    String determineParent(boolean interactive) throws IOException {
         return null;
     }
 
     @Override
-    String determineBranch() {
+    String determineBranch(boolean interactive) {
         return null;
     }
 }

--- a/src/org/opensolaris/opengrok/history/GitAnnotationParser.java
+++ b/src/org/opensolaris/opengrok/history/GitAnnotationParser.java
@@ -17,37 +17,46 @@
  * CDDL HEADER END
  */
 
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ */
 package org.opensolaris.opengrok.history;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
 
 /**
- * handles parsing the output of the {@code bk annotate} command
+ * handles parsing the output of the {@code git annotate} command
  * into an annotation object.
- *
- * @author James Service  {@literal <jas2701@googlemail.com>}
  */
-public class BitKeeperAnnotationParser implements Executor.StreamHandler {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(BitKeeperAnnotationParser.class);
-
+public class GitAnnotationParser implements Executor.StreamHandler {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(GitAnnotationParser.class);
+    
     /**
      * Store annotation created by processStream.
      */
     private final Annotation annotation;
-
+    
+    /**
+     * Pattern used to extract author/revision from git blame.
+     */
+    private static final Pattern BLAME_PATTERN
+            = Pattern.compile("^\\W*(\\w+).+?\\((\\D+).*$");
+    
     /**
      * @param fileName the name of the file being annotated
      */
-    public BitKeeperAnnotationParser(String fileName) {
+    public GitAnnotationParser(String fileName) {
         annotation = new Annotation(fileName);
     }
 
@@ -59,27 +68,24 @@ public class BitKeeperAnnotationParser implements Executor.StreamHandler {
     public Annotation getAnnotation() {
         return annotation;
     }
-
-    /**
-     * Process the output of a {@code bk annotate} command.
-     *
-     * Each input line should be in the following format:
-     *   USER\tREVISION\tTEXT
-     *
-     * @param input the executor input stream
-     * @throws IOException if the stream reader throws an IOException
-     */
+    
     @Override
     public void processStream(InputStream input) throws IOException {
-        final BufferedReader in = new BufferedReader(new InputStreamReader(input));
-        for (String line = in.readLine(); line != null; line = in.readLine()) {
-            final String fields[] = line.split("\t");
-            if (fields.length >= 2) {
-                final String author = fields[0];
-                final String rev = fields[1];
+        BufferedReader in = new BufferedReader(GitRepository.newLogReader(input));
+        String line = "";
+        int lineno = 0;
+        Matcher matcher = BLAME_PATTERN.matcher(line);
+        while ((line = in.readLine()) != null) {
+            ++lineno;
+            matcher.reset(line);
+            if (matcher.find()) {
+                String rev = matcher.group(1);
+                String author = matcher.group(2).trim();
                 annotation.addLine(rev, author, true);
             } else {
-                LOGGER.log(Level.SEVERE, "Error: malformed BitKeeper annotate output {0}", line);
+                LOGGER.log(Level.SEVERE,
+                        "Error: did not find annotation in line {0}: [{1}] of {2}",
+                        new Object[]{String.valueOf(lineno), line, annotation.getFilename()});
             }
         }
     }

--- a/src/org/opensolaris/opengrok/history/GitTagParser.java
+++ b/src/org/opensolaris/opengrok/history/GitTagParser.java
@@ -1,0 +1,90 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.history;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Date;
+import java.util.TreeSet;
+import org.opensolaris.opengrok.util.Executor;
+
+/**
+ * handles parsing the output of the {@code git log} command
+ * into a set of tag entries.
+ */
+public class GitTagParser implements Executor.StreamHandler {
+    /**
+     * Store tag entries created by {@link processStream()}.
+     */
+    private final TreeSet<TagEntry> entries = new TreeSet<>();
+    
+    private final String tags;
+    
+    GitTagParser(String tags) {
+        this.tags = tags;
+    }
+    
+    /**
+     * Returns the set of entries that has been created.
+     *
+     * @return entries a set of tag entries
+     */
+    public TreeSet<TagEntry> getEntries() {
+        return entries;
+    }
+    
+    @Override
+    public void processStream(InputStream input) throws IOException {
+        String hash = null;
+        Date date = null;
+        
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(input))) {
+            String line;
+            while ((line = in.readLine()) != null) {
+                if (line.startsWith("commit")) {
+                    String parts[] = line.split(":");
+                    if (parts.length < 2) {
+                        throw new IOException("Tag line contains more than 2 columns: " + line);
+                    }
+                    hash = parts[1];
+                }
+                if (line.startsWith("Date")) {
+                    String parts[] = line.split(":");
+                    if (parts.length < 2) {
+                        throw new IOException("Tag line contains more than 2 columns: " + line);
+                    }
+                    date = new Date((long) (Integer.parseInt(parts[1])) * 1000);
+                }
+            }
+        }
+
+        // Git can have tags not pointing to any commit, but tree instead
+        // Lets use Unix timestamp of 0 for such commits
+        if (date == null) {
+            date = new Date(0);
+        }
+        entries.add(new GitTagEntry(hash, date, tags));
+    }
+}

--- a/src/org/opensolaris/opengrok/history/HistoryGuru.java
+++ b/src/org/opensolaris/opengrok/history/HistoryGuru.java
@@ -895,7 +895,7 @@ public final class HistoryGuru {
      * @param repos list of repositories
      * @param dirs list of directories that might correspond to the repositories
      */
-    public void invalidateRepositories(Collection<? extends RepositoryInfo> repos, List<String> dirs) {
+    public void invalidateRepositories(Collection<? extends RepositoryInfo> repos, List<String> dirs, boolean interactive) {
         if (repos != null && !repos.isEmpty() && dirs != null && !dirs.isEmpty()) {
             List<RepositoryInfo> newrepos = new ArrayList<>();
             for (RepositoryInfo i : repos) {
@@ -910,7 +910,7 @@ public final class HistoryGuru {
             repos = newrepos;
         }
 
-        invalidateRepositories(repos);
+        invalidateRepositories(repos, interactive);
     }
 
     /**
@@ -927,7 +927,7 @@ public final class HistoryGuru {
      * @param repos collection of repositories to invalidate.
      * If null or empty, the internal map of repositories will be cleared.
      */
-    public void invalidateRepositories(Collection<? extends RepositoryInfo> repos) {
+    public void invalidateRepositories(Collection<? extends RepositoryInfo> repos, boolean interactive) {
         if (repos == null || repos.isEmpty()) {
             repositoryRoots.clear();
             repositories.clear();
@@ -965,7 +965,7 @@ public final class HistoryGuru {
                 @Override
                 public void run() {
                     try {
-                        Repository r = RepositoryFactory.getRepository(rinfo);
+                        Repository r = RepositoryFactory.getRepository(rinfo, interactive);
                         if (r == null) {
                             LOGGER.log(Level.WARNING,
                                     "Failed to instantiate internal repository data for {0} in {1}",

--- a/src/org/opensolaris/opengrok/history/MercurialAnnotationParser.java
+++ b/src/org/opensolaris/opengrok/history/MercurialAnnotationParser.java
@@ -1,0 +1,92 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.history;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.Executor;
+import org.opensolaris.opengrok.web.Util;
+
+/**
+ * handles parsing the output of the {@code hg annotate} command
+ * into an annotation object.
+ */
+class MercurialAnnotationParser implements Executor.StreamHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MercurialAnnotationParser.class);
+    
+    private Annotation annotation = null;
+    HashMap<String, HistoryEntry> revs;
+    File file;
+
+    /**
+     * Pattern used to extract author/revision from {@code hg annotate}.
+     */
+    private static final Pattern ANNOTATION_PATTERN
+            = Pattern.compile("^\\s*(\\d+):");
+    
+    MercurialAnnotationParser(File file, HashMap<String, HistoryEntry> revs) {
+        this.file = file;
+        this.revs = revs;
+    }
+
+    @Override
+    public void processStream(InputStream input) throws IOException {
+        annotation = new Annotation(file.getName());
+        String line;
+        int lineno = 0;
+        Matcher matcher = ANNOTATION_PATTERN.matcher("");
+
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(input))) {
+            while ((line = in.readLine()) != null) {
+                ++lineno;
+                matcher.reset(line);
+                if (matcher.find()) {
+                    String rev = matcher.group(1);
+                    String author = "N/A";
+                    // Use the history index hash map to get the author.
+                    if (revs.get(rev) != null) {
+                        author = revs.get(rev).getAuthor();
+                    }
+                    annotation.addLine(rev, Util.getEmail(author.trim()), true);
+                } else {
+                    LOGGER.log(Level.SEVERE,
+                            "Error: did not find annotation in line {0}: [{1}]",
+                            new Object[]{lineno, line});
+                }
+            }
+        }
+    }
+
+    Annotation getAnnotation() {
+        return this.annotation;
+    }
+}

--- a/src/org/opensolaris/opengrok/history/MercurialHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/MercurialHistoryParser.java
@@ -103,8 +103,8 @@ class MercurialHistoryParser implements Executor.StreamHandler {
     }
 
     /**
-     * Process the output from the hg log command and insert the HistoryEntries
-     * into the history field.
+     * Process the output from the {@code hg log} command and collect
+     * {@link HistoryEntry} elements.
      *
      * @param input The output from the process
      * @throws java.io.IOException If an error occurs while reading the stream

--- a/src/org/opensolaris/opengrok/history/MercurialRepository.java
+++ b/src/org/opensolaris/opengrok/history/MercurialRepository.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.TreeSet;
@@ -42,7 +42,6 @@ import java.util.regex.Pattern;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
-import org.opensolaris.opengrok.web.Util;
 
 /**
  * Access to a Mercurial repository.
@@ -103,12 +102,6 @@ public class MercurialRepository extends Repository {
             = TEMPLATE_STUB + FILE_LIST
             + END_OF_ENTRY + "\\n";
 
-    /**
-     * Pattern used to extract author/revision from hg annotate.
-     */
-    private static final Pattern ANNOTATION_PATTERN
-            = Pattern.compile("^\\s*(\\d+):");
-
     private static final Pattern LOG_COPIES_PATTERN
             = Pattern.compile("^(\\d+):(.*)");
 
@@ -127,13 +120,15 @@ public class MercurialRepository extends Repository {
      * Return name of the branch or "default"
      */
     @Override
-    String determineBranch() throws IOException {
+    String determineBranch(boolean interactive) throws IOException {
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         cmd.add(RepoCommand);
         cmd.add("branch");
 
-        Executor executor = new Executor(cmd, new File(getDirectoryName()));
+        Executor executor = new Executor(cmd, new File(getDirectoryName()),
+                interactive ? RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
+                        RuntimeEnvironment.getInstance().getCommandTimeout());
         if (executor.exec(false) != 0) {
             throw new IOException(executor.getErrorString());
         }
@@ -228,11 +223,13 @@ public class MercurialRepository extends Repository {
                     = fullpath.substring(getDirectoryName().length() + 1);
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
             String argv[] = {RepoCommand, "cat", "-r", revision, filename};
-            process = Runtime.getRuntime().exec(argv, null, directory);
-
+            Executor executor = new Executor(Arrays.asList(argv), directory,
+                    RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+            int status = executor.exec();
+            
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             byte[] buffer = new byte[32 * 1024];
-            try (InputStream in = process.getInputStream()) {
+            try (InputStream in = executor.getOutputStream()) {
                 int len;
 
                 while ((len = in.read(buffer)) != -1) {
@@ -246,31 +243,20 @@ public class MercurialRepository extends Repository {
              * If exit value of the process was not 0 then the file did
              * not exist or internal hg error occured.
              */
-            if (process.waitFor() == 0) {
+            if (status == 0) {
                 ret = new ByteArrayInputStream(out.toByteArray());
-            } else {
-                ret = null;
             }
         } catch (Exception exp) {
             LOGGER.log(Level.SEVERE,
                     "Failed to get history: {0}", exp.getClass().toString());
-        } finally {
-            // Clean up zombie-processes...
-            if (process != null) {
-                try {
-                    process.exitValue();
-                } catch (IllegalThreadStateException exp) {
-                    // the process is still running??? just kill it..
-                    process.destroy();
-                }
-            }
         }
 
         return ret;
     }
 
     /**
-     * Get the name of file in given revision.
+     * Get the name of file in given revision. This is used to get contents
+     * of a file in historical revision.
      *
      * @param fullpath file path
      * @param full_rev_to_find revision number (in the form of
@@ -282,6 +268,7 @@ public class MercurialRepository extends Repository {
         Matcher matcher = LOG_COPIES_PATTERN.matcher("");
         String file = fullpath.substring(getDirectoryName().length() + 1);
         ArrayList<String> argv = new ArrayList<>();
+        File directory = new File(getDirectoryName());
 
         // Extract {rev} from the full revision specification string.
         String[] rev_array = full_rev_to_find.split(":");
@@ -314,63 +301,59 @@ public class MercurialRepository extends Repository {
         argv.add("{rev}:{file_copies}\\n");
         argv.add(fullpath);
 
-        ProcessBuilder pb = new ProcessBuilder(argv);
-        Process process = null;
+        Executor executor = new Executor(argv, directory,
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+        int status = executor.exec();
 
-        try {
-            process = pb.start();
-            try (BufferedReader in = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()))) {
-                String line;
-                while ((line = in.readLine()) != null) {
-                    matcher.reset(line);
-                    if (!matcher.find()) {
-                        LOGGER.log(Level.SEVERE,
-                                "Failed to match: {0}", line);
-                        return (null);
-                    }
-                    String rev = matcher.group(1);
-                    String content = matcher.group(2);
+        try (BufferedReader in = new BufferedReader(
+                new InputStreamReader(executor.getOutputStream()))) {
+            String line;
+            while ((line = in.readLine()) != null) {
+                matcher.reset(line);
+                if (!matcher.find()) {
+                    LOGGER.log(Level.SEVERE,
+                            "Failed to match: {0}", line);
+                    return (null);
+                }
+                String rev = matcher.group(1);
+                String content = matcher.group(2);
 
-                    if (rev.equals(rev_to_find)) {
-                        break;
-                    }
+                if (rev.equals(rev_to_find)) {
+                    break;
+                }
 
-                    if (!content.isEmpty()) {
+                if (!content.isEmpty()) {
+                    /*
+                     * Split string of 'newfile1 (oldfile1)newfile2
+                     * (oldfile2) ...' into pairs of renames.
+                     */
+                    String[] splitArray = content.split("\\)");
+                    for (String s : splitArray) {
                         /*
-                         * Split string of 'newfile1 (oldfile1)newfile2
-                         * (oldfile2) ...' into pairs of renames.
+                         * This will fail for file names containing ' ('.
                          */
-                        String[] splitArray = content.split("\\)");
-                        for (String s : splitArray) {
-                            /*
-                             * This will fail for file names containing ' ('.
-                             */
-                            String[] move = s.split(" \\(");
+                        String[] move = s.split(" \\(");
 
-                            if (file.equals(move[0])) {
-                                file = move[1];
-                                break;
-                            }
+                        if (file.equals(move[0])) {
+                            file = move[1];
+                            break;
                         }
                     }
-
-                    if (rev.equals(rev_to_find)) {
-                        break;
-                    }
                 }
-            }
-        } finally {
-            if (process != null) {
-                try {
-                    process.exitValue();
-                } catch (IllegalThreadStateException e) {
-                    // the process is still running??? just kill it..
-                    process.destroy();
+
+                if (rev.equals(rev_to_find)) {
+                    break;
                 }
             }
         }
 
+        if (status != 0) {
+            LOGGER.log(Level.WARNING,
+                    "Failed to get original name in revision {3} for: \"{0}\" Exit code: {1}",
+                    new Object[]{fullpath, String.valueOf(status), full_rev_to_find});
+            return null;
+        }
+        
         return (fullpath.substring(0, getDirectoryName().length() + 1) + file);
     }
 
@@ -434,10 +417,9 @@ public class MercurialRepository extends Repository {
             }
         }
         argv.add(file.getName());
-        ProcessBuilder pb = new ProcessBuilder(argv);
-        pb.directory(file.getParentFile());
-        Process process = null;
-        Annotation ret = null;
+        Executor executor = new Executor(argv, file.getParentFile(),
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+        Annotation annotation = null;
         HashMap<String, HistoryEntry> revs = new HashMap<>();
 
         // Construct hash map for history entries from history cache. This is
@@ -457,45 +439,12 @@ public class MercurialRepository extends Repository {
             return null;
         }
 
-        try {
-            process = pb.start();
-            try (BufferedReader in = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()))) {
-                ret = new Annotation(file.getName());
-                String line;
-                int lineno = 0;
-                Matcher matcher = ANNOTATION_PATTERN.matcher("");
-                while ((line = in.readLine()) != null) {
-                    ++lineno;
-                    matcher.reset(line);
-                    if (matcher.find()) {
-                        String rev = matcher.group(1);
-                        String author = "N/A";
-                        // Use the history index hash map to get the author.
-                        if (revs.get(rev) != null) {
-                            author = revs.get(rev).getAuthor();
-                        }
-                        ret.addLine(rev, Util.getEmail(author.trim()), true);
-                    } else {
-                        LOGGER.log(Level.SEVERE,
-                                "Error: did not find annotation in line {0}: [{1}]",
-                                new Object[]{lineno, line});
-                    }
-                }
-            }
-        } finally {
-            if (process != null) {
-                try {
-                    process.exitValue();
-                } catch (IllegalThreadStateException e) {
-                    // the process is still running??? just kill it..
-                    process.destroy();
-                }
-            }
-        }
-        return ret;
-    }
+        MercurialAnnotationParser annotator = new MercurialAnnotationParser(file, revs);
+        executor.exec(true, annotator);
 
+        return annotator.getAnnotation();
+    }
+    
     @Override
     protected String getRevisionForAnnotate(String history_revision) {
         String[] brev = history_revision.split(":");
@@ -543,7 +492,7 @@ public class MercurialRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file) {
+    boolean isRepositoryFor(File file, boolean interactive) {
         if (file.isDirectory()) {
             File f = new File(file, ".hg");
             return f.exists() && f.isDirectory();
@@ -613,75 +562,29 @@ public class MercurialRepository extends Repository {
     }
 
     @Override
-    protected void buildTagList(File directory) {
+    protected void buildTagList(File directory, boolean interactive) {
         this.tagList = new TreeSet<>();
         ArrayList<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         argv.add(RepoCommand);
         argv.add("tags");
-        ProcessBuilder pb = new ProcessBuilder(argv);
-        pb.directory(directory);
-        Process process = null;
 
-        try {
-            process = pb.start();
-            try (BufferedReader in = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()))) {
-                String line;
-                while ((line = in.readLine()) != null) {
-                    String parts[] = line.split("  *");
-                    if (parts.length < 2) {
-                        LOGGER.log(Level.WARNING,
-                                "Failed to parse tag list: {0}",
-                                "Tag line contains more than 2 columns: " + line);
-                        this.tagList = null;
-                        break;
-                    }
-                    // Grrr, how to parse tags with spaces inside?
-                    // This solution will lose multiple spaces ;-/
-                    String tag = parts[0];
-                    for (int i = 1; i < parts.length - 1; ++i) {
-                        tag = tag.concat(" ");
-                        tag = tag.concat(parts[i]);
-                    }
-                    // The implicit 'tip' tag only causes confusion so ignore it. 
-                    if (tag.contentEquals("tip")) {
-                        continue;
-                    }
-                    String revParts[] = parts[parts.length - 1].split(":");
-                    if (revParts.length != 2) {
-                        LOGGER.log(Level.WARNING,
-                                "Failed to parse tag list: {0}",
-                                "Mercurial revision parsing error: "
-                                        + parts[parts.length - 1]);
-                        this.tagList = null;
-                        break;
-                    }
-                    TagEntry tagEntry
-                            = new MercurialTagEntry(Integer.parseInt(revParts[0]),
-                                    tag);
-                    // Reverse the order of the list
-                    this.tagList.add(tagEntry);
-                }
-            }
-        } catch (IOException e) {
+        Executor executor = new Executor(argv, directory, interactive ?
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
+                RuntimeEnvironment.getInstance().getCommandTimeout());
+        MercurialTagParser parser = new MercurialTagParser();
+        int status = executor.exec(true, parser);
+        if (status != 0) {
             LOGGER.log(Level.WARNING,
-                    "Failed to read tag list: {0}", e.getMessage());
-            this.tagList = null;
-        }
-
-        if (process != null) {
-            try {
-                process.exitValue();
-            } catch (IllegalThreadStateException e) {
-                // the process is still running??? just kill it..
-                process.destroy();
-            }
+                    "Failed to get tags for: \"{0}\" Exit code: {1}",
+                    new Object[]{directory.getAbsolutePath(), String.valueOf(status)});
+        } else {
+            this.tagList = parser.getEntries();
         }
     }
 
     @Override
-    String determineParent() throws IOException {
+    String determineParent(boolean interactive) throws IOException {
         File directory = new File(getDirectoryName());
 
         List<String> cmd = new ArrayList<>();
@@ -689,7 +592,9 @@ public class MercurialRepository extends Repository {
         cmd.add(RepoCommand);
         cmd.add("paths");
         cmd.add("default");
-        Executor executor = new Executor(cmd, directory);
+        Executor executor = new Executor(cmd, directory, interactive ?
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
+                RuntimeEnvironment.getInstance().getCommandTimeout());
         if (executor.exec(false) != 0) {
             throw new IOException(executor.getErrorString());
         }
@@ -698,7 +603,7 @@ public class MercurialRepository extends Repository {
     }
 
     @Override
-    public String determineCurrentVersion() throws IOException {
+    public String determineCurrentVersion(boolean interactive) throws IOException {
         String line = null;
         File directory = new File(getDirectoryName());
 
@@ -711,7 +616,9 @@ public class MercurialRepository extends Repository {
         cmd.add("--template");
         cmd.add("{date|isodate} {node|short} {author} {desc|strip}");
 
-        Executor executor = new Executor(cmd, directory);
+        Executor executor = new Executor(cmd, directory, interactive ?
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
+                RuntimeEnvironment.getInstance().getCommandTimeout());
         if (executor.exec(false) != 0) {
             throw new IOException(executor.getErrorString());
         }

--- a/src/org/opensolaris/opengrok/history/MercurialTagParser.java
+++ b/src/org/opensolaris/opengrok/history/MercurialTagParser.java
@@ -1,0 +1,104 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.history;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.Executor;
+
+/**
+ * handles parsing the output of the {@code hg tags} command
+ * into a set of tag entries.
+ */
+public class MercurialTagParser implements Executor.StreamHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MercurialTagParser.class);
+    
+    /**
+     * Store tag entries created by processStream.
+     */
+    private TreeSet<TagEntry> entries = new TreeSet<>();
+    
+    /**
+     * Returns the set of entries that has been created.
+     *
+     * @return entries a set of tag entries
+     */
+    public TreeSet<TagEntry> getEntries() {
+        return entries;
+    }
+    
+    @Override
+    public void processStream(InputStream input) throws IOException {
+        try {
+            try (BufferedReader in = new BufferedReader(
+                    new InputStreamReader(input))) {
+                String line;
+                while ((line = in.readLine()) != null) {
+                    String parts[] = line.split("  *");
+                    if (parts.length < 2) {
+                        LOGGER.log(Level.WARNING,
+                                "Failed to parse tag list: {0}",
+                                "Tag line contains more than 2 columns: " + line);
+                        entries = null;
+                        break;
+                    }
+                    // Grrr, how to parse tags with spaces inside?
+                    // This solution will lose multiple spaces ;-/
+                    String tag = parts[0];
+                    for (int i = 1; i < parts.length - 1; ++i) {
+                        tag = tag.concat(" ");
+                        tag = tag.concat(parts[i]);
+                    }
+                    // The implicit 'tip' tag only causes confusion so ignore it. 
+                    if (tag.contentEquals("tip")) {
+                        continue;
+                    }
+                    String revParts[] = parts[parts.length - 1].split(":");
+                    if (revParts.length != 2) {
+                        LOGGER.log(Level.WARNING,
+                                "Failed to parse tag list: {0}",
+                                "Mercurial revision parsing error: "
+                                        + parts[parts.length - 1]);
+                        entries = null;
+                        break;
+                    }
+                    TagEntry tagEntry
+                            = new MercurialTagEntry(Integer.parseInt(revParts[0]),
+                                    tag);
+                    // Reverse the order of the list
+                    entries.add(tagEntry);
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING,
+                    "Failed to read tag list: {0}", e.getMessage());
+            entries = null;
+        }
+    }
+}

--- a/src/org/opensolaris/opengrok/history/MonotoneAnnotationParser.java
+++ b/src/org/opensolaris/opengrok/history/MonotoneAnnotationParser.java
@@ -1,0 +1,88 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.history;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.opensolaris.opengrok.util.Executor;
+
+/**
+ * Handles handles parsing the output of the {@code mnt annotate} command
+ * into an annotation object. 
+ */
+public class MonotoneAnnotationParser implements Executor.StreamHandler {
+    /**
+     * Store annotation created by processStream.
+     */
+    private final Annotation annotation;
+
+    private final File file;
+    
+    /**
+     * Pattern used to extract author/revision from the {@code mnt annotate} command.
+     */
+    private static final Pattern ANNOTATION_PATTERN
+            = Pattern.compile("^(\\w+)\\p{Punct}\\p{Punct} by (\\S+)");
+    
+    /**
+     * @param file the file being annotated
+     */
+    public MonotoneAnnotationParser(File file) {
+        annotation = new Annotation(file.getName());
+        this.file = file;
+    }
+
+   /**
+     * Returns the annotation that has been created.
+     *
+     * @return annotation an annotation object
+     */
+    public Annotation getAnnotation() {
+        return annotation;
+    }
+    
+    @Override
+    public void processStream(InputStream input) throws IOException {
+        Annotation ret;
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(input))) {
+            String line;
+            String author = null;
+            String rev = null;
+            while ((line = in.readLine()) != null) {
+                Matcher matcher = ANNOTATION_PATTERN.matcher(line);
+                if (matcher.find()) {
+                    rev = matcher.group(1);
+                    author = matcher.group(2);
+                    annotation.addLine(rev, author, true);
+                } else {
+                    annotation.addLine(rev, author, true);
+                }
+            }
+        }
+    }
+}

--- a/src/org/opensolaris/opengrok/history/PerforceAnnotationParser.java
+++ b/src/org/opensolaris/opengrok/history/PerforceAnnotationParser.java
@@ -1,0 +1,109 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.history;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.Executor;
+
+/**
+ * handles parsing the output of the {@code p4 annotate} command
+ * into an annotation object.
+ */
+public class PerforceAnnotationParser implements Executor.StreamHandler {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(PerforceAnnotationParser.class);
+    
+    /**
+     * Store annotation created by processStream.
+     */
+    private final Annotation annotation;
+
+    private final File file;
+
+    private final String rev;
+    
+    private static final Pattern ANNOTATION_PATTERN
+            = Pattern.compile("^(\\d+): .*");
+   
+    /**
+     * @param file the file being annotated
+     * @param rev revision to be annotated
+     */
+    public PerforceAnnotationParser(File file, String rev) {
+        annotation = new Annotation(file.getName());
+        this.file = file;
+        this.rev = rev;
+    }
+
+    /**
+     * Returns the annotation that has been created.
+     *
+     * @return annotation an annotation object
+     */
+    public Annotation getAnnotation() {
+        return annotation;
+    }
+    
+    @Override
+    public void processStream(InputStream input) throws IOException {
+        List<HistoryEntry> revisions
+                = PerforceHistoryParser.getRevisions(file, rev).getHistoryEntries();
+        HashMap<String, String> revAuthor = new HashMap<>();
+        for (HistoryEntry entry : revisions) {
+            // a.addDesc(entry.getRevision(), entry.getMessage());
+            revAuthor.put(entry.getRevision(), entry.getAuthor());
+        }
+        
+        String line;
+        int lineno = 0;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
+            while ((line = reader.readLine()) != null) {
+                ++lineno;
+                Matcher matcher = ANNOTATION_PATTERN.matcher(line);
+                if (matcher.find()) {
+                    String revision = matcher.group(1);
+                    String author = revAuthor.get(revision);
+                    annotation.addLine(revision, author, true);
+                } else {
+                    LOGGER.log(Level.SEVERE,
+                            "Error: did not find annotation in line {0}: [{1}]",
+                            new Object[]{lineno, line});
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE,
+                    "Error: Could not read annotations for " + annotation.getFilename(), e);
+        }
+    }
+}

--- a/src/org/opensolaris/opengrok/history/PerforceHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/PerforceHistoryParser.java
@@ -54,7 +54,7 @@ public class PerforceHistoryParser {
     History parse(File file, Repository repos) throws HistoryException {
         History history;
 
-        if (!PerforceRepository.isInP4Depot(file)) {
+        if (!PerforceRepository.isInP4Depot(file, false)) {
             return null;
         }
 

--- a/src/org/opensolaris/opengrok/history/PerforceRepository.java
+++ b/src/org/opensolaris/opengrok/history/PerforceRepository.java
@@ -18,22 +18,18 @@
  */
 
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.history;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
@@ -58,9 +54,6 @@ public class PerforceRepository extends Repository {
      */
     public static final String CMD_FALLBACK = "p4";
 
-    private static final Pattern annotation_pattern
-            = Pattern.compile("^(\\d+): .*");
-
     public PerforceRepository() {
         type = "Perforce";
 
@@ -69,16 +62,6 @@ public class PerforceRepository extends Repository {
 
     @Override
     public Annotation annotate(File file, String rev) throws IOException {
-        Annotation a = new Annotation(file.getName());
-
-        List<HistoryEntry> revisions
-                = PerforceHistoryParser.getRevisions(file, rev).getHistoryEntries();
-        HashMap<String, String> revAuthor = new HashMap<>();
-        for (HistoryEntry entry : revisions) {
-            // a.addDesc(entry.getRevision(), entry.getMessage());
-            revAuthor.put(entry.getRevision(), entry.getAuthor());
-        }
-
         ArrayList<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         cmd.add(RepoCommand);
@@ -86,30 +69,12 @@ public class PerforceRepository extends Repository {
         cmd.add("-qci");
         cmd.add(file.getPath() + getRevisionCmd(rev));
 
-        Executor executor = new Executor(cmd, file.getParentFile());
-        executor.exec();
-
-        String line;
-        int lineno = 0;
-        try (BufferedReader reader = new BufferedReader(executor.getOutputReader())) {
-            while ((line = reader.readLine()) != null) {
-                ++lineno;
-                Matcher matcher = annotation_pattern.matcher(line);
-                if (matcher.find()) {
-                    String revision = matcher.group(1);
-                    String author = revAuthor.get(revision);
-                    a.addLine(revision, author, true);
-                } else {
-                    LOGGER.log(Level.SEVERE,
-                            "Error: did not find annotation in line {0}: [{1}]",
-                            new Object[]{lineno, line});
-                }
-            }
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE,
-                    "Error: Could not read annotations for " + file, e);
-        }
-        return a;
+        Executor executor = new Executor(cmd, file.getParentFile(),
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+        PerforceAnnotationParser parser = new PerforceAnnotationParser(file, rev);
+        executor.exec(true, parser);
+        
+        return parser.getAnnotation();
     }
 
     @Override
@@ -158,7 +123,7 @@ public class PerforceRepository extends Repository {
      * @param file The file to test
      * @return true if the given file is in the depot, false otherwise
      */
-    public static boolean isInP4Depot(File file) {
+    public static boolean isInP4Depot(File file, boolean interactive) {
         boolean status = false;
         if (testRepo.isWorking()) {
             ArrayList<String> cmd = new ArrayList<>();
@@ -170,7 +135,9 @@ public class PerforceRepository extends Repository {
                 cmd.add(testRepo.RepoCommand);
                 cmd.add("dirs");
                 cmd.add(name);
-                Executor executor = new Executor(cmd, dir);
+                Executor executor = new Executor(cmd, dir, interactive ?
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
+                RuntimeEnvironment.getInstance().getCommandTimeout());
                 executor.exec();
                 /* OUTPUT:
                  stdout: //depot_path/name
@@ -183,7 +150,9 @@ public class PerforceRepository extends Repository {
                 cmd.add(testRepo.RepoCommand);
                 cmd.add("files");
                 cmd.add(name);
-                Executor executor = new Executor(cmd, dir);
+                Executor executor = new Executor(cmd, dir, interactive ?
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
+                RuntimeEnvironment.getInstance().getCommandTimeout());
                 executor.exec();
                 /* OUTPUT:
                  stdout: //depot_path/name
@@ -196,8 +165,8 @@ public class PerforceRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file) {
-        return isInP4Depot(file);
+    boolean isRepositoryFor(File file, boolean interactive) {
+        return isInP4Depot(file, interactive);
     }
 
     @Override
@@ -220,12 +189,12 @@ public class PerforceRepository extends Repository {
     }
 
     @Override
-    String determineParent() throws IOException {
+    String determineParent(boolean interactive) throws IOException {
         return null;
     }
 
     @Override
-    String determineBranch() {
+    String determineBranch(boolean interactive) {
         return null;
     }
     /**
@@ -238,5 +207,10 @@ public class PerforceRepository extends Repository {
             return "";
         }
         return "@" + rev;
+    }
+
+    @Override
+    String determineCurrentVersion(boolean interactive) throws IOException {
+        return null;
     }
 }

--- a/src/org/opensolaris/opengrok/history/RCSRepository.java
+++ b/src/org/opensolaris/opengrok/history/RCSRepository.java
@@ -128,7 +128,7 @@ public class RCSRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file) {
+    boolean isRepositoryFor(File file, boolean interactive) {
         File rcsDir = new File(file, "RCS");
         if (!rcsDir.isDirectory()) {
             return false;
@@ -175,12 +175,17 @@ public class RCSRepository extends Repository {
     }
 
     @Override
-    String determineParent() throws IOException {
+    String determineParent(boolean interactive) throws IOException {
         return null;
     }
 
     @Override
-    String determineBranch() throws IOException {
+    String determineBranch(boolean interactive) throws IOException {
+        return null;
+    }
+
+    @Override
+    String determineCurrentVersion(boolean interactive) throws IOException {
         return null;
     }
 }

--- a/src/org/opensolaris/opengrok/history/RazorRepository.java
+++ b/src/org/opensolaris/opengrok/history/RazorRepository.java
@@ -35,9 +35,7 @@ import java.util.zip.GZIPInputStream;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 
 /**
- * Adds access to to a Razor Repository
- *
- * http://www.visible.com/Products/Razor/index.htm
+ * Adds access to to a <a href="http://www.visible.com/Products/Razor/index.htm">Razor</a> Repository
  *
  * A brief and simplistic overview of Razor
  *
@@ -74,7 +72,7 @@ import org.opensolaris.opengrok.logger.LoggerFactory;
  *
  * Unfortunately, the Razor command line interface does not support features
  * that other SCMS support like 'log' and 'annotate'. Also, Razor check-outs
- * leave no indication that the files are from a centralised repository, so it
+ * leave no indication that the files are from a centralized repository, so it
  * will not be possible to implement this module from a copy or check-out of the
  * repository, we will have to access (in a read-only manner) the actual
  * repository itself, extracting the information directly or via SCCS/RCS
@@ -145,7 +143,7 @@ public class RazorRepository extends Repository {
     // The base directory of that Razor Group (.razor symlink destination)
     private String razorGroupBaseDirectoryPath;
 
-    private static String RAZOR_DIR = ".razor";
+    private static final String RAZOR_DIR = ".razor";
 
     public RazorRepository() {
         type = "Razor";
@@ -330,7 +328,7 @@ public class RazorRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file) {
+    boolean isRepositoryFor(File file, boolean interactive) {
         File f = new File(file, ".razor");
         return f.exists() && f.isDirectory();
     }
@@ -346,12 +344,17 @@ public class RazorRepository extends Repository {
     }
 
     @Override
-    String determineParent() throws IOException {
-        return "N/A";
+    String determineParent(boolean interactive) throws IOException {
+        return null;
     }
 
     @Override
-    String determineBranch() {
+    String determineBranch(boolean interactive) {
+        return null;
+    }
+
+    @Override
+    String determineCurrentVersion(boolean interactive) throws IOException {
         return null;
     }
 }

--- a/src/org/opensolaris/opengrok/history/RepoRepository.java
+++ b/src/org/opensolaris/opengrok/history/RepoRepository.java
@@ -79,7 +79,7 @@ public class RepoRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file) {
+    boolean isRepositoryFor(File file, boolean interactive) {
         if (file.isDirectory()) {
             File f = new File(file, ".repo");
             return f.exists() && f.isDirectory();
@@ -123,12 +123,17 @@ public class RepoRepository extends Repository {
     }
 
     @Override
-    String determineParent() throws IOException {
+    String determineParent(boolean interactive) throws IOException {
         return null;
     }
 
     @Override
-    String determineBranch() {
+    String determineBranch(boolean interactive) {
+        return null;
+    }
+
+    @Override
+    String determineCurrentVersion(boolean interactive) throws IOException {
         return null;
     }
 }

--- a/src/org/opensolaris/opengrok/history/Repository.java
+++ b/src/org/opensolaris/opengrok/history/Repository.java
@@ -90,8 +90,8 @@ public abstract class Repository extends RepositoryInfo {
 
     public Repository() {
         super();
-        ignoredFiles = new ArrayList<String>();
-        ignoredDirs = new ArrayList<String>();
+        ignoredFiles = new ArrayList<>();
+        ignoredDirs = new ArrayList<>();
     }
 
     /**
@@ -268,16 +268,17 @@ public abstract class Repository extends RepositoryInfo {
      * Create internal list of all tags in this repository.
      *
      * @param directory directory of the repository
+     * @param interactive true if in interactive mode
      */
-    protected void buildTagList(File directory) {
+    protected void buildTagList(File directory, boolean interactive) {
         this.tagList = null;
     }
-
+    
     /**
      * Annotate the specified revision of a file.
      *
      * @param file the file to annotate
-     * @param revision revision of the file. Either {@code null} or a none-empty
+     * @param revision revision of the file. Either {@code null} or a non-empty
      * string.
      * @return an <code>Annotation</code> object
      * @throws java.io.IOException if an error occurs
@@ -355,7 +356,7 @@ public abstract class Repository extends RepositoryInfo {
         // We need to refresh list of tags for incremental reindex.
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         if (env.isTagsEnabled() && this.hasFileBasedTags()) {
-            this.buildTagList(new File(this.getDirectoryName()));
+            this.buildTagList(new File(this.getDirectoryName()), false);
         }
 
         if (history != null) {
@@ -377,18 +378,40 @@ public abstract class Repository extends RepositoryInfo {
      * @param file File to check if this is a repository for.
      * @return true if this is the correct repository for this file/directory.
      */
-    abstract boolean isRepositoryFor(File file);
+    abstract boolean isRepositoryFor(File file, boolean interactive);
+    
+    public final boolean isRepositoryFor(File file) {
+        return isRepositoryFor(file, false);
+    }
 
     /**
      * Determine parent of this repository.
      */
-    abstract String determineParent() throws IOException;
+    abstract String determineParent(boolean interactive) throws IOException;
+    
+    /**
+     * Determine parent of this repository.
+     * @return parent
+     * @throws java.io.IOException
+     */
+    public final String determineParent() throws IOException {
+        return determineParent(false);
+    }
 
     /**
      * Determine branch of this repository.
      */
-    abstract String determineBranch() throws IOException;
+    abstract String determineBranch(boolean interactive) throws IOException;
 
+    /**
+     * Determine branch of this repository.
+     * @return branch
+     * @throws java.io.IOException
+     */
+    public final String determineBranch() throws IOException {
+        return determineBranch(false);
+    }
+    
     /**
      * Get list of ignored files for this repository.
      * @return list of strings
@@ -411,11 +434,14 @@ public abstract class Repository extends RepositoryInfo {
      * This operation is consider "heavy" so this function should not be
      * called on every web request.
      *
+     * @param interactive true if interactive mode
      * @return the version
      * @throws IOException if I/O exception occurred
      */
-    public String determineCurrentVersion() throws IOException {
-        return null;
+    abstract String determineCurrentVersion(boolean interactive) throws IOException;
+    
+    public final String determineCurrentVersion() throws IOException {
+        return determineCurrentVersion(false);
     }
 
     /**

--- a/src/org/opensolaris/opengrok/history/RepositoryFactory.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryFactory.java
@@ -79,29 +79,36 @@ public final class RepositoryFactory {
         return list;
     }
 
+    public static Repository getRepository(File file)
+        throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException{
+        return getRepository(file, false);
+    }
+    
     /**
      * Returns a repository for the given file, or null if no repository was
      * found.
      *
      * Note that the operations performed by this method take quite a long time
      * thanks to external commands being executed. For that reason, when run
-     * on multiple files, it should be parallelized, e.g. like it is done in
-     * {@code invalidateRepositories()}.
+     * on multiple files, it should be parallelized (e.g. like it is done in
+     * {@code invalidateRepositories()}) and the commands run within should
+     * use interactive command timeout (as specified in {@code Configuration}).
      *
      * @param file File that might contain a repository
+     * @param interactive true if running in interactive mode
      * @return Correct repository for the given file
      * @throws InstantiationException in case we cannot create the repository object
      * @throws IllegalAccessException in case no permissions to repository file
      * @throws NoSuchMethodException in case we cannot create the repository object
      * @throws InvocationTargetException in case we cannot create the repository object
      */
-    public static Repository getRepository(File file) throws InstantiationException, IllegalAccessException, 
-            NoSuchMethodException, InvocationTargetException {
+    public static Repository getRepository(File file, boolean interactive)
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         Repository repo = null;
 
         for (Repository rep : repositories) {
-            if (rep.isRepositoryFor(file)) {
+            if (rep.isRepositoryFor(file, interactive)) {
                 repo = rep.getClass().getDeclaredConstructor().newInstance();
                 repo.setDirectoryName(file);
 
@@ -120,7 +127,7 @@ public final class RepositoryFactory {
 
                 if (repo.getParent() == null || repo.getParent().length() == 0) {
                     try {
-                        repo.setParent(repo.determineParent());
+                        repo.setParent(repo.determineParent(interactive));
                     } catch (IOException ex) {
                         LOGGER.log(Level.WARNING,
                                 "Failed to get parent for {0}: {1}",
@@ -130,7 +137,7 @@ public final class RepositoryFactory {
 
                 if (repo.getBranch() == null || repo.getBranch().length() == 0) {
                     try {
-                        repo.setBranch(repo.determineBranch());
+                        repo.setBranch(repo.determineBranch(interactive));
                     } catch (IOException ex) {
                         LOGGER.log(Level.WARNING,
                                 "Failed to get branch for {0}: {1}",
@@ -140,7 +147,7 @@ public final class RepositoryFactory {
 
                 if (repo.getCurrentVersion() == null || repo.getCurrentVersion().length() == 0) {
                     try {
-                        repo.setCurrentVersion(repo.determineCurrentVersion());
+                        repo.setCurrentVersion(repo.determineCurrentVersion(interactive));
                     } catch (IOException ex) {
                         LOGGER.log(Level.WARNING,
                                 "Failed to determineCurrentVersion for {0}: {1}",
@@ -151,7 +158,7 @@ public final class RepositoryFactory {
                 // If this repository displays tags only for files changed by tagged
                 // revision, we need to prepare list of all tags in advance.
                 if (env.isTagsEnabled() && repo.hasFileBasedTags()) {
-                    repo.buildTagList(file);
+                    repo.buildTagList(file, interactive);
                 }
 
                 break;
@@ -166,15 +173,16 @@ public final class RepositoryFactory {
      * found.
      *
      * @param info Information about the repository
+     * @param interactive true if used in interactive mode
      * @return Correct repository for the given file
      * @throws InstantiationException in case we cannot create the repository object
      * @throws IllegalAccessException in case no permissions to repository
      * @throws NoSuchMethodException in case we cannot create the repository object
      * @throws InvocationTargetException in case we cannot create the repository object
      */
-    public static Repository getRepository(RepositoryInfo info) throws InstantiationException, IllegalAccessException, 
-            NoSuchMethodException, InvocationTargetException {
-        return getRepository(new File(info.getDirectoryName()));
+    public static Repository getRepository(RepositoryInfo info, boolean interactive)
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        return getRepository(new File(info.getDirectoryName()), interactive);
     }
 
     /**

--- a/src/org/opensolaris/opengrok/history/SCCSRepository.java
+++ b/src/org/opensolaris/opengrok/history/SCCSRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.history;
 
@@ -28,15 +28,14 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.Executor;
 
 /**
  * This class gives access to repositories built on top of SCCS (including
@@ -56,8 +55,6 @@ public class SCCSRepository extends Repository {
      * The command to use to access the repository if none was given explicitly
      */
     public static final String CMD_FALLBACK = "sccs";
-
-    private Map<String, String> authors_cache;
 
     public SCCSRepository() {
         type = "SCCS";
@@ -83,15 +80,8 @@ public class SCCSRepository extends Repository {
         }
     }
 
-    /**
-     * Pattern used to extract revision from sccs get
-     */
-    private static final Pattern AUTHOR_PATTERN
-            = Pattern.compile("^([\\d.]+)\\s+(\\S+)");
-
-    private void getAuthors(File file) throws IOException {
-        //System.out.println("Alloc Authors cache");
-        authors_cache = new HashMap<>();
+    private Map<String,String> getAuthors(File file) throws IOException {
+        Map<String, String> authors = new HashMap<>();
 
         ArrayList<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
@@ -102,45 +92,13 @@ public class SCCSRepository extends Repository {
         argv.add(":I: :P:");
         argv.add(file.getCanonicalPath());
 
-        ProcessBuilder pb = new ProcessBuilder(argv);
-        pb.directory(file.getCanonicalFile().getParentFile());
-        Process process = null;
-        try {
-            process = pb.start();
-            try (BufferedReader in = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()))) {
-                String line;
-                int lineno = 0;
-                while ((line = in.readLine()) != null) {
-                    ++lineno;
-                    Matcher matcher = AUTHOR_PATTERN.matcher(line);
-                    if (matcher.find()) {
-                        String rev = matcher.group(1);
-                        String auth = matcher.group(2);
-                        authors_cache.put(rev, auth);
-                    } else {
-                        LOGGER.log(Level.SEVERE,
-                                "Error: did not find authors in line {0}: [{1}]",
-                                new Object[]{lineno, line});
-                    }
-                }
-            }
-        } finally {
-            if (process != null) {
-                try {
-                    process.exitValue();
-                } catch (IllegalThreadStateException e) {
-                    process.destroy();
-                }
-            }
-        }
+        Executor executor = new Executor(argv, file.getCanonicalFile().getParentFile(),
+            RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+        SCCSRepositoryAuthorParser parser = new SCCSRepositoryAuthorParser();
+        executor.exec(true, parser);
+        
+        return parser.getAuthors();
     }
-
-    /**
-     * Pattern used to extract revision from sccs get
-     */
-    private static final Pattern ANNOTATION_PATTERN
-            = Pattern.compile("^([\\d.]+)\\s+");
 
     /**
      * Annotate the specified file/revision.
@@ -152,9 +110,7 @@ public class SCCSRepository extends Repository {
      */
     @Override
     public Annotation annotate(File file, String revision) throws IOException {
-
-        //System.out.println("annotating " + file.getCanonicalPath());
-        getAuthors(file);
+        Map<String,String> authors = getAuthors(file);
 
         ArrayList<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
@@ -166,44 +122,11 @@ public class SCCSRepository extends Repository {
             argv.add("-r" + revision);
         }
         argv.add(file.getCanonicalPath());
-        ProcessBuilder pb = new ProcessBuilder(argv);
-        pb.directory(file.getCanonicalFile().getParentFile());
-        Process process = null;
-        try {
-            process = pb.start();
-            Annotation a = new Annotation(file.getName());
-            try (BufferedReader in = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()))) {
-                String line;
-                int lineno = 0;
-                while ((line = in.readLine()) != null) {
-                    ++lineno;
-                    Matcher matcher = ANNOTATION_PATTERN.matcher(line);
-                    if (matcher.find()) {
-                        String rev = matcher.group(1);
-                        String author = authors_cache.get(rev);
-                        if (author == null) {
-                            author = "unknown";
-                        }
-
-                        a.addLine(rev, author, true);
-                    } else {
-                        LOGGER.log(Level.SEVERE,
-                                "Error: did not find annotations in line {0}: [{1}]",
-                                new Object[]{lineno, line});
-                    }
-                }
-            }
-            return a;
-        } finally {
-            if (process != null) {
-                try {
-                    process.exitValue();
-                } catch (IllegalThreadStateException e) {
-                    process.destroy();
-                }
-            }
-        }
+        Executor executor = new Executor(argv, file.getCanonicalFile().getParentFile(),
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+        SCCSRepositoryAnnotationParser parser = new SCCSRepositoryAnnotationParser(file, authors);
+        executor.exec(true, parser);
+        return parser.getAnnotation();
     }
 
     @Override
@@ -218,17 +141,14 @@ public class SCCSRepository extends Repository {
 
     @Override
     public boolean fileHasHistory(File file) {
-        String parent = file.getParent();
+        String parentFile = file.getParent();
         String name = file.getName();
-        File f = new File(parent + "/SCCS/s." + name);
-        if (f.exists()) {
-            return true;
-        }
-        return false;
+        File f = new File(parentFile + "/SCCS/s." + name);
+        return f.exists();
     }
 
     @Override
-    boolean isRepositoryFor(File file) {
+    boolean isRepositoryFor(File file, boolean interactive) {
         if (file.isDirectory()) {
             File f = new File(file, "codemgr_wsdata");
             if (f.isDirectory()) {
@@ -266,7 +186,7 @@ public class SCCSRepository extends Repository {
     }
 
     @Override
-    String determineParent() throws IOException {
+    String determineParent(boolean interactive) throws IOException {
         File parentFile = new File(getDirectoryName() + File.separator
                 + "Codemgr_wsdata" + File.separator + "parent");
         String parent = null;
@@ -276,15 +196,18 @@ public class SCCSRepository extends Repository {
             try (BufferedReader in = new BufferedReader(new FileReader(parentFile))) {
                 if ((line = in.readLine()) == null) {
                     LOGGER.log(Level.WARNING,
-                            "Failed to get parent for {0} (cannot read line)", getDirectoryName());
+                            "Failed to get parent for {0} (cannot read line)",
+                            getDirectoryName());
                 }
                 if (!line.startsWith("VERSION")) {
                     LOGGER.log(Level.WARNING,
-                            "Failed to get parent for {0} (first line does not start with VERSION)", getDirectoryName());
+                            "Failed to get parent for {0} (first line does not start with VERSION)",
+                            getDirectoryName());
                 }
                 if ((parent = in.readLine()) == null) {
                     LOGGER.log(Level.WARNING,
-                            "Failed to get parent for {0} (cannot read second line)", getDirectoryName());
+                            "Failed to get parent for {0} (cannot read second line)",
+                            getDirectoryName());
                 }
             }
         }
@@ -293,7 +216,12 @@ public class SCCSRepository extends Repository {
     }
 
     @Override
-    String determineBranch() {
+    String determineBranch(boolean interactive) {
+        return null;
+    }
+
+    @Override
+    String determineCurrentVersion(boolean interactive) throws IOException {
         return null;
     }
 }

--- a/src/org/opensolaris/opengrok/history/SCCSRepositoryAnnotationParser.java
+++ b/src/org/opensolaris/opengrok/history/SCCSRepositoryAnnotationParser.java
@@ -1,0 +1,99 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.history;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.Executor;
+
+/**
+ * handles parsing into Annotation object.
+ */ 
+public class SCCSRepositoryAnnotationParser implements Executor.StreamHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SCCSRepositoryAnnotationParser.class);
+    
+    /**
+     * Store annotation created by processStream.
+     */
+    private final Annotation annotation;
+    
+    private final Map<String, String> authors;
+    
+    private final File file;
+    
+    /**
+     * Pattern used to extract revision from the {@code sccs get} command.
+     */
+    private static final Pattern ANNOTATION_PATTERN
+            = Pattern.compile("^([\\d.]+)\\s+");
+    
+    SCCSRepositoryAnnotationParser(File file, Map<String, String> authors) {
+        this.annotation = new Annotation(file.getName());
+        this.file = file;
+        this.authors = authors;
+    }
+    
+    /**
+     * Returns the annotation that has been created.
+     *
+     * @return annotation an annotation object
+     */
+    public Annotation getAnnotation() {
+        return annotation;
+    }
+    
+    @Override
+    public void processStream(InputStream input) throws IOException {
+        try (BufferedReader in = new BufferedReader(
+                new InputStreamReader(input))) {
+            String line;
+            int lineno = 0;
+            while ((line = in.readLine()) != null) {
+                ++lineno;
+                Matcher matcher = ANNOTATION_PATTERN.matcher(line);
+                if (matcher.find()) {
+                    String rev = matcher.group(1);
+                    String author = authors.get(rev);
+                    if (author == null) {
+                        author = "unknown";
+                    }
+
+                    annotation.addLine(rev, author, true);
+                } else {
+                    LOGGER.log(Level.SEVERE,
+                            "Error: did not find annotations in line {0}: [{1}]",
+                            new Object[]{lineno, line});
+                }
+            }
+        }
+    }
+}

--- a/src/org/opensolaris/opengrok/history/SCCSRepositoryAuthorParser.java
+++ b/src/org/opensolaris/opengrok/history/SCCSRepositoryAuthorParser.java
@@ -1,0 +1,81 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.history;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import jdk.nashorn.internal.objects.NativeDebug;
+import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.Executor;
+
+/**
+ * Get mapping of revision to author.
+ */
+public class SCCSRepositoryAuthorParser implements Executor.StreamHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SCCSRepositoryAuthorParser.class);
+
+    private final Map<String, String> authors = new HashMap<>();
+    
+    /**
+     * Pattern used to extract revision from the {@code sccs get} command.
+     */
+    private static final Pattern AUTHOR_PATTERN
+            = Pattern.compile("^([\\d.]+)\\s+(\\S+)");
+    
+    @Override
+    public void processStream(InputStream input) throws IOException {
+        try (BufferedReader in = new BufferedReader(
+                    new InputStreamReader(input))) {
+            String line;
+            int lineno = 0;
+            while ((line = in.readLine()) != null) {
+                ++lineno;
+                Matcher matcher = AUTHOR_PATTERN.matcher(line);
+                if (matcher.find()) {
+                    String rev = matcher.group(1);
+                    String auth = matcher.group(2);
+                    authors.put(rev, auth);
+                } else {
+                    LOGGER.log(Level.WARNING,
+                            "Error: did not find authors in line {0}: [{1}]",
+                            new Object[]{lineno, line});
+                }
+            }
+        }
+    }
+    
+    /**
+     * @return map of revision to author
+     */
+    public Map<String, String> getAuthors() {
+        return authors;
+    }
+}

--- a/src/org/opensolaris/opengrok/history/SSCMRepository.java
+++ b/src/org/opensolaris/opengrok/history/SSCMRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.history;
 
@@ -38,6 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
 
@@ -314,7 +315,8 @@ public class SSCMRepository extends Repository {
         if (revision != null) {
             argv.add("-aV:" + revision);
         }
-        Executor exec = new Executor(argv, file.getParentFile());
+        Executor exec = new Executor(argv, file.getParentFile(),
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
         int status = exec.exec();
 
         if (status != 0) {
@@ -385,7 +387,7 @@ public class SSCMRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file) {
+    boolean isRepositoryFor(File file, boolean interactive) {
         if (file.isDirectory()) {
             File f = new File(file, MYSCMSERVERINFO_FILE);
             return f.exists() && f.isFile();
@@ -394,12 +396,17 @@ public class SSCMRepository extends Repository {
     }
 
     @Override
-    String determineParent() throws IOException {
+    String determineParent(boolean interactive) throws IOException {
         return null;
     }
 
     @Override
-    String determineBranch() {
+    String determineBranch(boolean interactive) {
+        return null;
+    }
+
+    @Override
+    String determineCurrentVersion(boolean interactive) throws IOException {
         return null;
     }
 }

--- a/src/org/opensolaris/opengrok/history/SubversionAnnotationParser.java
+++ b/src/org/opensolaris/opengrok/history/SubversionAnnotationParser.java
@@ -1,0 +1,140 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.history;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import org.opensolaris.opengrok.logger.LoggerFactory;
+import org.opensolaris.opengrok.util.Executor;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.DefaultHandler2;
+
+/**
+ * handles parsing the output of the {@code svn annotate}
+ * command into an annotation object.
+ */
+public class SubversionAnnotationParser implements Executor.StreamHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubversionAnnotationParser.class);
+    
+    /**
+     * Store annotation created by processStream.
+     */
+    private final Annotation annotation;
+    
+    private final String fileName;
+
+    /**
+     * @param fileName the name of the file being annotated
+     */
+    public SubversionAnnotationParser(String fileName) {
+        annotation = new Annotation(fileName);
+        this.fileName = fileName;
+    }
+
+    /**
+     * Returns the annotation that has been created.
+     *
+     * @return annotation an annotation object
+     */
+    public Annotation getAnnotation() {
+        return annotation;
+    }
+    
+    @Override
+    public void processStream(InputStream input) throws IOException {
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        SAXParser saxParser = null;
+        try {
+            saxParser = factory.newSAXParser();
+        } catch (ParserConfigurationException | SAXException ex) {
+            IOException err = new IOException("Failed to create SAX parser", ex);
+            throw err;
+        }
+        
+        AnnotateHandler handler = new AnnotateHandler(fileName, annotation);
+        try (BufferedInputStream in
+                = new BufferedInputStream(input)) {
+            saxParser.parse(in, handler);
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE,
+                    "An error occurred while parsing the xml output", e);
+        }
+    }
+    
+    private static class AnnotateHandler extends DefaultHandler2 {
+
+        String rev;
+        String author;
+        final Annotation annotation;
+        final StringBuilder sb;
+
+        AnnotateHandler(String filename, Annotation annotation) {
+            this.annotation = annotation;
+            sb = new StringBuilder();
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qname,
+                Attributes attr) {
+            sb.setLength(0);
+            if (null != qname) {
+                switch (qname) {
+                    case "entry":
+                        rev = null;
+                        author = null;
+                        break;
+                    case "commit":
+                        rev = attr.getValue("revision");
+                        break;
+                }
+            }
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qname) {
+            if (null != qname) {
+                switch (qname) {
+                    case "author":
+                        author = sb.toString();
+                        break;
+                    case "entry":
+                        annotation.addLine(rev, author, true);
+                        break;
+                }
+            }
+        }
+
+        @Override
+        public void characters(char[] arg0, int arg1, int arg2) {
+            sb.append(arg0, arg1, arg2);
+        }
+    }
+}

--- a/src/org/opensolaris/opengrok/history/SubversionHistoryParser.java
+++ b/src/org/opensolaris/opengrok/history/SubversionHistoryParser.java
@@ -146,7 +146,7 @@ class SubversionHistoryParser implements Executor.StreamHandler {
      * @return object representing the file's history
      */
     History parse(File file, SubversionRepository repos, String sinceRevision,
-            int numEntries)
+            int numEntries, boolean interactive)
             throws HistoryException {
 
         initSaxParser();
@@ -157,7 +157,7 @@ class SubversionHistoryParser implements Executor.StreamHandler {
         Executor executor;
         try {
             executor = repos.getHistoryLogExecutor(file, sinceRevision,
-                    numEntries);
+                    numEntries, interactive);
         } catch (IOException e) {
             throw new HistoryException("Failed to get history for: \"" +
                     file.getAbsolutePath() + "\"", e);

--- a/src/org/opensolaris/opengrok/history/SubversionRepository.java
+++ b/src/org/opensolaris/opengrok/history/SubversionRepository.java
@@ -18,17 +18,14 @@
  */
 
 /*
- * Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -36,15 +33,12 @@ import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
-import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
-import org.xml.sax.ext.DefaultHandler2;
 
 /**
  * Access to a Subversion repository.
@@ -106,7 +100,7 @@ public class SubversionRepository extends Repository {
 
     /**
      * Get {@code Document} corresponding to the parsed XML output from 
-     * 'svn info' command.
+     * {@code svn info} command.
      * @return document with data from {@code info} or null if the {@code svn}
      * command failed
      */
@@ -119,7 +113,8 @@ public class SubversionRepository extends Repository {
         cmd.add("--xml");
         File directory = new File(getDirectoryName());
 
-        Executor executor = new Executor(cmd, directory);
+        Executor executor = new Executor(cmd, directory,
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
         if (executor.exec() == 0) {
             try {
                 DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -199,7 +194,7 @@ public class SubversionRepository extends Repository {
      * @return An Executor ready to be started
      */
     Executor getHistoryLogExecutor(final File file, String sinceRevision,
-            int numEntries) throws IOException {
+            int numEntries, boolean interactive) throws IOException {
 
         String filename = getRepoRelativePath(file);
 
@@ -226,7 +221,13 @@ public class SubversionRepository extends Repository {
             cmd.add(escapeFileName(filename));
         }
 
-        return new Executor(cmd, new File(getDirectoryName()), sinceRevision != null);
+        if (interactive) {
+            return new Executor(cmd, new File(getDirectoryName()),
+                    RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+        } else {
+            return new Executor(cmd, new File(getDirectoryName()),
+                    sinceRevision != null || numEntries > 0);
+        }
     }
 
     @Override
@@ -255,7 +256,8 @@ public class SubversionRepository extends Repository {
         cmd.add(rev);
         cmd.add(escapeFileName(filename));
 
-        Executor executor = new Executor(cmd, directory);
+        Executor executor = new Executor(cmd, directory,
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
         if (executor.exec() == 0) {
             ret = executor.getOutputStream();
         }
@@ -270,18 +272,19 @@ public class SubversionRepository extends Repository {
 
     @Override
     History getHistory(File file) throws HistoryException {
-        return getHistory(file, null);
+        return getHistory(file, null, 0, false);
     }
 
     @Override
     History getHistory(File file, String sinceRevision) throws HistoryException {
-        return getHistory(file, sinceRevision, 0);
+        return getHistory(file, sinceRevision, 0, false);
     }
 
-    private History getHistory(File file, String sinceRevision, int numEntries)
+    private History getHistory(File file, String sinceRevision, int numEntries,
+            boolean interactive)
             throws HistoryException {
         return new SubversionHistoryParser().parse(file, this, sinceRevision,
-                numEntries);
+                numEntries, interactive);
     }
 
     private String escapeFileName(String name) {
@@ -291,66 +294,8 @@ public class SubversionRepository extends Repository {
         return name + "@";
     }
 
-    private static class AnnotateHandler extends DefaultHandler2 {
-
-        String rev;
-        String author;
-        final Annotation annotation;
-        final StringBuilder sb;
-
-        AnnotateHandler(String filename) {
-            annotation = new Annotation(filename);
-            sb = new StringBuilder();
-        }
-
-        @Override
-        public void startElement(String uri, String localName, String qname,
-                Attributes attr) {
-            sb.setLength(0);
-            if (null != qname) {
-                switch (qname) {
-                    case "entry":
-                        rev = null;
-                        author = null;
-                        break;
-                    case "commit":
-                        rev = attr.getValue("revision");
-                        break;
-                }
-            }
-        }
-
-        @Override
-        public void endElement(String uri, String localName, String qname) {
-            if (null != qname) {
-                switch (qname) {
-                    case "author":
-                        author = sb.toString();
-                        break;
-                    case "entry":
-                        annotation.addLine(rev, author, true);
-                        break;
-                }
-            }
-        }
-
-        @Override
-        public void characters(char[] arg0, int arg1, int arg2) {
-            sb.append(arg0, arg1, arg2);
-        }
-    }
-
     @Override
     public Annotation annotate(File file, String revision) throws IOException {
-        SAXParserFactory factory = SAXParserFactory.newInstance();
-        SAXParser saxParser = null;
-        try {
-            saxParser = factory.newSAXParser();
-        } catch (ParserConfigurationException | SAXException ex) {
-            IOException err = new IOException("Failed to create SAX parser", ex);
-            throw err;
-        }
-
         ArrayList<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         argv.add(RepoCommand);
@@ -363,32 +308,19 @@ public class SubversionRepository extends Repository {
             argv.add(revision);
         }
         argv.add(escapeFileName(file.getName()));
-        ProcessBuilder pb = new ProcessBuilder(argv);
-        pb.directory(file.getParentFile());
-        Process process = null;
-        Annotation ret = null;
-        try {
-            process = pb.start();
-            AnnotateHandler handler = new AnnotateHandler(file.getName());
-            try (BufferedInputStream in
-                    = new BufferedInputStream(process.getInputStream())) {
-                saxParser.parse(in, handler);
-                ret = handler.annotation;
-            } catch (Exception e) {
-                LOGGER.log(Level.SEVERE,
-                        "An error occurred while parsing the xml output", e);
-            }
-        } finally {
-            if (process != null) {
-                try {
-                    process.exitValue();
-                } catch (IllegalThreadStateException e) {
-                    // the process is still running??? just kill it..
-                    process.destroy();
-                }
-            }
+        
+        Executor executor = new Executor(argv, file.getParentFile(),
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
+        SubversionAnnotationParser parser = new SubversionAnnotationParser(file.getName());
+        int status = executor.exec(true, parser);
+        if (status != 0) {
+            LOGGER.log(Level.WARNING,
+                    "Failed to get annotations for: \"{0}\" Exit code: {1}",
+                    new Object[]{file.getAbsolutePath(), String.valueOf(status)});
+            throw new IOException(executor.getErrorString());
+        } else {
+            return parser.getAnnotation();
         }
-        return ret;
     }
 
     @Override
@@ -421,7 +353,7 @@ public class SubversionRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file) {
+    boolean isRepositoryFor(File file, boolean interactive) {
         if (file.isDirectory()) {
             File f = new File(file, ".svn");
             return f.exists() && f.isDirectory();
@@ -454,7 +386,7 @@ public class SubversionRepository extends Repository {
     }
 
     @Override
-    String determineParent() {
+    String determineParent(boolean interactive) {
         String part = null;
         Document document = getInfoDocument();
 
@@ -466,7 +398,7 @@ public class SubversionRepository extends Repository {
     }
 
     @Override
-    String determineBranch() throws IOException {
+    String determineBranch(boolean interactive) throws IOException {
         String branch = null;
         Document document = getInfoDocument();
 
@@ -483,11 +415,11 @@ public class SubversionRepository extends Repository {
     }
 
     @Override
-    public String determineCurrentVersion() throws IOException {
+    public String determineCurrentVersion(boolean interactive) throws IOException {
         String curVersion = null;
 
         try {
-            History hist = getHistory(new File(getDirectoryName()), null, 1);
+            History hist = getHistory(new File(getDirectoryName()), null, 1, interactive);
             if (hist != null) {
                 List<HistoryEntry> hlist = hist.getHistoryEntries();
                 if (hlist != null && hlist.size() > 0) {

--- a/src/org/opensolaris/opengrok/index/Indexer.java
+++ b/src/org/opensolaris/opengrok/index/Indexer.java
@@ -222,7 +222,7 @@ public final class Indexer {
             }
 
             // Set updated configuration in RuntimeEnvironment.
-            env.setConfiguration(cfg, subFilesList);
+            env.setConfiguration(cfg, subFilesList, false);
 
             // Let repository types to add items to ignoredNames.
             // This changes env so is called after the setConfiguration()

--- a/src/org/opensolaris/opengrok/util/Executor.java
+++ b/src/org/opensolaris/opengrok/util/Executor.java
@@ -73,7 +73,7 @@ public class Executor {
     }
 
     /**
-     * Create a new instance of the Executor
+     * Create a new instance of the Executor with default command timeout value.
      * @param cmdList A list containing the command to execute
      * @param workingDirectory The directory the process should have as the
      *                         working directory
@@ -195,23 +195,22 @@ public class Executor {
             });
             thread.start();
 
+            int timeout = this.timeout;
             /*
              * Setup timer so if the process get stuck we can terminate it and
-             * make progress instead of hanging the whole indexer.
+             * make progress instead of hanging the whole operation.
              */
-            if (this.timeout != 0) {
+            if (timeout != 0) {
                 // invoking the constructor starts the background thread
                 timer = new Timer();
                 timer.schedule(new TimerTask() {
                     @Override public void run() {
-                        LOGGER.log(Level.INFO,
-                            "Terminating process of command {0} in directory {1} " +
-                            "due to timeout {2} seconds",
-                            new Object[] {cmd_str, dir_str,
-                            RuntimeEnvironment.getInstance().getCommandTimeout()});
+                        LOGGER.log(Level.WARNING,
+                            String.format("Terminating process of command %s in directory %s " +
+                            "due to timeout %d seconds", cmd_str, dir_str, timeout / 1000));
                         proc.destroy();
                     }
-                }, this.timeout);
+                }, timeout);
             }
 
             handler.processStream(process.getInputStream());

--- a/src/org/opensolaris/opengrok/web/WebappListener.java
+++ b/src/org/opensolaris/opengrok/web/WebappListener.java
@@ -69,9 +69,9 @@ public final class WebappListener
             LOGGER.severe("CONFIGURATION section missing in web.xml");
         } else {
             try {
-                env.readConfiguration(new File(config));
+                env.readConfiguration(new File(config), true);
             } catch (IOException ex) {
-                LOGGER.log(Level.WARNING, "OpenGrok Configuration error. Failed to read config file: ", ex);
+                LOGGER.log(Level.WARNING, "Configuration error. Failed to read config file: ", ex);
             }
         }
 

--- a/test/org/opensolaris/opengrok/configuration/messages/ProjectMessageTest.java
+++ b/test/org/opensolaris/opengrok/configuration/messages/ProjectMessageTest.java
@@ -304,7 +304,7 @@ public class ProjectMessageTest {
         // When 'indexpart' is run, this is called from setConfiguration() because
         // of the -R option is present.
         HistoryGuru.getInstance().invalidateRepositories(
-            env.getRepositories());
+            env.getRepositories(), null, false);
         env.setHistoryEnabled(true);
         Indexer.getInstance().prepareIndexer(
                 env,

--- a/test/org/opensolaris/opengrok/history/BazaarRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/BazaarRepositoryTest.java
@@ -22,8 +22,7 @@
  */
 package org.opensolaris.opengrok.history;
 
-import java.io.Reader;
-import java.io.StringReader;
+import java.io.ByteArrayInputStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -35,7 +34,8 @@ import org.opensolaris.opengrok.condition.RepositoryInstalled;
 import static org.junit.Assert.*;
 
 /**
- *
+ * Simple Bazaar repository test.
+ * 
  * @author austvik
  */
 @ConditionalRun(RepositoryInstalled.BazaarInstalled.class)
@@ -72,9 +72,12 @@ public class BazaarRepositoryTest {
                 revId2 + "  " + author2 + " 20050912 | and here.\n" +
                 revId3 + "           " + author3 + "          20030731 | \n";
        
-        Reader input = new StringReader(output);
         String fileName = "something.ext";
-        Annotation result = instance.parseAnnotation(input, fileName);
+        
+        BazaarAnnotationParser parser = new BazaarAnnotationParser(fileName);
+        parser.processStream(new ByteArrayInputStream(output.getBytes()));
+        Annotation result = parser.getAnnotation();
+        
         assertNotNull(result);
         assertEquals(3, result.size());
         for (int i = 1; i <= 3; i++) {
@@ -92,7 +95,7 @@ public class BazaarRepositoryTest {
     }
 
     /**
-     * Test of fileHasAnnotation method, of class GitRepository.
+     * Test of fileHasAnnotation method.
      */
     @Test
     public void fileHasAnnotation() {
@@ -101,7 +104,7 @@ public class BazaarRepositoryTest {
     }
 
     /**
-     * Test of fileHasHistory method, of class GitRepository.
+     * Test of fileHasHistory method.
      */
     @Test
     public void fileHasHistory() {

--- a/test/org/opensolaris/opengrok/history/CVSRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/CVSRepositoryTest.java
@@ -23,6 +23,7 @@
  */
 package org.opensolaris.opengrok.history;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
@@ -211,9 +212,13 @@ public class CVSRepositoryTest {
         String output = "just jibberish in output\n\n" + revId1 + "     (" + author1 + " 01-Mar-07) \n" +
                 revId2 + "    (" + author2 + " 02-Mar-08)   if (some code)\n" +
                 revId3 + "       (" + author3 + " 30-Apr-07)           call_function(i);\n";
-        Reader input = new StringReader(output);
+
         String fileName = "something.ext";
-        Annotation result = instance.parseAnnotation(input, fileName);
+        
+        CVSAnnotationParser parser = new CVSAnnotationParser(fileName);
+        parser.processStream(new ByteArrayInputStream(output.getBytes()));
+        Annotation result = parser.getAnnotation();
+        
         assertNotNull(result);
         assertEquals(3, result.size());
         for (int i = 1; i <= 3; i++) {

--- a/test/org/opensolaris/opengrok/history/GitRepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/GitRepositoryTest.java
@@ -17,12 +17,13 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.history;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -103,9 +104,12 @@ public class GitRepositoryTest {
         String output = revId1 + " file1.ext   (" + author1 + "     2005-06-06 16:38:26 -0400 272) \n" +
                 revId2 + " file2.h (" + author2 + "     2007-09-10 23:02:45 -0400 273)   if (some code)\n" +
                 revId3 + " file2.c  (" + author3 + "      2006-09-20 21:47:42 -0700 274)           call_function(i);\n";
-        Reader input = new StringReader(output);
         String fileName = "something.ext";
-        Annotation result = instance.parseAnnotation(input, fileName);
+        
+        GitAnnotationParser parser = new GitAnnotationParser(fileName);
+        parser.processStream(new ByteArrayInputStream(output.getBytes()));
+        Annotation result = parser.getAnnotation();
+        
         assertNotNull(result);
         assertEquals(3, result.size());
         for (int i = 1; i <= 3; i++) {

--- a/test/org/opensolaris/opengrok/history/RepositoryTest.java
+++ b/test/org/opensolaris/opengrok/history/RepositoryTest.java
@@ -180,18 +180,23 @@ public class RepositoryTest {
         }
 
         @Override
-        public boolean isRepositoryFor(File file) {
+        public boolean isRepositoryFor(File file, boolean interactive) {
             return false;
         }
 
         @Override
-        public String determineParent() throws IOException {
+        public String determineParent(boolean interactive) throws IOException {
             return "";
         }
 
         @Override
-        public String determineBranch() throws IOException {
+        public String determineBranch(boolean interactive) throws IOException {
             return "";
+        }
+
+        @Override
+        String determineCurrentVersion(boolean interactive) throws IOException {
+            return null;
         }
     }
 }

--- a/test/org/opensolaris/opengrok/index/IndexerTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerTest.java
@@ -247,7 +247,7 @@ public class IndexerTest {
         Repository r = null;
         for (RepositoryInfo ri : repos) {
             if (ri.getDirectoryName().equals(repository.getSourceRoot() + "/rfe2575")) {
-                r = RepositoryFactory.getRepository(ri);
+                r = RepositoryFactory.getRepository(ri, false);
                 break;
             }
         }


### PR DESCRIPTION
This change introduces interactive timeout that will be used when:
  - setting new configuration (happens e.g. when webapp is starting or when new configuration is set via `Message` or when `Search` is done using CLI)
  - getting content of a file in given revision
  - getting repository metadata

The first item basically triggers `invalidateRepositories()` in `HistoryGuru` that will in turn call `getRepositories()`. Thus, all the `Repository` calls inside need to be made "interactive".

Basically, I've modified all repositories to use `Executor` as opposed to `Runtime` or `ProcessBuilder` directly. I don't like the way how `Executor` sets up the timeout too much (it should not know about `RuntimeEnvironment` or unset `this.timeout` when it is already set. Maybe it should also have getter/setter for timeout.), however that's for next time.

Also, maybe all the repository annotation/tag parsers should be an interface/abstract class however there are subtle difference how these are implemented for various repositories so for the time being I mirrored the style already used by Bitkeeper repository.

After the change there will be 3 types of timeout related behavior:
  - no timeout (full reindex, i.e. no revision specification)
  - command timeout (incremental reindex, i.e. revision specification or number of entries - in case of Subversion)
  - interactive timeout (as described above)

Tested with unreachable Subversion repository + webapp start and also full reindex.