### PR TITLE
fix the logic and report ctags version

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -612,15 +612,16 @@ public final class RuntimeEnvironment {
             executor.exec(false);
             String output = executor.getOutputString();
             boolean isUnivCtags = output != null && output.contains("Universal Ctags");
-            if (output == null && !isUnivCtags) {
-                LOGGER.log(Level.SEVERE, "Error: No Universal Ctags found in PATH !\n"
+            if (output == null || !isUnivCtags) {
+                LOGGER.log(Level.SEVERE, "Error: No Universal Ctags found !\n"
                         + "(tried running " + "{0}" + ")\n"
                         + "Please use the -c option to specify path to a "
                         + "Universal Ctags program.\n"
-                        + "Or set it in Java system property "
-                        + SYSTEM_CTAGS_PROPERTY, getCtags());
+                        + "Or set it in Java system property {1}",
+                        new Object[]{getCtags(), SYSTEM_CTAGS_PROPERTY});
                 ctagsFound = false;
             } else {
+                LOGGER.log(Level.INFO, "Using ctags: {0}", output.trim());
                 ctagsFound = true;
             }
         }


### PR DESCRIPTION
The logic for ctags checking is wrong. It causes tests to fail if there is no valid ctags binary.