### PR TITLE
Fix #431 : option -w should die

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -133,10 +133,6 @@ Supported Environment Variables for configuring the default setup:
                                   (by default 3 directories from SRC_ROOT)
   - OPENGROK_WEBAPP_CFGADDR     Web app address to send configuration to
                                   (use "none" to avoid sending it to web app)
-  - OPENGROK_WEBAPP_CONTEXT     Context URL of the OpenGrok webapp
-                                  (by default /source). FULL reindex is needed
-                                  once this is used (old already indexed files
-                                  won't be refreshed)
   - OPENGROK_WPREFIX            Disable wildcard prefix search query support (*)
   - OPENGROK_TAG                Enable parsing of revision tags into the History
                                   view
@@ -386,13 +382,6 @@ DefaultInstanceConfiguration()
 
     if [ -n "${WEBAPP_CONFIG_ADDRESS}" ]; then
         WEBAPP_CONFIG="-U ${WEBAPP_CONFIG_ADDRESS}"
-    fi
-
-    # OPTIONAL: Context URL of the OpenGrok webapp
-    #           (default is /source)
-    WEBAPP_CONTEXT=""
-    if [ -n "${OPENGROK_WEBAPP_CONTEXT}" ]; then
-        WEBAPP_CONTEXT="-w ${OPENGROK_WEBAPP_CONTEXT}"
     fi
 
     # OPTIONAL: JVM Options
@@ -912,7 +901,6 @@ CommonInvocation()
         ${ASSIGNMENTS}							\
         ${READ_XML_CONF}                                        	\
         ${WEBAPP_CONFIG}						\
-        ${WEBAPP_CONTEXT}						\
         ${OPENGROK_PROFILER:+--profiler}				\
         "${@}"
 }

--- a/build.xml
+++ b/build.xml
@@ -371,6 +371,9 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
         <property name="gen.context.dir" value="/org/opensolaris/opengrok/search/context"/>
         <run-jflex dir="${gen.context.dir}" name="HistoryLineTokenizer"/>
         <run-jflex dir="${gen.context.dir}" name="PlainLineTokenizer"/>
+
+        <property name="gen.web.dir" value="/org/opensolaris/opengrok/web"/>
+        <run-jflex dir="${gen.web.dir}" name="XrefSourceTransformer"/>
     </target>
 
     <property name="git" value="git"/>

