### PR TITLE
Tools setup install req

### DIFF
--- a/opengrok-tools/setup.py
+++ b/opengrok-tools/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         'jsonschema==2.6.0',
         'pyyaml',
-        'requests==2.20.0',
+        'requests>=2.20.0',
         'resource'
     ],
     entry_points={

--- a/opengrok-tools/setup.py
+++ b/opengrok-tools/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         'jsonschema==2.6.0',
         'pyyaml',
-        'requests~=2.20.0',
+        'requests==2.20.0',
         'resource'
     ],
     entry_points={


### PR DESCRIPTION
After Travis fails with:
```
[INFO] --- exec-maven-plugin:1.6.0:exec (python-test-install) @ opengrok-tools ---
error in opengrok-tools setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
```
this is due to the `~=` specifier in `setup.py`. To make this usable in Travis env we need to stick to the basics.