### PR TITLE
add API endpoint for include files reload

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -294,7 +294,15 @@ public final class RuntimeEnvironment {
     public String getIncludeRootPath() {
         return threadConfig.get().getIncludeRoot();
     }
-    
+
+    /**
+     * Set include root path
+     * @param includeRoot path
+     */
+    public void setIncludeRoot(String includeRoot) {
+        threadConfig.get().setIncludeRoot(getCanonicalPath(includeRoot));
+    }
+
     /**
      * Get the path to the where the index database is stored
      *
@@ -1502,13 +1510,13 @@ public final class RuntimeEnvironment {
 
     /**
      * Reload the content of all include files.
-     * @param config configuration
+     * @param configuration configuration
      */
-    public void reloadIncludeFiles(Configuration config) {
-        config.getBodyIncludeFileContent(true);
-        config.getHeaderIncludeFileContent(true);
-        config.getFooterIncludeFileContent(true);
-        config.getForbiddenIncludeFileContent(true);
+    public void reloadIncludeFiles(Configuration configuration) {
+        configuration.getBodyIncludeFileContent(true);
+        configuration.getHeaderIncludeFileContent(true);
+        configuration.getFooterIncludeFileContent(true);
+        configuration.getForbiddenIncludeFileContent(true);
     }
 
     public Configuration getConfiguration() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1500,11 +1500,15 @@ public final class RuntimeEnvironment {
         reloadIncludeFiles(configuration);
     }
 
-    private void reloadIncludeFiles(Configuration configuration1) {
-        configuration1.getBodyIncludeFileContent(true);
-        configuration1.getHeaderIncludeFileContent(true);
-        configuration1.getFooterIncludeFileContent(true);
-        configuration1.getForbiddenIncludeFileContent(true);
+    /**
+     * Reload the content of all include files.
+     * @param config configuration
+     */
+    public void reloadIncludeFiles(Configuration config) {
+        config.getBodyIncludeFileContent(true);
+        config.getHeaderIncludeFileContent(true);
+        config.getFooterIncludeFileContent(true);
+        config.getForbiddenIncludeFileContent(true);
     }
 
     public Configuration getConfiguration() {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
@@ -48,4 +48,9 @@ public class SystemController {
         suggester.refresh(project);
     }
 
+    @PUT
+    @Path("/includes/reload")
+    public void reloadIncludes() {
+        env.reloadIncludeFiles(env.getConfiguration());
+    }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -42,7 +42,7 @@ public class SystemControllerTest extends JerseyTest {
         Path includeRootPath = Files.createTempDirectory("systemControllerTest");
         File includeRoot = includeRootPath.toFile();
         env.setIncludeRoot(includeRoot.getAbsolutePath());
-        assertEquals(includeRoot.getAbsolutePath(), env.getIncludeRootPath());
+        assertEquals(includeRoot.getCanonicalPath(), env.getIncludeRootPath());
 
         // Create footer include file.
         File footerFile = new File(includeRoot, Configuration.FOOTER_INCLUDE_FILE);

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -1,0 +1,79 @@
+package org.opengrok.web.api.v1.controller;
+
+import org.glassfish.jersey.server.*;
+import org.glassfish.jersey.test.*;
+import org.junit.*;
+import org.mockito.*;
+import org.opengrok.indexer.configuration.*;
+import org.opengrok.indexer.configuration.Configuration;
+import org.opengrok.indexer.util.*;
+import org.opengrok.web.api.v1.*;
+
+import javax.ws.rs.client.*;
+import javax.ws.rs.core.*;
+
+import java.io.*;
+import java.nio.file.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class SystemControllerTest extends JerseyTest {
+
+    private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+    @Override
+    protected Application configure() {
+        return new RestApp();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    public void testIncludeReload() throws IOException {
+        // Set new include root directory.
+        Path includeRootPath = Files.createTempDirectory("systemControllerTest");
+        File includeRoot = includeRootPath.toFile();
+        env.setIncludeRoot(includeRoot.getAbsolutePath());
+        assertEquals(includeRoot.getAbsolutePath(), env.getIncludeRootPath());
+
+        // Create footer include file.
+        File footerFile = new File(includeRoot, Configuration.FOOTER_INCLUDE_FILE);
+        String content = "foo";
+        try (PrintWriter out = new PrintWriter(footerFile)) {
+            out.println(content);
+        }
+
+        // Sanity check that getFooterIncludeFileContent() works since the test depends on it.
+        String before = env.getConfiguration().getFooterIncludeFileContent(false);
+        assertEquals(content, before.trim());
+
+        // Modify the contents of the file.
+        content = content + "bar";
+        try (PrintWriter out = new PrintWriter(footerFile)) {
+            out.println(content);
+        }
+
+        // Reload the contents via API call.
+        Response r = target("system")
+                .path("includes").path("reload")
+                .request().put(Entity.text(""));
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), r.getStatus());
+
+        // Check that the content was reloaded.
+        String after = env.getConfiguration().getFooterIncludeFileContent(false);
+        assertNotEquals(before, after);
+        assertEquals(content, after.trim());
+
+        // Cleanup
+        IOUtils.removeRecursive(includeRootPath);
+    }
+}

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -32,16 +32,6 @@ public class SystemControllerTest extends JerseyTest {
         return new RestApp();
     }
 
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     @Test
     public void testIncludeReload() throws IOException {
         // Set new include root directory.

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -1,19 +1,24 @@
 package org.opengrok.web.api.v1.controller;
 
-import org.glassfish.jersey.server.*;
-import org.glassfish.jersey.test.*;
-import org.junit.*;
-import org.mockito.*;
-import org.opengrok.indexer.configuration.*;
+
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.opengrok.indexer.configuration.Configuration;
-import org.opengrok.indexer.util.*;
-import org.opengrok.web.api.v1.*;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.util.IOUtils;
+import org.opengrok.web.api.v1.RestApp;
 
-import javax.ws.rs.client.*;
-import javax.ws.rs.core.*;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
 
-import java.io.*;
-import java.nio.file.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -32,6 +32,10 @@ public class SystemControllerTest extends JerseyTest {
         return new RestApp();
     }
 
+    /**
+     * This method tests include files reload by testing it for one specific file out of the whole set.
+     * @throws IOException
+     */
     @Test
     public void testIncludeReload() throws IOException {
         // Set new include root directory.


### PR DESCRIPTION
Tested with:

- create `footer_include` file
- deploy webapp
- check the footer is displayed
- change include file content
- reload:
```shell
curl -v -X PUT http://localhost:8080/source/api/v1/system/includes/reload
```
- check the changed footer is displayed