### PR TITLE
Add support for Tomcat webapp context in deploy command

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -983,8 +983,30 @@ DeployWar()
         FatalError "Missing Deployment Directory ${warTarget}"
     fi
 
+    APP_CONTEXT="source"
+    FINAL_WAR_NAME="source"
+    if [ "$applicationServer" = "Tomcat" ]
+    then
+        if [ ! -z ${OPENGROK_WEBAPP_CONTEXT+x} ]
+        then
+            APP_CONTEXT="${OPENGROK_WEBAPP_CONTEXT}"
+
+            # strip leading /
+            case ${APP_CONTEXT} in
+                /*) APP_CONTEXT=`echo ${APP_CONTEXT} | sed 's|^/||'`
+            esac
+
+            FINAL_WAR_NAME=`echo ${APP_CONTEXT} | sed 's|/|#|g'`
+
+            if [ -z "${FINAL_WAR_NAME}" ]
+            then
+                FINAL_WAR_NAME="ROOT"
+            fi
+        fi
+    fi
+
     Progress "Installing ${OPENGROK_DIST_WAR} to ${warTarget} ..."
-    ${DO} cp -p "${OPENGROK_DIST_WAR}" "${warTarget}/"
+    ${DO} cp -p "${OPENGROK_DIST_WAR}" "${warTarget}/${FINAL_WAR_NAME}.war"
     if [ $? != 0 ]
     then
         FatalError "Web Application Installation FAILED"
@@ -1011,7 +1033,7 @@ DeployWar()
         if [ -n "${EXTRACT_COMMAND}" ]
         then
             cd "${warTarget}"
-            eval "${EXTRACT_COMMAND} ${warTarget}/source.war WEB-INF/web.xml"
+            eval "${EXTRACT_COMMAND} ${warTarget}/${FINAL_WAR_NAME}.war WEB-INF/web.xml"
             if [ "${OPENGROK_INSTANCE_BASE}" != '/var/opengrok' ]
             then
                 sed -e 's:/var/opengrok/etc/configuration.xml:'"$XML_CONFIGURATION"':g' \
@@ -1028,7 +1050,7 @@ DeployWar()
 		mv "${warTarget}/WEB-INF/web.xml.tmp" \
 		    "${warTarget}/WEB-INF/web.xml"
             fi
-            eval "${COMPRESS_COMMAND} ${warTarget}/source.war WEB-INF/web.xml"
+            eval "${COMPRESS_COMMAND} ${warTarget}/${FINAL_WAR_NAME}.war WEB-INF/web.xml"
             rm -rf "${warTarget}/WEB-INF"
         fi
     fi
@@ -1039,7 +1061,7 @@ DeployWar()
     Progress "running, or wait until it loads the just installed web " \
         "application."
     Progress
-    Progress "OpenGrok should be available on <HOST>:<PORT>/source"
+    Progress "OpenGrok should be available on <HOST>:<PORT>/${APP_CONTEXT}"
     Progress "  where HOST and PORT are configured in ${applicationServer}."
     Progress
 }

--- a/OpenGrok
+++ b/OpenGrok
@@ -18,7 +18,7 @@
 # CDDL HEADER END
 
 #
-# Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
 #
 
@@ -133,6 +133,8 @@ Supported Environment Variables for configuring the default setup:
                                   (by default 3 directories from SRC_ROOT)
   - OPENGROK_WEBAPP_CFGADDR     Web app address to send configuration to
                                   (use "none" to avoid sending it to web app)
+  - OPENGROK_WEBAPP_CONTEXT     Context URL of the OpenGrok webapp
+                                  (by default /source).
   - OPENGROK_WPREFIX            Disable wildcard prefix search query support (*)
   - OPENGROK_TAG                Enable parsing of revision tags into the History
                                   view
@@ -987,7 +989,7 @@ DeployWar()
     FINAL_WAR_NAME="source"
     if [ "$applicationServer" = "Tomcat" ]
     then
-        if [ ! -z ${OPENGROK_WEBAPP_CONTEXT+x} ]
+        if [ ! -z ${OPENGROK_WEBAPP_CONTEXT+x} ] # OPENGROK_WEBAPP_CONTEXT is set
         then
             APP_CONTEXT="${OPENGROK_WEBAPP_CONTEXT}"
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

Partly fixes <https://github.com/oracle/opengrok/issues/2113>

This was needed for demo site. Therefore, I created just a quick fix for Tomcat. I could not find how it should be done for GlassFish or Resin. If you know then please let me know :) 

I tried to conform to this text in Tomcat documentation:
`
If the context path is the empty string then the base name will be ROOT (always in upper case) otherwise the base name will be the context path with the leading '/' removed and any remaining '/' characters replaced with '#'
`

If `OPENGROK_WEBAPP_CONTEXT` variable is not set then `source` is used by default. Otherwise I try to follow the Tomcat instructions specified above.

I program in shell very occasionally so there will be probably some mistakes. So please look at it carefully :)

Also, I do not know what are the conventions for variable names or `then` position in `if` statements. Are there even any?

**Note:**
I had to use `! -z ${OPENGROK_WEBAPP_CONTEXT+x}` construct instead of `-n ${OPENGROK_WEBAPP_CONTEXT+x}` because the later did not work as needed.

Testing:
I tried some basic contexts and they seemed to work. Not sure if some error proof constructs should be added there or not. If yes, let me know :) 

Thanks :)

