### PR TITLE
modify the opengrok-tools env paths on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\uctags-bin.zip", "C:\uctags")
       }
 build_script:
-    - mvn -B -V -Dorg.opengrok.indexer.analysis.Ctags=c:\uctags\ctags.exe clean verify
+    - mvn -B -V -Dorg.opengrok.indexer.analysis.Ctags=c:\uctags\ctags.exe -DskipTests clean verify
 cache:
   - C:\maven\ -> appveyor.yml
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,10 @@ install:
       }
   - cmd: SET M2_HOME=C:\maven\apache-maven-%MAVEN_VERSION%
   # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
-  - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
+  - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PYTHON%;%PATH:C:\Ruby193\bin;=%;
   - cmd: mvn --version
   - cmd: java -version
+  - cmd: python --version
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\uctags" )) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
   MAVEN_VERSION: 3.5.0
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+      PYTHON: "C:\\Python34"
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   MAVEN_VERSION: 3.5.0
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-      PYTHON: "C:\\Python34"
+      PYTHON: C:\\Python34
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\uctags-bin.zip", "C:\uctags")
       }
 build_script:
-    - mvn -B -V -Dorg.opengrok.indexer.analysis.Ctags=c:\uctags\ctags.exe -DskipTests clean verify
+    - mvn -B -V -Dorg.opengrok.indexer.analysis.Ctags=c:\uctags\ctags.exe clean verify
 cache:
   - C:\maven\ -> appveyor.yml
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   MAVEN_VERSION: 3.5.0
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-      PYTHON: C:\\Python34
+      PYTHON: C:\Python34
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem

--- a/dev/install-python-packages.sh
+++ b/dev/install-python-packages.sh
@@ -2,7 +2,7 @@
 
 python3 -m pip install --upgrade pip
 
-python3 -m pip install pep8 flake8 virtualenv
+python3 -m pip install pep8 virtualenv
 if [[ $? != 0 ]]; then
 	echo "cannot install Python packages"
 	exit 1

--- a/opengrok-tools/pom.xml
+++ b/opengrok-tools/pom.xml
@@ -38,34 +38,24 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
 
     <name>OpenGrok tools</name>
 
+    <properties>
+        <python.executable>env/bin/python</python.executable>
+    </properties>
+
     <profiles>
         <profile>
-            <id>not-windows</id>
+            <id>Windows python environment</id>
             <activation>
                 <os>
-                    <family>!windows</family>
+                    <family>Windows</family>
                 </os>
             </activation>
             <properties>
-                <python3Command>python3</python3Command>
-                <pythonEnvBin>env/bin</pythonEnvBin>
-            </properties>
-        </profile>
-        <profile>
-            <id>windows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <properties>
-                <python3Command>python</python3Command>
-                <pythonEnvBin>env/Scripts</pythonEnvBin>
-                <!-- Tests do not run on Windows because the python code is Unix-specific -->
-                <skipTests>true</skipTests>
+                <python.executable>env/Scripts/python</python.executable>
             </properties>
         </profile>
     </profiles>
+
     <build>
         <sourceDirectory>src/main/python</sourceDirectory>
         <testSourceDirectory>src/test/python</testSourceDirectory>
@@ -181,7 +171,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                 <argument>${project.build.sourceDirectory}</argument>
                                 <argument>setup.py</argument>
                             </arguments>
-                            <skip>${skipTests}</skip>
+                            <!--    <skip>${skipTests}</skip> -->
                         </configuration>
                         <phase>verify</phase>
                         <goals>
@@ -208,14 +198,16 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                         <!-- needed for 'pip install pylint' to work -->
                         <id>Upgrade pip</id>
                         <configuration>
-                            <executable>${pythonEnvBin}/pip3</executable>
-                            <workingDirectory>${project.build.directory}</workingDirectory> 
+                            <executable>${python.executable}</executable>
+                            <workingDirectory>${project.build.directory}</workingDirectory>
                             <arguments>
+                                <argument>-m</argument>
+                                <argument>pip</argument>
                                 <argument>install</argument>
                                 <argument>--upgrade</argument>
                                 <argument>pip</argument>
                             </arguments>
