### PR TITLE
add Lucene as dependency to the web module

### DIFF
--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>org.suigeneris.jrcs.diff</artifactId>
             <version>0.4.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+            <version>7.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
-            <version>7.3.1</version>
+            <version>${lucene.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
IDEA was unhappy because it could not resolve dependency to compile `SuggesterQueryBuilder.java` due to the imports:
```
import org.apache.lucene.queryparser.classic.ParseException;
import org.apache.lucene.search.Query;
```

This change makes it happy again.