### PR TITLE
Improve suggester temporary files handling

### DIFF
--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
@@ -46,8 +46,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,11 +66,13 @@ import java.util.logging.Logger;
  */
 class SuggesterProjectData implements Closeable {
 
+    private static final String TMP_DIR_PROPERTY = "java.io.tmpdir";
+
     private static final Logger logger = Logger.getLogger(SuggesterProjectData.class.getName());
 
     private static final int MAX_TERM_SIZE = Short.MAX_VALUE - 3;
 
-    private static final String TEMP_DIR_PREFIX = "opengrok_suggester";
+    private static final String WFST_TEMP_FILE_PREFIX = "opengrok_suggester_wfst";
 
     private static final String WFST_FILE_SUFFIX = ".wfst";
 
@@ -98,7 +100,7 @@ class SuggesterProjectData implements Closeable {
 
     private Set<String> fields;
 
-    private final Path tempDir;
+    private final Directory tempDir;
 
     SuggesterProjectData(
             final Directory indexDir,
@@ -110,7 +112,7 @@ class SuggesterProjectData implements Closeable {
         this.suggesterDir = suggesterDir;
         this.allowMostPopular = allowMostPopular;
 
-        tempDir = Files.createTempDirectory(TEMP_DIR_PREFIX);
+        tempDir = FSDirectory.open(Paths.get(System.getProperty(TMP_DIR_PROPERTY)));
 
         initFields(fields);
     }
@@ -210,8 +212,8 @@ class SuggesterProjectData implements Closeable {
         }
     }
 
-    private WFSTCompletionLookup createWFST() throws IOException {
-        return new WFSTCompletionLookup(FSDirectory.open(tempDir), TEMP_DIR_PREFIX);
+    private WFSTCompletionLookup createWFST() {
+        return new WFSTCompletionLookup(tempDir, WFST_TEMP_FILE_PREFIX);
     }
 
     private File getWFSTFile(final String field) {
@@ -451,7 +453,7 @@ class SuggesterProjectData implements Closeable {
             });
             indexDir.close();
 
-            FileUtils.deleteDirectory(tempDir.toFile());
+            tempDir.close();
         } finally {
             lock.writeLock().unlock();
         }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
Hello,

this way there is no temporary directory created for the whole time the application is running. `WFSTCompletionLookup` creates a temporary file in the directory `java.io.tmpdir` and removes it when it is not needed anymore.

Thanks :)