### PR TITLE
generate info.properties file from Maven

### DIFF
--- a/opengrok-indexer/build.xml
+++ b/opengrok-indexer/build.xml
@@ -54,56 +54,11 @@ Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
 
     <property name="git" value="git"/>
 
-    <!-- Get the id of the changeset we're building from using a
-         Mercurial command.
-      -->
-    <target name="-get-changeset-from-command"
-            depends="-check-is-git-repo" if="build.from.repo">
-        <exec executable="${git}"
-              failifexecutionfails="no"
-              outputproperty="changeset">
-            <arg value="rev-parse"/>
-            <arg value="HEAD"/>
-        </exec>
-    </target>
-
-    <!-- Check if we build from a checked out copy of the repository,
-         so that we have history information from git available.
-      -->
-    <target name="-check-is-git-repo">
-      <available property="build.from.repo" file=".git" filepath=".." type="dir"/>
-    </target>
-
-    <!-- Get the id of the changeset we're building from by reading
-         .git_archival.txt file created by git archive. This will only
-         be used when we're not building from a checked out copy of
-         the repository, for example the source distribution.
-      -->
-    <target name="-get-changeset-from-file"
-            depends="-check-is-git-repo" unless="build.from.repo">
-        <tempfile property="git.archival.temp" deleteonexit="true"/>
-        <copy file="../.git_archival.txt" tofile="${git.archival.temp}"/>
-        <replaceregexp file="${g.archival.temp}" flags="s"
-                     match=".*node: ([0-9a-f]{12}).*"
-                     replace="\1"/>
-        <loadfile srcFile="${git.archival.temp}" property="changeset"/>
-    </target>
-
     <target name="-collect-lex-lexh">
         <mkdir dir="${tgt.dir}"/>
         <copy todir="${tgt.dir}" flatten="true">
             <fileset dir="${src.dir}" includes="**/*.lex,**/*.lexh"/>
         </copy>
-    </target>
-
-    <target name="-update-build-info"
-            depends="-get-changeset-from-command,-get-changeset-from-file">
-        <mkdir dir="${build.classes.dir}/org/opengrok/indexer"/>
-        <propertyfile
-            file="${build.classes.dir}/org/opengrok/indexer/info.properties">
-            <entry  key="version" value="${version}"/>
-            <entry  key="changeset" value="${changeset}"/>
-        </propertyfile>
     </target>
 
     <target name="-post-compile-test">

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -37,6 +37,10 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
 
     <name>OpenGrok Indexer</name>
 
+    <properties>
+        <version>${project.version}</version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.bcel</groupId>
@@ -152,9 +156,78 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
     </dependencies>
 
     <build>
-
         <plugins>
-
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.2.4</version>
+                <configuration>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                    <execution>
+                        <id>validate-the-git-infos</id>
+                        <goals>
+                            <goal>validateRevision</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-info-properties</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>write-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>
+                                ${project.build.outputDirectory}/org/opengrok/indexer/info.properties
+                            </outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>perform-git-substitutions</id>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <filesToInclude>
+                                ${project.build.outputDirectory}/org/opengrok/indexer/info.properties
+                            </filesToInclude>
+                            <replacements>
+                                <replacement>
+                                    <token>git.commit.id</token>
+                                    <value>changeset</value>
+                                </replacement>
+                            </replacements>
+                            <quiet>false</quiet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -210,6 +283,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                 <version>1.5.3</version>
                 <executions>
                     <execution>
+                        <id>replace-in-jflex-sources</id>
                         <phase>generate-sources</phase>
                         <goals>
                             <goal>replace</goal>
@@ -243,7 +317,6 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                             <token>[ \t]*/\* not supposed to occur according to specification of java\.io\.Reader \*/\s+if \(numRead == 0.*?\}[ \t]*\r?\n</token>
                             <value></value>
                         </replacement>
-
                     </replacements>
                     <regexFlags>
                         <regexFlag>DOTALL</regexFlag>
@@ -264,19 +337,6 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                 <property name="src.dir" value="src/main/resources"/>
                                 <property name="tgt.dir" value="${basedir}/target/jflex-sources"/>
                                 <ant target="-collect-lex-lexh"/>
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>update-build-info</id>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <target>
-                                <property name="version" value="${project.version}"/>
-                                <ant target="-update-build-info"/>
                             </target>
                         </configuration>
                         <goals>


### PR DESCRIPTION
This gets rid of the `-update-build-info` Ant target by using Git and Properties Maven plugins. I tried to set a system property using the Properties plugin which did not work (it is not clear what properties are written to the file plus the ordering of the plugins can be funny) so in the end I resorted to the replacer plugin that is already used to process Jflex files (having multiple versions of the plugin seems to work fine).

Once piece that is missing compared to previous state is the parsing of the `.git_archival.txt` file. I believe this is no longer needed.