### PR TITLE
Remove redundant createTemporaryDirectory method from FileUtilities

### DIFF
--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -18,7 +18,7 @@
  */
 
  /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.configuration;
@@ -32,7 +32,7 @@ import java.io.StringWriter;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -43,7 +43,6 @@ import java.util.TreeMap;
 import java.util.regex.PatternSyntaxException;
 import org.apache.tools.ant.filters.StringInputStream;
 import org.json.simple.parser.ParseException;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,7 +64,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import org.opensolaris.opengrok.util.FileUtilities;
 import org.opensolaris.opengrok.util.ForbiddenSymlinkException;
 import org.opensolaris.opengrok.util.IOUtils;
 
@@ -97,14 +95,10 @@ public class RuntimeEnvironmentTest {
     }
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() {
         // Create a default configuration
         Configuration config = new Configuration();
         RuntimeEnvironment.getInstance().setConfiguration(config);
-    }
-
-    @After
-    public void tearDown() throws IOException {
     }
 
     @Test
@@ -160,7 +154,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testGroups() throws IOException {
+    public void testGroups() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertFalse(instance.hasGroups());
         assertNotNull(instance.getGroups());
@@ -178,18 +172,14 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testRegister() throws InterruptedException, IOException {
+    public void testRegister() throws InterruptedException {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         String path = "/tmp/dataroot";
         instance.setDataRoot(path);
         instance.register();
-        Thread t = new Thread(new Runnable() {
-
-            public void run() {
-                Configuration c = new Configuration();
-                RuntimeEnvironment.getInstance().setConfiguration(c);
-
-            }
+        Thread t = new Thread(() -> {
+            Configuration c = new Configuration();
+            RuntimeEnvironment.getInstance().setConfiguration(c);
         });
         t.start();
         t.join();
@@ -232,17 +222,17 @@ public class RuntimeEnvironmentTest {
     @Test
     public void testFetchHistoryWhenNotInCache() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
-        assertEquals(true, instance.isFetchHistoryWhenNotInCache());
+        assertTrue(instance.isFetchHistoryWhenNotInCache());
         instance.setFetchHistoryWhenNotInCache(false);
-        assertEquals(false, instance.isFetchHistoryWhenNotInCache());
+        assertFalse(instance.isFetchHistoryWhenNotInCache());
     }
 
     @Test
     public void testUseHistoryCache() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
-        assertEquals(true, instance.useHistoryCache());
+        assertTrue(instance.useHistoryCache());
         instance.setUseHistoryCache(false);
-        assertEquals(false, instance.useHistoryCache());
+        assertFalse(instance.useHistoryCache());
     }
 
     @Test
@@ -1052,13 +1042,13 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test(expected = IOException.class)
-    public void testSaveNullStatistics() throws IOException, ParseException {
+    public void testSaveNullStatistics() throws IOException {
         RuntimeEnvironment.getInstance().getConfiguration().setStatisticsFilePath(null);
         RuntimeEnvironment.getInstance().saveStatistics();
     }
 
     @Test(expected = IOException.class)
-    public void testSaveNullStatisticsFile() throws IOException, ParseException {
+    public void testSaveNullStatisticsFile() throws IOException {
         RuntimeEnvironment.getInstance().saveStatistics((File) null);
     }
 
@@ -1085,7 +1075,7 @@ public class RuntimeEnvironmentTest {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
         // Create and set source root.
-        File sourceRoot = FileUtilities.createTemporaryDirectory("src");
+        File sourceRoot = Files.createTempDirectory("src").toFile();
         assertTrue(sourceRoot.exists());
         assertTrue(sourceRoot.isDirectory());
         env.setSourceRoot(sourceRoot.getPath());
@@ -1100,11 +1090,9 @@ public class RuntimeEnvironmentTest {
 
         // Create symlink underneath source root.
         String symlinkName = "symlink";
-        File realDir = FileUtilities.createTemporaryDirectory("realdir");
+        Path realDir = Files.createTempDirectory("realdir");
         File symlink = new File(sourceRoot, symlinkName);
-        Files.createSymbolicLink(
-                Paths.get(symlink.getPath()),
-                Paths.get(realDir.getPath()));
+        Files.createSymbolicLink(symlink.toPath(), realDir);
         assertTrue(symlink.exists());
         env.setAllowedSymlinks(new HashSet<>());
         ForbiddenSymlinkException expex = null;
@@ -1113,8 +1101,8 @@ public class RuntimeEnvironmentTest {
         } catch (ForbiddenSymlinkException e) {
             expex = e;
         }
-        assertTrue("getPathRelativeToSourceRoot() should have thrown " +
-            "IOexception for symlink that is not allowed", expex != null);
+        assertNotNull("getPathRelativeToSourceRoot() should have thrown " +
+                "IOexception for symlink that is not allowed", expex);
 
         // Allow the symlink and retest.
         env.setAllowedSymlinks(new HashSet<>(Arrays.asList(symlink.getPath())));
@@ -1123,6 +1111,6 @@ public class RuntimeEnvironmentTest {
 
         // cleanup
         IOUtils.removeRecursive(sourceRoot.toPath());
-        IOUtils.removeRecursive(realDir.toPath());
+        IOUtils.removeRecursive(realDir);
     }
 }

--- a/test/org/opensolaris/opengrok/index/IgnoredNamesTest.java
+++ b/test/org/opensolaris/opengrok/index/IgnoredNamesTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.index;
 
@@ -26,7 +26,6 @@ import java.beans.ExceptionListener;
 import java.beans.XMLDecoder;
 import java.beans.XMLEncoder;
 import java.io.BufferedOutputStream;
-import java.io.BufferedReader;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -34,9 +33,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -55,7 +54,8 @@ import org.opensolaris.opengrok.util.TestRepository;
  * @author Trond Norbye
  */
 public class IgnoredNamesTest {
-    RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+    private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
     private static TestRepository repository;
 
     @BeforeClass
@@ -155,27 +155,20 @@ public class IgnoredNamesTest {
 
     /**
      * Make sure that encoding and decoding IgnoredNames object is 1:1 operation.
-     * @throws FileNotFoundException
-     * @throws IOException 
      */
     @Test
-    public void testEncodeDecode() throws FileNotFoundException, IOException {
+    public void testEncodeDecode() throws IOException {
         IgnoredNames in = new IgnoredNames();
         // Add file and directory to list of ignored items.
         in.add("f:foo.txt");
         in.add("d:bar");
 
         // Create an exception listener to detect errors while encoding and decoding
-        final LinkedList<Exception> exceptions = new LinkedList<Exception>();
-        ExceptionListener listener = new ExceptionListener() {
-            @Override
-            public void exceptionThrown(Exception e) {
-                exceptions.addLast(e);
-            }
-        };
+        final LinkedList<Exception> exceptions = new LinkedList<>();
+        ExceptionListener listener = exceptions::addLast;
 
         // Actually create the file and directory for much better test coverage.
-        File tmpdir = FileUtilities.createTemporaryDirectory("ignoredNames");
+        File tmpdir = Files.createTempDirectory("ignoredNames").toFile();
         File foo = new File(tmpdir, "foo.txt");
         foo.createNewFile();
         assertTrue(foo.isFile());

--- a/test/org/opensolaris/opengrok/index/IndexVersionTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexVersionTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import org.junit.After;
 import static org.junit.Assert.assertNotNull;
@@ -55,9 +54,9 @@ public class IndexVersionTest {
     @Rule
     public ConditionalRunRule rule = new ConditionalRunRule();
 
-    TestRepository repository;
-    RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-    private File oldIndexDataDir;
+    private TestRepository repository;
+    private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+    private Path oldIndexDataDir;
     
     @BeforeClass
     public static void setUpClass() {
@@ -78,7 +77,7 @@ public class IndexVersionTest {
         repository.destroy();
         
         if (oldIndexDataDir != null) {
-            IOUtils.removeRecursive(Paths.get(oldIndexDataDir.getPath()));
+            IOUtils.removeRecursive(oldIndexDataDir);
         }
     }
     
@@ -117,8 +116,8 @@ public class IndexVersionTest {
     @Test(expected = IndexVersion.IndexVersionException.class)
     public void testIndexVersionOldIndex() throws Exception {
         Configuration cfg = new Configuration();
-        oldIndexDataDir = FileUtilities.createTemporaryDirectory("data");
-        Path indexPath = Paths.get(oldIndexDataDir.getPath(), "index");
+        oldIndexDataDir = Files.createTempDirectory("data");
+        Path indexPath = oldIndexDataDir.resolve("index");
         Files.createDirectory(indexPath);
         File indexDir = new File(indexPath.toString());
         assertTrue("index directory check", indexDir.isDirectory());
@@ -127,7 +126,7 @@ public class IndexVersionTest {
         File archive = new File(oldindex.getPath());
         assertTrue("archive exists", archive.isFile());
         FileUtilities.extractArchive(archive, indexDir);
-        cfg.setDataRoot(oldIndexDataDir.getPath());
+        cfg.setDataRoot(oldIndexDataDir.toString());
         cfg.setProjectsEnabled(false);
         IndexVersion.check(cfg);
     }

--- a/test/org/opensolaris/opengrok/search/context/SearchAndContextFormatterTest2.java
+++ b/test/org/opensolaris/opengrok/search/context/SearchAndContextFormatterTest2.java
@@ -21,7 +21,6 @@
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
-
 package org.opensolaris.opengrok.search.context;
 
 import java.io.File;
@@ -38,11 +37,9 @@ import java.util.TreeSet;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.highlight.InvalidTokenOffsetsException;
-import org.junit.After;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,7 +57,6 @@ import org.opensolaris.opengrok.history.RepositoryFactory;
 import org.opensolaris.opengrok.search.QueryBuilder;
 import org.opensolaris.opengrok.search.SearchEngine;
 import static org.opensolaris.opengrok.util.CustomAssertions.assertLinesEqual;
-import org.opensolaris.opengrok.util.FileUtilities;
 import org.opensolaris.opengrok.util.IOUtils;
 
 /**
@@ -148,7 +144,7 @@ public class SearchAndContextFormatterTest2 {
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {
+    public static void tearDownClass() {
         env.setProjectsEnabled(originalProjectsEnabled);
         env.setAllowedSymlinks(new HashSet<>());
 
@@ -173,14 +169,6 @@ public class SearchAndContextFormatterTest2 {
         } finally {
             TEMP_DIRS.clear();
         }
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
     }
 
     @Test
@@ -218,7 +206,7 @@ public class SearchAndContextFormatterTest2 {
         ContextFormatter formatter = new ContextFormatter(args);
         OGKUnifiedHighlighter uhi = new OGKUnifiedHighlighter(env,
             instance.getSearcher(), anz);
-        uhi.setBreakIterator(() -> new StrictLineBreakIterator());
+        uhi.setBreakIterator(StrictLineBreakIterator::new);
         uhi.setFormatter(formatter);
         uhi.setTabSize(TABSIZE);
 
@@ -248,7 +236,7 @@ public class SearchAndContextFormatterTest2 {
 
     private static File createTemporaryDirectory(String name)
             throws IOException {
-        File f = FileUtilities.createTemporaryDirectory(name);
+        File f = Files.createTempDirectory(name).toFile();
         TEMP_DIRS.add(f);
         return f;
     }

--- a/test/org/opensolaris/opengrok/util/FileUtilities.java
+++ b/test/org/opensolaris/opengrok/util/FileUtilities.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opensolaris.opengrok.util;
 
@@ -100,27 +100,6 @@ public class FileUtilities {
                 }
             }
         }
-    }
-
-    /**
-     * Create an empty directory under {@code /tmp} or similar.
-     *
-     * @param prefix string to prefix the directory name with
-     * @return a {@code File} object pointing to the directory
-     * @throws IOException if the temporary directory cannot be created
-     */
-    public static File createTemporaryDirectory(String prefix)
-            throws IOException {
-        File file = File.createTempFile(prefix, "opengrok");
-        if (!file.delete()) {
-            throw new IOException(
-                    "Could not create delete temporary file " + file);
-        }
-        if (!file.mkdir()) {
-            throw new IOException(
-                    "Could not create temporary directory " + file);
-        }
-        return file;
     }
 
     private FileUtilities() {

--- a/test/org/opensolaris/opengrok/util/PathUtilsTest.java
+++ b/test/org/opensolaris/opengrok/util/PathUtilsTest.java
@@ -19,9 +19,8 @@
 
 /*
  * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  */
-
 package org.opensolaris.opengrok.util;
 
 import java.io.File;
@@ -48,7 +47,7 @@ public class PathUtilsTest {
     private final List<File> tempDirs = new ArrayList<>();
 
     @After
-    public void tearDown() throws IOException {
+    public void tearDown() {
         try {
             tempDirs.forEach((tempDir) -> {
                 try {
@@ -160,7 +159,7 @@ public class PathUtilsTest {
     }
 
     private File createTemporaryDirectory(String name) throws IOException {
-        File f = FileUtilities.createTemporaryDirectory(name);
+        File f = Files.createTempDirectory(name).toFile();
         tempDirs.add(f);
         return f;
     }

--- a/test/org/opensolaris/opengrok/util/TestRepository.java
+++ b/test/org/opensolaris/opengrok/util/TestRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.util;
@@ -46,8 +46,8 @@ public class TestRepository {
 
     public void createEmpty() throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        sourceRoot = FileUtilities.createTemporaryDirectory("source");
-        dataRoot = FileUtilities.createTemporaryDirectory("data");
+        sourceRoot = Files.createTempDirectory("source").toFile();
+        dataRoot = Files.createTempDirectory("data").toFile();
         env.setSourceRoot(sourceRoot.getAbsolutePath());
         env.setDataRoot(dataRoot.getAbsolutePath());
     }
@@ -55,8 +55,8 @@ public class TestRepository {
     public void create(InputStream inputBundle) throws IOException {
         File sourceBundle = null;
         try {
-            sourceRoot = FileUtilities.createTemporaryDirectory("source");
-            dataRoot = FileUtilities.createTemporaryDirectory("data");
+            sourceRoot = Files.createTempDirectory("source").toFile();
+            dataRoot = Files.createTempDirectory("data").toFile();
             sourceBundle = File.createTempFile("srcbundle", ".zip");
 
             if (sourceBundle.exists()) {


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

This method is redundant since Java 7 and it was causing some trouble in determining the line between web and indexer modules.

While I was touching the files I also removed some warnings per IDEA suggestions.

Thanks :) 