### PR TITLE
fix referencing configmerge if not needed

### DIFF
--- a/tools/src/main/python/projadm.py
+++ b/tools/src/main/python/projadm.py
@@ -234,6 +234,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     doit = not args.noop
+    configmerge = None
 
     #
     # Setup logger as a first thing after parsing arguments so that it can be


### PR DESCRIPTION
fixes:

```
$ ./projadm.py -a test --jar ../../../../distribution/target/dist/opengrok-1.1-rc40.jar 
Lock 140106125077248 acquired on /tmp/projadm.py.lock
Adding project test
Starting new HTTP connection (1): localhost
Lock 140106125077248 released on /tmp/projadm.py.lock
Traceback (most recent call last):
  File "./projadm.py", line 309, in <module>
    configmerge=configmerge,
NameError: name 'configmerge' is not defined
```