### PR TITLE
make the tests pass in Wercker

### DIFF
--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -444,7 +444,8 @@ public class PageConfigTest {
         assertTrue(temp.exists());
         set = Files.getPosixFilePermissions(temp.toPath());
         System.out.println("XXX: after " + temp.toString() + " " + PosixFilePermissions.toString(set));
-        assertFalse(temp.canRead());
+        File newtemp = new File(temp.toString());
+        assertFalse(newtemp.canRead());
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(temp.getAbsolutePath());
         try {
             cfg.checkSourceRootExistence();

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -435,6 +435,7 @@ public class PageConfigTest {
         File temp = Files.createTempDirectory("opengrok-src-root4").toFile();
         temp.deleteOnExit();
         temp.setReadable(false);
+        assertTrue(temp.canRead());
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(temp.getAbsolutePath());
         try {
             cfg.checkSourceRootExistence();
@@ -442,7 +443,6 @@ public class PageConfigTest {
         } catch (IOException ex) {
         }
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(path);
-
         PageConfig.cleanup(req);
     }
 
@@ -456,13 +456,11 @@ public class PageConfigTest {
         HttpServletRequest req = new DummyHttpServletRequest();
         PageConfig cfg = PageConfig.get(req);
         String path = RuntimeEnvironment.getInstance().getSourceRootPath();
-        File temp = File.createTempFile("opengrok", "-test-file.tmp");
-        temp.delete();
-        temp.mkdirs();
+        File temp = Files.createTempDirectory("opengrok-src-root5").toFile();
+        temp.deleteOnExit();
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(temp.getAbsolutePath());
         cfg.checkSourceRootExistence();
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(path);
-        temp.deleteOnExit();
         PageConfig.cleanup(req);
     }
 

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -437,11 +437,13 @@ public class PageConfigTest {
         String origSourceRoot = RuntimeEnvironment.getInstance().getSourceRootPath();
         File temp = Files.createTempDirectory("opengrok-src-root4").toFile();
         temp.deleteOnExit();
+        Set<PosixFilePermission> set = Files.getPosixFilePermissions(temp.toPath());
+        System.out.println("XXX: before " + temp.toString() + " " + PosixFilePermissions.toString(set));
         temp.setReadable(false);
         assertTrue(temp.isDirectory());
         assertTrue(temp.exists());
-        Set<PosixFilePermission> set = Files.getPosixFilePermissions(temp.toPath());
-        System.out.println("XXX: " + temp.toString() + " " + PosixFilePermissions.toString(set));
+        set = Files.getPosixFilePermissions(temp.toPath());
+        System.out.println("XXX: after " + temp.toString() + " " + PosixFilePermissions.toString(set));
         assertFalse(temp.canRead());
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(temp.getAbsolutePath());
         try {

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -435,7 +435,7 @@ public class PageConfigTest {
         File temp = Files.createTempDirectory("opengrok-src-root4").toFile();
         temp.deleteOnExit();
         temp.setReadable(false);
-        assertTrue(temp.canRead());
+        assertFalse(temp.canRead());
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(temp.getAbsolutePath());
         try {
             cfg.checkSourceRootExistence();

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -22,6 +22,7 @@
  */
 package org.opensolaris.opengrok.web;
 
+import com.sun.security.auth.module.UnixSystem;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -432,20 +433,17 @@ public class PageConfigTest {
      */
     @Test
     public void testCheckSourceRootExistence4() throws IOException {
+        UnixSystem unix = new UnixSystem();
+        System.out.println("XXX UID: " + unix.getUid());
         HttpServletRequest req = new DummyHttpServletRequest();
         PageConfig cfg = PageConfig.get(req);
         String origSourceRoot = RuntimeEnvironment.getInstance().getSourceRootPath();
         File temp = Files.createTempDirectory("opengrok-src-root4").toFile();
         temp.deleteOnExit();
-        Set<PosixFilePermission> set = Files.getPosixFilePermissions(temp.toPath());
-        System.out.println("XXX: before " + temp.toString() + " " + PosixFilePermissions.toString(set));
         temp.setReadable(false);
         assertTrue(temp.isDirectory());
         assertTrue(temp.exists());
-        set = Files.getPosixFilePermissions(temp.toPath());
-        System.out.println("XXX: after " + temp.toString() + " " + PosixFilePermissions.toString(set));
-        File newtemp = new File(temp.toString());
-        assertFalse(newtemp.canRead());
+        assertFalse(temp.canRead());
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(temp.getAbsolutePath());
         try {
             cfg.checkSourceRootExistence();

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -64,7 +64,10 @@ public class PageConfigTest {
         repository = new TestRepository();
         repository.create(
                 HistoryGuru.class.getResourceAsStream("repositories.zip"));
-        RuntimeEnvironment.getInstance().setRepositories(repository.getSourceRoot());
+        
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setRepositories(repository.getSourceRoot());
+        env.setHistoryEnabled(true);
     }
 
     @AfterClass

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -431,9 +432,8 @@ public class PageConfigTest {
         HttpServletRequest req = new DummyHttpServletRequest();
         PageConfig cfg = PageConfig.get(req);
         String path = RuntimeEnvironment.getInstance().getSourceRootPath();
-        File temp = File.createTempFile("opengrok", "-test-file.tmp");
-        Files.delete(temp.toPath());
-        Files.createDirectories(temp.toPath());
+        File temp = Files.createTempDirectory("opengrok-src-root4").toFile();
+        temp.deleteOnExit();
         temp.setReadable(false);
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(temp.getAbsolutePath());
         try {
@@ -444,7 +444,6 @@ public class PageConfigTest {
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(path);
 
         PageConfig.cleanup(req);
-        temp.deleteOnExit();
     }
 
     /**

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -27,10 +27,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -431,12 +434,14 @@ public class PageConfigTest {
     public void testCheckSourceRootExistence4() throws IOException {
         HttpServletRequest req = new DummyHttpServletRequest();
         PageConfig cfg = PageConfig.get(req);
-        String path = RuntimeEnvironment.getInstance().getSourceRootPath();
+        String origSourceRoot = RuntimeEnvironment.getInstance().getSourceRootPath();
         File temp = Files.createTempDirectory("opengrok-src-root4").toFile();
         temp.deleteOnExit();
         temp.setReadable(false);
         assertTrue(temp.isDirectory());
         assertTrue(temp.exists());
+        Set<PosixFilePermission> set = Files.getPosixFilePermissions(temp.toPath());
+        System.out.println("XXX:" + PosixFilePermissions.toString(set));
         assertFalse(temp.canRead());
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(temp.getAbsolutePath());
         try {
@@ -444,7 +449,7 @@ public class PageConfigTest {
             fail("This should throw an exception when the file is not readable");
         } catch (IOException ex) {
         }
-        RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(path);
+        RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(origSourceRoot);
         PageConfig.cleanup(req);
     }
 

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -435,6 +435,8 @@ public class PageConfigTest {
         File temp = Files.createTempDirectory("opengrok-src-root4").toFile();
         temp.deleteOnExit();
         temp.setReadable(false);
+        assertTrue(temp.isDirectory());
+        assertTrue(temp.exists());
         assertFalse(temp.canRead());
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(temp.getAbsolutePath());
         try {

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -441,7 +441,7 @@ public class PageConfigTest {
         assertTrue(temp.isDirectory());
         assertTrue(temp.exists());
         Set<PosixFilePermission> set = Files.getPosixFilePermissions(temp.toPath());
-        System.out.println("XXX:" + PosixFilePermissions.toString(set));
+        System.out.println("XXX: " + temp.toString() + " " + PosixFilePermissions.toString(set));
         assertFalse(temp.canRead());
         RuntimeEnvironment.getInstance().getConfiguration().setSourceRoot(temp.getAbsolutePath());
         try {

--- a/test/org/opensolaris/opengrok/web/PageConfigTest.java
+++ b/test/org/opensolaris/opengrok/web/PageConfigTest.java
@@ -243,6 +243,7 @@ public class PageConfigTest {
     }
 
     @Test
+    @ConditionalRun(RepositoryInstalled.GitInstalled.class)
     public void testGetLatestRevisionValid() {
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
             @Override

--- a/tools/sync/sync.py
+++ b/tools/sync/sync.py
@@ -71,6 +71,7 @@ def worker(base):
 
     return base
 
+
 if __name__ == '__main__':
     output = []
     dirs_to_process = []

--- a/wercker.yml
+++ b/wercker.yml
@@ -20,8 +20,8 @@ build:
     # http://devcenter.wercker.com/docs/steps/index.html
   steps:
     - script:
-      name: maven install
-      code: maven install
+      name: Maven install
+      code: mvn install
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -26,6 +26,7 @@ build:
       code: |
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
+	cd $WERCKER_ROOT
         /usr/bin/sudo -i -u foobar /usr/bin/mvn install
 
 #    # https://github.com/wercker/step-maven

--- a/wercker.yml
+++ b/wercker.yml
@@ -28,8 +28,10 @@ build:
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
         echo $WERCKER_ROOT > /tmp/wroot
         chown -R foobar $WERCKER_ROOT
-        /usr/bin/sudo -i -u foobar -- bash -c 'cd `cat /tmp/wroot`; /usr/bin/mvn install'
+        # Execute just the 'package' phase as javadoc fails for jrcs during the 'verify' phase.
+        /usr/bin/sudo -i -u foobar -- bash -c 'cd `cat /tmp/wroot`; /usr/bin/mvn package'
 
+# Ideally this should support running under non-root user:
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:
 #      goals: install

--- a/wercker.yml
+++ b/wercker.yml
@@ -23,7 +23,7 @@ build:
       name: Maven install
       code: |
         cat /etc/passwd
-        sudo -u root mvn install
+        sudo -u root /usr/bin/mvn install
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -10,12 +10,9 @@ box: openjdk:8-jdk
 #  tag: 8
 
 build:
-    # Steps make up the actions in your pipeline
-    # Read more about steps on our dev center:
-    # http://devcenter.wercker.com/docs/steps/index.html
   steps:
     - install-packages:
-      packages: git subversion mercurial sudo maven pep8
+      packages: sudo maven exuberant-ctags cvs git mercurial cssc bzr subversion monotone rcs pep8
     - script:
       name: Maven install
       code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -29,7 +29,7 @@ build:
         echo $WERCKER_ROOT > /tmp/wroot
         chown -R foobar $WERCKER_ROOT
         # Execute just the 'package' phase as javadoc fails for jrcs during the 'verify' phase.
-        /usr/bin/sudo -i -u foobar -- bash -c 'cd `cat /tmp/wroot`; /usr/bin/mvn package'
+        /usr/bin/sudo -i -u foobar -- bash -c 'cd `cat /tmp/wroot`; /usr/bin/mvn verify'
 
 # Ideally this should support running under non-root user:
 #    # https://github.com/wercker/step-maven

--- a/wercker.yml
+++ b/wercker.yml
@@ -20,7 +20,7 @@ build:
     # http://devcenter.wercker.com/docs/steps/index.html
   steps:
     - install-packages:
-      packages: git subversion sudo
+      packages: git subversion mercurial sudo
     - script:
       name: Maven install
       code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -27,7 +27,8 @@ build:
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
         echo $WERCKER_ROOT
-        /usr/bin/sudo -i -u foobar -- bash -c 'cd /pipeline/source; /usr/bin/mvn install'
+	chown -R foobar $WERCKER_ROOT
+        /usr/bin/sudo -i -u foobar -- bash -c 'cd /pipeline/source; /usr/bin/mvn -X install'
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -23,7 +23,7 @@ build:
       name: Maven install
       code: |
         /usr/sbin/groupadd -g 1000 foobar
-        /usr/sbin/useradd -u 1000 -g 1000 /bin/bash -m foobar
+        /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
         sudo -u foobar /usr/bin/mvn install
 
 #    # https://github.com/wercker/step-maven

--- a/wercker.yml
+++ b/wercker.yml
@@ -27,7 +27,7 @@ build:
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
         echo $WERCKER_ROOT
-        /usr/bin/sudo -i -u foobar -- 'cd /pipeline/source; /usr/bin/mvn install'
+        /usr/bin/sudo -i -u foobar -- bash -c 'cd /pipeline/source; /usr/bin/mvn install'
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -24,7 +24,7 @@ build:
       code: |
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
-        sudo -u foobar /usr/bin/mvn install
+        sudo foobar -- /usr/bin/mvn install
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -24,7 +24,7 @@ build:
       code: |
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
-        sudo foobar -- /usr/bin/mvn install
+        sudo -i -u foobar /usr/bin/mvn install
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,19 +1,14 @@
 # This references an OpenJDK container from the
 # Docker Hub https://hub.docker.com/_/openjdk/
-# Read more about containers on our dev center
-# http://devcenter.wercker.com/docs/containers/index.html
 box: openjdk:8-jdk
 
 # This should switch to Oracle JDK however does not work:
-##box:
-##  id: store/oracle/serverjre
-##  username: $DOCKER_USERNAME
-##  password: $DOCKER_PASSWORD
-##  tag: 8
+#box:
+#  id: store/oracle/serverjre
+#  username: $DOCKER_USERNAME
+#  password: $DOCKER_PASSWORD
+#  tag: 8
 
-# This is the build pipeline. Pipelines are the core of wercker
-# Read more about pipelines on our dev center
-# http://devcenter.wercker.com/docs/pipelines/index.html
 build:
     # Steps make up the actions in your pipeline
     # Read more about steps on our dev center:
@@ -28,7 +23,6 @@ build:
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
         echo $WERCKER_ROOT > /tmp/wroot
         chown -R foobar $WERCKER_ROOT
-        # Execute just the 'package' phase as javadoc fails for jrcs during the 'verify' phase.
         /usr/bin/sudo -i -u foobar -- bash -c 'cd `cat /tmp/wroot`; /usr/bin/mvn verify'
 
 # Ideally this should support running under non-root user:

--- a/wercker.yml
+++ b/wercker.yml
@@ -23,7 +23,8 @@ build:
       name: Maven install
       code: |
         /usr/sbin/groupadd -g 1000 foobar
-        /usr/bin/sudo -u root /usr/bin/mvn install
+	/usr/sbin/useradd -u 1000 -g 1000 /bin/bash -m foobar
+        sudo -u foobar /usr/bin/mvn install
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -26,7 +26,7 @@ build:
       code: |
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
-        sudo -i -u foobar /usr/bin/mvn install
+        /usr/bin/sudo -i -u foobar /usr/bin/mvn install
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -19,6 +19,8 @@ build:
     # Read more about steps on our dev center:
     # http://devcenter.wercker.com/docs/steps/index.html
   steps:
+    - install-packages:
+      packages: git subversion sudo
     - script:
       name: Maven install
       code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -2,7 +2,12 @@
 # Docker Hub https://hub.docker.com/_/openjdk/
 # Read more about containers on our dev center
 # http://devcenter.wercker.com/docs/containers/index.html
-box: openjdk:8-jdk
+# box: openjdk:8-jdk
+box:
+  id: store/oracle/serverjre
+  username: $DOCKER_USERNAME
+  password: $DOCKER_PASSWORD
+  tag: 8
 
 # This is the build pipeline. Pipelines are the core of wercker
 # Read more about pipelines on our dev center

--- a/wercker.yml
+++ b/wercker.yml
@@ -14,17 +14,13 @@ build:
     - install-packages:
       packages: sudo maven exuberant-ctags cvs git mercurial cssc bzr subversion monotone rcs pep8
     - script:
-      name: Maven install
+      name: Create non-root user
       code: |
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
-        echo $WERCKER_ROOT > /tmp/wroot
         chown -R foobar:foobar $WERCKER_ROOT
-        /usr/bin/sudo -i -u foobar -- bash -c 'cd `cat /tmp/wroot`; /usr/bin/mvn verify'
-
-# Ideally this should support running under non-root user:
-#    # https://github.com/wercker/step-maven
-#    - wercker/maven:
-#      goals: install
-#      cache_repo: true
-#      version: 3.5.2
+    - wercker/maven@1.3.8:
+      goals: install
+      cache_repo: true
+      sudo_user: foobar
+      version: 3.5.2

--- a/wercker.yml
+++ b/wercker.yml
@@ -2,12 +2,14 @@
 # Docker Hub https://hub.docker.com/_/openjdk/
 # Read more about containers on our dev center
 # http://devcenter.wercker.com/docs/containers/index.html
-# box: openjdk:8-jdk
-box:
-  id: store/oracle/serverjre
-  username: $DOCKER_USERNAME
-  password: $DOCKER_PASSWORD
-  tag: 8
+box: openjdk:8-jdk
+
+# This should switch to Oracle JDK however does not work:
+##box:
+##  id: store/oracle/serverjre
+##  username: $DOCKER_USERNAME
+##  password: $DOCKER_PASSWORD
+##  tag: 8
 
 # This is the build pipeline. Pipelines are the core of wercker
 # Read more about pipelines on our dev center
@@ -16,9 +18,12 @@ build:
     # Steps make up the actions in your pipeline
     # Read more about steps on our dev center:
     # http://devcenter.wercker.com/docs/steps/index.html
-  steps:
-    # https://github.com/wercker/step-maven
-    - wercker/maven:
-      goals: install
-      cache_repo: true
-      version: 3.5.2
+  - script:
+    name: maven install
+    code: maven install
+#  steps:
+#    # https://github.com/wercker/step-maven
+#    - wercker/maven:
+#      goals: install
+#      cache_repo: true
+#      version: 3.5.2

--- a/wercker.yml
+++ b/wercker.yml
@@ -22,8 +22,8 @@ build:
     - script:
       name: Maven install
       code: |
-        cat /etc/passwd
-        sudo -u root /usr/bin/mvn install
+        /usr/sbin/groupadd -g 1000 foobar
+        /usr/bin/sudo -u root /usr/bin/mvn install
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -19,7 +19,7 @@ build:
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
         echo $WERCKER_ROOT > /tmp/wroot
-        chown -R foobar $WERCKER_ROOT
+        chown -R foobar:foobar $WERCKER_ROOT
         /usr/bin/sudo -i -u foobar -- bash -c 'cd `cat /tmp/wroot`; /usr/bin/mvn verify'
 
 # Ideally this should support running under non-root user:

--- a/wercker.yml
+++ b/wercker.yml
@@ -26,9 +26,9 @@ build:
       code: |
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
-        echo $WERCKER_ROOT
+        echo $WERCKER_ROOT > /tmp/wroot
         chown -R foobar $WERCKER_ROOT
-        /usr/bin/sudo -i -u foobar -- bash -c 'cd /pipeline/source; /usr/bin/mvn -X install'
+        /usr/bin/sudo -i -u foobar -- bash -c 'cd `cat /tmp/wroot`; /usr/bin/mvn install'
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -23,7 +23,7 @@ build:
       name: Maven install
       code: |
         /usr/sbin/groupadd -g 1000 foobar
-	/usr/sbin/useradd -u 1000 -g 1000 /bin/bash -m foobar
+        /usr/sbin/useradd -u 1000 -g 1000 /bin/bash -m foobar
         sudo -u foobar /usr/bin/mvn install
 
 #    # https://github.com/wercker/step-maven

--- a/wercker.yml
+++ b/wercker.yml
@@ -20,7 +20,7 @@ build:
     # http://devcenter.wercker.com/docs/steps/index.html
   steps:
     - install-packages:
-      packages: git subversion mercurial sudo maven
+      packages: git subversion mercurial sudo maven pep8
     - script:
       name: Maven install
       code: |

--- a/wercker.yml
+++ b/wercker.yml
@@ -18,10 +18,11 @@ build:
     # Steps make up the actions in your pipeline
     # Read more about steps on our dev center:
     # http://devcenter.wercker.com/docs/steps/index.html
-  - script:
-    name: maven install
-    code: maven install
-#  steps:
+  steps:
+    - script:
+      name: maven install
+      code: maven install
+
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:
 #      goals: install

--- a/wercker.yml
+++ b/wercker.yml
@@ -26,7 +26,7 @@ build:
       code: |
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
-	cd $WERCKER_ROOT
+        cd $WERCKER_ROOT
         /usr/bin/sudo -i -u foobar /usr/bin/mvn install
 
 #    # https://github.com/wercker/step-maven

--- a/wercker.yml
+++ b/wercker.yml
@@ -21,7 +21,9 @@ build:
   steps:
     - script:
       name: Maven install
-      code: mvn install
+      code: |
+        cat /etc/passwd
+        sudo -u root mvn install
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -26,8 +26,8 @@ build:
       code: |
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
-        cd $WERCKER_ROOT
-        /usr/bin/sudo -i -u foobar /usr/bin/mvn install
+        echo $WERCKER_ROOT
+        /usr/bin/sudo -i -u foobar -- 'cd /pipeline/source; /usr/bin/mvn install'
 
 #    # https://github.com/wercker/step-maven
 #    - wercker/maven:

--- a/wercker.yml
+++ b/wercker.yml
@@ -27,7 +27,7 @@ build:
         /usr/sbin/groupadd -g 1000 foobar
         /usr/sbin/useradd -u 1000 -g 1000 -s /bin/bash -m foobar
         echo $WERCKER_ROOT
-	chown -R foobar $WERCKER_ROOT
+        chown -R foobar $WERCKER_ROOT
         /usr/bin/sudo -i -u foobar -- bash -c 'cd /pipeline/source; /usr/bin/mvn -X install'
 
 #    # https://github.com/wercker/step-maven

--- a/wercker.yml
+++ b/wercker.yml
@@ -20,7 +20,7 @@ build:
     # http://devcenter.wercker.com/docs/steps/index.html
   steps:
     - install-packages:
-      packages: git subversion mercurial sudo
+      packages: git subversion mercurial sudo maven
     - script:
       name: Maven install
       code: |


### PR DESCRIPTION
I am submitting this pull req mainly to experiment with Wercker, namely trying to get the `PageConfig` tests to pass in that environment.

Initially, there are only bunch of tests failing:

```
[ERROR] Failures: 
[ERROR]   PageConfigTest.canProcessHistory:110->assertCanProcess:480 expected:<> but was:<null>
[ERROR]   PageConfigTest.canProcessXref:130->assertCanProcess:480 expected:<> but was:<null>
[ERROR]   PageConfigTest.testCheckSourceRootExistence4:438 This should throw an exception when the file is not readable
[ERROR]   PageConfigTest.testGetAnnotation:343
[ERROR]   PageConfigTest.testGetLatestRevisionValid:258 expected:<aa35c258> but was:<null>
[INFO] 
[ERROR] Tests run: 717, Failures: 5, Errors: 0, Skipped: 58
```

so that's not too bad.

Originally I thought that's because of missing pre-requisites however it seems to boil down to the `testCheckSourceRootExistence4` test that removes permission read bit(s) from a directory and verifies `canRead()` returns false which it fails to do, therefore the test is failing. Possibly, the other tests fail as a result of cleanup not being completed.