### PR TITLE
set directory name before BazaarHistoryParser is created

### DIFF
--- a/test/org/opensolaris/opengrok/history/BazaarHistoryParserTest.java
+++ b/test/org/opensolaris/opengrok/history/BazaarHistoryParserTest.java
@@ -57,7 +57,10 @@ public class BazaarHistoryParserTest {
         if (RuntimeEnvironment.getInstance().getSourceRootPath() == null) {
             RuntimeEnvironment.getInstance().setSourceRoot("");
         }
-        instance = new BazaarHistoryParser(new BazaarRepository());
+        BazaarRepository bzrRepo = new BazaarRepository();
+        // BazaarHistoryParser needs to have a valid directory name.
+        bzrRepo.setDirectoryNameRelative("bzrRepo");
+        instance = new BazaarHistoryParser(bzrRepo);
     }
 
     @After


### PR DESCRIPTION
prevents the test from hitting `null` pointer exception if relative directory name is accessed (needed for #2235)