### PR TITLE
Subsume --checkIndexVersion into regular run

### DIFF
--- a/OpenGrok
+++ b/OpenGrok
@@ -450,6 +450,10 @@ ${BZR:+-Dorg.opensolaris.opengrok.history.Bazaar=$BZR} \
         ASSIGNMENTS="`echo $OPENGROK_ASSIGNMENTS | sed 's/[:space:]+/_/g'`"
         ASSIGNMENTS="-A `echo $ASSIGNMENTS | sed 's/,/ -A /g'`"
     fi
+
+    if [ -f "${XML_CONFIGURATION}" ]; then
+        CHK_INDEX_CONF="${XML_CONFIGURATION}"
+    fi
 }
 
 #
@@ -858,21 +862,6 @@ CreateRuntimeRequirements()
     fi
 }
 
-CheckIndexVersion()
-{
-    if [ ! -f "${XML_CONFIGURATION}" ]
-    then
-        return
-    fi
-    if ! MinimalInvocation --checkIndexVersion \
-        -R "${XML_CONFIGURATION}" -d "${DATA_ROOT}" "$@"
-    then
-        echo "\nIndex version check failed. You might want to remove all data" \
-            "under the data root directory ${DATA_ROOT} and reindex.\n"
-        exit 1
-    fi
-}
-
 MinimalInvocation()
 {
     ${DO} ${JAVA} ${JAVA_OPTS} ${PROPERTIES}                    	\
@@ -901,6 +890,7 @@ CommonInvocation()
         ${ASSIGNMENTS}							\
         ${READ_XML_CONF}                                        	\
         ${WEBAPP_CONFIG}						\
+        ${CHK_INDEX_CONF:+--checkIndexVersion} ${CHK_INDEX_CONF}	\
         ${OPENGROK_PROFILER:+--profiler}				\
         "${@}"
 }
@@ -1095,14 +1085,12 @@ case "${1}" in
 
     update)
         ValidateConfiguration
-        CheckIndexVersion
         CreateRuntimeRequirements
         UpdateGeneratedData && UpdateDescriptionCache
         ;;
 
     updateQuietly)
         ValidateConfiguration
-        CheckIndexVersion
         CreateRuntimeRequirements
         QUIET="-q"
         VERBOSE=""
@@ -1129,7 +1117,6 @@ case "${1}" in
             SRC_ROOT="${2}"
         fi
         ValidateConfiguration
-        CheckIndexVersion
         CreateRuntimeRequirements
         UpdateGeneratedData && UpdateDescriptionCache
         ;;
@@ -1144,7 +1131,6 @@ case "${1}" in
 	    FatalError "need configuration via OPENGROK_READ_XML_CONFIGURATION"
 	fi
         ValidateConfiguration
-        CheckIndexVersion $@
         CreateRuntimeRequirements
         UpdateDataPartial $@
         ;;

--- a/src/org/opensolaris/opengrok/index/IndexVersion.java
+++ b/src/org/opensolaris/opengrok/index/IndexVersion.java
@@ -19,12 +19,15 @@
 
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.index;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.lucene.index.IndexNotFoundException;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.store.Directory;
@@ -33,6 +36,7 @@ import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.NativeFSLockFactory;
 import org.apache.lucene.util.Version;
 import org.opensolaris.opengrok.configuration.Configuration;
+import org.opensolaris.opengrok.logger.LoggerFactory;
 
 /**
  * Index version checker
@@ -40,6 +44,9 @@ import org.opensolaris.opengrok.configuration.Configuration;
  * @author Vladimir Kotal
  */
 public class IndexVersion {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(IndexVersion.class);
+
     /**
      * exception thrown when index version does not match Lucene version
      */
@@ -58,18 +65,28 @@ public class IndexVersion {
      */
     public static void check(Configuration cfg, List<String> subFilesList) throws Exception {
         File indexRoot = new File(cfg.getDataRoot(), IndexDatabase.INDEX_DIR);
+        LOGGER.log(Level.FINE, "Checking for Lucene index version mismatch in {0}",
+                indexRoot);
         
         if (!subFilesList.isEmpty()) {
             // Assumes projects are enabled.
             for (String projectName : subFilesList) {
+                LOGGER.log(Level.FINER,
+                        "Checking Lucene index version in project {0}",
+                        projectName);
                 checkDir(getDirectory(new File(indexRoot, projectName)));
             }
         } else {
             if (cfg.isProjectsEnabled()) {
                 for (String projectName : cfg.getProjects().keySet()) {
+                    LOGGER.log(Level.FINER,
+                            "Checking Lucene index version in project {0}",
+                            projectName);
                     checkDir(getDirectory(new File(indexRoot, projectName)));
                 }
             } else {
+                LOGGER.log(Level.FINER, "Checking Lucene index version in {0}",
+                        indexRoot);
                 checkDir(getDirectory(indexRoot));
             }
         }


### PR DESCRIPTION
Hello,

Please consider for integration this patch to fold `--checkIndexVersion` handling into a regular run of opengrok.jar.

When `--checkIndexVersion` was activated a couple of months ago, it added an inconvenience to `JAVA_DEBUG` because a developer had to attach to two, serial runs of opengrok.jar.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
