### PR TITLE
Jersey JDK 9 support

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -555,6 +555,16 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
             <version>${jersey.version}</version>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/src/org/opensolaris/opengrok/history/SCCSRepositoryAuthorParser.java
+++ b/src/org/opensolaris/opengrok/history/SCCSRepositoryAuthorParser.java
@@ -32,7 +32,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import jdk.nashorn.internal.objects.NativeDebug;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 import org.opensolaris.opengrok.util.Executor;
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

Jersey does not work with JDK9 right away because of the java modularization. 

As mentioned here: https://www.jeffryhouser.com/index.cfm/2017/12/21/Why-wont-Jersey-work-on-JDK-9

I added these 2 libraries and everything seems to work fine (no exceptions thrown during Tomcat startup).

I also removed one unused import which were preventing compilation with JDK 10.

Thanks :)
