### PR TITLE
Re-gen xref if missing. Fix list.jsp w.r.t. isGenerateHtml().

### DIFF
--- a/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
+++ b/src/org/opensolaris/opengrok/analysis/AnalyzerGuru.java
@@ -696,6 +696,16 @@ public class AnalyzerGuru {
     }
 
     /**
+     * Finds a {@code FileAnalyzerFactory} for the specified
+     * {@link FileAnalyzer#getFileTypeName()}.
+     * @param fileTypeName a defined instance
+     * @return a defined instance or {@code null}
+     */
+    public static FileAnalyzerFactory findByFileTypeName(String fileTypeName) {
+        return FILETYPE_FACTORIES.get(fileTypeName);
+    }
+
+    /**
      * Find a {@code FileAnalyzerFactory} with the specified class name. If one
      * doesn't exist, create one and register it. Allow specification of either
      * the complete class name (which includes the package name) or the simple

--- a/web/list.jsp
+++ b/web/list.jsp
@@ -20,7 +20,7 @@ CDDL HEADER END
 
 Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
-Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
 
 --%>
 <%@page errorPage="error.jsp" import="
@@ -176,7 +176,9 @@ document.pageReady.push(function() { pageReadyList();});
         }
     } else if (rev.length() != 0) {
         // requesting a revision
-        if (cfg.isLatestRevision(rev)) {
+        File xrefFile = null;
+        if (cfg.isLatestRevision(rev) &&
+                (xrefFile = cfg.findDataFile()) != null) {
             if (cfg.annotate()) {
                 // annotate
                 BufferedInputStream bin =
@@ -232,8 +234,6 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
                 }
 
             } else {
-                File xrefFile = cfg.findDataFile();
-                if (xrefFile != null) {
 %>
 <div id="src" data-navigate-window-enabled="<%= navigateWindowEnabled %>">
     <pre><%
@@ -242,7 +242,6 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
                             request.getContextPath());
     %></pre>
 </div><%
-                }
             }
         } else {
             // requesting a previous revision


### PR DESCRIPTION
Hello,

Please consider for integration this patch that re-generates an xref when it is detected as missing or as stale (e.g. for issue #2092 when source code is updated but not yet re-indexed). This patch also fixes handling of `isGenerateHtml()` in list.jsp.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