--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -25,6 +25,7 @@ package org.opensolaris.opengrok.analysis;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -629,6 +630,35 @@ public class AnalyzerGuru {
         analyzer.setScopesEnabled(env.isScopesEnabled());
         analyzer.setFoldingEnabled(env.isFoldingEnabled());
         analyzer.writeXref(args);
+    }
+
+    /**
+     * Writes a browse-able version of the file transformed for immediate
+     * serving to a web client.
+     * @param contextPath the web context path for
+     * {@link Util#dumpXref(java.io.Writer, java.io.Reader, java.lang.String)}
+     * @param factory the analyzer factory for this file type
+     * @param in the input stream containing the data
+     * @param out a defined instance to write
+     * @param defs definitions for the source file, if available
+     * @param annotation annotation information for the file
+     * @param project project the file belongs to
+     * @throws java.io.IOException if an error occurs while creating the output
+     */
+    public static void writeDumpedXref(String contextPath,
+            FileAnalyzerFactory factory, Reader in, Writer out,
+            Definitions defs, Annotation annotation, Project project)
+            throws IOException {
+
+        File xrefTemp = File.createTempFile("ogxref", ".html");
+        try {
+            try (FileWriter tmpout = new FileWriter(xrefTemp)) {
+                writeXref(factory, in, tmpout, defs, annotation, project);
+            }
+            Util.dumpXref(out, xrefTemp, false, contextPath);
+        } finally {
+            xrefTemp.delete();
+        }
     }
 
     /**

--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -144,6 +144,14 @@ public final class Configuration {
     private String sourceRoot;
     private String dataRoot;
     private List<RepositoryInfo> repositories;
+    /**
+     * @deprecated This is kept around so not to break object deserialization
+     * but it is ignored and cannot be truly set. This should mean that the
+     * configuration is written leaving out this deprecated property; so after
+     * some time it can be retired with the expectation that zero or a
+     * miniscule number of production configurations still have this deprecated
+     * property.
+     */
     private String urlPrefix;
     private boolean generateHtml;
     /**
@@ -461,8 +469,7 @@ public final class Configuration {
         setStatisticsFilePath(null);
         //setTabSize(4);
         setTagsEnabled(false);
-        setUrlPrefix("/source/s?");
-        //setUrlPrefix("../s?"); // TODO generate relative search paths, get rid of -w <webapp> option to indexer !
+        //urlPrefix's constant value is moved to RuntimeEnvironment.
         //setUserPage("http://www.myserver.org/viewProfile.jspa?username=");
         // Set to empty string so we can append it to the URL
         // unconditionally later.
@@ -812,15 +819,16 @@ public final class Configuration {
     }
 
     /**
-     * Set the URL prefix to be used by the {@link
-     * org.opensolaris.opengrok.analysis.executables.JavaClassAnalyzer} as well
-     * as lexers (see {@link org.opensolaris.opengrok.analysis.JFlexXref}) when
-     * they create output with html links.
-     *
-     * @param urlPrefix prefix to use.
+     * Formerly this allowed setting the URL prefix to be used for the Java
+     * class analyzer and for language cross-referencing (xref) when they
+     * created HTML links. Now, a static value is used and transformed as
+     * necessary to the servlet {@code contextPath} so that users can deploy
+     * OpenGrok as they like.
+     * @param urlPrefix ignored
      */