-                            <skip>${skipTests}</skip>
+                            <!--    <skip>${skipTests}</skip> -->
                         </configuration>
                         <phase>test</phase>
                         <goals>
@@ -228,7 +220,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${pythonEnvBin}/python</executable>
+                            <executable>${python.executable}</executable>
                             <workingDirectory>${project.build.directory}</workingDirectory>
                             <arguments>
                                 <argument>setup.py</argument>
@@ -242,13 +234,13 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                     <execution>
                         <id>python-test-install</id>
                         <configuration>
-                            <executable>${pythonEnvBin}/python</executable>
+                            <executable>${python.executable}</executable>
                             <workingDirectory>${project.build.directory}</workingDirectory>
                             <arguments>
                                 <argument>setup.py</argument>
                                 <argument>install</argument>
                             </arguments>
-                            <skip>${skipTests}</skip>
+                            <!--    <skip>${skipTests}</skip> -->
                         </configuration>
                         <phase>test</phase>
                         <goals>
@@ -258,12 +250,14 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                     <execution>
                         <id>Install Python lint</id>
                         <configuration>
-                            <executable>${project.build.directory}/env/bin/pip3</executable>
+                            <executable>${python.executable}</executable>
                             <arguments>
+                                <argument>-m</argument>
+                                <argument>pip</argument>
                                 <argument>install</argument>
                                 <argument>pylint</argument>
                             </arguments>
-                            <skip>${skipTests}</skip>
+                            <!--    <skip>${skipTests}</skip> -->
                         </configuration>
                         <phase>verify</phase>
                         <goals>
@@ -273,14 +267,16 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                     <execution>
                         <id>Python lint</id>
                         <configuration>
-                            <executable>env/bin/pylint</executable>
+                            <executable>${python.executable}</executable>
                             <workingDirectory>${project.build.directory}</workingDirectory>
                             <arguments>
+                                <argument>-m</argument>
+                                <argument>pylint</argument>
                                 <argument>-E</argument>
                                 <argument>${project.build.sourceDirectory}/opengrok_tools</argument>
                                 <argument>${project.build.directory}/setup.py</argument>
                             </arguments>
-                            <skip>${skipTests}</skip>
+                            <!--    <skip>${skipTests}</skip> -->
                         </configuration>
                         <phase>verify</phase>
                         <goals>
@@ -290,13 +286,13 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                     <execution>
                         <id>python-test</id>
                         <configuration>
-                            <executable>env/bin/python</executable>
+                            <executable>${python.executable}</executable>
                             <workingDirectory>${project.build.directory}</workingDirectory>
                             <arguments>
                                 <argument>setup.py</argument>
                                 <argument>test</argument>
                             </arguments>
-                            <skip>${skipTests}</skip>
+                            <!--    <skip>${skipTests}</skip> -->
                         </configuration>
                         <phase>test</phase>
                         <goals>

--- a/opengrok-tools/pom.xml
+++ b/opengrok-tools/pom.xml
@@ -164,23 +164,6 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                 <version>1.6.0</version>
                 <executions>
                     <execution>
-                        <id>Python flake8</id>
-                        <configuration>
-                            <executable>flake8</executable>
-                            <arguments>
-                                <argument>-v</argument>
-                                <argument>--exclude=filelock.py,test_command.py,test_commands.py</argument>
-                                <argument>${project.build.sourceDirectory}</argument>
-                                <argument>setup.py</argument>
-                            </arguments>
-                            <!--    <skip>${skipTests}</skip> -->
-                        </configuration>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                    <execution>
                         <id>Generate python env</id>
                         <configuration>
                             <executable>${python.system.executable}</executable>
@@ -227,8 +210,8 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                             <arguments>
                                 <argument>setup.py</argument>
                                 <argument>sdist</argument>
-								<argument>--formats</argument>
-								<argument>gztar</argument>
+                                <argument>--formats</argument>
+                                <argument>gztar</argument>
                             </arguments>
                         </configuration>
                         <phase>package</phase>
@@ -250,7 +233,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                         </goals>
                     </execution>
                     <execution>
-                        <id>Install Python lint</id>
+                        <id>Install Python lint and flake8</id>
                         <configuration>
                             <executable>${python.executable}</executable>
                             <workingDirectory>${project.build.directory}</workingDirectory>
