### PR TITLE
Index version check partial

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -864,7 +864,8 @@ CheckIndexVersion()
     then
         return
     fi
-    if ! MinimalInvocation --checkIndexVersion -R "${XML_CONFIGURATION}" -d "${DATA_ROOT}"
+    if ! MinimalInvocation --checkIndexVersion \
+        -R "${XML_CONFIGURATION}" -d "${DATA_ROOT}" "$@"
     then
         echo "\nIndex version check failed. You might want to remove all data" \
             "under the data root directory ${DATA_ROOT} and reindex.\n"
@@ -1143,7 +1144,7 @@ case "${1}" in
 	    FatalError "need configuration via OPENGROK_READ_XML_CONFIGURATION"
 	fi
         ValidateConfiguration
-        CheckIndexVersion
+        CheckIndexVersion $@
         CreateRuntimeRequirements
         UpdateDataPartial $@
         ;;

--- a/src/org/opensolaris/opengrok/index/IndexVersion.java
+++ b/src/org/opensolaris/opengrok/index/IndexVersion.java
@@ -24,6 +24,7 @@ package org.opensolaris.opengrok.index;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import org.apache.lucene.index.IndexNotFoundException;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.Directory;
@@ -52,16 +53,25 @@ public class IndexVersion {
     /**
      * Check if version of index(es) matches major Lucene version.
      * @param cfg configuration
+     * @param subFilesList list of paths. If non-empty, only projects matching these paths will be checked.
      * @throws Exception otherwise
      */
-    public static void check(Configuration cfg) throws Exception {
+    public static void check(Configuration cfg, List<String> subFilesList) throws Exception {
         File indexRoot = new File(cfg.getDataRoot(), IndexDatabase.INDEX_DIR);
-        if (cfg.isProjectsEnabled()) {
-            for (String projectName : cfg.getProjects().keySet()) {
+        
+        if (subFilesList.size() > 0) {
+            // Assumes projects are enabled.
+            for (String projectName : subFilesList) {
                 checkDir(getDirectory(new File(indexRoot, projectName)));
             }
         } else {
-            checkDir(getDirectory(indexRoot));
+            if (cfg.isProjectsEnabled()) {
+                for (String projectName : cfg.getProjects().keySet()) {
+                    checkDir(getDirectory(new File(indexRoot, projectName)));
+                }
+            } else {
+                checkDir(getDirectory(indexRoot));
+            }
         }
     }
     

--- a/src/org/opensolaris/opengrok/index/IndexVersion.java
+++ b/src/org/opensolaris/opengrok/index/IndexVersion.java
@@ -59,7 +59,7 @@ public class IndexVersion {
     public static void check(Configuration cfg, List<String> subFilesList) throws Exception {
         File indexRoot = new File(cfg.getDataRoot(), IndexDatabase.INDEX_DIR);
         
-        if (subFilesList.size() > 0) {
+        if (!subFilesList.isEmpty()) {
             // Assumes projects are enabled.
             for (String projectName : subFilesList) {
                 checkDir(getDirectory(new File(indexRoot, projectName)));

--- a/src/org/opensolaris/opengrok/index/Indexer.java
+++ b/src/org/opensolaris/opengrok/index/Indexer.java
@@ -144,19 +144,6 @@ public final class Indexer {
                 System.exit(status);
             }
             
-            // Check version of index(es) versus current Lucene version and exit
-            // with return code indicating success or failure.
-            if (checkIndexVersion) {
-                int retval = 0;
-                try {
-                    IndexVersion.check(cfg);
-                } catch (IndexVersionException e) {
-                    System.err.printf("Index version check failed: %s", e);
-                    retval = 1;
-                }
-                System.exit(retval);
-            }
-            
             if (awaitProfiler) pauseToAwaitProfiler();
 
             env = RuntimeEnvironment.getInstance();
@@ -206,11 +193,24 @@ public final class Indexer {
             // Assemble the unprocessed command line arguments (possibly
             // a list of paths). This will be used to perform more fine
             // grained checking in invalidateRepositories().
-            for (int optind=0; optind< argv.length; optind++) {
+            for (int optind = 0; optind < argv.length; optind++) {
                 String path = Paths.get(cfg.getSourceRoot(), argv[optind]).toString();
                 subFilesList.add(path);
             }
 
+            // Check version of index(es) versus current Lucene version and exit
+            // with return code indicating success or failure.
+            if (checkIndexVersion) {
+                int retval = 0;
+                try {
+                    IndexVersion.check(cfg, subFilesList);
+                } catch (IndexVersionException e) {
+                    System.err.printf("Index version check failed: %s", e);
+                    retval = 1;
+                }
+                System.exit(retval);
+            }
+            
             // If an user used customizations for projects he perhaps just
             // used the key value for project without a name but the code
             // expects a name for the project. Therefore we fill the name

--- a/test/org/opensolaris/opengrok/index/IndexVersionTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexVersionTest.java
@@ -28,6 +28,8 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.After;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -86,7 +88,7 @@ public class IndexVersionTest {
      * Generate index(es) and check version.
      * @throws Exception 
      */
-    private void testIndexVersion(boolean projectsEnabled) throws Exception {
+    private void testIndexVersion(boolean projectsEnabled, List<String> subFiles) throws Exception {
         env.setVerbose(true);
         env.setHistoryEnabled(false);
         env.setProjectsEnabled(projectsEnabled);
@@ -94,7 +96,7 @@ public class IndexVersionTest {
                 false, false, null, null, new ArrayList<>(), false);
         Indexer.getInstance().doIndexerExecution(true, null, null);
 
-        IndexVersion.check(env.getConfiguration(), new ArrayList<>());
+        IndexVersion.check(env.getConfiguration(), subFiles);
     }
     
     @Test
@@ -104,14 +106,20 @@ public class IndexVersionTest {
     
     @Test
     @ConditionalRun(CtagsInstalled.class)
-    public void testIndexVersionNoProjects() throws Exception {
-        testIndexVersion(true);
+    public void testIndexVersionProjects() throws Exception {
+        testIndexVersion(true, new ArrayList<>());
     }
     
     @Test
     @ConditionalRun(CtagsInstalled.class)
-    public void testIndexVersionProjects() throws Exception {
-        testIndexVersion(false);
+    public void testIndexVersionSelectedProjects() throws Exception {
+        testIndexVersion(true, Arrays.asList(new String[]{ "mercurial", "git" }));
+    }
+    
+    @Test
+    @ConditionalRun(CtagsInstalled.class)
+    public void testIndexVersionNoProjects() throws Exception {
+        testIndexVersion(false, new ArrayList<>());
     }
     
     @Test(expected = IndexVersion.IndexVersionException.class)

--- a/test/org/opensolaris/opengrok/index/IndexVersionTest.java
+++ b/test/org/opensolaris/opengrok/index/IndexVersionTest.java
@@ -47,6 +47,7 @@ import org.opensolaris.opengrok.util.TestRepository;
 
 /**
  * Verify index version check.
+ * 
  * @author Vladimir Kotal
  */
 public class IndexVersionTest {
@@ -93,12 +94,12 @@ public class IndexVersionTest {
                 false, false, null, null, new ArrayList<>(), false);
         Indexer.getInstance().doIndexerExecution(true, null, null);
 
-        IndexVersion.check(env.getConfiguration());
+        IndexVersion.check(env.getConfiguration(), new ArrayList<>());
     }
     
     @Test
     public void testIndexVersionNoIndex() throws Exception {
-        IndexVersion.check(env.getConfiguration());
+        IndexVersion.check(env.getConfiguration(), new ArrayList<>());
     }
     
     @Test
@@ -128,6 +129,6 @@ public class IndexVersionTest {
         FileUtilities.extractArchive(archive, indexDir);
         cfg.setDataRoot(oldIndexDataDir.toString());
         cfg.setProjectsEnabled(false);
-        IndexVersion.check(cfg);
+        IndexVersion.check(cfg, new ArrayList<>());
     }
 }


### PR DESCRIPTION
Today I tried to create some partal indexes (with `indexpart` sub-command of the `OpenGrok` script) by hand and got an error that different project than what was being indexed had old index version. This change should fix that.