### PR TITLE
Muting exception for non-existent directory

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -35,12 +35,12 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -790,7 +790,7 @@ class FileHistoryCache implements HistoryCache {
             // Remove all files which constitute the history cache.
             try {
                 IOUtils.removeRecursive(Paths.get(histDir));
-            } catch (FileNotFoundException ex) {
+            } catch (NoSuchFileException ex) {
                 LOGGER.log(Level.WARNING, "directory {} does not exist", histDir);
             } catch (IOException ex) {
                 LOGGER.log(Level.SEVERE, "tried removeRecursive()", ex);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -791,7 +791,7 @@ class FileHistoryCache implements HistoryCache {
             try {
                 IOUtils.removeRecursive(Paths.get(histDir));
             } catch (NoSuchFileException ex) {
-                LOGGER.log(Level.WARNING, "directory {} does not exist", histDir);
+                LOGGER.log(Level.WARNING, String.format("directory %s does not exist", histDir));
             } catch (IOException ex) {
                 LOGGER.log(Level.SEVERE, "tried removeRecursive()", ex);
             }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -35,6 +35,7 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
@@ -789,6 +790,8 @@ class FileHistoryCache implements HistoryCache {
             // Remove all files which constitute the history cache.
             try {
                 IOUtils.removeRecursive(Paths.get(histDir));
+            } catch (FileNotFoundException ex) {
+                LOGGER.log(Level.WARNING, "directory {} does not exist", histDir);
             } catch (IOException ex) {
                 LOGGER.log(Level.SEVERE, "tried removeRecursive()", ex);
             }


### PR DESCRIPTION
The logged exception produces a very long stack trace. I'd just print a warning for non-existent directory as the directory is expected to be deleted.