### PR TITLE
Search endpoint filtered by localhost filter fix

### DIFF
--- a/src/org/opensolaris/opengrok/web/api/v1/filter/LocalhostFilter.java
+++ b/src/org/opensolaris/opengrok/web/api/v1/filter/LocalhostFilter.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Level;
@@ -44,6 +45,8 @@ import java.util.logging.Logger;
 public class LocalhostFilter implements ContainerRequestFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(LocalhostFilter.class);
+
+    private static final Set<String> allowedPaths = Collections.singleton("search");
 
     @Context
     private HttpServletRequest request;
@@ -64,6 +67,11 @@ public class LocalhostFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(final ContainerRequestContext context) {
+        String path = context.getUriInfo().getPath();
+        if (allowedPaths.contains(path)) {
+            return;
+        }
+
         if (!localAddresses.contains(request.getRemoteAddr())) {
             context.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
         }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

I totally forgot to exclude `search` from `LocalhostFilter`. Therefore, this fix.

Thanks :) 