### PR TITLE
Improve URI-ending pushback for comma and odd right paren

### DIFF
--- a/src/org/opensolaris/opengrok/util/StringUtils.java
+++ b/src/org/opensolaris/opengrok/util/StringUtils.java
@@ -116,7 +116,7 @@ public final class StringUtils {
     private static final Pattern URI_CHARS_STARTSMATCH =
         Pattern.compile("^" + URI_CHARS_PAT);
 
-    /** Private to enforce singleton */
+    /** Private to enforce static */
     private StringUtils() {
     }
 
@@ -249,12 +249,19 @@ public final class StringUtils {
      */
     public static int countURIEndingPushback(String value) {
         int n = 0;
+        OUTER:
         for (int i = value.length() - 1; i >= 0; --i) {
             char c = value.charAt(i);
-            if (c == '.') {
-                ++n;
-            } else {
-                break;
+            switch (c) {
+                case '.':
+                case ',':
+                    ++n;
+                    break;
+                case ')':
+                    n += countURIUnmatchedRightParen(value, i);
+                    break;
+                default:
+                    break OUTER;
             }
         }
         return n;
@@ -322,5 +329,21 @@ public final class StringUtils {
             }
         }
         return 0;
+    }
+
+    private static int countURIUnmatchedRightParen(String value, int ridx) {
+        int n = 1;
+        for (int i = ridx - 1; i >= 0; --i) {
+            char c = value.charAt(i);
+            if (c == '(') {
+                --n;
+            } else if (c == ')') {
+                ++n;
+            }
+            if (n < 1) {
+                break;
+            }
+        }
+        return n > 0 ? 1 : 0;
     }
 }

--- a/test/org/opensolaris/opengrok/analysis/vb/sample_xref.html
+++ b/test/org/opensolaris/opengrok/analysis/vb/sample_xref.html
@@ -62,7 +62,7 @@ function get_sym_list(){return [];} /* ]]> */</script><a class="l" name="1" href
 <a class="l" name="56" href="#56">56</a><span class="c">&apos;</span>
 <a class="l" name="57" href="#57">57</a><span class="c">&apos; @class WebResponse</span>
 <a class="l" name="58" href="#58">58</a><span class="c">&apos; @author tim.hall.engr@gmail.com</span>
-<a class="l" name="59" href="#59">59</a><span class="c">&apos; @license MIT (<a href="http://www.opensource.org/licenses/mit-license.php)">http://www.opensource.org/licenses/mit-license.php)</a></span>
+<a class="l" name="59" href="#59">59</a><span class="c">&apos; @license MIT (<a href="http://www.opensource.org/licenses/mit-license.php">http://www.opensource.org/licenses/mit-license.php</a>)</span>
 <a class="hl" name="60" href="#60">60</a><span class="c">&apos;&apos; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ &apos;</span>
 <a class="l" name="61" href="#61">61</a><b>Option</b> <a href="/source/s?defs=Explicit" class="intelliWindow-symbol" data-definition-place="undefined-in-file">Explicit</a>
 <a class="l" name="62" href="#62">62</a>

--- a/test/org/opensolaris/opengrok/util/StringUtilsTest.java
+++ b/test/org/opensolaris/opengrok/util/StringUtilsTest.java
@@ -125,6 +125,69 @@ public class StringUtilsTest {
     }
 
     @Test
+    public void uriAtCommaSeparatorShouldCountPushback() {
+        String uri = "http://www.example.com,";
+        int n = StringUtils.countURIEndingPushback(uri);
+        assertEquals(uri + " pushback", 1, n);
+    }
+
+    @Test
+    public void uriAtDanglingRightParenShouldCountPushback() {
+        String uri = "http://www.example.com)";
+        int n = StringUtils.countURIEndingPushback(uri);
+        assertEquals(uri + " pushback", 1, n);
+    }
+
+    @Test
+    public void uriWithPairedUpRightParenShouldNotCountPushback() {
+        String uri = "http://www.example.com/article(v=vs.110)";
+        int n = StringUtils.countURIEndingPushback(uri);
+        assertEquals(uri + " pushback", 0, n);
+    }
+
+    @Test
+    public void uriWithPairedUpRightParenBeforeDotShouldCountPushback() {
+        String uri = "http://www.example.com/article(v=vs.110).";
+        int n = StringUtils.countURIEndingPushback(uri);
+        assertEquals(uri + " pushback", 1, n);
+    }
+
+    @Test
+    public void uriWithOddRightParen1ShouldCountPushback() {
+        String uri = "http://www.example.com/article(v=vs.110))";
+        int n = StringUtils.countURIEndingPushback(uri);
+        assertEquals(uri + " pushback", 1, n);
+    }
+
+    @Test
+    public void uriWithOddRightParen2ShouldCountPushback() {
+        String uri = "http://www.example.com/article(v=vs.110)?arg=1)";
+        int n = StringUtils.countURIEndingPushback(uri);
+        assertEquals(uri + " pushback", 1, n);
+    }
+
+    @Test
+    public void uriWithOddRightParenAndDot1ShouldCountWiderPushback() {
+        String uri = "http://www.example.com/article(v=vs.110).)";
+        int n = StringUtils.countURIEndingPushback(uri);
+        assertEquals(uri + " pushback", 2, n);
+    }
+
+    @Test
+    public void uriWithOddRightParenAndDot2ShouldCountWiderPushback() {
+        String uri = "http://www.example.com/article(v=vs.110)).";
+        int n = StringUtils.countURIEndingPushback(uri);
+        assertEquals(uri + " pushback", 2, n);
+    }
+
+    @Test
+    public void uriWithOddRightParenAndDot3ShouldCountWiderPushback() {
+        String uri = "http://www.example.com/article(v=vs.110))).";
+        int n = StringUtils.countURIEndingPushback(uri);
+        assertEquals(uri + " pushback", 3, n);
+    }
+
+    @Test
     public void uriEmptyShouldNotCountAnyPushback() {
         String uri = "";
         int n = StringUtils.countURIEndingPushback(uri);


### PR DESCRIPTION
Hello,

Please consider for integration this patch to improve the URI-ending pushback to recognize trailing commas or dangling right parentheses.

(I did not consider this change significant enough to bump `FileAnalyzer.getVersionNo()` to force automatic re-analysis.)

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
