### PR TITLE
Using weak tag instead of just last modification date

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1691,7 +1691,7 @@ public final class PageConfig {
         }
 
         // return 200 OK
-        response.setHeader("ETag", currentEtag);
+        response.setHeader(HttpHeaders.ETAG, currentEtag);
         return false;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1663,10 +1663,11 @@ public final class PageConfig {
      * <p>
      * If the resource was modified, appropriate headers in the response are filled.
      *
+     * @param request the http request containing the headers
      * @param response the http response for setting the headers
      * @return true if resource was not modified; false otherwise
-     * @see <a href="https://tools.ietf.org/html/rfc7232#section-2.3>HTTP ETag</a>
-     * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html>HTTP Caching</a>
+     * @see <a href="https://tools.ietf.org/html/rfc7232#section-2.3">HTTP ETag</a>
+     * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html">HTTP Caching</a>
      */
     public boolean isNotModified(HttpServletRequest request, HttpServletResponse response) {
         String currentEtag = String.format("W/\"%s\"",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1631,7 +1631,7 @@ public final class PageConfig {
      * <li>Messages with tag = project's groups names</li>
      * </ol>
      *
-     * @return the sorted set of messages according the accept time
+     * @return the sorted set of messages according to the accept time
      * @see org.opengrok.indexer.web.messages.MessagesContainer#MESSAGES_MAIN_PAGE_TAG
      */
     private SortedSet<AcceptedMessage> getProjectMessages() {
@@ -1668,7 +1668,7 @@ public final class PageConfig {
     public boolean isNotModified(HttpServletRequest request, HttpServletResponse response) {
         String currentEtag = String.format("W/\"%s\"",
                 Objects.hash(
-                        // last modified time as utc timestamp in millis
+                        // last modified time as UTC timestamp in millis
                         getLastModified(),
                         // all project related messages which changes the view
                         getProjectMessages(),

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -53,6 +53,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
 import org.opengrok.indexer.Info;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.analysis.ExpandTabsReader;
@@ -1650,7 +1651,7 @@ public final class PageConfig {
     /**
      * Decide if this resource has been modified since the header value in the request.
      * <p>
-     * The resource is modified since the weak etag value in the reuqest, the etag is
+     * The resource is modified since the weak ETag value in the request, the ETag is
      * computed using:
      * <ul>
      * <li>the source file modification</li>
@@ -1664,6 +1665,8 @@ public final class PageConfig {
      *
      * @param response the http response for setting the headers
      * @return true if resource was not modified; false otherwise
+     * @see <a href="https://tools.ietf.org/html/rfc7232#section-2.3>HTTP ETag</a>
+     * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html>HTTP Caching</a>
      */
     public boolean isNotModified(HttpServletRequest request, HttpServletResponse response) {
         String currentEtag = String.format("W/\"%s\"",
@@ -1679,7 +1682,7 @@ public final class PageConfig {
                 )
         );
 
-        String headerEtag = request.getHeader("If-None-Match");
+        String headerEtag = request.getHeader(HttpHeaders.IF_NONE_MATCH);
 
         if (headerEtag != null && headerEtag.equals(currentEtag)) {
             // weak ETag has not changed, return 304 NOT MODIFIED

--- a/opengrok-web/src/main/webapp/WEB-INF/web.xml
+++ b/opengrok-web/src/main/webapp/WEB-INF/web.xml
@@ -56,11 +56,8 @@
     <filter-mapping>
         <filter-name>ExpiresHalfHourFilter</filter-name>
         <url-pattern>/history/*</url-pattern>
-        <url-pattern>/xref/*</url-pattern>
         <url-pattern>/raw/*</url-pattern>
         <url-pattern>/download/*</url-pattern>
-        <url-pattern>/diff/*</url-pattern>
-        <url-pattern>/more/*</url-pattern>
         <url-pattern>/rss/*</url-pattern>
         <url-pattern>/error</url-pattern>
         <url-pattern>/enoent</url-pattern>

--- a/opengrok-web/src/main/webapp/mast.jsp
+++ b/opengrok-web/src/main/webapp/mast.jsp
@@ -54,13 +54,11 @@ org.opengrok.indexer.web.Util"%><%
         return;
     }
 
-    // jel: hmmm - questionable for dynamic content
-    long flast = cfg.getLastModified();
-    if (request.getDateHeader("If-Modified-Since") >= flast) {
-        response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+    if (cfg.isNotModified(request, response)) {
+        // the resource was not modified
+        // the code 304 NOT MODIFIED has been inserted to the response
         return;
     }
-    response.setDateHeader("Last-Modified", flast);
 
     // Use UTF-8 if no encoding is specified in the request
     if (request.getCharacterEncoding() == null) {


### PR DESCRIPTION
This enables us to reflect all other factors
   which contribute to the resource freshness
 - the last file timestamp
 - messages on the project
 - the timestamp of last index
 - the opengrok version
We assemble all these to the weak tag,
   and the resource is reloaded only in any of these change

OpenGrok version is added to the weak tag attributes because of utils.js. Until now event when we increase the version of utils.js, the cached xref still pointed to the old version causing some drama with javascript. This way with every new OpenGrok version, each xref will be reloaded (no need for ctrl+shift+R).


fixes #2405 