### PR TITLE
adding logging.properties.template to opengrok-tools

### DIFF
--- a/distribution/assembly.xml
+++ b/distribution/assembly.xml
@@ -24,6 +24,11 @@
         <outputDirectory>tools</outputDirectory>
         <destName>opengrok-tools-${project.python.package.version}.tar.gz</destName>
       </file>
+      <file>
+        <source>${project.basedir}/../opengrok-tools/${project.build.directory}/dist/logging.properties.template</source>
+        <outputDirectory>doc</outputDirectory>
+        <destName>logging.properties.template</destName>
+      </file>
     </files>
     <fileSets>
         <fileSet>

--- a/opengrok-tools/pom.xml
+++ b/opengrok-tools/pom.xml
@@ -91,7 +91,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                         </configuration>
                     </execution>
                     <execution>
-                        <id>copy-resources-setup.py</id>
+                        <id>copy package resources</id>
                         <phase>compile</phase>
                         <goals>
                             <goal>copy-resources</goal>
@@ -103,6 +103,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                     <directory>${basedir}</directory>
                                     <includes>
                                         <include>MANIFEST.in</include>
+                                        <include>logging.properties.template</include>
                                     </includes>
                                 </resource>
                                 <!-- replace ${project.python.package.version} in setup.py -->
@@ -112,6 +113,24 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                         <include>setup.py</include>
                                     </includes>
                                     <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy logging.properties.template to dist</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/dist</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}</directory>
+                                    <includes>
+                                        <include>logging.properties.template</include>
+                                    </includes>
                                 </resource>
                             </resources>
                         </configuration>


### PR DESCRIPTION
fixes #2448

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