@@ -259,6 +242,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                 <argument>pip</argument>
                                 <argument>install</argument>
                                 <argument>pylint</argument>
+                                <argument>flake8</argument>
                             </arguments>
                             <!--    <skip>${skipTests}</skip> -->
                         </configuration>
@@ -279,6 +263,26 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                 <argument>${project.build.sourceDirectory}/opengrok_tools</argument>
                                 <argument>${project.build.directory}/setup.py</argument>
                             </arguments>
+                        </configuration>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>Python flake8</id>
+                        <configuration>
+                            <executable>${python.executable}</executable>
+                            <workingDirectory>${project.build.directory}</workingDirectory>
+                            <arguments>
+                                <argument>-m</argument>
+                                <argument>flake8</argument>
+                                <argument>-v</argument>
+                                <argument>--exclude=filelock.py,test_command.py,test_commands.py</argument>
+                                <argument>${project.build.sourceDirectory}</argument>
+                                <argument>setup.py</argument>
+                            </arguments>
+                            <!--    <skip>${skipTests}</skip> -->
                         </configuration>
                         <phase>verify</phase>
                         <goals>

--- a/opengrok-tools/pom.xml
+++ b/opengrok-tools/pom.xml
@@ -192,7 +192,6 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                 <argument>--upgrade</argument>
                                 <argument>pip</argument>
                             </arguments>
-                            <!--    <skip>${skipTests}</skip> -->
                         </configuration>
                         <phase>test</phase>
                         <goals>
@@ -225,7 +224,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                 <argument>setup.py</argument>
                                 <argument>install</argument>
                             </arguments>
-                            <!--    <skip>${skipTests}</skip> -->
+                            <skip>${skipTests}</skip>
                         </configuration>
                         <phase>test</phase>
                         <goals>
@@ -233,7 +232,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                         </goals>
                     </execution>
                     <execution>
-                        <id>Install Python lint and flake8</id>
+                        <id>Install python lint and flake8</id>
                         <configuration>
                             <executable>${python.executable}</executable>
                             <workingDirectory>${project.build.directory}</workingDirectory>
@@ -244,7 +243,6 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                 <argument>pylint</argument>
                                 <argument>flake8</argument>
                             </arguments>
-                            <!--    <skip>${skipTests}</skip> -->
                         </configuration>
                         <phase>verify</phase>
                         <goals>
@@ -282,7 +280,6 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                 <argument>${project.build.sourceDirectory}</argument>
                                 <argument>setup.py</argument>
                             </arguments>
-                            <!--    <skip>${skipTests}</skip> -->
                         </configuration>
                         <phase>verify</phase>
                         <goals>
@@ -298,7 +295,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                 <argument>setup.py</argument>
                                 <argument>test</argument>
                             </arguments>
-                            <!--    <skip>${skipTests}</skip> -->
+                            <skip>${skipTests}</skip>
                         </configuration>
                         <phase>test</phase>
                         <goals>

--- a/opengrok-tools/pom.xml
+++ b/opengrok-tools/pom.xml
@@ -52,8 +52,8 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                 </os>
             </activation>
             <properties>
-                <python.system.executable>py -3</python.system.executable>
-                <python.executable>env/Scripts/py</python.executable>
+                <python.system.executable>python</python.system.executable>
+                <python.executable>env/Scripts/python</python.executable>
             </properties>
         </profile>
     </profiles>

--- a/opengrok-tools/pom.xml
+++ b/opengrok-tools/pom.xml
@@ -181,7 +181,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                         </goals>
                     </execution>
                     <execution>
-                        <id>generate python env</id>
+                        <id>Generate python env</id>
                         <configuration>
                             <executable>${python.system.executable}</executable>
                             <workingDirectory>${project.build.directory}</workingDirectory>
@@ -217,7 +217,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                         </goals>
                     </execution>
                     <execution>
-                        <id>generate-package</id>
+                        <id>Generate python package</id>
                         <goals>
                             <goal>exec</goal>
                         </goals>
@@ -234,7 +234,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                         <phase>package</phase>
                     </execution>
                     <execution>
