### PR TITLE
Config merge switch over

### DIFF
--- a/tools/src/main/python/config-merge.py
+++ b/tools/src/main/python/config-merge.py
@@ -29,7 +29,7 @@ import logging
 
 
 """
- Script for merging OpenGrok configuration
+ Wrapper for Java program merging OpenGrok configuration.
 """
 
 if __name__ == '__main__':
@@ -48,12 +48,14 @@ if __name__ == '__main__':
     logger = logging.getLogger(os.path.basename(sys.argv[0]))
 
     cmd = Java(args.options, classpath=args.jar, java=args.java,
-               java_opts=args.java_opts,
+               java_opts=args.java_opts, redirect_stderr=False,
                main_class='org.opengrok.indexer.configuration.ConfigMerge',
                logger=logger)
     cmd.execute()
     ret = cmd.getretcode()
     if ret is None or ret != 0:
-        logger.error(cmd.getoutputstr())
+        logger.error(cmd.geterroutput())
         logger.error("command failed (return code {})".format(ret))
         sys.exit(1)
+
+    print(cmd.getoutputstr())

--- a/tools/src/main/python/java.py
+++ b/tools/src/main/python/java.py
@@ -37,7 +37,7 @@ class Java(Command):
     """
 
     def __init__(self, command, logger=None, main_class=None, java=None,
-                 jar=None, java_opts=None, classpath=None):
+                 jar=None, java_opts=None, classpath=None, redirect_stderr=True):
 
         if not java:
             java = self.FindJava(logger)
@@ -63,7 +63,8 @@ class Java(Command):
         java_command.extend(command)
         logger.debug("Java command: {}".format(java_command))
 
-        super().__init__(java_command, logger=logger)
+        super().__init__(java_command, logger=logger,
+                         redirect_stderr=redirect_stderr)
 
     def FindJava(self, logger):
         """

--- a/tools/src/main/python/java.py
+++ b/tools/src/main/python/java.py
@@ -37,7 +37,8 @@ class Java(Command):
     """
 
     def __init__(self, command, logger=None, main_class=None, java=None,
-                 jar=None, java_opts=None, classpath=None, redirect_stderr=True):
+                 jar=None, java_opts=None, classpath=None,
+                 redirect_stderr=True):
 
         if not java:
             java = self.FindJava(logger)

--- a/tools/src/main/python/projadm.py
+++ b/tools/src/main/python/projadm.py
@@ -103,7 +103,8 @@ def install_config(doit, src, dst):
         sys.exit(1)
 
 
-def config_refresh(doit, logger, basedir, uri, configmerge, jar_file, roconfig):
+def config_refresh(doit, logger, basedir, uri, configmerge, jar_file,
+                   roconfig):
     """
     Refresh current configuration file with configuration retrieved
     from webapp. If roconfig is not None, the current config is merged with
@@ -260,7 +261,8 @@ if __name__ == '__main__':
             logger.error("File {} does not exist".format(args.roconfig))
             sys.exit(1)
 
-        configmerge_file = get_command(logger, args.configmerge, "config-merge.py")
+        configmerge_file = get_command(logger, args.configmerge,
+                                       "config-merge.py")
         if configmerge_file is None:
             logger.error("Use the --configmerge option to specify the path to"
                          "the config merge script")

--- a/tools/src/main/python/projadm.py
+++ b/tools/src/main/python/projadm.py
@@ -48,7 +48,7 @@ if (MAJOR_VERSION < 3):
     print("Need Python 3, you are running {}".format(MAJOR_VERSION))
     sys.exit(1)
 
-__version__ = "0.2"
+__version__ = "0.3"
 
 
 def exec_command(doit, logger, cmd, msg):
@@ -103,7 +103,7 @@ def install_config(doit, src, dst):
         sys.exit(1)
 
 
