### PR TITLE
handle JSON decode error for older json module versions

### DIFF
--- a/tools/src/main/python/readconfig.py
+++ b/tools/src/main/python/readconfig.py
@@ -26,6 +26,7 @@ import json
 import yaml
 import sys
 
+# The following is to make the json parsing work on Python 3.4.
 try:
     from json.decoder import JSONDecodeError
 except ImportError:

--- a/tools/src/main/python/readconfig.py
+++ b/tools/src/main/python/readconfig.py
@@ -26,6 +26,11 @@ import json
 import yaml
 import sys
 
+try:
+    from json.decoder import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
+
 
 def read_config(logger, inputfile):
     """
@@ -43,7 +48,7 @@ def read_config(logger, inputfile):
             try:
                 logger.debug("trying JSON")
                 cfg = json.loads(data)
-            except json.decoder.JSONDecodeError:
+            except JSONDecodeError:
                 # Not a valid JSON file.
                 logger.debug("got exception {}".format(sys.exc_info()[0]))
                 pass


### PR DESCRIPTION
The tools scripts are written so they only work on Python 3. However, in Python 3.4 the `ValueError` is thrown instead of `json.decoder.JSONDecodeError` so this needs special handling.