### PR TITLE
Use more native path separators on Windows

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -523,6 +523,10 @@ public class AnalyzerGuru {
         FileAnalyzer fa, Writer xrefOut) throws IOException,
             InterruptedException, ForbiddenSymlinkException {
 
+        // Sanitize Windows path delimiters in order not to conflict with Lucene escape character
+        // and also so the path appears as correctly formed URI in the search results.
+        path = path.replace("\\", "/");
+
         String date = DateTools.timeToString(file.lastModified(),
                 DateTools.Resolution.MILLISECOND);
         doc.add(new Field(QueryBuilder.U, Util.path2uid(path, date),

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -157,10 +157,8 @@ public class RepositoryInfo implements Serializable {
         String originalPath = dir.getPath();
         try {
             path = PathUtils.getRelativeToCanonical(originalPath, rootPath);
-            // N.b. OpenGrok has a weird convention that
-            // `directoryNameRelative' must start with a '/', as it is
-            // elsewhere directly appended to env.getSourceRootPath() and
-            // also stored as such.
+            // OpenGrok has a weird convention that directoryNameRelative must start with a path separator,
+            // as it is elsewhere directly appended to env.getSourceRootPath() and also stored as such.
             if (!path.equals(originalPath)) {
                 path = File.separator + path;
             }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1521,9 +1521,8 @@ public class IndexDatabase {
             LOGGER.log(Level.FINER, e.getMessage());
             return null;
         }
-        //sanitize windows path delimiters
-        //in order not to conflict with Lucene escape character
-        path=path.replace("\\", "/");
+        // Sanitize Windows path delimiters in order not to conflict with Lucene escape character.
+        path = path.replace("\\", "/");
 
         IndexReader ireader = getIndexReader(path);
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -898,7 +898,7 @@ public final class Indexer {
             // Add a project for each top-level directory in source root.
             for (File file : files) {
                 String name = file.getName();
-                String path = "/" + name;
+                String path = File.separator + name;
                 if (oldProjects.containsKey(name)) {
                     // This is an existing object. Reuse the old project,
                     // possibly with customizations, instead of creating a


### PR DESCRIPTION
Primarily this should fix the recently reported brokeness on Windows where backward slashes ended up in the index.

While at it, I also replaced the leading project path slash with native path separator.