### PR TITLE
Webapp URI param should be more robust

### DIFF
--- a/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
+++ b/src/org/opensolaris/opengrok/configuration/RuntimeEnvironment.java
@@ -1383,7 +1383,9 @@ public final class RuntimeEnvironment {
      */
     public void writeConfiguration(String host) throws IOException {
         Response r = ClientBuilder.newClient()
-                .target(host + "/api/v1")
+                .target(host)
+                .path("api")
+                .path("v1")
                 .path("configuration")
                 .queryParam("reindex", true)
                 .request()
@@ -1407,7 +1409,10 @@ public final class RuntimeEnvironment {
 
         subFiles.stream().map(proj -> new File(proj).getName()).forEach(project -> {
             Response r = ClientBuilder.newClient()
-                    .target(host + "/api/v1/system")
+                    .target(host)
+                    .path("api")
+                    .path("v1")
+                    .path("system")
                     .path("refresh")
                     .request()
                     .put(Entity.text(project));

--- a/src/org/opensolaris/opengrok/index/IndexDatabase.java
+++ b/src/org/opensolaris/opengrok/index/IndexDatabase.java
@@ -371,7 +371,10 @@ public class IndexDatabase {
         if (project != null) {
             if (env.getConfigHost() != null) {
                 Response r = ClientBuilder.newClient()
-                        .target(env.getConfigHost() + "/api/v1/projects")
+                        .target(env.getConfigHost())
+                        .path("api")
+                        .path("v1")
+                        .path("projects")
                         .path(Util.URIEncode(project.getName()))
                         .path("indexed")
                         .request()

--- a/src/org/opensolaris/opengrok/index/IndexerUtil.java
+++ b/src/org/opensolaris/opengrok/index/IndexerUtil.java
@@ -32,7 +32,10 @@ class IndexerUtil {
 
     static void enableProjects(final String host) {
         ClientBuilder.newClient()
-                .target(host + "/api/v1/configuration")
+                .target(host)
+                .path("api")
+                .path("v1")
+                .path("configuration")
                 .path("projectsEnabled")
                 .request()
                 .put(Entity.text(Boolean.TRUE.toString()));

--- a/tools/sync/opengrok.py
+++ b/tools/sync/opengrok.py
@@ -66,8 +66,8 @@ def get_repos(logger, project, uri):
     Return  string with the result on success, None on failure.
     """
 
-    r = get(logger, uri + '/api/v1/projects/' +
-            urllib.parse.quote_plus(project) + '/repositories')
+    r = get(logger, get_uri(uri, 'api', 'v1', 'projects',
+                            urllib.parse.quote_plus(project), 'repositories'))
 
     if not r:
         logger.error('could not get repositories for ' + project)
@@ -86,8 +86,9 @@ def get_config_value(logger, name, uri):
 
     Return string with the result on success, None on failure.
     """
-    r = get(logger, uri + '/api/v1/configuration/' +
-            urllib.parse.quote_plus(name))
+    r = get(logger, get_uri(uri, 'api', 'v1', 'configuration',
+                            urllib.parse.quote_plus(name)))
+
     if not r:
         logger.error('could not get config value ' + name)
         return None
@@ -103,7 +104,8 @@ def get_repo_type(logger, repository, uri):
     """
     payload = {'repository': repository}
 
-    r = get(logger, uri + '/api/v1/repositories/type', params=payload)
+    r = get(logger, get_uri(uri, 'api', 'v1', 'repositories', 'type'),
+            params=payload)
     if not r:
         logger.error('could not get repo type for ' + repository)
         return None
@@ -115,7 +117,7 @@ def get_repo_type(logger, repository, uri):
 
 
 def get_configuration(logger, uri):
-    r = get(logger, uri + '/api/v1/configuration')
+    r = get(logger, get_uri(uri, 'api', 'v1', 'configuration'))
     if not r:
         logger.error('could not get configuration')
         return None
@@ -124,7 +126,8 @@ def get_configuration(logger, uri):
 
 
 def set_configuration(logger, configuration, uri):
-    r = put(logger, uri + '/api/v1/configuration', data=configuration)
+    r = put(logger, get_uri(uri, 'api', 'v1', 'configuration'),
+            data=configuration)
 
     if not r:
         logger.error('could not set configuration')
@@ -134,7 +137,7 @@ def set_configuration(logger, configuration, uri):
 
 
 def list_indexed_projects(logger, uri):
-    r = get(logger, uri + '/api/v1/projects/indexed')
+    r = get(logger, get_uri(uri, 'api', 'v1', 'projects', 'indexed'))
     if not r:
         logger.error('could not list indexed projects')
         return None
@@ -143,7 +146,7 @@ def list_indexed_projects(logger, uri):
 
 
 def add_project(logger, project, uri):
-    r = post(logger, uri + '/api/v1/projects', data=project)
+    r = post(logger, get_uri(uri, 'api', 'v1', 'projects'), data=project)
 
     if not r:
         logger.error('could not add project ' + project)
@@ -153,11 +156,15 @@ def add_project(logger, project, uri):
 
 
 def delete_project(logger, project, uri):
-    r = delete(logger, uri + '/api/v1/projects/' +
-               urllib.parse.quote_plus(project))
+    r = delete(logger, get_uri(uri, 'api', 'v1', 'projects',
+                               urllib.parse.quote_plus(project)))
 
     if not r:
         logger.error('could not delete project ' + project)
         return False
 
     return True
+
+
+def get_uri(*uri_parts):
+    return '/'.join(s.strip('/') for s in uri_parts)

--- a/tools/sync/reindex-project.ksh
+++ b/tools/sync/reindex-project.ksh
@@ -67,7 +67,10 @@ function reindex_one
 		exit 1
 	fi
 
-	curl "${OPENGROK_WEBAPP_CFGADDR}/${OPENGROK_WEBAPP_CONTEXT}/api/v1/configuration" > "$config_xml"
+	CFG_URI_PATH="${OPENGROK_WEBAPP_CONTEXT}/api/v1/configuration"
+	CFG_URI_PATH=$(echo ${CFG_URI_PATH} | sed 's://:/:g')
+
+	curl "${OPENGROK_WEBAPP_CFGADDR%/}/${CFG_URI_PATH#/}" > "$config_xml"
 	if (( $? != 0 )); then
 		print -u2 "failed to get configuration from webapp"
 		rm -f "$config_xml"


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
Fixes #2194

There were a few problems:
* if the webapp URI (`-U`) was passed with trailing `/` (e.g. `http://localhost:8080/`) to `Indexer` then it was not able to contact the webapp
* if the webapp URI (`-U`) was passed with trailing `/` to Python scripts then they were not able to contact the webapp
* if the `OPENGROK_WEBAPP_CONTEXT ` env param was empty or contained leading/trailing slashes then `reindex-project.ksh` was not able to download the configuration

The problem was that resulting URIs were containing multiple slashes (e.g. `http://localhost:8080//api/v1/configuration`) which were causing the calls to fail.

This patch should fix the above errors.

Thanks :) 