### PR TITLE
get rid of multiple replacer plugin instances

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -226,6 +226,49 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                             <quiet>false</quiet>
                         </configuration>
                     </execution>
+                    <execution>
+                        <!-- patches jflex generated files to stop increasing buffer beyond token size that lucene accepts
+                        https://github.com/OpenGrok/OpenGrok/issues/1170 make parsers stop producing tokens > 32766 chars
+                        at least for PlainFullTokenizer, PlainSymbolTokenizer, JavaScriptSymbolTokenizer, JavaSymbolTokenizer
+                        use below
+                        -->
+                        <id>replace-in-jflex-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                          <filesToInclude>
+                              ${basedir}/target/generated-sources/jflex/org/opengrok/indexer/analysis/java/JavaSymbolTokenizer.java,${basedir}/target/generated-sources/jflex/org/opengrok/indexer/analysis/javascript/JavaScriptSymbolTokenizer.java,${basedir}/target/generated-sources/jflex/org/opengrok/indexer/analysis/plain/PlainFullTokenizer.java,${basedir}/target/generated-sources/jflex/org/opengrok/indexer/analysis/plain/PlainSymbolTokenizer.java
+                          </filesToInclude>
+                          <replacements>
+                              <replacement>
+                                  <token>private static final int ZZ_BUFFERSIZE =</token>
+                                  <value>private int ZZ_BUFFERSIZE =</value>
+                              </replacement>
+                              <replacement>
+                                  <token>int requested = zzBuffer\.length - zzEndRead;</token>
+                                  <value>int requested = zzBuffer.length - zzEndRead - zzFinalHighSurrogate;</value>
+                              </replacement>
+                              <replacement>
+                                  <token>(zzFinalHighSurrogate = 1;)(\r?\n)</token>
+                                  <value>$1$2          if (numRead == 1) { return true; }$2</value>
+                              </replacement>
+                              <replacement>
+                                  <token>[ \t]*/\* is the buffer big enough\? \*/\s+if \(zzCurrentPos >= zzBuffer\.length.*?\}[ \t]*\r?\n</token>
+                                  <value></value>
+                              </replacement>
+                              <!-- also revert 0 character check that got in with 1.6.1 : https://github.com/jflex-de/jflex/blob/master/jflex/examples/zero-reader/README.md -->
+                              <replacement>
+                                  <token>[ \t]*/\* not supposed to occur according to specification of java\.io\.Reader \*/\s+if \(numRead == 0.*?\}[ \t]*\r?\n</token>
+                                  <value></value>
+                              </replacement>
+                          </replacements>
+                          <regexFlags>
+                              <regexFlag>DOTALL</regexFlag>
+                          </regexFlags>
+                       </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -271,60 +314,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                 </executions>
             </plugin>
 
-            <!-- patches jflex generated files to stop increasing buffer beyond token size that lucene accepts
-            https://github.com/OpenGrok/OpenGrok/issues/1170 make parsers stop producing tokens > 32766 chars
-            at least for PlainFullTokenizer, PlainSymbolTokenizer, JavaScriptSymbolTokenizer, JavaSymbolTokenizer
-            use below
-            -->
-
-            <plugin>
-                <groupId>com.google.code.maven-replacer-plugin</groupId>
-                <artifactId>replacer</artifactId>
-                <version>1.5.3</version>
-                <executions>
-                    <execution>
-                        <id>replace-in-jflex-sources</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>replace</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <filesToInclude>
-                        ${basedir}/target/generated-sources/jflex/org/opengrok/indexer/analysis/java/JavaSymbolTokenizer.java,${basedir}/target/generated-sources/jflex/org/opengrok/indexer/analysis/javascript/JavaScriptSymbolTokenizer.java,${basedir}/target/generated-sources/jflex/org/opengrok/indexer/analysis/plain/PlainFullTokenizer.java,${basedir}/target/generated-sources/jflex/org/opengrok/indexer/analysis/plain/PlainSymbolTokenizer.java
-                    </filesToInclude>
-                    <replacements>
-                        <replacement>
-                            <token>private static final int ZZ_BUFFERSIZE =</token>
-                            <value>private int ZZ_BUFFERSIZE =</value>
-                        </replacement>
-                        <replacement>
-                            <token>int requested = zzBuffer\.length - zzEndRead;</token>
-                            <value>int requested = zzBuffer.length - zzEndRead - zzFinalHighSurrogate;</value>
-                        </replacement>
-                        <replacement>
-                            <token>(zzFinalHighSurrogate = 1;)(\r?\n)</token>
-                            <value>$1$2          if (numRead == 1) { return true; }$2</value>
-                        </replacement>
-
-                        <replacement>
-                            <token>[ \t]*/\* is the buffer big enough\? \*/\s+if \(zzCurrentPos >= zzBuffer\.length.*?\}[ \t]*\r?\n</token>
-                            <value></value>
-                        </replacement>
-                        <!-- also revert 0 character check that got in with 1.6.1 : https://github.com/jflex-de/jflex/blob/master/jflex/examples/zero-reader/README.md -->
-                        <replacement>
-                            <token>[ \t]*/\* not supposed to occur according to specification of java\.io\.Reader \*/\s+if \(numRead == 0.*?\}[ \t]*\r?\n</token>
-                            <value></value>
-                        </replacement>
-                    </replacements>
-                    <regexFlags>
-                        <regexFlag>DOTALL</regexFlag>
-                    </regexFlags>
-                </configuration>
-            </plugin>
-
-            <plugin>
+           <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>1.8</version>


### PR DESCRIPTION
Gets rid of:

```
$ mvn -DskipTests install
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.opengrok:opengrok:jar:1.1-rc40
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin com.google.code.maven-replacer-plugin:replacer @ line 318, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```