### PR TITLE
Update LineHighlight.java to fix #2479

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/LineHighlight.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/LineHighlight.java
@@ -179,7 +179,14 @@ public class LineHighlight {
                 end = relide;
             }
         }
-        String str = line.substring(start, end);
+        final String str;
+        if (line == null || line.length() <= 0) {
+            str = "_";
+        } else if (line.length() <= end) {
+            str = line;
+        } else {
+            str = line.substring(start, end);
+        }
         if (lell && !didLelide) {
             dest.append(HtmlConsts.HELLIP);
             didLelide = true;


### PR DESCRIPTION
Exception in search 
SEVERE [http-nio-8080-exec-7] org.opengrok.indexer.search.context.Context.getContext2 ERROR highlightFieldsUnion(...)
 java.lang.StringIndexOutOfBoundsException: String index out of range: 26
	at java.lang.String.substring(String.java:1963)
	at org.opengrok.indexer.search.context.LineHighlight.hsub(LineHighlight.java:182)
	at org.opengrok.indexer.search.context.ContextFormatter.format(ContextFormatter.java:272)
	at org.apache.lucene.search.uhighlight.FieldHighlighter.highlightFieldForDoc(FieldHighlighter.java:88)
	at org.apache.lucene.search.uhighlight.UnifiedHighlighter.highlightFieldsAsObjects(UnifiedHighlighter.java:639)
	at org.opengrok.indexer.search.context.OGKUnifiedHighlighter.highlightFieldsUnionWork(OGKUnifiedHighlighter.java:162)
	at org.opengrok.indexer.search.context.OGKUnifiedHighlighter.highlightFieldsUnion(OGKUnifiedHighlighter.java:134)
	at org.opengrok.indexer.search.context.Context.getContext2(Context.java:217)
	at org.opengrok.indexer.search.Results.printPlain(Results.java:271)
	at org.opengrok.indexer.search.Results.prettyPrint(Results.java:239)

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
