### PR TITLE
Issue #2156 : speed up JarAnalyzer

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/executables/JFieldBuilder.java
+++ b/src/org/opensolaris/opengrok/analysis/executables/JFieldBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opensolaris.opengrok.analysis.executables;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a package-private container for {@link StringWriter} instances
+ * used when aggregating content for a jar's class files for the jar's indexed
+ * fields.
+ */
+class JFieldBuilder {
+    private final Map<String, StringWriter> fieldBuilders = new HashMap<>();
+
+    boolean hasField(String fieldName) {
+        return fieldBuilders.containsKey(fieldName);
+    }
+
+    StringWriter write(String fieldName) {
+        StringWriter res = fieldBuilders.getOrDefault(fieldName, null);
+        if (res != null) {
+            return res;
+        }
+        res = new StringWriter();
+        fieldBuilders.put(fieldName, res);
+        return res;
+    }
+}


### PR DESCRIPTION
Hello,

Please consider for integration this patch to speed up `JarAnalyzer` by reusing the same string builders for an entire jar.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
