### PR TITLE
removing the version from the distribution of opengrok-tools

### DIFF
--- a/distribution/assembly.xml
+++ b/distribution/assembly.xml
@@ -22,7 +22,7 @@
       <file>
         <source>${project.basedir}/../opengrok-tools/${project.build.directory}/dist/opengrok-tools-${project.python.package.version}.tar.gz</source>
         <outputDirectory>tools</outputDirectory>
-        <destName>opengrok-tools-${project.python.package.version}.tar.gz</destName>
+        <destName>opengrok-tools.tar.gz</destName>
       </file>
     </files>
     <fileSets>


### PR DESCRIPTION
I noticed that we distribute opengrok.jar without the version, so I think this should be aligned also with the opengrok tools.