### PR TITLE
make getProject() more robust

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -341,14 +341,19 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
         if (env.hasProjects()) {
             final String lpath = path.replace(File.separatorChar, '/');
             for (Project p : env.getProjectList()) {
-                String pp = p.getPath();
+                String projectPath = p.getPath();
+                if (projectPath == null) {
+                    LOGGER.log(Level.WARNING, "Path of project {0} is not set", p.getName());
+                    return null;
+                }
+
                 // Check if the project's path is a prefix of the given
                 // path. It has to be an exact match, or the project's path
                 // must be immediately followed by a separator. "/foo" is
                 // a prefix for "/foo" and "/foo/bar", but not for "/foof".
-                if (lpath.startsWith(pp)
-                        && (pp.length() == lpath.length()
-                        || lpath.charAt(pp.length()) == '/')) {
+                if (lpath.startsWith(projectPath)
+                        && (projectPath.length() == lpath.length()
+                        || lpath.charAt(projectPath.length()) == '/')) {
                     return p;
                 }
             }


### PR DESCRIPTION
I have accidentally run full indexer with per-project settings in read-only configuration with trailing argument, something like:

```shell
indexer.py ... \
     -P -S \
     -R /opengrok-upgrade/etc/readonly_configuration.xml \
     -s /ws-local-upgrade \
     -d /opengrok-upgrade/data \
     -W /opengrok-upgrade/etc/configuration.xml \
     /opengrok-upgrade/log/reindex.log 2>&1
```

(notice the missing redirect to the ` /opengrok-upgrade/log/reindex.log` log file - it will be treated as `subFile` in `Indexer`, i.e. per-project reindex)

which caused this:

```
java.lang.NullPointerException
        at java.lang.String.startsWith(String.java:1405)
        at java.lang.String.startsWith(String.java:1434)
        at org.opengrok.indexer.configuration.Project.getProject(Project.java:349)
        at org.opengrok.indexer.index.Indexer.main(Indexer.java:257)
```

This is because the projects in read-only configuration did not have path set:

```
   <void method="put">
    <string>linux-master</string>
    <object class="org.opengrok.indexer.configuration.Project">
     <void property="handleRenamedFiles">
      <boolean>false</boolean>
     </void>
    </object>
   </void>
  </void>
```

so the null was hit because project rescan happens only in `prepareIndexer`.

This change will make getProject() resilient against this problem.