### PR TITLE
wait for output thread to finish reading

### DIFF
--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -168,7 +168,7 @@ class Command:
                 return
 
         timeout_thread = None
-        sema = asyncio.Semaphore(value=1)
+        sema = asyncio.Semaphore(value=0)
         output_thread = OutputThread(sema, self.logger)
         try:
             start_time = time.time()

--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -120,6 +120,7 @@ class Command:
                 self.out = []
                 self.condition = condition
                 self.logger = logger
+                self.done = False
                 self.start()
 
             def run(self):
@@ -131,6 +132,7 @@ class Command:
                 while True:
                     line = self.pipe_fobj.readline()
                     if not line:
+                        self.done = True
                         self.logger.debug("end of output")
                         self.pipe_fobj.close()
                         with self.condition:
@@ -228,8 +230,9 @@ class Command:
             # gracefully exit the read loop we have to close it here ourselves.
             output_thread.close()
             self.logger.debug("Waiting on output thread to finish reading")
-            with output_condition:
-                output_condition.wait()
+            if not output_thread.done:
+                with output_condition:
+                    output_condition.wait()
 
             self.out = output_thread.getoutput()
             elapsed_time = time.time() - start_time

--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -126,8 +126,8 @@ class Command:
             def run(self):
                 """
                 It might happen that after the process is gone, the thread
-                still has data to read from the pipe. Hence, condition is used
-                to synchronize with the caller.
+                still has data to read from the pipe. Hence, a semaphore
+                is used to synchronize with the caller.
                 """
                 while True:
                     line = self.pipe_fobj.readline()

--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -125,8 +125,8 @@ class Command:
             def run(self):
                 """
                 It might happen that after the process is gone, the thread
-                still has data to read from the pipe. Hence, a eventphore
-                is used to synchronize with the caller.
+                still has data to read from the pipe. Hence, event is used
+                to synchronize with the caller.
                 """
                 while True:
                     line = self.pipe_fobj.readline()

--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -27,7 +27,6 @@ import subprocess
 import string
 import threading
 import time
-import asyncio
 
 
 class TimeoutException(Exception):
@@ -168,7 +167,7 @@ class Command:
                 return
 
         timeout_thread = None
-        sema = asyncio.Semaphore(value=0)
+        sema = threading.Semaphore(value=0)
         output_thread = OutputThread(sema, self.logger)
         try:
             start_time = time.time()

--- a/tools/sync/command.py
+++ b/tools/sync/command.py
@@ -222,9 +222,9 @@ class Command:
                 with time_condition:
                     time_condition.notifyAll()
 
-            # Strangely, the subprocess module does not close the write pipe
-            # descriptor it fetched via OutputThread's fileno() so in order to
-            # gracefully exit the read loop we have to close it here ourselves.
+            # The subprocess module does not close the write pipe descriptor
+            # it fetched via OutputThread's fileno() so in order to gracefully
+            # exit the read loop we have to close it here ourselves.
             output_thread.close()
             self.logger.debug("Waiting on output thread to finish reading")
             sema.acquire()


### PR DESCRIPTION
Lately, the mirroring on our production instance started failing with strange conditions such as `Messages` not being able to retrieve source root or because a branch of a Mercurial repository could not be determined. These commands exited with 0 however the output was empty. It might be because the server is more loaded than usual due to full reindex running in background so thread scheduling is not going in its usual lines.

I think this is caused by an outstanding TODO item (another reason to get rid of these comments and file bugs for each one of them) in `command.py` - if a process exits too quickly, the main thread will not wait for the output thread to read the full output. As a result these single line cases mentioned above will complete with empty output.