### PR TITLE
sanitize more paths on windows, fixes #2335

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -523,12 +523,9 @@ public class AnalyzerGuru {
         FileAnalyzer fa, Writer xrefOut) throws IOException,
             InterruptedException, ForbiddenSymlinkException {
 
-        // Sanitize Windows path delimiters in order not to conflict with Lucene escape character
-        // and also so the path appears as correctly formed URI in the search results.
-        path = path.replace("\\", "/");
-
         String date = DateTools.timeToString(file.lastModified(),
                 DateTools.Resolution.MILLISECOND);
+        path = Util.fixPathIfWindows(path);
         doc.add(new Field(QueryBuilder.U, Util.path2uid(path, date),
                 string_ft_stored_nanalyzed_norms));
         doc.add(new Field(QueryBuilder.FULLPATH, file.getAbsolutePath(),

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -34,6 +34,7 @@ import java.util.logging.Logger;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.ClassUtil;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
+import org.opengrok.indexer.web.Util;
 
 /**
  * Placeholder for the information that builds up a project
@@ -112,7 +113,7 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
      */
     public Project(String name, String path) {
         this.name = name;
-        this.path = path;
+        this.path = Util.fixPathIfWindows(path);
         completeWithDefaults();
     }
 
@@ -332,7 +333,7 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
         // Try to match each project path as prefix of the given path.
         final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         if (env.hasProjects()) {
-            final String lpath = path.replace(File.separatorChar, '/');
+            final String lpath = Util.fixPathIfWindows(path);
             for (Project p : env.getProjectList()) {
                 String projectPath = p.getPath();
                 if (projectPath == null) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -464,6 +464,8 @@ public class IndexDatabase {
                     }
                 }
 
+                dir = Util.fixPathIfWindows(dir);
+
                 String startuid = Util.path2uid(dir, "");
                 reader = DirectoryReader.open(indexDirectory); // open existing index
                 settings = readAnalysisSettings();
@@ -1100,6 +1102,7 @@ public class IndexDatabase {
                     }
 
                     if (uidIter != null) {
+                        path = Util.fixPathIfWindows(path);
                         String uid = Util.path2uid(path,
                             DateTools.timeToString(file.lastModified(),
                             DateTools.Resolution.MILLISECOND)); // construct uid for doc

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -71,6 +71,12 @@ import org.opengrok.indexer.util.Statistics;
 /**
  * Creates and updates an inverted source index as well as generates Xref, file
  * stats etc., if specified in the options
+ *
+ * We shall use / as path delimiter in whole opengrok for uuids and paths
+ * from Windows systems, the path shall be converted when entering the index or web
+ * and converted back if needed* to access original file
+ *
+ * *Windows already supports opening /var/opengrok as C:\var\opengrok
  */
 @SuppressWarnings({"PMD.AvoidPrintStackTrace", "PMD.SystemPrintln"})
 public final class Indexer {
@@ -82,6 +88,10 @@ public final class Indexer {
     private static final String OFF = "off";
     private static final String DIRBASED = "dirbased";
     private static final String UIONLY = "uionly";
+
+    //whole app uses this separator
+    public static final char PATH_SEPARATOR ='/';
+    public static String PATH_SEPARATOR_STRING =Character.toString(PATH_SEPARATOR);
 
     private static final Indexer index = new Indexer();
     private static Configuration cfg = null;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/OGKUnifiedHighlighter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/OGKUnifiedHighlighter.java
@@ -297,6 +297,7 @@ public class OGKUnifiedHighlighter extends UnifiedHighlighter {
             return null;
         }
 
+        repoRelPath = Util.fixPathIfWindows(repoRelPath);
         // Verify that timestamp (U) is unchanged by comparing UID.
         String uid = Util.path2uid(repoRelPath,
             DateTools.timeToString(repoAbsFile.lastModified(),

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -156,6 +156,14 @@ public class UtilTest {
     }
 
     @Test
+    public void fixPathIfWindows() {
+        if (Util.isWindows()) {
+            assertEquals("/var/opengrok",
+                    Util.fixPathIfWindows("\\var\\opengrok"));
+        }
+    }
+
+    @Test
     public void uid2url() {
         assertEquals("/etc/passwd", Util.uid2url(
                 Util.path2uid("/etc/passwd", "date")));


### PR DESCRIPTION
this is a good start, next steps are sanitize C:\ or any other letter and strip them
and make sure whole app just uses "/" and on windows all input or output gets properly sanitized and stripped if needed
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
