### PR TITLE
Add Ctags installed condition to suggester tests

### DIFF
--- a/test/org/opensolaris/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
+++ b/test/org/opensolaris/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
@@ -26,8 +26,12 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.opengrok.suggest.Suggester;
+import org.opensolaris.opengrok.condition.ConditionalRun;
+import org.opensolaris.opengrok.condition.ConditionalRunRule;
+import org.opensolaris.opengrok.condition.CtagsInstalled;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.configuration.SuggesterConfig;
 import org.opensolaris.opengrok.index.Indexer;
@@ -49,7 +53,11 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
+@ConditionalRun(CtagsInstalled.class)
 public class SuggesterControllerProjectsDisabledTest extends JerseyTest {
+
+    @ClassRule
+    public static ConditionalRunRule rule = new ConditionalRunRule();
 
     private static final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 

--- a/test/org/opensolaris/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/test/org/opensolaris/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -27,8 +27,12 @@ import org.glassfish.jersey.test.JerseyTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.opengrok.suggest.Suggester;
+import org.opensolaris.opengrok.condition.ConditionalRun;
+import org.opensolaris.opengrok.condition.ConditionalRunRule;
+import org.opensolaris.opengrok.condition.CtagsInstalled;
 import org.opensolaris.opengrok.configuration.RuntimeEnvironment;
 import org.opensolaris.opengrok.configuration.SuggesterConfig;
 import org.opensolaris.opengrok.index.Indexer;
@@ -60,6 +64,7 @@ import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+@ConditionalRun(CtagsInstalled.class)
 public class SuggesterControllerTest extends JerseyTest {
 
     public static class Result {
@@ -82,6 +87,9 @@ public class SuggesterControllerTest extends JerseyTest {
         public String token;
         public int increment;
     }
+
+    @ClassRule
+    public static ConditionalRunRule rule = new ConditionalRunRule();
 
     private static final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

fixes #2228 

Fixes problem when tests failed if Ctags were not installed.

Thanks :)