### PR TITLE
if economy mode is on and history off, generate xref on the fly

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1221,7 +1221,7 @@ public final class PageConfig {
                 path, env.isCompressXref());
     }
 
-    protected String getLatestRevision() {
+    public String getLatestRevision() {
         if (!getEnv().isHistoryEnabled()) {
             return null;
         }
@@ -1265,15 +1265,14 @@ public final class PageConfig {
     }
 
     /**
-     * Get the location of cross reference for given file containing the current
-     * revision.
-     * @return location to redirect to or null if failed
+     * Get the location of cross reference for given file containing the given revision.
+     * @param revStr revision string
+     * @return location to redirect to or null if revision string is empty
      */
-    public String getLatestRevisionLocation() {
+    public String getRevisionLocation(String revStr) {
         StringBuilder sb = new StringBuilder();
-        String revStr;
 
-        if ((revStr = getLatestRevision()) == null) {
+        if (revStr == null) {
             return null;
         }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigTest.java
@@ -270,7 +270,7 @@ public class PageConfigTest {
         String rev = cfg.getLatestRevision();
         assertNull(rev);
 
-        String location = cfg.getLatestRevisionLocation();
+        String location = cfg.getRevisionLocation(cfg.getLatestRevision());
         assertNull(location);
     }
 

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -349,8 +349,7 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
         // requesting cross referenced file
         File xrefFile = null;
 
-        // Get the latest revision and redirect so that  the revision number
-        // appears in the URL.
+        // Get the latest revision and redirect so that the revision number appears in the URL.
         String location = cfg.getRevisionLocation(cfg.getLatestRevision());
         if (location != null) {
             response.sendRedirect(location);

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -88,7 +88,7 @@ document.pageReady.push(function() { pageReadyList();});
     PageConfig cfg = PageConfig.get(request);
     String rev = cfg.getRequestedRevision();
     Project project = cfg.getProject();
-    final String DUMMY_REVISION = "dummy";
+    final String DUMMY_REVISION = "unknown";
 
     String navigateWindowEnabled = project != null ? Boolean.toString(
             project.isNavigateWindowEnabled()) : "false";

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -375,9 +375,8 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
     %></pre>
 </div><%
         } else {
-            String error = "Failed to get xref file";
 %>
-<p class="error"><%= error %></p><%
+<p class="error">Failed to get xref file</p><%
         }
     }
 }

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -358,7 +358,7 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
         } else {
             if (!cfg.getEnv().isGenerateHtml()) {
                 // Economy mode is on and failed to get the last revision (presumably running with history turned off).
-                // Generate dummy revision string so that xref can be generated from the resource file directly.
+                // Use dummy revision string so that xref can be generated from the resource file directly.
                 location = cfg.getRevisionLocation(DUMMY_REVISION);
                 response.sendRedirect(location);
                 return;


### PR DESCRIPTION
This is a bit of a hack to make `list.jsp` jump into the code that generates xrefs on the fly if latest revision cannot be determined and economy mode is on.

Also, an error message was added to avoid empty page appearing on error.