### PR TITLE
add parameter to Command constructor to disable stderr redirection

### DIFF
--- a/tools/sync/projadm.py
+++ b/tools/sync/projadm.py
@@ -55,14 +55,15 @@ def exec_command(doit, logger, cmd, msg):
     Execute given command and return its output.
     Exit the program on failure.
     """
-    cmd = Command(cmd, logger=logger)
+    cmd = Command(cmd, logger=logger, redirect_stderr=False)
     if not doit:
         logger.info(cmd)
         return
     cmd.execute()
     if cmd.getstate() is not Command.FINISHED or cmd.getretcode() != 0:
         logger.error(msg)
-        logger.error(cmd.getoutput())
+        logger.error("Standard output: {}".format(cmd.getoutput()))
+        logger.error("Error output: {}".format(cmd.geterroutput()))
         sys.exit(1)
 
     return cmd.getoutput()

--- a/tools/sync/test/test_command.py
+++ b/tools/sync/test/test_command.py
@@ -121,6 +121,18 @@ class TestApp(unittest.TestCase):
         self.assertEqual(Command.FINISHED, cmd.getstate())
         self.assertEqual(0, cmd.getretcode())
 
+    @unittest.skipUnless(os.name.startswith("posix"), "requires Unix")
+    def test_stderr(self):
+        cmd = Command(["/bin/cat", "/foo/bar", "/etc/passwd"],
+                      redirect_stderr=False)
+        cmd.execute()
+        self.assertEqual(Command.FINISHED, cmd.getstate())
+        self.assertNotEqual(0, cmd.getretcode())
+        # The error could contain localized output strings so check just
+        # for the path itself.
+        self.assertTrue("/foo/bar" in "\n".join(cmd.geterroutput()))
+        self.assertFalse("/foo/bar" in "\n".join(cmd.getoutput()))
+        self.assertTrue("root" in "\n".join(cmd.getoutput()))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Basically adds a parameter to `Command` constructor to specify whether `stderr` should be redirected to `stdout` as it used to be until now. If not, a new thread consuming `stderr` will be created. New method `geterroutput()` can be used to gather this output.
