### PR TITLE
Allow RESTful API in AuthorizationFilter

### DIFF
--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -29,6 +29,16 @@
                     <warSourceDirectory>../web</warSourceDirectory>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.tomcat.maven</groupId>
+                <artifactId>tomcat7-maven-plugin</artifactId>
+                <version>2.2</version>
+                <configuration>
+                    <url>http://localhost:8080/manager/text</url>
+                    <server>OpenGrok</server>
+                    <path>/${project.build.finalName}</path>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/org/opensolaris/opengrok/search/SearchEngine.java
+++ b/src/org/opensolaris/opengrok/search/SearchEngine.java
@@ -290,9 +290,9 @@ public class SearchEngine {
      */
     public int search(HttpServletRequest req, String... projectNames) {
         ProjectHelper pHelper = PageConfig.get(req).getProjectHelper();
-        Set<Project> projects = pHelper.getAllProjects();
+        Set<Project> allProjects = pHelper.getAllProjects();
         List<Project> filteredProjects = new ArrayList<Project>();
-        for(Project project: projects) {
+        for(Project project: allProjects) {
             for (String name : projectNames) {
                 if (project.getName().equalsIgnoreCase(name)) {
                     filteredProjects.add(project);

--- a/src/org/opensolaris/opengrok/web/api/v1/RestApp.java
+++ b/src/org/opensolaris/opengrok/web/api/v1/RestApp.java
@@ -26,9 +26,11 @@ import org.glassfish.jersey.server.ResourceConfig;
 
 import javax.ws.rs.ApplicationPath;
 
-@ApplicationPath("/api/v1")
+@ApplicationPath(RestApp.API_PATH)
 public class RestApp extends ResourceConfig {
 
+    public static final String API_PATH = "/api/v1";
+    
     public RestApp() {
         packages("org.opensolaris.opengrok.web.api.v1.controller", "org.opensolaris.opengrok.web.api.v1.filter");
     }


### PR DESCRIPTION
This explicitly allows RESTful API calls to go through `AuthorizationFilter`. It seems this is not strictly necessary (as mentioned in #2203 for the `/search` endpoint) however it is better not to rely on the fact that `config.getProject()` returns `null` in `AuthorizationFilter.doFilter()`.
