### PR TITLE
remove tests for default encoding in TextAnalyzer

### DIFF
--- a/test/org/opensolaris/opengrok/analysis/TextAnalyzerTest.java
+++ b/test/org/opensolaris/opengrok/analysis/TextAnalyzerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opensolaris.opengrok.analysis;
@@ -40,7 +40,6 @@ import org.opensolaris.opengrok.analysis.plain.PlainAnalyzerFactory;
 
 public class TextAnalyzerTest {
 
-    private final String defaultEncoding = new InputStreamReader(new ByteArrayInputStream(new byte[0])).getEncoding();
     private String encoding;
     private String contents;
 
@@ -54,21 +53,9 @@ public class TextAnalyzerTest {
     }
 
     @Test
-    public void defaultEncoding() throws IOException {
-        new TestableTextAnalyzer().analyze(new Document(),
-                getStreamSource("hello".getBytes()), null);
-
-        assertEquals(defaultEncoding, encoding);
-
-        assertEquals("hello", contents);
-    }
-
-    @Test
     public void resetsStreamOnShortInput() throws IOException {
         new TestableTextAnalyzer().analyze(new Document(),
                 getStreamSource("hi".getBytes()), null);
-
-        assertEquals(defaultEncoding, encoding);
 
         assertEquals("hi", contents);
     }


### PR DESCRIPTION
fixes #2205
