### PR TITLE
Reading the python version from pom.xml

### DIFF
--- a/distribution/assembly.xml
+++ b/distribution/assembly.xml
@@ -20,9 +20,9 @@
         <destName>source.war</destName>
       </file>
       <file>
-        <source>${project.basedir}/../opengrok-tools/${project.build.directory}/dist/opengrok-tools-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}${parsedVersion.qualifier}.tar.gz</source>
+        <source>${project.basedir}/../opengrok-tools/${project.build.directory}/dist/opengrok-tools-${project.python.package.version}.tar.gz</source>
         <outputDirectory>tools</outputDirectory>
-        <destName>opengrok-tools.tar.gz</destName>
+        <destName>opengrok-tools-${project.python.package.version}.tar.gz</destName>
       </file>
     </files>
     <fileSets>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -67,13 +67,25 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>1.8</version>
             <executions>
               <execution>
-                <id>parse-version</id>
+                <id>generate-python-package-version</id>
                 <goals>
-                  <goal>parse-version</goal>
+                  <goal>regex-property</goal>
                 </goals>
+                <phase>package</phase>
+                <configuration>
+                  <!--
+                      Use property ${project.version} but delete the "-" (dash) from it
+                      and place it into the property ${project.python.package.version}
+                  -->
+                  <name>project.python.package.version</name>
+                  <regex>-rc</regex>
+                  <value>${project.version}</value>
+                  <replacement>rc</replacement>
+                  <failIfNoMatch>false</failIfNoMatch>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/opengrok-tools/pom.xml
+++ b/opengrok-tools/pom.xml
@@ -43,7 +43,31 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
         <testSourceDirectory>src/test/python</testSourceDirectory>
 
         <plugins>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>generate-python-package-version</id>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <!--
+                                Use property ${project.version} but delete the "-" (dash) from it
+                                and place it into the property ${project.python.package.version}
+                             -->
+                            <name>project.python.package.version</name>
+                            <regex>-rc</regex>
+                            <value>${project.version}</value>
+                            <replacement>rc</replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <!-- copy all the python files to the target directory
                      so we produce the dist and build directories there -->
@@ -78,9 +102,16 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                 <resource>
                                     <directory>${basedir}</directory>
                                     <includes>
-                                        <include>setup.py</include>
                                         <include>MANIFEST.in</include>
                                     </includes>
+                                </resource>
+                                <!-- replace ${project.python.package.version} in setup.py -->
+                                <resource>
+                                    <directory>${basedir}</directory>
+                                    <includes>
+                                        <include>setup.py</include>
+                                    </includes>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                         </configuration>

--- a/opengrok-tools/setup.py
+++ b/opengrok-tools/setup.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+
 from setuptools import setup
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -20,7 +21,10 @@ def my_test_suite():
 
 setup(
     name='opengrok-tools',
-    version='1.1rc63',
+    # The package version is taken from maven.
+    # this "variable" is replaced by maven on the fly so don't change it here
+    # see pom.xml for this module
+    version='${project.python.package.version}',
     packages=[
         'opengrok_tools',
         'opengrok_tools.utils',


### PR DESCRIPTION
Use maven native plugins to read and transform
the module version and place it into the setup.py.

fixes #2393

When releasing 1.1 directly, I'd still verify it by hand if everything goes correctly, but there should not be a problem with the transition to the direct release.