### PR TITLE
Update Servlet API to 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Official page of the project is on:
 ## 2. Requirements
 * Latest Java (at least 1.8)
   <http://www.oracle.com/technetwork/java/>
-* A servlet container like Tomcat (8.x or later) supporting Servlet 2.5 and JSP 2.1
+* A servlet container like Tomcat (8.x or later) supporting Servlet 3.1 and JSP 2.1
   <http://tomcat.apache.org/>
 * Exuberant Ctags or Universal Ctags
   <http://ctags.sourceforge.net/>

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -515,7 +515,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -72,7 +72,7 @@ Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
 	<dependency>
 	    <groupId>junit</groupId>

--- a/plugins/test/opengrok/auth/plugin/util/DummyHttpServletRequestLdap.java
+++ b/plugins/test/opengrok/auth/plugin/util/DummyHttpServletRequestLdap.java
@@ -18,37 +18,44 @@
  */
 
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.security.Principal;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpSessionContext;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
+
 import opengrok.auth.plugin.UserPlugin;
 import opengrok.auth.plugin.entity.User;
 import org.opensolaris.opengrok.util.RandomString;
 
 public class DummyHttpServletRequestLdap implements HttpServletRequest {
 
-    private final Map<String, String> headers = new HashMap<String, String>();
-    private final Map<String, Object> attrs = new HashMap<String, Object>();
+    private final Map<String, String> headers = new HashMap<>();
+    private final Map<String, Object> attrs = new HashMap<>();
     private HttpSession sessions = new HttpSession() {
 
-        private final Map<String, Object> attrs = new HashMap<String, Object>();
+        private final Map<String, Object> attrs = new HashMap<>();
 
         @Override
         public long getCreationTime() {
@@ -83,8 +90,9 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
             return 3600;
         }
 
+        @Override
         @SuppressWarnings("deprecation")
-        public HttpSessionContext getSessionContext() {
+        public javax.servlet.http.HttpSessionContext getSessionContext() {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
@@ -153,10 +161,6 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
     @Override
     public long getDateHeader(String string) {
         throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    public void setHeader(String string, String value) {
-        headers.put(string, value);
     }
 
     @Override
@@ -249,8 +253,9 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
         return sessions;
     }
 
-    public void setSession(HttpSession session) {
-        this.sessions = session;
+    @Override
+    public String changeSessionId() {
+        return null;
     }
 
     @Override
@@ -275,6 +280,36 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
     }
 
     @Override
+    public boolean authenticate(HttpServletResponse httpServletResponse) {
+        return false;
+    }
+
+    @Override
+    public void login(String s, String s1) {
+
+    }
+
+    @Override
+    public void logout() {
+
+    }
+
+    @Override
+    public Collection<Part> getParts() {
+        return null;
+    }
+
+    @Override
+    public Part getPart(String s) {
+        return null;
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) {
+        return null;
+    }
+
+    @Override
     public Object getAttribute(String string) {
         return attrs.get(string);
     }
@@ -290,13 +325,18 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
     }
 
     @Override
-    public void setCharacterEncoding(String string) throws UnsupportedEncodingException {
+    public void setCharacterEncoding(String string) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public int getContentLength() {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        return 0;
     }
 
     @Override
@@ -418,5 +458,40 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
     @Override
     public int getLocalPort() {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return null;
     }
 }

--- a/plugins/test/opengrok/auth/plugin/util/DummyHttpServletRequestUser.java
+++ b/plugins/test/opengrok/auth/plugin/util/DummyHttpServletRequestUser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin.util;
 
@@ -26,23 +26,30 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpSessionContext;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
 
 public class DummyHttpServletRequestUser implements HttpServletRequest {
 
-    private final Map<String, String> headers = new HashMap<String, String>();
-    private final Map<String, Object> attrs = new HashMap<String, Object>();
+    private final Map<String, String> headers = new HashMap<>();
+    private final Map<String, Object> attrs = new HashMap<>();
     private HttpSession sessions = new HttpSession() {
 
         private final Map<String, Object> attrs = new HashMap<>();
@@ -76,8 +83,9 @@ public class DummyHttpServletRequestUser implements HttpServletRequest {
             return 3600;
         }
 
+        @Override
         @SuppressWarnings("deprecation")
-        public HttpSessionContext getSessionContext() {
+        public javax.servlet.http.HttpSessionContext getSessionContext() {
             throw new UnsupportedOperationException("Not supported yet."); 
         }
 
@@ -241,9 +249,10 @@ public class DummyHttpServletRequestUser implements HttpServletRequest {
     public HttpSession getSession() {
         return sessions;
     }
-    
-    public void setSession(HttpSession session) {
-        this.sessions = session;
+
+    @Override
+    public String changeSessionId() {
+        return null;
     }
 
     @Override
@@ -265,6 +274,36 @@ public class DummyHttpServletRequestUser implements HttpServletRequest {
     @Deprecated
     public boolean isRequestedSessionIdFromUrl() {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse httpServletResponse) {
+        return false;
+    }
+
+    @Override
+    public void login(String s, String s1) {
+
+    }
+
+    @Override
+    public void logout() {
+
+    }
+
+    @Override
+    public Collection<Part> getParts() {
+        return null;
+    }
+
+    @Override
+    public Part getPart(String s) {
+        return null;
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) {
+        return null;
     }
 
     @Override
@@ -290,6 +329,11 @@ public class DummyHttpServletRequestUser implements HttpServletRequest {
     @Override
     public int getContentLength() {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        return 0;
     }
 
     @Override
@@ -411,5 +455,40 @@ public class DummyHttpServletRequestUser implements HttpServletRequest {
     @Override
     public int getLocalPort() {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return null;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,9 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>3.1.0</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                     <groupId>com.googlecode.json-simple</groupId>

--- a/test/org/opensolaris/opengrok/web/DummyHttpServletRequest.java
+++ b/test/org/opensolaris/opengrok/web/DummyHttpServletRequest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.web;
 
@@ -26,18 +26,26 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpSessionContext;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
+
 import static org.opensolaris.opengrok.util.RandomString.generate;
 
 /**
@@ -57,7 +65,7 @@ import static org.opensolaris.opengrok.util.RandomString.generate;
  */
 public class DummyHttpServletRequest implements HttpServletRequest {
 
-    private final Map<String, Object> attrs = new HashMap<String, Object>();
+    private final Map<String, Object> attrs = new HashMap<>();
     
     private class DummyHttpSession implements HttpSession {
         private Map<String, Object> attrs = new HashMap<>();
@@ -91,8 +99,9 @@ public class DummyHttpServletRequest implements HttpServletRequest {
             return 3600;
         }
 
+        @Override
         @SuppressWarnings("deprecation")
-        public HttpSessionContext getSessionContext() {
+        public javax.servlet.http.HttpSessionContext getSessionContext() {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
@@ -262,7 +271,12 @@ public class DummyHttpServletRequest implements HttpServletRequest {
         }
         return session;
     }
-    
+
+    @Override
+    public String changeSessionId() {
+        return null;
+    }
+
     @Override
     public boolean isRequestedSessionIdValid() {
         throw new UnsupportedOperationException("Not supported yet.");
@@ -281,6 +295,36 @@ public class DummyHttpServletRequest implements HttpServletRequest {
     @Override @Deprecated
     public boolean isRequestedSessionIdFromUrl() {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse httpServletResponse) {
+        return false;
+    }
+
+    @Override
+    public void login(String s, String s1) {
+
+    }
+
+    @Override
+    public void logout() {
+
+    }
+
+    @Override
+    public Collection<Part> getParts() {
+        return null;
+    }
+
+    @Override
+    public Part getPart(String s) {
+        return null;
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) {
+        return null;
     }
 
     @Override
@@ -306,6 +350,11 @@ public class DummyHttpServletRequest implements HttpServletRequest {
     @Override
     public int getContentLength() {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        return 0;
     }
 
     @Override
@@ -426,5 +475,40 @@ public class DummyHttpServletRequest implements HttpServletRequest {
     @Override
     public int getLocalPort() {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return null;
     }
 }

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
     <display-name>OpenGrok</display-name>
     <description>A wicked fast source browser</description>
     <context-param>


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

Basic functionality seems to work on Tomcat 9. I tried search and navigating through project files.

Added methods were generated automatically by Idea. 

I also used fully qualified class name for `javax.servlet.http.HttpSessionContext` so I could remove `import` which caused deprecation warning.

fixes https://github.com/oracle/opengrok/issues/2089

Thanks :) 