### PR TITLE
Add reindex-project.ksh to distribution TAR Ball

### DIFF
--- a/distribution/assembly.xml
+++ b/distribution/assembly.xml
@@ -15,77 +15,78 @@
         <destName>plugins.jar</destName>
       </file>
       <file>
-	<source>${project.build.directory}/dist/opengrok-web-${version}.war</source>
-	<outputDirectory>lib</outputDirectory>
+        <source>${project.build.directory}/dist/opengrok-web-${version}.war</source>
+        <outputDirectory>lib</outputDirectory>
         <destName>source.war</destName>
       </file>
     </files>
     <fileSets>
         <fileSet>
-	    <directory>${project.basedir}/..</directory>
-	    <outputDirectory>doc</outputDirectory>
-	    <includes>
-	      <include>README*</include>
-	      <include>LICENSE*</include>
-	      <include>CHANGES*</include>
-	      <include>paths.tsv</include>
-	      <include>logging.properties</include>
-	    </includes>
+          <directory>${project.basedir}/..</directory>
+          <outputDirectory>doc</outputDirectory>
+          <includes>
+            <include>README*</include>
+            <include>LICENSE*</include>
+            <include>CHANGES*</include>
+            <include>paths.tsv</include>
+            <include>logging.properties</include>
+          </includes>
         </fileSet>
         <fileSet>
-	    <directory>${project.basedir}/../doc</directory>
-	    <outputDirectory>doc</outputDirectory>
-	    <includes>
-	      <include>README*</include>
-	      <include>authorization_howto.txt</include>
-	      <include>ctags.config</include>
-	      <include>EXAMPLE.txt</include>
-	      <include>groups_howto.txt</include>
-	    </includes>
+          <directory>${project.basedir}/../doc</directory>
+          <outputDirectory>doc</outputDirectory>
+          <includes>
+            <include>README*</include>
+            <include>authorization_howto.txt</include>
+            <include>ctags.config</include>
+            <include>EXAMPLE.txt</include>
+            <include>groups_howto.txt</include>
+          </includes>
         </fileSet>
         <fileSet>
-	    <directory>${project.build.directory}/dist</directory>
-	    <outputDirectory>man/man1</outputDirectory>
-	    <includes>
-	      <include>opengrok.1</include>
-	    </includes>
+          <directory>${project.build.directory}/dist</directory>
+          <outputDirectory>man/man1</outputDirectory>
+          <includes>
+            <include>opengrok.1</include>
+          </includes>
         </fileSet>
         <fileSet>
-	    <directory>${project.basedir}/..</directory>
-	    <outputDirectory>bin</outputDirectory>
-	    <includes>
-	      <include>OpenGrok</include>
-	    </includes>
+          <directory>${project.basedir}/..</directory>
+          <outputDirectory>bin</outputDirectory>
+          <includes>
+            <include>OpenGrok</include>
+          </includes>
         </fileSet>
         <fileSet>
-	    <directory>${project.basedir}/../tools</directory>
-	    <outputDirectory>bin</outputDirectory>
-	    <includes>
-	      <include>ConfigMerge</include>
-	      <include>Messages</include>
-	      <include>Groups</include>
-	    </includes>
+          <directory>${project.basedir}/../tools</directory>
+          <outputDirectory>bin</outputDirectory>
+          <includes>
+            <include>ConfigMerge</include>
+            <include>Messages</include>
+            <include>Groups</include>
+          </includes>
         </fileSet>
         <fileSet>
-	    <directory>${project.basedir}/../tools/sync</directory>
-	    <outputDirectory>bin</outputDirectory>
-	    <includes>
-	      <include>*.py</include>
-	    </includes>
+          <directory>${project.basedir}/../tools/sync</directory>
+          <outputDirectory>bin</outputDirectory>
+          <includes>
+            <include>*.py</include>
+            <include>reindex-project.ksh</include>
+          </includes>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/../lib</directory>
-	    <outputDirectory>lib/lib</outputDirectory>
-	    <includes>
-	      <include>*.jar</include>
-	    </includes>
+          <directory>${project.build.directory}/../lib</directory>
+          <outputDirectory>lib/lib</outputDirectory>
+          <includes>
+            <include>*.jar</include>
+          </includes>
         </fileSet>
         <fileSet>
-            <directory>${project.build.directory}/dist</directory>
-	    <outputDirectory>lib/lib</outputDirectory>
-	    <includes>
-	      <include>*.jar</include>
-	    </includes>
+          <directory>${project.build.directory}/dist</directory>
+          <outputDirectory>lib/lib</outputDirectory>
+          <includes>
+            <include>*.jar</include>
+          </includes>
         </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
`reindex-project.ksh` script is missing from distribution TAR Ball