### PR TITLE
Allow configuration objects to be set via REST API

### DIFF
--- a/src/org/opensolaris/opengrok/util/ClassUtil.java
+++ b/src/org/opensolaris/opengrok/util/ClassUtil.java
@@ -45,6 +45,9 @@ public class ClassUtil {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClassUtil.class);
 
+    private ClassUtil() {
+    }
+
     /**
      * Mark all transient fields in {@code targetClass} as @Transient for the
      * XML serialization.

--- a/src/org/opensolaris/opengrok/util/ClassUtil.java
+++ b/src/org/opensolaris/opengrok/util/ClassUtil.java
@@ -33,6 +33,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensolaris.opengrok.logger.LoggerFactory;
 
 /**
@@ -122,7 +124,7 @@ public class ClassUtil {
                                 setter.getName(), field));
             }
 
-            Class c = setter.getParameterTypes()[0];
+            Class<?> c = setter.getParameterTypes()[0];
             String paramClass = c.getName();
 
             /**
@@ -165,10 +167,9 @@ public class ClassUtil {
             } else if (paramClass.equals(String.class.getName())) {
                 setter.invoke(obj, value);
             } else {
-                // error unknown type
-                throw new IOException(
-                        String.format("Unsupported type conversion for the name \"%s\". Expecting \"%s\".",
-                                field, paramClass));
+                ObjectMapper mapper = new ObjectMapper();
+                Object objValue = mapper.readValue(value, c);
+                setter.invoke(obj, objValue);
             }
         } catch (NumberFormatException ex) {
             throw new IOException(

--- a/test/org/opensolaris/opengrok/util/ClassUtilTest.java
+++ b/test/org/opensolaris/opengrok/util/ClassUtilTest.java
@@ -1,0 +1,143 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClassUtilTest {
+
+    private static class TestObject {
+
+        private String strField;
+        private int intField;
+        private TestObject objField;
+
+        public String getStrField() {
+            return strField;
+        }
+
+        public void setStrField(String strField) {
+            this.strField = strField;
+        }
+
+        public int getIntField() {
+            return intField;
+        }
+
+        public void setIntField(int intField) {
+            this.intField = intField;
+        }
+
+        public TestObject getObjField() {
+            return objField;
+        }
+
+        public void setObjField(TestObject objField) {
+            this.objField = objField;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TestObject testObject = (TestObject) o;
+            return intField == testObject.intField &&
+                    Objects.equals(strField, testObject.strField) &&
+                    Objects.equals(objField, testObject.objField);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(strField, intField, objField);
+        }
+    }
+
+    private TestObject testObject;
+
+    @Before
+    public void setUp() {
+        testObject = new TestObject();
+    }
+
+    @Test
+    public void setStrFieldTest() throws IOException {
+        ClassUtil.invokeSetter(testObject, "strField", "value");
+
+        assertEquals("value", testObject.strField);
+    }
+
+    @Test
+    public void setIntFieldTest() throws IOException {
+        ClassUtil.invokeSetter(testObject, "intField", "124");
+
+        assertEquals(124, testObject.intField);
+    }
+
+    @Test
+    public void setObjFieldTest() throws IOException {
+        TestObject t = new TestObject();
+        t.strField = "test";
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        ClassUtil.invokeSetter(testObject, "objField", mapper.writeValueAsString(t));
+
+        assertEquals(t, testObject.objField);
+    }
+
+    @Test
+    public void getStrFieldTest() throws IOException {
+        testObject.strField = "value2";
+
+        assertEquals("value2", ClassUtil.invokeGetter(testObject, "strField"));
+    }
+
+    @Test
+    public void getIntFieldTest() throws IOException {
+        testObject.intField = 1;
+
+        assertEquals(1, ClassUtil.invokeGetter(testObject, "intField"));
+    }
+
+    @Test
+    public void getObjFieldTest() throws IOException {
+        TestObject t = new TestObject();
+        t.strField = "test";
+
+        testObject.objField = t;
+
+        assertEquals(t, ClassUtil.invokeGetter(testObject, "objField"));
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

Hello,

this is useful for setting POJO objects in configuration. Also useful for suggester (and its config): https://github.com/oracle/opengrok/pull/2212

Example usage:
```bash
curl -d '{"enabled":"false"}' -X PUT http://localhost:8080/api/v1/configuration/suggesterConfig
```

I wanted to write some tests but I was not able to find any POJO class in configuration (`IgnoredNames` does not work and collections (e.g. `Set<Project>`) cannot be converted from JSON because of the type erasure)

I think it makes sense to extend this in the future to allow nested paths (e.g. `/suggesterConfig/enabled`)

Thanks :)