### PR TITLE
Per project history test data fix

### DIFF
--- a/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexerRepoTest.java
@@ -124,8 +124,8 @@ public class IndexerRepoTest {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         
         // Make sure we start from scratch.
-        File dataRoot = Files.createTempDirectory("dataForPerProjectHistoryTest").toFile();
-        env.setDataRoot(dataRoot.getName());
+        Path dataRoot = Files.createTempDirectory("dataForPerProjectHistoryTest");
+        env.setDataRoot(dataRoot.toString());
         env.setProjectsEnabled(true);
         env.setHistoryEnabled(globalOn);
         
@@ -164,7 +164,7 @@ public class IndexerRepoTest {
             assertNotNull(HistoryGuru.getInstance().getHistory(fileInRepo));
         }
         
-        IOUtils.removeRecursive(dataRoot.toPath());
+        IOUtils.removeRecursive(dataRoot);
     }
     
     /**


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

When running per project history tests a directory `dataForPerProjectHistoryTest{number}` is created under `opengrok-indexer`. This can be achieved simply by running `mvn test`.

It can look like this:
<img width="401" alt="screen shot 2018-06-16 at 19 10 37" src="https://user-images.githubusercontent.com/12401160/41500902-d9da558c-719a-11e8-84e8-f157c992e47a.png">

However, these directories are not removed when running `mvn clean`.

This PR fixes the problem.

Thanks :)