-def config_refresh(doit, logger, basedir, uri, configmerge, roconfig):
+def config_refresh(doit, logger, basedir, uri, configmerge, jar_file, roconfig):
     """
     Refresh current configuration file with configuration retrieved
     from webapp. If roconfig is not None, the current config is merged with
@@ -137,7 +137,8 @@ def config_refresh(doit, logger, basedir, uri, configmerge, roconfig):
             logger.info('Refreshing configuration '
                         '(merging with read-only config)')
             merged_config = exec_command(doit, logger,
-                                         [configmerge, roconfig, fcur.name],
+                                         [configmerge, '-a', jar_file,
+                                          roconfig, fcur.name],
                                          "cannot merge configuration")
             with tempfile.NamedTemporaryFile() as fmerged:
                 logger.debug("Temporary file for merged config: {}".
@@ -192,8 +193,7 @@ def project_delete(doit, logger, project, uri):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='grok configuration '
-                                     'management.',
+    parser = argparse.ArgumentParser(description='project management.',
                                      formatter_class=argparse.
                                      ArgumentDefaultsHelpFormatter)
     parser.add_argument('-D', '--debug', action='store_true',
@@ -203,9 +203,10 @@ if __name__ == '__main__':
     parser.add_argument('-R', '--roconfig',
                         help='OpenGrok read-only configuration file')
     parser.add_argument('-U', '--uri', default='http://localhost:8080/source',
-                        help='uri of the webapp with context path')
+                        help='URI of the webapp with context path')
     parser.add_argument('-c', '--configmerge',
                         help='path to the ConfigMerge binary')
+    parser.add_argument('--jar', help='Path to jar archive to run')
     parser.add_argument('-u', '--upload', action='store_true',
                         help='Upload configuration at the end')
     parser.add_argument('-n', '--noop', action='store_true', default=False,
@@ -248,7 +249,10 @@ if __name__ == '__main__':
                          .format(args.base))
             sys.exit(1)
 
-    # read-only configuration file.
+    # If read-only configuration file is specified, this means read-only
+    # configuration will need to be merged with active webapp configuration.
+    # This requires config merge tool to be run so couple of other things
+    # need to be checked.
     if args.roconfig:
         if path.isfile(args.roconfig):
             logger.debug("Using {} as read-only config".format(args.roconfig))
@@ -256,15 +260,20 @@ if __name__ == '__main__':
             logger.error("File {} does not exist".format(args.roconfig))
             sys.exit(1)
 
+        configmerge_file = get_command(logger, args.configmerge, "config-merge.py")
+        if configmerge_file is None:
+            logger.error("Use the --configmerge option to specify the path to"
+                         "the config merge script")
+            sys.exit(1)
+
+        if args.jar is None:
+            logger.error('jar file needed for config merge tool, '
+                         'use --jar to specify one')
+            sys.exit(1)
+
     uri = args.uri
     if not uri:
-        logger.error("uri of the webapp not specified")
-        sys.exit(1)
-
-    configmerge_file = get_command(logger, args.configmerge, "ConfigMerge")
-    if not configmerge_file:
-        logger.error("Use the --configmerge option to specify the path to"
-                     "the ConfigMerge script")
+        logger.error("URI of the webapp not specified")
         sys.exit(1)
 
     lock = filelock.FileLock(os.path.join(tempfile.gettempdir(),
@@ -281,6 +290,7 @@ if __name__ == '__main__':
                                basedir=args.base,
                                uri=uri,
                                configmerge=configmerge_file,
+                               jar_file=args.jar,
                                roconfig=args.roconfig)
             elif args.delete:
                 for proj in args.delete:
@@ -292,12 +302,14 @@ if __name__ == '__main__':
                                basedir=args.base,
                                uri=uri,
                                configmerge=configmerge_file,
+                               jar_file=args.jar,
                                roconfig=args.roconfig)
             elif args.refresh:
                 config_refresh(doit=doit, logger=logger,
                                basedir=args.base,
                                uri=uri,
                                configmerge=configmerge_file,
+                               jar_file=args.jar,
                                roconfig=args.roconfig)
             else:
                 parser.print_help()


### PR DESCRIPTION
I forgot to update `projadm.py` to use the `config-merge.py`. Here are the changes that make it possible, e.g.:

```shell
/opengrok/dist/bin/projadm.py -b /opengrok -R /opengrok/etc/readonly_configuration.xml \
    -u -r --jar /opengrok/dist/lib/opengrok.jar
```

This will:
  - retrieve current config from webapp
  - run `config-merge.py` on `/opengrok/etc/readonly_configuration.xml` and the current config and stores the result in `/opengrok/etc/configuration.xml`
  - uploads `/opengrok/etc/configuration.xml` to the webapp