### PR TITLE
continuous output printing in indexer.py

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/all/utils/indexer.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/all/utils/indexer.py
@@ -42,7 +42,7 @@ class Indexer(Java):
     """
 
     def __init__(self, command, logger=None, java=None, jar='opengrok.jar',
-                 java_opts=None, env_vars=None):
+                 java_opts=None, env_vars=None, doprint=False):
 
         java_options = []
         if java_opts:
@@ -52,7 +52,7 @@ class Indexer(Java):
         logger.debug("Java options: {}".format(java_options))
 
         super().__init__(command, jar=jar, java=java, java_opts=java_options,
-                         logger=logger, env_vars=env_vars)
+                         logger=logger, env_vars=env_vars, doprint=doprint)
 
 
 def get_SCM_properties(logger):

--- a/opengrok-tools/src/main/python/opengrok_tools/all/utils/java.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/all/utils/java.py
@@ -36,7 +36,7 @@ class Java(Command):
 
     def __init__(self, command, logger=None, main_class=None, java=None,
                  jar=None, java_opts=None, classpath=None, env_vars=None,
-                 redirect_stderr=True):
+                 redirect_stderr=True, doprint=False):
 
         if not java:
             java = self.FindJava(logger)
@@ -71,7 +71,7 @@ class Java(Command):
         logger.debug("Java command: {}".format(java_command))
 
         super().__init__(java_command, logger=logger, env_vars=env,
-                         redirect_stderr=redirect_stderr)
+                         redirect_stderr=redirect_stderr, doprint=doprint)
 
     def FindJava(self, logger):
         """

--- a/opengrok-tools/src/main/python/opengrok_tools/indexer.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/indexer.py
@@ -63,11 +63,11 @@ def main():
 
     indexer = Indexer(args.options, logger=logger, java=args.java,
                       jar=args.jar, java_opts=args.java_opts,
-                      env_vars=args.environment)
+                      env_vars=args.environment, doprint=True)
     indexer.execute()
     ret = indexer.getretcode()
     if ret is None or ret != 0:
-        logger.error(indexer.getoutputstr())
+        # The output is already printed thanks to 'doprint' above.
         logger.error("Indexer command failed (return code {})".format(ret))
         sys.exit(1)
 


### PR DESCRIPTION
This change enables continuous printing of Indexer output to stdout. The output is still stored in pertaining buffers.