### PR TITLE
Fix SuggesterTest and ChronicleMapAdapterTest failing under Windows

### DIFF
--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
@@ -46,6 +46,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -67,9 +68,13 @@ public class SuggesterTest {
         private Suggester s;
         private Path indexDir;
         private Path suggesterDir;
+        private List<Suggester.NamedIndexReader> namedIndexReaders = new ArrayList<>();
 
 
         private void close() throws IOException {
+            for (Suggester.NamedIndexReader ir: namedIndexReaders) {
+                ir.getReader().close();
+            }
             s.close();
             FileUtils.deleteDirectory(indexDir.toFile());
             FileUtils.deleteDirectory(suggesterDir.toFile());
@@ -84,7 +89,9 @@ public class SuggesterTest {
         }
 
         private Suggester.NamedIndexReader getNamedIndexReader() throws IOException {
-            return new Suggester.NamedIndexReader("test", DirectoryReader.open(getIndexDirectory()));
+            Suggester.NamedIndexReader ir = new Suggester.NamedIndexReader("test", DirectoryReader.open(getIndexDirectory()));
+            namedIndexReaders.add(ir);
+            return ir;
         }
 
     }

--- a/suggester/src/test/java/org/opengrok/suggest/popular/impl/ChronicleMapAdapterTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/popular/impl/ChronicleMapAdapterTest.java
@@ -56,6 +56,7 @@ public class ChronicleMapAdapterTest {
 
     @After
     public void tearDown() throws IOException {
+        map.close();
         Files.delete(tempFile);
     }
 


### PR DESCRIPTION
Re issue #2302 , here are some fixes for suggester tests that I did while trying to get the tests to run under Windows, caused by Windows being more picky about deleting open files and directories. 

Errors fixed are:
ChronicleMapAdapterTest:
java.nio.file.FileSystemException: C:\Users\me\AppData\Local\Temp\opengrok7369985377004991146test: The process cannot access the file because it is being used by another process.
	at sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:86)
	at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:97)
	at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:102)
	at sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:269)
	at sun.nio.fs.AbstractFileSystemProvider.delete(AbstractFileSystemProvider.java:103)
	at java.nio.file.Files.delete(Files.java:1126)
	at org.opengrok.suggest.popular.impl.ChronicleMapAdapterTest.tearDown(ChronicleMapAdapterTest.java:60)

SuggesterTest:
java.io.IOException: Unable to delete file: C:\Users\me\AppData\Local\Temp\opengrok7256344301848795850\_1.cfs
	at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:2400)
	at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:1721)
	at org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.java:1617)
	at org.opengrok.suggest.SuggesterTest$SuggesterTestData.close(SuggesterTest.java:74)
	at org.opengrok.suggest.SuggesterTest$SuggesterTestData.access$500(SuggesterTest.java:65)
	at org.opengrok.suggest.SuggesterTest.testIndexChangedWhileOffline(SuggesterTest.java:214)
	
	(and similar error for 3 other test cases in SuggesterTest)
