### PR TITLE
Add generic exception mapper for REST API

### DIFF
--- a/src/org/opensolaris/opengrok/web/api/constraints/PositiveDuration.java
+++ b/src/org/opensolaris/opengrok/web/api/constraints/PositiveDuration.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
  */
-package org.opensolaris.opengrok.web.constraints;
+package org.opensolaris.opengrok.web.api.constraints;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;

--- a/src/org/opensolaris/opengrok/web/api/constraints/PositiveDurationValidator.java
+++ b/src/org/opensolaris/opengrok/web/api/constraints/PositiveDurationValidator.java
@@ -20,23 +20,24 @@
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
  */
-package org.opensolaris.opengrok.web.constraints;
+package org.opensolaris.opengrok.web.api.constraints;
 
-import javax.validation.ValidationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+import java.time.Duration;
 
-@Provider
-public class ValidationExceptionMapper implements ExceptionMapper<ValidationException> {
+@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
+public class PositiveDurationValidator implements ConstraintValidator<PositiveDuration, Duration> {
 
     @Override
-    public Response toResponse(final ValidationException e) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                .entity(e.getMessage())
-                .type(MediaType.TEXT_PLAIN)
-                .build();
+    public void initialize(final PositiveDuration positiveDuration) {
+
     }
 
+    @Override
+    public boolean isValid(final Duration duration, final ConstraintValidatorContext context) {
+        return duration != null && !duration.isNegative() && !duration.isZero();
+    }
 }

--- a/src/org/opensolaris/opengrok/web/api/error/ExceptionMapperUtils.java
+++ b/src/org/opensolaris/opengrok/web/api/error/ExceptionMapperUtils.java
@@ -22,24 +22,36 @@
  */
 package org.opensolaris.opengrok.web.api.error;
 
-import org.opensolaris.opengrok.logger.LoggerFactory;
-
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
-@Provider
-public class GenericExceptionMapper implements ExceptionMapper<Exception> {
+public class ExceptionMapperUtils {
 
-    private static final Logger logger = LoggerFactory.getLogger(GenericExceptionMapper.class);
+    private ExceptionMapperUtils() {
+    }
 
-    @Override
-    public Response toResponse(final Exception e) {
-        logger.log(Level.FINE, "Exception while processing request", e);
+    public static Response toResponse(final Response.Status status, final Exception e) {
+        return Response.status(status)
+                .entity(new ExceptionModel(e.getMessage()))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
 
-        return ExceptionMapperUtils.toResponse(Response.Status.INTERNAL_SERVER_ERROR, e);
+    private static class ExceptionModel {
+
+        private String message;
+
+        public ExceptionModel(final String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(final String message) {
+            this.message = message;
+        }
     }
 
 }

--- a/src/org/opensolaris/opengrok/web/api/error/ExceptionMapperUtils.java
+++ b/src/org/opensolaris/opengrok/web/api/error/ExceptionMapperUtils.java
@@ -30,6 +30,12 @@ public class ExceptionMapperUtils {
     private ExceptionMapperUtils() {
     }
 
+    /**
+     * Turns the exception into JSON format and embeds it into the response with the provided status.
+     * @param status status of the created response
+     * @param e exception to embed into the response
+     * @return response with the {@code status} and JSON media type with encoded {@code e} in the body
+     */
     public static Response toResponse(final Response.Status status, final Exception e) {
         return Response.status(status)
                 .entity(new ExceptionModel(e.getMessage()))
@@ -41,7 +47,7 @@ public class ExceptionMapperUtils {
 
         private String message;
 
-        public ExceptionModel(final String message) {
+        ExceptionModel(final String message) {
             this.message = message;
         }
 

--- a/src/org/opensolaris/opengrok/web/api/error/GenericExceptionMapper.java
+++ b/src/org/opensolaris/opengrok/web/api/error/GenericExceptionMapper.java
@@ -37,7 +37,7 @@ public class GenericExceptionMapper implements ExceptionMapper<Exception> {
 
     @Override
     public Response toResponse(final Exception e) {
-        logger.log(Level.FINE, "Exception while processing request", e);
+        logger.log(Level.WARNING, "Exception while processing request", e);
 
         return ExceptionMapperUtils.toResponse(Response.Status.INTERNAL_SERVER_ERROR, e);
     }

--- a/src/org/opensolaris/opengrok/web/api/error/GenericExceptionMapper.java
+++ b/src/org/opensolaris/opengrok/web/api/error/GenericExceptionMapper.java
@@ -20,18 +20,22 @@
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
  */
-package org.opensolaris.opengrok.web.api.v1;
+package org.opensolaris.opengrok.web.api.error;
 
-import org.glassfish.jersey.server.ResourceConfig;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
 
-import javax.ws.rs.ApplicationPath;
+@Provider
+public class GenericExceptionMapper implements ExceptionMapper<Exception> {
 
-@ApplicationPath("/api/v1")
-public class RestApp extends ResourceConfig {
-
-    public RestApp() {
-        packages("org.opensolaris.opengrok.web.api.constraints", "org.opensolaris.opengrok.web.api.error");
-        packages(true, "org.opensolaris.opengrok.web.api.v1");
+    @Override
+    public Response toResponse(final Exception e) {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                .entity(e.getMessage())
+                .type(MediaType.TEXT_PLAIN)
+                .build();
     }
 
 }

--- a/src/org/opensolaris/opengrok/web/api/error/ValidationExceptionMapper.java
+++ b/src/org/opensolaris/opengrok/web/api/error/ValidationExceptionMapper.java
@@ -20,24 +20,23 @@
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
  */
-package org.opensolaris.opengrok.web.constraints;
+package org.opensolaris.opengrok.web.api.error;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.constraintvalidation.SupportedValidationTarget;
-import javax.validation.constraintvalidation.ValidationTarget;
-import java.time.Duration;
+import javax.validation.ValidationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
 
-@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
-public class PositiveDurationValidator implements ConstraintValidator<PositiveDuration, Duration> {
-
-    @Override
-    public void initialize(final PositiveDuration positiveDuration) {
-
-    }
+@Provider
+public class ValidationExceptionMapper implements ExceptionMapper<ValidationException> {
 
     @Override
-    public boolean isValid(final Duration duration, final ConstraintValidatorContext context) {
-        return duration != null && !duration.isNegative() && !duration.isZero();
+    public Response toResponse(final ValidationException e) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(e.getMessage())
+                .type(MediaType.TEXT_PLAIN)
+                .build();
     }
+
 }

--- a/src/org/opensolaris/opengrok/web/api/error/ValidationExceptionMapper.java
+++ b/src/org/opensolaris/opengrok/web/api/error/ValidationExceptionMapper.java
@@ -23,7 +23,6 @@
 package org.opensolaris.opengrok.web.api.error;
 
 import javax.validation.ValidationException;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -33,10 +32,7 @@ public class ValidationExceptionMapper implements ExceptionMapper<ValidationExce
 
     @Override
     public Response toResponse(final ValidationException e) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                .entity(e.getMessage())
-                .type(MediaType.TEXT_PLAIN)
-                .build();
+        return ExceptionMapperUtils.toResponse(Response.Status.BAD_REQUEST, e);
     }
 
 }

--- a/src/org/opensolaris/opengrok/web/api/error/WebApplicationExceptionMapper.java
+++ b/src/org/opensolaris/opengrok/web/api/error/WebApplicationExceptionMapper.java
@@ -22,24 +22,17 @@
  */
 package org.opensolaris.opengrok.web.api.error;
 
-import org.opensolaris.opengrok.logger.LoggerFactory;
-
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 @Provider
-public class GenericExceptionMapper implements ExceptionMapper<Exception> {
-
-    private static final Logger logger = LoggerFactory.getLogger(GenericExceptionMapper.class);
+public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {
 
     @Override
-    public Response toResponse(final Exception e) {
-        logger.log(Level.FINE, "Exception while processing request", e);
-
-        return ExceptionMapperUtils.toResponse(Response.Status.INTERNAL_SERVER_ERROR, e);
+    public Response toResponse(final WebApplicationException e) {
+        return e.getResponse();
     }
 
 }

--- a/src/org/opensolaris/opengrok/web/messages/Message.java
+++ b/src/org/opensolaris/opengrok/web/messages/Message.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.NotEmpty;
-import org.opensolaris.opengrok.web.constraints.PositiveDuration;
+import org.opensolaris.opengrok.web.api.constraints.PositiveDuration;
 
 import java.io.IOException;
 import java.time.Duration;

--- a/test/org/opensolaris/opengrok/web/api/constraint/PositiveDurationValidatorTest.java
+++ b/test/org/opensolaris/opengrok/web/api/constraint/PositiveDurationValidatorTest.java
@@ -20,10 +20,10 @@
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
  */
-package org.opensolaris.opengrok.web.constraint;
+package org.opensolaris.opengrok.web.api.constraint;
 
 import org.junit.Test;
-import org.opensolaris.opengrok.web.constraints.PositiveDurationValidator;
+import org.opensolaris.opengrok.web.api.constraints.PositiveDurationValidator;
 
 import java.time.Duration;
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

Now when an exception is thrown from REST API endpoint then `error.jsp` page is returned. This change returns only the exception `message` text since it is more readable and better for use with REST API.

Thanks :)