+    @Deprecated
     public void setUrlPrefix(String urlPrefix) {
-        this.urlPrefix = urlPrefix;
+        // ignore the value
     }
 
     public void setGenerateHtml(boolean generateHtml) {

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -103,6 +103,7 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static org.opensolaris.opengrok.configuration.Configuration.makeXMLStringAsConfiguration;
 import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 import org.opensolaris.opengrok.util.PathUtils;
+import org.opensolaris.opengrok.web.Prefix;
 
 /**
  * The RuntimeEnvironment class is used as a placeholder for the current
@@ -111,6 +112,9 @@ import org.opensolaris.opengrok.util.PathUtils;
 public final class RuntimeEnvironment {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RuntimeEnvironment.class);
+
+    /** {@code "/source"} + {@link Prefix#SEARCH_R} + {@code "?"} */
+    private static final String URL_PREFIX = "/source" + Prefix.SEARCH_R + "?";
 
     private Configuration configuration;
     private final ThreadLocal<Configuration> threadConfig;
@@ -556,21 +560,12 @@ public final class RuntimeEnvironment {
     }
 
     /**
-     * Get the context name of the web application
-     *
-     * @return the web applications context name
+     * Gets a static placeholder for the web application context name that is
+     * translated to the true servlet {@code contextPath} on demand.
+     * @return {@code "/source"} + {@link Prefix#SEARCH_R} + {@code "?"}
      */
     public String getUrlPrefix() {
-        return threadConfig.get().getUrlPrefix();
-    }
-
-    /**
-     * Set the web context name
-     *
-     * @param urlPrefix the web applications context name
-     */
-    public void setUrlPrefix(String urlPrefix) {
-        threadConfig.get().setUrlPrefix(urlPrefix);
+        return URL_PREFIX;
     }
 
     /**

--- a/src/org/opensolaris/opengrok/index/Indexer.java
+++ b/src/org/opensolaris/opengrok/index/Indexer.java
@@ -771,22 +771,6 @@ public final class Indexer {
                 "(so that the web application can use the same configuration)").Do( configFile -> {
                 configFilename = (String)configFile;
             });
-
-            parser.on("-w", "--web", "=webapp-context",
-                "Context of webapp. Default is /source. If you specify a different",
-                "name, make sure to rename source.war to that name. Also FULL reindex",
-                "is needed if this is changed.").
-                Do( webContext -> {
-                    String webapp = (String)webContext;
-                    if (webapp.charAt(0) != '/' && !webapp.startsWith("http")) {
-                        webapp = "/" + webapp;
-                    }
-                    if (!webapp.endsWith("/")) {
-                        webapp += "/";
-                    }
-                    cfg.setUrlPrefix(webapp + "s?");
-                }
-            );
         });
 
         // Need to read the configuration file first

--- a/src/org/opensolaris/opengrok/web/XrefSourceTransformer.lex
+++ b/src/org/opensolaris/opengrok/web/XrefSourceTransformer.lex
@@ -1,0 +1,108 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.web;
+
+import java.io.Writer;
+import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
+%%
+%public
+%class XrefSourceTransformer
+%unicode
+%type boolean
+%eofval{
+    return false;
+%eofval}
+%{
+    private static final String SOURCE = "source";
+    private static final String SOURCE1 = "/" + SOURCE;
+    private static final String SOURCE2 = SOURCE1 + "/";
+    private static final String HREF_EQ_QUOT = "href=\"";
+    private static final String HREF_EQ_QSOURCE2 = HREF_EQ_QUOT + SOURCE2;
+
+    private Writer out;
+
+    /**
+     * If set, this will have a leading and trailing slash (which might be the
+     * same character for the root path). It's intended to substitute the
+     * default {@code "/source/"} from
+     * {@link RuntimeEnvironment#getUrlPrefix()}.
+     */
+    private String contextPath;
+
+    /**
+     * Sets the required target to write.
+     * @param out a required instance
+     */
+    public void setWriter(Writer out) {
+        if (out == null) {
+            throw new IllegalArgumentException("`out' is null");
+        }
+        this.out = out;
+    }
+
+    /**
+     * Sets the optional context path override.
+     * @param path an optional instance
+     */
+    public void setContextPath(String path) {
+        if (path == null || path.equals(SOURCE) || path.equals(SOURCE1) ||
+                path.equals(SOURCE2)) {
+            this.contextPath = null;
+        } else {
+            StringBuilder pathBuilder = new StringBuilder();
+
+            if (!path.startsWith("/")) {
+                pathBuilder.append("/");
+            }
+            pathBuilder.append(path);
+            this.contextPath = pathBuilder.toString();
+
+            if (!this.contextPath.endsWith("/")) {
+                pathBuilder.append("/");
+                this.contextPath = pathBuilder.toString();
+            }
+        }
+    }
+%}
+
+%%
+
+/*
+ * Matches a hyperlink to the static OpenGrok urlPrefix for possible
+ * substitution.
+ */
+"href=\"/source/"    {
+    if (contextPath == null) {
+        out.write(HREF_EQ_QSOURCE2); // faster than yytext()
+    } else {
+        out.write(HREF_EQ_QUOT);
+        out.write(contextPath);
+    }
+}
+
+[^]    {
+    for (int i = 0; i < yylength(); ++i) {
+        out.write(yycharat(i)); // faster than yytext()
+    }
+}

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -200,9 +200,6 @@ public class RuntimeEnvironmentTest {
     public void testUrlPrefix() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertEquals("/source/s?", instance.getUrlPrefix());
-        String prefix = "/opengrok/s?";
-        instance.setUrlPrefix(prefix);
-        assertEquals(prefix, instance.getUrlPrefix());
     }
 
     @Test

--- a/web/enoent.jsp
+++ b/web/enoent.jsp
@@ -31,9 +31,6 @@ org.opensolaris.opengrok.configuration.RuntimeEnvironment"
     PageConfig cfg = PageConfig.get(request);
     cfg.checkSourceRootExistence();
     cfg.setTitle("File not found");
