### PR TITLE
report more information during webapp startup

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -1340,6 +1340,7 @@ public final class Configuration {
     }
 
     public static Configuration read(File file) throws IOException {
+        LOGGER.log(Level.INFO, "Reading configuration from {0}", file.getCanonicalPath());
         try (FileInputStream in = new FileInputStream(file)) {
             return decodeObject(in);
         }

--- a/src/org/opensolaris/opengrok/web/WebappListener.java
+++ b/src/org/opensolaris/opengrok/web/WebappListener.java
@@ -95,10 +95,10 @@ public final class WebappListener
                 try {
                     SocketAddress addr = new InetSocketAddress(InetAddress.getByName(cfg[0]), Integer.parseInt(cfg[1]));
                     if (!RuntimeEnvironment.getInstance().startConfigurationListenerThread(addr)) {
-                        LOGGER.log(Level.SEVERE, "OpenGrok: Failed to start configuration listener thread");
+                        LOGGER.log(Level.SEVERE, "Failed to start configuration listener thread");
                     }
                 } catch (NumberFormatException | UnknownHostException ex) {
-                    LOGGER.log(Level.SEVERE, "OpenGrok: Failed to start configuration listener thread:", ex);
+                    LOGGER.log(Level.SEVERE, "Failed to start configuration listener thread:", ex);
                 }
             } else {
                 LOGGER.log(Level.SEVERE, "Incorrect format for the configuration address: ");

--- a/src/org/opensolaris/opengrok/web/WebappListener.java
+++ b/src/org/opensolaris/opengrok/web/WebappListener.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.web;
 
@@ -37,6 +37,7 @@ import javax.servlet.ServletContextListener;
 import javax.servlet.ServletRequestEvent;
 import javax.servlet.ServletRequestListener;
 import org.json.simple.parser.ParseException;
+import org.opensolaris.opengrok.Info;
 import org.opensolaris.opengrok.authorization.AuthorizationFramework;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.logger.LoggerFactory;
@@ -64,6 +65,9 @@ public final class WebappListener
         ServletContext context = servletContextEvent.getServletContext();
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
+        LOGGER.log(Level.INFO, "Starting webapp with version {0} ({1})",
+                    new Object[]{ Info.getVersion(), Info.getRevision()});
+        
         String config = context.getInitParameter("CONFIGURATION");
         if (config == null) {
             LOGGER.severe("CONFIGURATION section missing in web.xml");


### PR DESCRIPTION
2 lines added to log during webapp startup, e.g.:

```
05-Jun-2018 10:19:48.811 INFO [localhost-startStop-1] org.opensolaris.opengrok.web.WebappListener.contextInitialized Starting webapp with version 1.1-rc22 (f8c14b49af83451078552967dac5d22d949f2a09)
05-Jun-2018 10:19:48.811 INFO [localhost-startStop-1] org.opensolaris.opengrok.configuration.Configuration.read Reading configuration from /opengrok/etc/configuration.xml
```
