### PR TITLE
bump OS X image to Xcode 8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       sudo: required
       jdk: oraclejdk8
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8.3
 before_install: scripts/before_install
 install: true
 before_script: scripts/before


### PR DESCRIPTION
Originally I wanted to go to Xcode 9.4 (https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce) however it has too new Java which makes Suggester tests to fail so will do this incremental step first.
