### PR TITLE
support passing environment variables to indexer

### DIFF
--- a/tools/src/main/python/command.py
+++ b/tools/src/main/python/command.py
@@ -223,6 +223,7 @@ class Command:
             if self.env_vars:
                 my_env = os.environ.copy()
                 my_env.update(self.env_vars)
+                self.logger.debug("environment variables: {}".format(my_env))
                 my_args['env'] = my_env
             if self.limits:
                 my_args['preexec_fn'] = \

--- a/tools/src/main/python/indexer.py
+++ b/tools/src/main/python/indexer.py
@@ -44,7 +44,7 @@ class Indexer(Java):
     """
 
     def __init__(self, command, logger=None, java=None, jar='opengrok.jar',
-                 java_opts=None):
+                 java_opts=None, env_vars=None):
 
         java_options = []
         java_options.extend(self.get_SCM_properties(logger))
@@ -53,7 +53,7 @@ class Indexer(Java):
         logger.debug("Java options: {}".format(java_options))
 
         super().__init__(command, jar=jar, java=java, java_opts=java_options,
-                         logger=logger)
+                         logger=logger, env_vars=env_vars)
 
     def get_SCM_properties(self, logger):
         """
@@ -132,7 +132,8 @@ if __name__ == '__main__':
         logger.warning("Unable to determine Universal CTags command")
 
     indexer = Indexer(args.options, logger=logger, java=args.java,
-                      jar=args.jar, java_opts=args.java_opts)
+                      jar=args.jar, java_opts=args.java_opts,
+                      env_vars=args.environment)
     indexer.execute()
     ret = indexer.getretcode()
     if ret is None or ret != 0:

--- a/tools/src/main/python/java.py
+++ b/tools/src/main/python/java.py
@@ -37,7 +37,7 @@ class Java(Command):
     """
 
     def __init__(self, command, logger=None, main_class=None, java=None,
-                 jar=None, java_opts=None, classpath=None):
+                 jar=None, java_opts=None, classpath=None, env_vars=None):
 
         if not java:
             java = self.FindJava(logger)
@@ -60,10 +60,18 @@ class Java(Command):
             java_command.append(jar)
         if main_class:
             java_command.append(main_class)
+        env = None
+        if env_vars:
+            env = {}
+            for spec in env_vars:
+                if spec.find('=') != -1:
+                    name, value = spec.split('=')
+                    env[name] = value
+
         java_command.extend(command)
         logger.debug("Java command: {}".format(java_command))
 
-        super().__init__(java_command, logger=logger)
+        super().__init__(java_command, logger=logger, env_vars=env)
 
     def FindJava(self, logger):
         """
@@ -99,6 +107,8 @@ def get_javaparser():
                         help='path to java binary')
     parser.add_argument('-J', '--java_opts',
                         help='java options', action='append')
+    parser.add_argument('-e', '--environment', action='append',
+                        help='Environment variables in the form of name=value')
 
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-a', '--jar',
@@ -129,7 +139,8 @@ if __name__ == '__main__':
 
     java = Java(args.options, logger=logger, java=args.java,
                 jar=args.jar, java_opts=args.java_opts,
-                classpath=args.classpath, main_class=args.mainclass)
+                classpath=args.classpath, main_class=args.mainclass,
+                env_vars=args.environment)
     java.execute()
     ret = java.getretcode()
     if ret is None or ret != 0:

--- a/tools/src/main/python/reindex-project.py
+++ b/tools/src/main/python/reindex-project.py
@@ -114,7 +114,8 @@ if __name__ == '__main__':
     java_opts.append("-Djava.util.logging.config.file={}".
                      format(logprop_file))
     indexer = Indexer(command, logger=logger, jar=args.jar,
-                      java=args.java, java_opts=java_opts)
+                      java=args.java, java_opts=java_opts,
+                      env_vars=args.environment)
     indexer.execute()
     ret = indexer.getretcode()
     os.remove(conf_file)


### PR DESCRIPTION
Compared to the old `OpenGrok` shell script, the Python scripts do not support passing environment variables to the indexer which hampers things like running the indexer with correct locale. This change should fix that.

Tested with:
```shell
./indexer.py -C -e BAR=YYYYYYYYYYYYYYYYYYYYYYY -e FOO=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
    -D -a ~/opengrok-git-vladak/distribution/target/dist/opengrok-1.1-rc38.jar -- -s
```

and checking the debug output. And also running `indexer.py` with -e and checking its environment variables (with `pargs -e`).