-                        <id>python-test-install</id>
+                        <id>Install python package for tests</id>
                         <configuration>
                             <executable>${python.executable}</executable>
                             <workingDirectory>${project.build.directory}</workingDirectory>
@@ -253,6 +253,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                         <id>Install Python lint</id>
                         <configuration>
                             <executable>${python.executable}</executable>
+                            <workingDirectory>${project.build.directory}</workingDirectory>
                             <arguments>
                                 <argument>-m</argument>
                                 <argument>pip</argument>
@@ -278,7 +279,6 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                                 <argument>${project.build.sourceDirectory}/opengrok_tools</argument>
                                 <argument>${project.build.directory}/setup.py</argument>
                             </arguments>
-                            <!--    <skip>${skipTests}</skip> -->
                         </configuration>
                         <phase>verify</phase>
                         <goals>
@@ -286,7 +286,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                         </goals>
                     </execution>
                     <execution>
-                        <id>python-test</id>
+                        <id>Test python package</id>
                         <configuration>
                             <executable>${python.executable}</executable>
                             <workingDirectory>${project.build.directory}</workingDirectory>

--- a/opengrok-tools/pom.xml
+++ b/opengrok-tools/pom.xml
@@ -39,6 +39,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
     <name>OpenGrok tools</name>
 
     <properties>
+        <python.system.executable>python3</python.system.executable>
         <python.executable>env/bin/python</python.executable>
     </properties>
 
@@ -51,7 +52,8 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                 </os>
             </activation>
             <properties>
-                <python.executable>env/Scripts/python</python.executable>
+                <python.system.executable>py -3</python.system.executable>
+                <python.executable>env/Scripts/py</python.executable>
             </properties>
         </profile>
     </profiles>
@@ -181,7 +183,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                     <execution>
                         <id>generate python env</id>
                         <configuration>
-                            <executable>${python3Command}</executable>
+                            <executable>${python.system.executable}</executable>
                             <workingDirectory>${project.build.directory}</workingDirectory>
                             <arguments>
                                 <argument>-m</argument>

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
@@ -103,7 +103,10 @@ class Command:
                 # the process and is specific to Unix.
                 if os.name == 'posix':
                     timeout = self.timeout
+                    # disable E1101 - non existent attribute SIGKILL on windows
+                    # pylint: disable=E1101
                     term_signals = [signal.SIGINT, signal.SIGKILL]
+                    # pylint: enable=E1101
                     for sig in term_signals:
                         timeout = timeout / 2  # exponential back-off
                         self.logger.info("Sleeping for {} seconds".

--- a/opengrok-tools/src/test/python/test_command.py
+++ b/opengrok-tools/src/test/python/test_command.py
@@ -29,10 +29,6 @@ import os
 import time
 
 
-sys.path.insert(0, os.path.abspath(
-                os.path.join(os.path.dirname(__file__), '..', '..',
-                'main', 'python')))
-
 from opengrok_tools.utils.command import Command
 import tempfile
 

--- a/opengrok-tools/src/test/python/test_commands.py
+++ b/opengrok-tools/src/test/python/test_commands.py
@@ -28,10 +28,6 @@ import os
 import sys
 
 
-sys.path.insert(0, os.path.abspath(
-                os.path.join(os.path.dirname(__file__), '..', '..',
-                'main', 'python')))
-
 from opengrok_tools.utils.commandsequence import CommandSequence, CommandSequenceBase
 
 

--- a/opengrok-tools/src/test/python/test_indexer.py
+++ b/opengrok-tools/src/test/python/test_indexer.py
@@ -28,10 +28,6 @@ import sys
 import os
 
 
-sys.path.insert(0, os.path.abspath(
-                os.path.join(os.path.dirname(__file__), '..', '..',
-                'main', 'python', 'opengrok_tools')))
-
 from opengrok_tools.utils.indexer import merge_properties
 
 


### PR DESCRIPTION
Refactor of the property naming, verifying that the build + tests pass correctly on windows build. Ensure python3.4 in appveyor.

When user wants to use his custom version of python, he can use
```bash
mvn -Dpython.system.executable=/opt/python50/bin/python test
```
it will create the virtul env with this base python.