### PR TITLE
Allow post-compile-test for SVN to run on Windows

### DIFF
--- a/opengrok-indexer/build.xml
+++ b/opengrok-indexer/build.xml
@@ -164,7 +164,7 @@ Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
       
       <!-- need absolute path for svn url -->
       <pathconvert property="test.svn.url">
-        <map from="" to="file://"/>
+        <map from="" to="file:///"/>
         <path location="${build.test.reposroots}/svn"/>
       </pathconvert>
 


### PR DESCRIPTION
When passing `file://` protocol url to svn.exe on Windows, it fails. Let's use `file:///` prefix, with which both Linux and Windows work fine.

Proof: [AppVeyor (Windows)](https://ci.appveyor.com/project/0xfeeddeadbeef/opengrok#L1774) and [Travis CI (Linux)](https://travis-ci.org/0xfeeddeadbeef/opengrok/builds/416571245#L3209) (These builds are for different branch containing [same fix](https://github.com/0xfeeddeadbeef/opengrok/commit/5c5d88bf741614d55238ac477f300268fc1970b8) as this pull request).

Related to #2302.
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

I agree to OCA terms and conditions: http://www.oracle.com/technetwork/community/oca-486395.html