### PR TITLE
make the output when scanning/listing repositories a bit more verbose

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -947,11 +947,10 @@ public final class Indexer {
         
         if (searchRepositories || listRepoPaths || !zapCache.isEmpty()) {
             LOGGER.log(Level.INFO, "Scanning for repositories...");
-            long start = System.currentTimeMillis();
+            Statistics stats = new Statistics();
             env.setRepositories(env.getSourceRootPath());
-            long time = (System.currentTimeMillis() - start) / 1000;
-            LOGGER.log(Level.INFO, "Done scanning for repositories, found {1} repositories ({0}s)",
-                    new Object[]{time, env.getRepositories().size()});
+            stats.report(LOGGER, String.format("Done scanning for repositories, found %d repositories",
+                    env.getRepositories().size()));
             
             if (listRepoPaths || !zapCache.isEmpty()) {
                 List<RepositoryInfo> repos = env.getRepositories();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -950,7 +950,8 @@ public final class Indexer {
             long start = System.currentTimeMillis();
             env.setRepositories(env.getSourceRootPath());
             long time = (System.currentTimeMillis() - start) / 1000;
-            LOGGER.log(Level.INFO, "Done scanning for repositories ({0}s)", time);
+            LOGGER.log(Level.INFO, "Done scanning for repositories, found {1} repositories ({0}s)",
+                    new Object[]{time, env.getRepositories().size()});
             
             if (listRepoPaths || !zapCache.isEmpty()) {
                 List<RepositoryInfo> repos = env.getRepositories();
@@ -963,7 +964,7 @@ public final class Indexer {
                     System.out.println("Repositories in " + prefix + ":");
                     for (RepositoryInfo info : env.getRepositories()) {
                         String dir = info.getDirectoryName();
-                        System.out.println(dir.substring(prefix.length()));
+                        System.out.println(String.format("%s (%s)", dir.substring(prefix.length()), info.getType()));
                     }
                 }
                 if (!zapCache.isEmpty()) {


### PR DESCRIPTION
The output when using `-S --listRepos` looks like this:
```
INFO: Done scanning for repositories, found 18 repositories (4s)
Repositories in /var/opengrok/src:
/foo (Mercurial)
/foo3 (Mercurial)
/foo-renamed (Mercurial)
/on-test (Mercurial)
/on-test/closed (Mercurial)
/foo(bar) (git)
/my-scripts (Mercurial)
/userland-s11u4 (Mercurial)
/universal-ctags (git)
/symlink (git)
/solaris-userland (git)
/OpenGrok (git)
/OpenGrok/testdata/sources/rfe2575 (SCCS)
/OpenGrok/testdata/repositories/rcs_test (RCS)
/OpenGrok/testdata/repositories/teamware (SCCS)
/tomcat (git)
/bar-renamed (Mercurial)
/symlink2 (git)
```