### PR TITLE
Do not cache the front page and search results

### DIFF
--- a/opengrok-web/src/main/webapp/WEB-INF/web.xml
+++ b/opengrok-web/src/main/webapp/WEB-INF/web.xml
@@ -54,9 +54,17 @@
         <dispatcher>REQUEST</dispatcher>
     </filter-mapping>
     <filter-mapping>
-        <!-- Place this mapping last, so /* wildcard is only a fallback -->
         <filter-name>ExpiresHalfHourFilter</filter-name>
-        <url-pattern>/*</url-pattern>
+        <url-pattern>/history/*</url-pattern>
+        <url-pattern>/xref/*</url-pattern>
+        <url-pattern>/raw/*</url-pattern>
+        <url-pattern>/download/*</url-pattern>
+        <url-pattern>/diff/*</url-pattern>
+        <url-pattern>/more/*</url-pattern>
+        <url-pattern>/rss/*</url-pattern>
+        <url-pattern>/error</url-pattern>
+        <url-pattern>/enoent</url-pattern>
+        <url-pattern>/eforbidden</url-pattern>
         <dispatcher>REQUEST</dispatcher>
     </filter-mapping>
     <servlet>


### PR DESCRIPTION
The reason for this is that front page and search results can be pretty dynamic today. We have messages, the projects can change over time frequently (partial reindex, continual updates via the rest api).

 - This should avoid caching the from page for 30 minutes
    - The view can be inconsistent with the system state
        - different cookies
        - different messages
        - different projects
 - The same applies for search results
 - Other resources are hidden behind the 30 minutes cache interval

touches #2405