### PR TITLE
add global tunable for navigate window

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -274,6 +274,12 @@ public final class Configuration {
      */
     private boolean listDirsFirst = true;
 
+    /**
+     * A flag if the navigate window should be opened by default when browsing
+     * the source code of projects.
+     */
+    private boolean navigateWindowEnabled;
+
     private SuggesterConfig suggesterConfig = new SuggesterConfig();
 
     /*
@@ -441,6 +447,7 @@ public final class Configuration {
         //mandoc is default(String)
         setMaxSearchThreadCount(2 * Runtime.getRuntime().availableProcessors());
         setMessageLimit(500);
+        setNavigateWindowEnabled(false);
         setOptimizeDatabase(true);
         setPluginDirectory(null);
         setPluginStack(new AuthorizationStack(AuthControlFlag.REQUIRED, "default stack"));
@@ -725,6 +732,14 @@ public final class Configuration {
 
     public void setHandleHistoryOfRenamedFiles(boolean enable) {
         this.handleHistoryOfRenamedFiles = enable;
+    }
+
+    public boolean isNavigateWindowEnabled() {
+        return navigateWindowEnabled;
+    }
+
+    public void setNavigateWindowEnabled(boolean navigateWindowEnabled) {
+        this.navigateWindowEnabled = navigateWindowEnabled;
     }
 
     public Map<String,Project> getProjects() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -66,7 +66,7 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
      * A flag if the navigate window should be opened by default when browsing
      * the source code of this project.
      */
-    private boolean navigateWindowEnabled = false;
+    private Boolean navigateWindowEnabled = null;
 
     /**
      * This flag sets per-project handling of renamed files.
@@ -227,7 +227,7 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
      * @return true if yes; false otherwise
      */
     public boolean isNavigateWindowEnabled() {
-        return navigateWindowEnabled;
+        return navigateWindowEnabled != null && navigateWindowEnabled;
     }
 
     /**
@@ -325,6 +325,11 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
         // Allow project to override global setting of history cache generation.
         if (historyEnabled == null) {
             setHistoryEnabled(cfg.isHistoryEnabled());
+        }
+
+        // Allow project to override global setting of navigate window.
+        if (navigateWindowEnabled == null) {
+            setNavigateWindowEnabled(cfg.isNavigateWindowEnabled());
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1182,6 +1182,14 @@ public final class RuntimeEnvironment {
         return threadConfig.get().isHandleHistoryOfRenamedFiles();
     }
 
+    public void setNavigateWindowEnabled(boolean enable) {
+        threadConfig.get().setNavigateWindowEnabled(enable);
+    }
+
+    public boolean isNavigateWindowEnabled() {
+        return threadConfig.get().isNavigateWindowEnabled();
+    }
+
     public void setRevisionMessageCollapseThreshold(int threshold) {
         threadConfig.get().setRevisionMessageCollapseThreshold(threshold);
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ProjectTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ProjectTest.java
@@ -140,13 +140,15 @@ public class ProjectTest {
     public void testMergeProjects1() {
         Configuration cfg = new Configuration();
         cfg.setTabSize(new Configuration().getTabSize() + 3731);
+        cfg.setNavigateWindowEnabled(!new Configuration().isNavigateWindowEnabled());
 
         Project p1 = new Project();
+        assertNotNull(p1);
 
         p1.completeWithDefaults(cfg);
 
-        assertNotNull(p1);
-        assertEquals(new Configuration().getTabSize() + 3731, p1.getTabSize());
+        assertEquals(cfg.getTabSize(), p1.getTabSize());
+        assertEquals(cfg.isNavigateWindowEnabled(), p1.isNavigateWindowEnabled());
     }
 
     /**


### PR DESCRIPTION
Tested with this read-only configuration:
```XML
<?xml version="1.0" encoding="UTF-8"?>
<java version="1.8.0_60" class="java.beans.XMLDecoder">
 <object class="org.opengrok.indexer.configuration.Configuration" id="Configuration0">
  <void property="navigateWindowEnabled">
     <boolean>true</boolean>
  </void>

  <void property="projects">                                                    
   <void method="put">                                                          
    <string>OpenGrok</string>                                                   
    <object class="org.opengrok.indexer.configuration.Project">                 
     <void property="navigateWindowEnabled">                                    
      <boolean>false</boolean>                                                  
     </void>                                                                    
    </object>                                                                   
   </void>                                                                      
  </void>   

 </object>
</java>
```
The feature is that the resulting configuration (written with `-W` indexer option) will have the flag set in each of the projects that does not override it, the result of the way serialization is done.