### PR TITLE
allow to enable/disable history per project

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -308,9 +308,6 @@ DefaultInstanceConfiguration()
 
     # OPTIONAL: Ignore these patterns as names of files or directories
     #OPENGROK_IGNORE_PATTERNS="-i dummy"
-    # To ignore skipping just the history cache creation for a particular
-    # directory and all of it's subdirectories, touch an empty
-    # .opengrok_skip_history file at the root of that directory
 
     # OPTIONAL: Enable Projects
     #           (Every directory in SRC_ROOT is considered a separate project)

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ by OpenGrok.
 
 Note that OpenGrok ignores symbolic links.
 
-If you want to skip indexing the history of a particular directory
-(and all of it's subdirectories), you can touch `.opengrok_skip_history` file
-at the root of that directory.
+If you want to skip indexing the history of a particular directory,
+use per project settings as per
+https://github.com/oracle/opengrok/wiki/Per-project-configuration
 If you want to disable history generation for all repositories globally, then
 set `OPENGROK_GENERATE_HISTORY` environment variable to `off` during indexing.
 

--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -184,7 +184,7 @@ public final class Configuration {
     private RemoteSCM remoteScmSupported;
     private boolean optimizeDatabase;
     /**
-     * @deprecated This is kept around so not to break object deserialization.
+     * @deprecated This is kept around so not to break object de-serialization.
      * <p>Anyone who is using `--lock on` will now be setting
      * {@link #luceneLocking} and resetting this field back to its default
      * value. This should mean that the configuration is written leaving out
@@ -198,6 +198,8 @@ public final class Configuration {
     private boolean compressXref;
     private boolean indexVersionedFilesOnly;
     private int indexingParallelism;
+    private int historyParallelism;
+    private int historyRenamedParallelism;
     private boolean tagsEnabled;
     private int hitsPerPage;
     private int cachePages;
@@ -1061,6 +1063,22 @@ public final class Configuration {
         this.indexingParallelism = value > 0 ? value : 0;
     }
 
+    public int getHistoryParallelism() {
+        return historyParallelism;
+    }
+
+    public void setHistoryParallelism(int value) {
+        this.historyParallelism = value > 0 ? value : 0;
+    }
+    
+    public int getHistoryRenamedParallelism() {
+        return historyRenamedParallelism;
+    }
+
+    public void setHistoryRenamedParallelism(int value) {
+        this.historyRenamedParallelism = value > 0 ? value : 0;
+    }
+    
     public boolean isTagsEnabled() {
         return this.tagsEnabled;
     }

--- a/src/org/opensolaris/opengrok/configuration/Project.java
+++ b/src/org/opensolaris/opengrok/configuration/Project.java
@@ -74,6 +74,11 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     private Boolean handleRenamedFiles = null;
     
     /**
+     * This flag enables/disables per-project history cache.
+     */
+    private Boolean historyEnabled = null;
+    
+    /**
      * This marks the project as (not)ready before initial index is done. this
      * is to avoid all/multi-project searches referencing this project from
      * failing.
@@ -184,7 +189,7 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
      * that you should ALWAYS prefix the path with current file.separator ,
      * current environment should always have it set up
      *
-     * @param path the relative path from source sroot where this project is
+     * @param path the relative path from source root where this project is
      * located.
      */
     public void setPath(String path) {
@@ -249,6 +254,20 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     }
     
     /**
+     * @return true if this project should have history cache.
+     */
+    public boolean isHistoryEnabled() {
+        return historyEnabled != null && historyEnabled;
+    }
+    
+    /**
+     * @param flag true if project should have history cache, false otherwise.
+     */
+    public void setHistoryEnabled(boolean flag) {
+        this.historyEnabled = flag;
+    }
+    
+    /**
      * Return groups where this project belongs
      *
      * @return set of groups|empty if none
@@ -301,6 +320,11 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
         // Allow project to override global setting of renamed file handling.
         if (handleRenamedFiles == null) {
             setHandleRenamedFiles(cfg.isHandleHistoryOfRenamedFiles());
+        }
+        
+        // Allow project to override global setting of history cache generation.
+        if (historyEnabled == null) {
+            setHistoryEnabled(cfg.isHistoryEnabled());
         }
     }
 

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -803,7 +803,7 @@ public final class RuntimeEnvironment {
     public void setRepositories(String dir) {
         List<RepositoryInfo> repos = new ArrayList<>(HistoryGuru.getInstance().
                 addRepositories(new File[]{new File(dir)},
-                RuntimeEnvironment.getInstance().getIgnoredNames()));
+                    RuntimeEnvironment.getInstance().getIgnoredNames()));
         RuntimeEnvironment.getInstance().setRepositories(repos);
     }
 
@@ -1235,18 +1235,6 @@ public final class RuntimeEnvironment {
 
     public boolean isHandleHistoryOfRenamedFiles() {
         return threadConfig.get().isHandleHistoryOfRenamedFiles();
-    }
-
-    public boolean isHandleHistoryOfRenamedFilesForProject(Project project) {
-        if (hasProjects() && project != null) {
-            return project.isHandleRenamedFiles();
-        } else {
-            return isHandleHistoryOfRenamedFiles();
-        }
-    }
-    
-    public boolean isHandleHistoryOfRenamedFilesFor(String path) {
-        return isHandleHistoryOfRenamedFilesForProject(Project.getProject(path));
     }
     
     public void setRevisionMessageCollapseThreshold(int threshold) {

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -178,18 +178,7 @@ public final class RuntimeEnvironment {
     /* Get thread pool used for top-level repository history generation. */
     public static synchronized ExecutorService getHistoryExecutor() {
         if (historyExecutor == null) {
-            int num = Runtime.getRuntime().availableProcessors();
-            String total = System.getProperty("org.opensolaris.opengrok.history.NumCacheThreads");
-            if (total != null) {
-                try {
-                    num = Integer.valueOf(total);
-                } catch (Throwable t) {
-                    LOGGER.log(Level.WARNING, "Failed to parse the number of "
-                            + "cache threads to use for cache creation", t);
-                }
-            }
-
-            historyExecutor = Executors.newFixedThreadPool(num,
+            historyExecutor = Executors.newFixedThreadPool(getInstance().getHistoryParallelism(),
                     new ThreadFactory() {
                 @Override
                 public Thread newThread(Runnable runnable) {
@@ -206,18 +195,7 @@ public final class RuntimeEnvironment {
     /* Get thread pool used for history generation of renamed files. */
     public static synchronized ExecutorService getHistoryRenamedExecutor() {
         if (historyRenamedExecutor == null) {
-            int num = Runtime.getRuntime().availableProcessors();
-            String total = System.getProperty("org.opensolaris.opengrok.history.NumCacheRenamedThreads");
-            if (total != null) {
-                try {
-                    num = Integer.valueOf(total);
-                } catch (Throwable t) {
-                    LOGGER.log(Level.WARNING, "Failed to parse the number of "
-                            + "cache threads to use for cache creation of renamed files", t);
-                }
-            }
-
-            historyRenamedExecutor = Executors.newFixedThreadPool(num,
+            historyRenamedExecutor = Executors.newFixedThreadPool(getInstance().getHistoryRenamedParallelism(),
                     new ThreadFactory() {
                 @Override
                 public Thread newThread(Runnable runnable) {
@@ -1133,6 +1111,28 @@ public final class RuntimeEnvironment {
             parallelism;
     }
 
+    /**
+     * Gets the value of {@link Configuration#getHistoryParallelism()} -- or
+     * if zero, then as a default gets the number of available processors.
+     * @return a natural number &gt;= 1
+     */
+    public int getHistoryParallelism() {
+        int parallelism = threadConfig.get().getHistoryParallelism();
+        return parallelism < 1 ? Runtime.getRuntime().availableProcessors() :
+            parallelism;
+    }
+    
+    /**
+     * Gets the value of {@link Configuration#getHistoryRenamedParallelism()} -- or
+     * if zero, then as a default gets the number of available processors.
+     * @return a natural number &gt;= 1
+     */
+    public int getHistoryRenamedParallelism() {
+        int parallelism = threadConfig.get().getHistoryRenamedParallelism();
+        return parallelism < 1 ? Runtime.getRuntime().availableProcessors() :
+            parallelism;
+    }
+    
     public boolean isTagsEnabled() {
         return threadConfig.get().isTagsEnabled();
     }

--- a/src/org/opensolaris/opengrok/history/FileHistoryCache.java
+++ b/src/org/opensolaris/opengrok/history/FileHistoryCache.java
@@ -54,7 +54,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
-import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
@@ -69,8 +68,8 @@ class FileHistoryCache implements HistoryCache {
 
     private final Object lock = new Object();
 
-    private final static String historyCacheDirName = "historycache";
-    private final static String latestRevFileName = "OpenGroklatestRev";
+    private final static String HISTORY_CACHE_DIR_NAME = "historycache";
+    private final static String LATEST_REV_FILE_NAME = "OpenGroklatestRev";
     private final static String DIRECTORY_FILE_PREFIX = "OpenGrokDirHist";
 
     private boolean historyIndexDone = false;
@@ -201,7 +200,7 @@ class FileHistoryCache implements HistoryCache {
         StringBuilder sb = new StringBuilder();
         sb.append(env.getDataRootPath());
         sb.append(File.separatorChar);
-        sb.append(historyCacheDirName);
+        sb.append(HISTORY_CACHE_DIR_NAME);
 
         try {
             String add = env.getPathRelativeToSourceRoot(file);
@@ -589,7 +588,8 @@ class FileHistoryCache implements HistoryCache {
          * fetched in the first phase of indexing.
          */
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (isHistoryIndexDone() && repository.hasHistoryForDirectories() &&
+        if (isHistoryIndexDone() && repository.isHistoryEnabled() &&
+            repository.hasHistoryForDirectories() &&
             !env.isFetchHistoryWhenNotInCache()) {
                 return null;
         }
@@ -651,7 +651,7 @@ class FileHistoryCache implements HistoryCache {
         }
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         File dir = env.getDataRootFile();
-        dir = new File(dir, FileHistoryCache.historyCacheDirName);
+        dir = new File(dir, FileHistoryCache.HISTORY_CACHE_DIR_NAME);
         try {
             dir = new File(dir, env.getPathRelativeToSourceRoot(
                 new File(repos.getDirectoryName())));
@@ -692,14 +692,14 @@ class FileHistoryCache implements HistoryCache {
         }
 
         return env.getDataRootPath() + File.separatorChar
-            + FileHistoryCache.historyCacheDirName
+            + FileHistoryCache.HISTORY_CACHE_DIR_NAME
             + repoDirBasename;
     }
 
     private String getRepositoryCachedRevPath(Repository repository) {
         String histDir = getRepositoryHistDataDirname(repository);
         if (histDir == null) return null;
-        return histDir + File.separatorChar + latestRevFileName;
+        return histDir + File.separatorChar + LATEST_REV_FILE_NAME;
     }
 
     /**

--- a/src/org/opensolaris/opengrok/history/HistoryGuru.java
+++ b/src/org/opensolaris/opengrok/history/HistoryGuru.java
@@ -250,7 +250,7 @@ public final class HistoryGuru {
                 || (rscm == RemoteSCM.ON)
                 || (ui || ((rscm == RemoteSCM.DIRBASED) && (repo != null) && repo.hasHistoryForDirectories()));
 
-        if (repo != null && repo.isWorking() && repo.fileHasHistory(file)
+        if (repo != null && repo.isHistoryEnabled() && repo.isWorking() && repo.fileHasHistory(file)
                 && (!repo.isRemote() || doRemote)) {
 
             if (useCache() && historyCache.supportsRepository(repo)) {
@@ -387,14 +387,6 @@ public final class HistoryGuru {
             String path;
             try {
                 path = file.getCanonicalPath();
-                File skipRepository = new File(path, ".opengrok_skip_history");
-                // Should potential repository be ignored?
-                if (skipRepository.exists()) {
-                    LOGGER.log(Level.INFO,
-                        "Skipping history cache creation for {0} and its subdirectories",
-                        file.getAbsolutePath());
-                    continue;
-                }
 
                 Repository repository = null;
                 try {
@@ -576,6 +568,12 @@ public final class HistoryGuru {
         String path = repository.getDirectoryName();
         String type = repository.getClass().getSimpleName();
 
+        if (!repository.isHistoryEnabled()) {
+            LOGGER.log(Level.INFO,
+                    "Skipping history cache creation of {0} repository in {1} and its subdirectories",
+                    new Object[]{type, path});
+        }
+        
         if (repository.isWorking()) {
             boolean verbose = RuntimeEnvironment.getInstance().isVerbose();
             Statistics elapsed = new Statistics();

--- a/src/org/opensolaris/opengrok/history/RepositoryFactory.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryFactory.java
@@ -161,6 +161,8 @@ public final class RepositoryFactory {
                     repo.buildTagList(file, interactive);
                 }
 
+                repo.fillFromProject();
+                
                 break;
             }
         }

--- a/src/org/opensolaris/opengrok/history/RepositoryInfo.java
+++ b/src/org/opensolaris/opengrok/history/RepositoryInfo.java
@@ -30,6 +30,7 @@ import java.text.SimpleDateFormat;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.ClassUtil;
@@ -67,6 +68,7 @@ public class RepositoryInfo implements Serializable {
     protected String currentVersion;
 
     private boolean handleRenamedFiles;
+    private boolean historyEnabled;
     
     /**
      * format used for printing the date in {@code currentVersion}
@@ -99,6 +101,24 @@ public class RepositoryInfo implements Serializable {
     }
     
     /**
+     * @param flag true if the repository should handle renamed files, false otherwise.
+     */
+    public void setHandleRenamedFiles(boolean flag) {
+        this.handleRenamedFiles = flag;
+    }
+    
+    /**
+     * @return true if the repository should have history cache.
+     */
+    public boolean isHistoryEnabled() {
+        return this.historyEnabled;
+    }
+    
+    public void setHistoryEnabled(boolean flag) {
+        this.historyEnabled = flag;
+    }
+    
+    /**
      * @return relative path to source root
      */
     public String getDirectoryNameRelative() {
@@ -111,9 +131,6 @@ public class RepositoryInfo implements Serializable {
      */
     public void setDirectoryNameRelative(String dir) {
         this.directoryNameRelative = dir;
-        
-        handleRenamedFiles = RuntimeEnvironment.getInstance().
-                isHandleHistoryOfRenamedFilesFor(dir);
     }
 
     /**
@@ -254,6 +271,22 @@ public class RepositoryInfo implements Serializable {
 
     public void setCurrentVersion(String currentVersion) {
         this.currentVersion = currentVersion;
+    }
+    
+    /**
+     * Fill configurable properties from associated project (if any) or Configuration.
+     */
+    public void fillFromProject() {
+        Project proj = Project.getProject(getDirectoryNameRelative());
+        if (proj != null) {
+            setHistoryEnabled(proj.isHistoryEnabled());
+            setHandleRenamedFiles(proj.isHandleRenamedFiles());
+        } else {
+            RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+            
+            setHistoryEnabled(env.isHistoryEnabled());
+            setHandleRenamedFiles(env.isHandleHistoryOfRenamedFiles());
+        }
     }
     
     @Override

--- a/src/org/opensolaris/opengrok/index/IgnoredFiles.java
+++ b/src/org/opensolaris/opengrok/index/IgnoredFiles.java
@@ -55,7 +55,6 @@ public final class IgnoredFiles extends Filter {
         ".vsmdi", // Visual Studio tests
         "*.dll",
         "*.DLL",
-        ".opengrok_skip_history",
     };
 
     public IgnoredFiles() {

--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -98,6 +98,7 @@ import org.opensolaris.opengrok.search.QueryBuilder;
 import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 import org.opensolaris.opengrok.util.IOUtils;
 import org.opensolaris.opengrok.util.ObjectPool;
+import org.opensolaris.opengrok.util.Statistics;
 import org.opensolaris.opengrok.web.Util;
 
 /**
@@ -597,6 +598,7 @@ public class IndexDatabase {
         IndexWriter wrt = null;
         IOException writerException = null;
         try {
+            Statistics elapsed = new Statistics();
             String projectDetail = this.project != null ? " for project " + project.getName() : "";
             LOGGER.log(Level.INFO, "Optimizing the index{0}", projectDetail);
             Analyzer analyzer = new StandardAnalyzer();
@@ -605,7 +607,7 @@ public class IndexDatabase {
 
             wrt = new IndexWriter(indexDirectory, conf);
             wrt.forceMerge(1); // this is deprecated and not needed anymore
-            LOGGER.log(Level.INFO, "Done optimizing index{0}", projectDetail);
+            elapsed.report(LOGGER, String.format("Done optimizing index%s", projectDetail));
             synchronized (lock) {
                 if (dirtyFile.exists() && !dirtyFile.delete()) {
                     LOGGER.log(Level.FINE, "Failed to remove \"dirty-file\": {0}",

--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -597,14 +597,15 @@ public class IndexDatabase {
         IndexWriter wrt = null;
         IOException writerException = null;
         try {
-            LOGGER.info("Optimizing the index ... ");
+            String projectDetail = this.project != null ? " for project " + project.getName() : "";
+            LOGGER.log(Level.INFO, "Optimizing the index{0}", projectDetail);
             Analyzer analyzer = new StandardAnalyzer();
             IndexWriterConfig conf = new IndexWriterConfig(analyzer);
             conf.setOpenMode(OpenMode.CREATE_OR_APPEND);
 
             wrt = new IndexWriter(indexDirectory, conf);
             wrt.forceMerge(1); // this is deprecated and not needed anymore
-            LOGGER.info("done");
+            LOGGER.log(Level.INFO, "Done optimizing index{0}", projectDetail);
             synchronized (lock) {
                 if (dirtyFile.exists() && !dirtyFile.delete()) {
                     LOGGER.log(Level.FINE, "Failed to remove \"dirty-file\": {0}",

--- a/src/org/opensolaris/opengrok/index/Indexer.java
+++ b/src/org/opensolaris/opengrok/index/Indexer.java
@@ -884,6 +884,8 @@ public final class Indexer {
             throw new IndexerException("Internal error, zapCache shouldn't be null");
         }
 
+        // Projects need to be created first since when adding repositories below,
+        // some of the project properties might be needed for that.
         if (addProjects) {
             File files[] = env.getSourceRootFile().listFiles();
             Map<String,Project> projects = env.getProjects();
@@ -921,11 +923,10 @@ public final class Indexer {
         if (searchRepositories || listRepoPaths || !zapCache.isEmpty()) {
             LOGGER.log(Level.INFO, "Scanning for repositories...");
             long start = System.currentTimeMillis();
-            if (env.isHistoryEnabled()) {
-                env.setRepositories(env.getSourceRootPath());
-            }
+            env.setRepositories(env.getSourceRootPath());
             long time = (System.currentTimeMillis() - start) / 1000;
             LOGGER.log(Level.INFO, "Done scanning for repositories ({0}s)", time);
+            
             if (listRepoPaths || !zapCache.isEmpty()) {
                 List<RepositoryInfo> repos = env.getRepositories();
                 String prefix = env.getSourceRootPath();
@@ -990,18 +991,17 @@ public final class Indexer {
             }
         }
 
-        if (env.isHistoryEnabled()) {
-            if (repositories != null && !repositories.isEmpty()) {
-                LOGGER.log(Level.INFO, "Generating history cache for repositories: " +
-                    repositories.stream().collect(Collectors.joining(",")));
-                HistoryGuru.getInstance().createCache(repositories);
-                LOGGER.info("Done...");
-              } else {
-                  LOGGER.log(Level.INFO, "Generating history cache for all repositories ...");
-                  HistoryGuru.getInstance().createCache();
-                  LOGGER.info("Done...");
-              }
-        }
+        // Even if history is disabled globally, it can be enabled for some repositories.
+        if (repositories != null && !repositories.isEmpty()) {
+            LOGGER.log(Level.INFO, "Generating history cache for repositories: " +
+                repositories.stream().collect(Collectors.joining(",")));
+            HistoryGuru.getInstance().createCache(repositories);
+            LOGGER.info("Done...");
+          } else {
+              LOGGER.log(Level.INFO, "Generating history cache for all repositories ...");
+              HistoryGuru.getInstance().createCache();
+              LOGGER.info("Done...");
+          }
 
         if (listFiles) {
             for (String file : IndexDatabase.getAllFiles(subFiles)) {

--- a/test/org/opensolaris/opengrok/configuration/messages/ProjectMessageTest.java
+++ b/test/org/opensolaris/opengrok/configuration/messages/ProjectMessageTest.java
@@ -86,6 +86,7 @@ public class ProjectMessageTest {
         env.setSourceRoot(repository.getSourceRoot());
         env.setDataRoot(repository.getDataRoot());
         env.setProjectsEnabled(true);
+        env.setHistoryEnabled(true);
         RepositoryFactory.initializeIgnoredNames(env);
     }
 

--- a/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
@@ -35,6 +35,8 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.junit.After;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Rule;
@@ -43,7 +45,9 @@ import org.opensolaris.opengrok.condition.ConditionalRun;
 import org.opensolaris.opengrok.condition.ConditionalRunRule;
 import org.opensolaris.opengrok.condition.CtagsInstalled;
 import org.opensolaris.opengrok.condition.RepositoryInstalled;
+import org.opensolaris.opengrok.configuration.Project;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
+import org.opensolaris.opengrok.history.HistoryException;
 import org.opensolaris.opengrok.history.HistoryGuru;
 import org.opensolaris.opengrok.history.MercurialRepositoryTest;
 import org.opensolaris.opengrok.history.RepositoryInfo;
@@ -95,6 +99,79 @@ public class IndexerRepoTest {
     }
 
     /**
+     * Test it is possible to disable history per project.
+     * @throws IndexerException
+     * @throws IOException 
+     * @throws org.opensolaris.opengrok.history.HistoryException 
+     */
+    @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
+    @ConditionalRun(RepositoryInstalled.GitInstalled.class)
+    @Test
+    public void testPerProjectHistoryGlobalOn() throws IndexerException, IOException, HistoryException {
+        testPerProjectHistory(true);
+    }
+    
+    /**
+     * Test it is possible to enable history per project.
+     * @throws IndexerException
+     * @throws IOException 
+     * @throws org.opensolaris.opengrok.history.HistoryException 
+     */
+    @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
+    @ConditionalRun(RepositoryInstalled.GitInstalled.class)
+    @Test
+    public void testPerProjectHistoryGlobalOff() throws IndexerException, IOException, HistoryException {
+        testPerProjectHistory(false);
+    }
+    
+    private void testPerProjectHistory(boolean globalOn) throws IndexerException, IOException, HistoryException {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        
+        // Make sure we start from scratch.
+        File dataRoot = FileUtilities.createTemporaryDirectory("dataForPerProjectHistoryTest");
+        env.setDataRoot(dataRoot.getName());
+        env.setProjectsEnabled(true);
+        env.setHistoryEnabled(globalOn);
+        
+        Project proj = new Project("mercurial", "/mercurial");
+        proj.setHistoryEnabled(!globalOn);
+        env.getProjects().clear();
+        env.getProjects().put("mercurial", proj);
+        
+        Indexer.getInstance().prepareIndexer(
+                env,
+                true, // search for repositories
+                true, // scan and add projects
+                null, // no default project
+                false, // don't list files
+                false, // don't create dictionary
+                null, // subFiles - not needed since we don't list files
+                null, // repositories - not needed when not refreshing history
+                new ArrayList<>(), // don't zap cache
+                false); // don't list repos
+        
+        File repoRoot = new File(env.getSourceRootFile(), "git");
+        File fileInRepo = new File(repoRoot, "main.c");
+        assertTrue(fileInRepo.exists());
+        if (globalOn) {
+            assertNotNull(HistoryGuru.getInstance().getHistory(fileInRepo));
+        } else {
+            assertNull(HistoryGuru.getInstance().getHistory(fileInRepo));
+        }
+        
+        repoRoot = new File(env.getSourceRootFile(), "mercurial");
+        fileInRepo = new File(repoRoot, "main.c");
+        assertTrue(fileInRepo.exists());
+        if (globalOn) {
+            assertNull(HistoryGuru.getInstance().getHistory(fileInRepo));
+        } else {
+            assertNotNull(HistoryGuru.getInstance().getHistory(fileInRepo));
+        }
+        
+        IOUtils.removeRecursive(dataRoot.toPath());
+    }
+    
+    /**
      * Test that symlinked directories from source root get their relative
      * path set correctly in RepositoryInfo objects.
      */
@@ -118,8 +195,8 @@ public class IndexerRepoTest {
         String symlinkPath = sourceRoot.toString() + File.separator + SYMLINK;
         Files.createSymbolicLink(Paths.get(symlinkPath), Paths.get(realSource.getPath()));
 
+        // Use alternative source root.
         env.setSourceRoot(sourceRoot.toString());
-        env.setDataRoot(repository.getDataRoot());
         // Need to have history cache enabled in order to perform scan of repositories.
         env.setHistoryEnabled(true);
         // Normally the Indexer would add the symlink automatically.


### PR DESCRIPTION
This basically removes the notion that `Repository` presence constitutes history creation. With these changes it is possible to have history disabled globally and enabled on project level and vice versa.

Also, I believe this is one of the last pieces where configuration is stored outside of `Configuration` object.