### PR TITLE
prevent get_command() from emitting errors when searching for ctags

### DIFF
--- a/tools/src/main/python/indexer.py
+++ b/tools/src/main/python/indexer.py
@@ -91,7 +91,7 @@ def FindCtags(logger):
     binary = None
     logger.debug("Trying to find ctags binary")
     for program in ['universal-ctags', 'ctags']:
-        executable = get_command(logger, None, program)
+        executable = get_command(logger, None, program, level=logging.DEBUG)
         if executable:
             # Verify that this executable is or is Universal Ctags
             # by matching the output when run with --version.


### PR DESCRIPTION
When `indexer.py` is run without -C, it will try to verify there is Universal ctags binary in `PATH` by checking various program names. For those which failed `get_command()` that is called to perform this verification will emit log message with the `ERROR` level which is confusing. This change makes it to use `DEBUG` log level.