### PR TITLE
configurable directory for web app include files

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -143,6 +143,10 @@ public final class Configuration {
     private Set<Group> groups;
     private String sourceRoot;
     private String dataRoot;
+    /**
+     * directory with include files for web application (header, footer, etc.)
+     */
+    private String includeRoot;
     private List<RepositoryInfo> repositories;
     /**
      * @deprecated This is kept around so not to break object deserialization
@@ -804,6 +808,18 @@ public final class Configuration {
         this.dataRoot = dataRoot;
     }
 
+    /**
+     * If {@link includeRoot} is not set, {@link dataRoot} will be returned.
+     * @return web include root directory
+     */
+    public String getIncludeRoot() {
+        return includeRoot != null ? includeRoot : dataRoot;
+    }
+    
+    public void setIncludeRoot(String newRoot) {
+        this.includeRoot = newRoot;
+    }
+    
     public List<RepositoryInfo> getRepositories() {
         return repositories;
     }
@@ -1175,12 +1191,13 @@ public final class Configuration {
     /**
      * Get the contents of the footer include file.
      *
+     * @param force if true, reload even if already set
      * @return an empty string if it could not be read successfully, the
      * contents of the file otherwise.
      * @see #FOOTER_INCLUDE_FILE
      */
-    public String getFooterIncludeFileContent() {
-        if (footer == null) {
+    public String getFooterIncludeFileContent(boolean force) {
+        if (footer == null || force) {
             footer = getFileContent(new File(getDataRoot(), FOOTER_INCLUDE_FILE));
         }
         return footer;
@@ -1197,17 +1214,18 @@ public final class Configuration {
     /**
      * Get the contents of the header include file.
      *
+     * @param force if true, reload even if already set
      * @return an empty string if it could not be read successfully, the
      * contents of the file otherwise.
      * @see #HEADER_INCLUDE_FILE
      */
-    public String getHeaderIncludeFileContent() {
-        if (header == null) {
-            header = getFileContent(new File(getDataRoot(), HEADER_INCLUDE_FILE));
+    public String getHeaderIncludeFileContent(boolean force) {
+        if (header == null || force) {
+            header = getFileContent(new File(includeRoot, HEADER_INCLUDE_FILE));
         }
         return header;
     }
-
+    
     /**
      * The name of the file relative to the <var>DATA_ROOT</var>, which should
      * be included into the body of web app's "Home" page.
@@ -1219,13 +1237,14 @@ public final class Configuration {
     /**
      * Get the contents of the body include file.
      *
+     * @param force if true, reload even if already set
      * @return an empty string if it could not be read successfully, the
      * contents of the file otherwise.
      * @see Configuration#BODY_INCLUDE_FILE
      */
-    public String getBodyIncludeFileContent() {
-        if (body == null) {
-            body = getFileContent(new File(getDataRoot(), BODY_INCLUDE_FILE));
+    public String getBodyIncludeFileContent(boolean force) {
+        if (body == null || force) {
+            body = getFileContent(new File(includeRoot, BODY_INCLUDE_FILE));
         }
         return body;
     }
@@ -1243,13 +1262,14 @@ public final class Configuration {
      * Get the contents of the page for forbidden error page (403 Forbidden)
      * include file.
      *
+     * @param force if true, reload even if already set
      * @return an empty string if it could not be read successfully, the
      * contents of the file otherwise.
      * @see Configuration#E_FORBIDDEN_INCLUDE_FILE
      */
-    public String getForbiddenIncludeFileContent() {
-        if (eforbidden_content == null) {
-            eforbidden_content = getFileContent(new File(getDataRoot(), E_FORBIDDEN_INCLUDE_FILE));
+    public String getForbiddenIncludeFileContent(boolean force) {
+        if (eforbidden_content == null || force) {
+            eforbidden_content = getFileContent(new File(includeRoot, E_FORBIDDEN_INCLUDE_FILE));
         }
         return eforbidden_content;
     }

--- a/src/org/opensolaris/opengrok/configuration/Configuration.java
+++ b/src/org/opensolaris/opengrok/configuration/Configuration.java
@@ -1198,7 +1198,7 @@ public final class Configuration {
      */
     public String getFooterIncludeFileContent(boolean force) {
         if (footer == null || force) {
-            footer = getFileContent(new File(getDataRoot(), FOOTER_INCLUDE_FILE));
+            footer = getFileContent(new File(getIncludeRoot(), FOOTER_INCLUDE_FILE));
         }
         return footer;
     }
@@ -1221,7 +1221,7 @@ public final class Configuration {
      */
     public String getHeaderIncludeFileContent(boolean force) {
         if (header == null || force) {
-            header = getFileContent(new File(includeRoot, HEADER_INCLUDE_FILE));
+            header = getFileContent(new File(getIncludeRoot(), HEADER_INCLUDE_FILE));
         }
         return header;
     }
@@ -1244,7 +1244,7 @@ public final class Configuration {
      */
     public String getBodyIncludeFileContent(boolean force) {
         if (body == null || force) {
-            body = getFileContent(new File(includeRoot, BODY_INCLUDE_FILE));
+            body = getFileContent(new File(getIncludeRoot(), BODY_INCLUDE_FILE));
         }
         return body;
     }
@@ -1269,7 +1269,7 @@ public final class Configuration {
      */
     public String getForbiddenIncludeFileContent(boolean force) {
         if (eforbidden_content == null || force) {
-            eforbidden_content = getFileContent(new File(includeRoot, E_FORBIDDEN_INCLUDE_FILE));
+            eforbidden_content = getFileContent(new File(getIncludeRoot(), E_FORBIDDEN_INCLUDE_FILE));
         }
         return eforbidden_content;
     }

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -318,6 +318,15 @@ public final class RuntimeEnvironment {
     }
 
     /**
+     * Get the path to the where the web application includes are stored
+     *
+     * @return the path to the web application include files
+     */
+    public String getIncludeRootPath() {
+        return threadConfig.get().getIncludeRoot();
+    }
+    
+    /**
      * Get the path to the where the index database is stored
      *
      * @return the path to the index database
@@ -1552,6 +1561,11 @@ public final class RuntimeEnvironment {
         // The invalidation of repositories above might have excluded some
         // repositories in HistoryGuru so the configuration needs to reflect that.
         configuration.setRepositories(new ArrayList<>(histGuru.getRepositories()));
+        
+        configuration.getBodyIncludeFileContent(true);
+        configuration.getHeaderIncludeFileContent(true);
+        configuration.getFooterIncludeFileContent(true);
+        configuration.getForbiddenIncludeFileContent(true);
     }
 
     public Configuration getConfiguration() {

--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -1562,10 +1562,14 @@ public final class RuntimeEnvironment {
         // repositories in HistoryGuru so the configuration needs to reflect that.
         configuration.setRepositories(new ArrayList<>(histGuru.getRepositories()));
         
-        configuration.getBodyIncludeFileContent(true);
-        configuration.getHeaderIncludeFileContent(true);
-        configuration.getFooterIncludeFileContent(true);
-        configuration.getForbiddenIncludeFileContent(true);
+        reloadIncludeFiles(configuration);
+    }
+
+    private void reloadIncludeFiles(Configuration configuration1) {
+        configuration1.getBodyIncludeFileContent(true);
+        configuration1.getHeaderIncludeFileContent(true);
+        configuration1.getFooterIncludeFileContent(true);
+        configuration1.getForbiddenIncludeFileContent(true);
     }
 
     public Configuration getConfiguration() {

--- a/src/org/opensolaris/opengrok/web/AuthorizationFilter.java
+++ b/src/org/opensolaris/opengrok/web/AuthorizationFilter.java
@@ -75,7 +75,7 @@ public class AuthorizationFilter implements Filter {
             config.getEnv().getStatistics().addRequestTime("requests_forbidden",
                     System.currentTimeMillis() - processTime);
             
-            if (!config.getEnv().getConfiguration().getForbiddenIncludeFileContent().isEmpty()) {
+            if (!config.getEnv().getConfiguration().getForbiddenIncludeFileContent(false).isEmpty()) {
                 sr.getRequestDispatcher("/eforbidden").forward(sr, sr1);
                 return;
             }

--- a/test/org/opensolaris/opengrok/configuration/IncludeFilesTest.java
+++ b/test/org/opensolaris/opengrok/configuration/IncludeFilesTest.java
@@ -43,6 +43,7 @@ public class IncludeFilesTest {
     static final String CONTENT_1 = "foo";
     static final String CONTENT_2 = "bar";
     static RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+    static final String LINE_SEP = System.getProperty("line.separator");
     
     @BeforeClass
     public static void setUpClass() throws IOException {
@@ -60,10 +61,10 @@ public class IncludeFilesTest {
     public void testGetHeaderIncludeFileContent() throws IOException {
         File file = new File(includeRoot.toFile(), Configuration.HEADER_INCLUDE_FILE);
         writeStringToFile(file, CONTENT_1);
-        assertEquals(CONTENT_1 + System.getProperty("line.separator"),
+        assertEquals(CONTENT_1 + LINE_SEP,
                 env.getConfiguration().getHeaderIncludeFileContent(false));
         writeStringToFile(file, CONTENT_2);
-        assertEquals(CONTENT_2 + System.getProperty("line.separator"),
+        assertEquals(CONTENT_2 + LINE_SEP,
                 env.getConfiguration().getHeaderIncludeFileContent(true));
     }
     
@@ -71,10 +72,10 @@ public class IncludeFilesTest {
     public void testGetBodyIncludeFileContent() throws IOException {
         File file = new File(includeRoot.toFile(), Configuration.BODY_INCLUDE_FILE);
         writeStringToFile(file, CONTENT_1);
-        assertEquals(CONTENT_1 + System.getProperty("line.separator"),
+        assertEquals(CONTENT_1 + LINE_SEP,
                 env.getConfiguration().getBodyIncludeFileContent(false));
         writeStringToFile(file, CONTENT_2);
-        assertEquals(CONTENT_2 + System.getProperty("line.separator"),
+        assertEquals(CONTENT_2 + LINE_SEP,
                 env.getConfiguration().getBodyIncludeFileContent(true));
     }
     
@@ -82,10 +83,10 @@ public class IncludeFilesTest {
     public void testGetFooterIncludeFileContent() throws IOException {
         File file = new File(includeRoot.toFile(), Configuration.FOOTER_INCLUDE_FILE);
         writeStringToFile(file, CONTENT_1);
-        assertEquals(CONTENT_1 + System.getProperty("line.separator"),
+        assertEquals(CONTENT_1 + LINE_SEP,
                 env.getConfiguration().getFooterIncludeFileContent(false));
         writeStringToFile(file, CONTENT_2);
-        assertEquals(CONTENT_2 + System.getProperty("line.separator"),
+        assertEquals(CONTENT_2 + LINE_SEP,
                 env.getConfiguration().getFooterIncludeFileContent(true));
     }
     
@@ -93,10 +94,10 @@ public class IncludeFilesTest {
     public void testGetForbiddenIncludeFileContent() throws IOException {
         File file = new File(includeRoot.toFile(), Configuration.E_FORBIDDEN_INCLUDE_FILE);
         writeStringToFile(file, CONTENT_1);
-        assertEquals(CONTENT_1 + System.getProperty("line.separator"),
+        assertEquals(CONTENT_1 + LINE_SEP,
                 env.getConfiguration().getForbiddenIncludeFileContent(false));
         writeStringToFile(file, CONTENT_2);
-        assertEquals(CONTENT_2 + System.getProperty("line.separator"),
+        assertEquals(CONTENT_2 + LINE_SEP,
                 env.getConfiguration().getForbiddenIncludeFileContent(true));
     }
 }

--- a/test/org/opensolaris/opengrok/configuration/IncludeFilesTest.java
+++ b/test/org/opensolaris/opengrok/configuration/IncludeFilesTest.java
@@ -1,0 +1,102 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.configuration;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test include file functionality for web application.
+ * 
+ * @author Vladimir Kotal
+ */
+public class IncludeFilesTest {
+    static Path includeRoot;
+    static final String CONTENT_1 = "foo";
+    static final String CONTENT_2 = "bar";
+    static RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+    
+    @BeforeClass
+    public static void setUpClass() throws IOException {
+        includeRoot = Files.createTempDirectory("include_root");
+        env.getConfiguration().setIncludeRoot(includeRoot.toString());
+    }
+    
+    private void writeStringToFile(File file, String str) throws IOException {
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(file.toString()))) {
+            bw.write(str);
+        }
+    }
+    
+    @Test
+    public void testGetHeaderIncludeFileContent() throws IOException {
+        File file = new File(includeRoot.toFile(), Configuration.HEADER_INCLUDE_FILE);
+        writeStringToFile(file, CONTENT_1);
+        assertEquals(CONTENT_1 + System.getProperty("line.separator"),
+                env.getConfiguration().getHeaderIncludeFileContent(false));
+        writeStringToFile(file, CONTENT_2);
+        assertEquals(CONTENT_2 + System.getProperty("line.separator"),
+                env.getConfiguration().getHeaderIncludeFileContent(true));
+    }
+    
+    @Test
+    public void testGetBodyIncludeFileContent() throws IOException {
+        File file = new File(includeRoot.toFile(), Configuration.BODY_INCLUDE_FILE);
+        writeStringToFile(file, CONTENT_1);
+        assertEquals(CONTENT_1 + System.getProperty("line.separator"),
+                env.getConfiguration().getBodyIncludeFileContent(false));
+        writeStringToFile(file, CONTENT_2);
+        assertEquals(CONTENT_2 + System.getProperty("line.separator"),
+                env.getConfiguration().getBodyIncludeFileContent(true));
+    }
+    
+    @Test
+    public void testGetFooterIncludeFileContent() throws IOException {
+        File file = new File(includeRoot.toFile(), Configuration.FOOTER_INCLUDE_FILE);
+        writeStringToFile(file, CONTENT_1);
+        assertEquals(CONTENT_1 + System.getProperty("line.separator"),
+                env.getConfiguration().getFooterIncludeFileContent(false));
+        writeStringToFile(file, CONTENT_2);
+        assertEquals(CONTENT_2 + System.getProperty("line.separator"),
+                env.getConfiguration().getFooterIncludeFileContent(true));
+    }
+    
+    @Test
+    public void testGetForbiddenIncludeFileContent() throws IOException {
+        File file = new File(includeRoot.toFile(), Configuration.E_FORBIDDEN_INCLUDE_FILE);
+        writeStringToFile(file, CONTENT_1);
+        assertEquals(CONTENT_1 + System.getProperty("line.separator"),
+                env.getConfiguration().getForbiddenIncludeFileContent(false));
+        writeStringToFile(file, CONTENT_2);
+        assertEquals(CONTENT_2 + System.getProperty("line.separator"),
+                env.getConfiguration().getForbiddenIncludeFileContent(true));
+    }
+}

--- a/test/org/opensolaris/opengrok/configuration/IncludeFilesTest.java
+++ b/test/org/opensolaris/opengrok/configuration/IncludeFilesTest.java
@@ -43,7 +43,7 @@ public class IncludeFilesTest {
     static final String CONTENT_1 = "foo";
     static final String CONTENT_2 = "bar";
     static RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-    static final String LINE_SEP = System.getProperty("line.separator");
+    static final String LINE_SEP = System.lineSeparator();
     
     @BeforeClass
     public static void setUpClass() throws IOException {
@@ -52,7 +52,7 @@ public class IncludeFilesTest {
     }
     
     private void writeStringToFile(File file, String str) throws IOException {
-        try (BufferedWriter bw = new BufferedWriter(new FileWriter(file.toString()))) {
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(file))) {
             bw.write(str);
         }
     }

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -127,7 +127,6 @@ public class RuntimeEnvironmentTest {
         // set data root
         File f = File.createTempFile("dataroot", null);
         String path = f.getCanonicalPath();
-        assertTrue(f.exists());
         instance.setDataRoot(path);
         
         // verify they are the same
@@ -136,7 +135,6 @@ public class RuntimeEnvironmentTest {
         // set include root
         f = File.createTempFile("includeroot", null);
         path = f.getCanonicalPath();
-        assertTrue(f.exists());
         instance.getConfiguration().setIncludeRoot(path);
         assertEquals(path, instance.getIncludeRootPath());
     }

--- a/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
+++ b/test/org/opensolaris/opengrok/configuration/RuntimeEnvironmentTest.java
@@ -17,7 +17,7 @@
  * CDDL HEADER END
  */
 
- /*
+/*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
@@ -119,6 +119,28 @@ public class RuntimeEnvironmentTest {
         assertEquals(path, instance.getDataRootFile().getCanonicalPath());
     }
 
+    @Test
+    public void testIncludeRoot() throws IOException {
+        RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
+        assertNull(instance.getIncludeRootPath());
+        
+        // set data root
+        File f = File.createTempFile("dataroot", null);
+        String path = f.getCanonicalPath();
+        assertTrue(f.exists());
+        instance.setDataRoot(path);
+        
+        // verify they are the same
+        assertEquals(instance.getDataRootPath(), instance.getIncludeRootPath());
+        
+        // set include root
+        f = File.createTempFile("includeroot", null);
+        path = f.getCanonicalPath();
+        assertTrue(f.exists());
+        instance.getConfiguration().setIncludeRoot(path);
+        assertEquals(path, instance.getIncludeRootPath());
+    }
+    
     @Test
     public void testSourceRoot() throws IOException {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();

--- a/web/foot.jspf
+++ b/web/foot.jspf
@@ -45,7 +45,7 @@ org.opensolaris.opengrok.web.Prefix"
 <% if(dateForLastIndexRun != null) { %>
 <p>Last Index update <%= dateForLastIndexRun %></p>
 <%}%>
-    <%= cfg.getEnv().getConfiguration().getFooterIncludeFileContent() %>
+    <%= cfg.getEnv().getConfiguration().getFooterIncludeFileContent(false) %>
     <%
     if (needAddDiv.contains(cfg.getPrefix())) {
         %></div><% // #content

--- a/web/index.jsp
+++ b/web/index.jsp
@@ -58,7 +58,7 @@ include file="menu.jspf"
             %></div>
         </div>
         <div id="results">
-            <%= PageConfig.get(request).getEnv().getConfiguration().getBodyIncludeFileContent() %>
+            <%= PageConfig.get(request).getEnv().getConfiguration().getBodyIncludeFileContent(false) %>
             <% if (PageConfig.get(request).getEnv().getDisplayRepositories()) { %><%@
 
 include file="repos.jspf"

--- a/web/pageheader.jspf
+++ b/web/pageheader.jspf
@@ -24,7 +24,7 @@ Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
 {
     PageConfig cfg = PageConfig.get(request);
 %>
-<%= cfg.getEnv().getConfiguration().getHeaderIncludeFileContent() %>
+<%= cfg.getEnv().getConfiguration().getHeaderIncludeFileContent(false) %>
 <% 
 }
 /* ---------------------- pageheader.jspf end --------------------- */


### PR DESCRIPTION
This change makes the location of include files used in web application configurable. By default they are searched for in data root, if include root is specified they are searched for there.

This change also refreshes the contents of these files when new configuration is set in the web application.