### PR TITLE
read and send configuration as UTF-8

### DIFF
--- a/tools/projadm.py
+++ b/tools/projadm.py
@@ -309,9 +309,10 @@ if __name__ == '__main__':
                     if doit:
                         with io.open(main_config, mode='r',
                                      encoding="utf-8") as config_file:
-                            config_data = config_file.read()
-                            set_configuration(logger,
-                                              config_data.encode("utf-8"), uri)
+                            config_data = config_file.read().encode("utf-8")
+                            if not set_configuration(logger,
+                                                     config_data, uri):
+                                sys.exit(1)
                 else:
                     logger.error("file {} does not exist".format(main_config))
                     sys.exit(1)


### PR DESCRIPTION
`set_configuration()` should be called with actual data, not file path. Also, due to exceptions are handled in generic way in `put()`, encoding/decoding problem while preparing the data for sending was not apparent until I ran `projadm` in debug mode.