### PR TITLE
Don't select line numbers when highlighting code

### DIFF
--- a/web/default/style.css
+++ b/web/default/style.css
@@ -24,6 +24,10 @@ div#src0 a.l.selected:after, div#src0 a.hl.selected:after{
 div[id^='src'] a.l.target, div[id^='src'] a.hl.target {
     background: orange;
     color:yellow;
+    -webkit-user-select: none;  /* Chrome all / Safari all */
+    -moz-user-select: none;     /* Firefox all */
+    -ms-user-select: none;      /* IE 10+ */
+    user-select: none;          /* Likely future */
 }
 
 a:link {

--- a/web/default/style.css
+++ b/web/default/style.css
@@ -24,10 +24,6 @@ div#src0 a.l.selected:after, div#src0 a.hl.selected:after{
 div[id^='src'] a.l.target, div[id^='src'] a.hl.target {
     background: orange;
     color:yellow;
-    -webkit-user-select: none;  /* Chrome all / Safari all */
-    -moz-user-select: none;     /* Firefox all */
-    -ms-user-select: none;      /* IE 10+ */
-    user-select: none;          /* Likely future */
 }
 
 a:link {
@@ -749,6 +745,10 @@ div[id^='src'] pre {
     background-color: #dddddd;
     color: #666;
     margin-right: .5ex;
+    -webkit-user-select: none;  /* Chrome all / Safari all */
+    -moz-user-select: none;     /* Firefox all */
+    -ms-user-select: none;      /* IE 10+ */
+    user-select: none;          /* Likely future */
 }
 
 .blame .search {


### PR DESCRIPTION
When you copy and paste code results from OpenGrok, it will no longer copy the line numbers with this change.

Will save us the trouble of having to view the raw file before copying.