### PR TITLE
call getHistory() from PageConfig with ui = True

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -278,9 +278,9 @@ public final class HistoryGuru {
     public InputStream getRevision(String parent, String basename, String rev) {
         InputStream ret = null;
 
-        Repository rep = getRepository(new File(parent));
-        if (rep != null) {
-            ret = rep.getHistoryGet(parent, basename, rev);
+        Repository repo = getRepository(new File(parent));
+        if (repo != null) {
+            ret = repo.getHistoryGet(parent, basename, rev);
         }
         return ret;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1229,7 +1229,7 @@ public final class PageConfig {
         History hist;
         try {
             hist = HistoryGuru.getInstance().
-                    getHistory(new File(getEnv().getSourceRootFile(), getPath()));
+                    getHistory(new File(getEnv().getSourceRootFile(), getPath()), false, true);
         } catch (HistoryException ex) {
             return null;
         }

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -248,7 +248,7 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
             FileAnalyzerFactory a = AnalyzerGuru.find(basename);
             Genre g = AnalyzerGuru.getGenre(a);
             String error = null;
-            if (g == Genre.PLAIN|| g == Genre.HTML || g == null) {
+            if (g == Genre.PLAIN || g == Genre.HTML || g == null) {
                 InputStream in = null;
                 try {
                     in = HistoryGuru.getInstance()
@@ -263,8 +263,7 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
                             a = AnalyzerGuru.find(in);
                             g = AnalyzerGuru.getGenre(a);
                         }
-                        if (g == Genre.DATA || g == Genre.XREFABLE
-                            || g == null)
+                        if (g == Genre.DATA || g == Genre.XREFABLE || g == null)
                         {
     %>
     <div id="src">

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -263,8 +263,7 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
                             a = AnalyzerGuru.find(in);
                             g = AnalyzerGuru.getGenre(a);
                         }
-                        if (g == Genre.DATA || g == Genre.XREFABLE || g == null)
-                        {
+                        if (g == Genre.DATA || g == Genre.XREFABLE || g == null) {
     %>
     <div id="src">
     Binary file [Click <a href="<%= rawPath %>?r=<%= Util.URIEncode(rev) %>">here</a> to download]


### PR DESCRIPTION
When traversing `PageConfig#getLatestRevision()` I noticed that `getHistory()` is called with UI flag set to false. This is not correct since `PageConfig` is used from UI.