-
-    String context = request.getContextPath();
-    cfg.getEnv().setUrlPrefix(context + Prefix.SEARCH_R + "?");
 }
 %><%@
 

--- a/web/list.jsp
+++ b/web/list.jsp
@@ -28,6 +28,7 @@ java.io.BufferedInputStream,
 java.io.BufferedReader,
 java.io.FileInputStream,
 java.io.FileReader,
+java.io.FileWriter,
 java.io.InputStream,
 java.io.InputStreamReader,
 java.io.Reader,
@@ -86,10 +87,10 @@ document.pageReady.push(function() { pageReadyList();});
 {
     PageConfig cfg = PageConfig.get(request);
     String rev = cfg.getRequestedRevision();
+    Project project = cfg.getProject();
 
-    String navigateWindowEnabled = cfg.getProject() != null
-                ? Boolean.toString(cfg.getProject().isNavigateWindowEnabled())
-                : "false";
+    String navigateWindowEnabled = project != null ? Boolean.toString(
+            project.isNavigateWindowEnabled()) : "false";
     File resourceFile = cfg.getResourceFile();
     String path = cfg.getPath();
     String basename = resourceFile.getName();
@@ -99,16 +100,15 @@ document.pageReady.push(function() { pageReadyList();});
         // valid resource is requested
         // mast.jsp assures, that resourceFile is valid and not /
         // see cfg.resourceNotAvailable()
-        Project activeProject = Project.getProject(resourceFile);
         String cookieValue = cfg.getRequestedProjectsAsString();
-        if (activeProject != null) {
+        if (project != null) {
             Set<String>  projects = cfg.getRequestedProjects();
-            if (!projects.contains(activeProject.getName())) {
-                projects.add(activeProject.getName());
+            if (!projects.contains(project.getName())) {
+                projects.add(project.getName());
                 // update cookie
                 cookieValue = cookieValue.length() == 0
-                    ? activeProject.getName()
-                    : activeProject.getName() + ',' + cookieValue;
+                    ? project.getName()
+                    : project.getName() + ',' + cookieValue;
                 Cookie cookie = new Cookie(PageConfig.OPEN_GROK_PROJECT, URLEncoder.encode(cookieValue, "utf-8"));
                 // TODO hmmm, projects.jspf doesn't set a path
                 cookie.setPath(request.getContextPath() + '/');
@@ -120,13 +120,13 @@ document.pageReady.push(function() { pageReadyList();});
         List<String> files = cfg.getResourceFileList();
         if (!files.isEmpty()) {
             List<FileExtra> extras = null;
-            if (activeProject != null) {
+            if (project != null) {
                 SearchHelper searchHelper = cfg.prepareInternalSearch();
                 // N.b. searchHelper.destroy() is called via
                 // WebappListener.requestDestroyed() on presence of the
                 // following REQUEST_ATTR.
                 request.setAttribute(SearchHelper.REQUEST_ATTR, searchHelper);
-                searchHelper.prepareExec(activeProject);
+                searchHelper.prepareExec(project);
 
                 if (searchHelper.searcher != null) {
                     DirectoryExtraReader extraReader =
@@ -196,7 +196,8 @@ document.pageReady.push(function() { pageReadyList();});
                      * document using the system default charset.
                      */
                     r = new InputStreamReader(bin);
-                    Util.dump(out, r);
+                    // dumpXref() is also useful here for translating links.
+                    Util.dumpXref(out, r, request.getContextPath());
                 } else if (g == Genre.PLAIN) {
 %>
 <div id="src" data-navigate-window-enabled="<%= navigateWindowEnabled %>">
@@ -208,8 +209,8 @@ document.pageReady.push(function() { pageReadyList();});
                     // SRCROOT is read with UTF-8 as a default.
                     r = IOUtils.createBOMStrippedReader(bin,
                         StandardCharsets.UTF_8.name());
-                    AnalyzerGuru.writeXref(a, r, out, defs, annotation,
-                        Project.getProject(resourceFile));
+                    AnalyzerGuru.writeDumpedXref(request.getContextPath(), a,
+                            r, out, defs, annotation, project);
     %></pre>
 </div><%
                 } else {
@@ -234,7 +235,9 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
 %>
 <div id="src" data-navigate-window-enabled="<%= navigateWindowEnabled %>">
     <pre><%
-                Util.dump(out, xrefFile, xrefFile.getName().endsWith(".gz"));
+                boolean compressed = xrefFile.getName().endsWith(".gz");
+                Util.dumpXref(out, xrefFile, compressed,
+                        request.getContextPath());
     %></pre>
 </div><%
             }
@@ -279,8 +282,9 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
                                 // SRCROOT is read with UTF-8 as a default.
                                 r = IOUtils.createBOMStrippedReader(in,
                                     StandardCharsets.UTF_8.name());
-                                AnalyzerGuru.writeXref(a, r, out, defs,
-                                    annotation, Project.getProject(resourceFile));
+                                AnalyzerGuru.writeDumpedXref(
+                                        request.getContextPath(), a, r, out,
+                                        defs, annotation, project);
                             } else if (g == Genre.IMAGE) {
         %></pre>
         <img src="<%= rawPath %>?r=<%= Util.URIEncode(rev) %>"/>
@@ -292,7 +296,11 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
                                  * default charset.
                                  */
                                 r = new InputStreamReader(in);
-                                Util.dump(out, r);
+                                /**
+                                 * dumpXref() is also useful here for
+                                 * translating links.
+                                 */
+                                Util.dumpXref(out, r, request.getContextPath());
                             } else {
         %> Click <a href="<%= rawPath %>?r=<%= Util.URIEncode(rev) %>">download <%= basename %></a><%
                             }
@@ -349,7 +357,8 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
 %>
 <div id="src" data-navigate-window-enabled="<%= navigateWindowEnabled %>">
     <pre><%
-            Util.dump(out, xrefFile, xrefFile.getName().endsWith(".gz"));
+            boolean compressed = xrefFile.getName().endsWith(".gz");
+            Util.dumpXref(out, xrefFile, compressed, request.getContextPath());
     %></pre>
 </div><%
         }

--- a/web/mast.jsp
+++ b/web/mast.jsp
@@ -71,9 +71,6 @@ org.opensolaris.opengrok.web.Util"%><%
     // set the default page title
     String path = cfg.getPath();
     cfg.setTitle(cfg.getPathTitle());
-
-    String context = request.getContextPath();
-    cfg.getEnv().setUrlPrefix(context + Prefix.SEARCH_R + "?");
 }
 %>
 <%@

--- a/web/projects.jspf
+++ b/web/projects.jspf
@@ -19,8 +19,8 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
-
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 --%>
 <%@page import="
@@ -39,7 +39,6 @@ org.opensolaris.opengrok.configuration.Project
     }
 
     PageConfig cfg = PageConfig.get(request);
-    cfg.getEnv().setUrlPrefix(request.getContextPath() + Prefix.SEARCH_R + "?");
 
     String projects = cfg.getRequestedProjectsAsString();
     if (projects.length() != 0) {

--- a/web/rss.jsp
+++ b/web/rss.jsp
@@ -49,7 +49,6 @@ org.opensolaris.opengrok.web.PageConfig"
         }
         return;
     }
-    cfg.getEnv().setUrlPrefix(request.getContextPath() + Prefix.SEARCH_R + '?');
     String path = cfg.getPath();
     String dtag = cfg.getDefineTagsIndex();
     String ForwardedHost = request.getHeader("X-Forwarded-Host");


### PR DESCRIPTION
Hello,

Please consider for integration this patch to allow serving OpenGrok content through arbitrary web app deployments and to therefore expunge the `-w` option.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
