### PR TITLE
Splitting the install and test phase

### DIFF
--- a/opengrok-tools/pom.xml
+++ b/opengrok-tools/pom.xml
@@ -139,13 +139,28 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                         <phase>package</phase>
                     </execution>
                     <execution>
-                        <id>python-test</id>
+                        <id>python-test-install</id>
                         <configuration>
                             <executable>env/bin/python</executable>
                             <workingDirectory>${project.build.directory}</workingDirectory>
                             <arguments>
                                 <argument>setup.py</argument>
                                 <argument>install</argument>
+                            </arguments>
+                            <skip>${skipTests}</skip>
+                        </configuration>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>python-test</id>
+                        <configuration>
+                            <executable>env/bin/python</executable>
+                            <workingDirectory>${project.build.directory}</workingDirectory>
+                            <arguments>
+                                <argument>setup.py</argument>
                                 <argument>test</argument>
                             </arguments>
                             <skip>${skipTests}</skip>


### PR DESCRIPTION
  It didn't work well when splitted.
  The package was not ready for testing.
