### PR TITLE
Fix stale temporary directories created by suggester

### DIFF
--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
@@ -70,7 +70,7 @@ class SuggesterProjectData implements Closeable {
 
     private static final int MAX_TERM_SIZE = Short.MAX_VALUE - 3;
 
-    private static final String TEMP_DIR_PREFIX = "opengrok";
+    private static final String TEMP_DIR_PREFIX = "opengrok_suggester";
 
     private static final String WFST_FILE_SUFFIX = ".wfst";
 
@@ -98,6 +98,8 @@ class SuggesterProjectData implements Closeable {
 
     private Set<String> fields;
 
+    private final Path tempDir;
+
     SuggesterProjectData(
             final Directory indexDir,
             final Path suggesterDir,
@@ -107,6 +109,8 @@ class SuggesterProjectData implements Closeable {
         this.indexDir = indexDir;
         this.suggesterDir = suggesterDir;
         this.allowMostPopular = allowMostPopular;
+
+        tempDir = Files.createTempDirectory(TEMP_DIR_PREFIX);
 
         initFields(fields);
     }
@@ -207,7 +211,7 @@ class SuggesterProjectData implements Closeable {
     }
 
     private WFSTCompletionLookup createWFST() throws IOException {
-        return new WFSTCompletionLookup(FSDirectory.open(Files.createTempDirectory(TEMP_DIR_PREFIX)), TEMP_DIR_PREFIX);
+        return new WFSTCompletionLookup(FSDirectory.open(tempDir), TEMP_DIR_PREFIX);
     }
 
     private File getWFSTFile(final String field) {
@@ -446,6 +450,8 @@ class SuggesterProjectData implements Closeable {
                 }
             });
             indexDir.close();
+
+            FileUtils.deleteDirectory(tempDir.toFile());
         } finally {
             lock.writeLock().unlock();
         }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
Hello,

fixes problem of stale directories that were created by a suggester. It seems to work fine -> temporary directories are deleted upon stopping the web application. 

Thanks :)