### PR TITLE
Improve logs when suggester data could not be created

### DIFF
--- a/src/org/opensolaris/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/src/org/opensolaris/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -184,6 +184,10 @@ public class SuggesterServiceImpl implements SuggesterService {
                     project);
             return;
         }
+        if (!p.isIndexed()) {
+            logger.log(Level.WARNING, "Cannot refresh project {0} because it is not indexed yet", project);
+            return;
+        }
         lock.readLock().lock();
         try {
             if (suggester == null) {

--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
@@ -119,7 +119,9 @@ class SuggesterProjectData implements Closeable {
             } else if (!indexedFields.containsAll(fields)) {
                 Set<String> copy = new HashSet<>(fields);
                 copy.removeAll(indexedFields);
-                logger.log(Level.WARNING, "Fields {0} will be ignored because they are not indexed", copy);
+                logger.log(Level.WARNING,
+                        "Fields {0} will be ignored because they were not found in index directory {1}",
+                        new Object[] {copy, indexDir});
 
                 copy = new HashSet<>(fields);
                 copy.retainAll(indexedFields);
@@ -346,7 +348,7 @@ class SuggesterProjectData implements Closeable {
         try {
             WFSTCompletionLookup lookup = lookups.get(field);
             if (lookup == null) {
-                logger.log(Level.WARNING, "No WFST for field {0}", field);
+                logger.log(Level.WARNING, "No WFST for field {0} in {1}", new Object[] {field, suggesterDir});
                 return Collections.emptyList();
             }
             return lookup.lookup(prefix, false, resultSize);


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

Hello,

improves log messages in #2219.

I also added one more check if the project is indexed to `SuggesterServiceImpl`.

Thanks :)