### PR TITLE
Actually skip history cache creation when history is disabled for project

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -562,6 +562,7 @@ public final class HistoryGuru {
             LOGGER.log(Level.INFO,
                     "Skipping history cache creation of {0} repository in {1} and its subdirectories",
                     new Object[]{type, path});
+            return;
         }
         
         if (repository.isWorking()) {


### PR DESCRIPTION
This typo/bug was introduced in https://github.com/oracle/opengrok/commit/2b892162bcf709338fb6776ed184615f9b9890c5.