### PR TITLE
redact URL in repository listing

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1675,8 +1675,31 @@ public final class Util {
         return url.getProtocol().equals("http") || url.getProtocol().equals("https");
     }
 
+    protected final static String REDACTED_USER_INFO = "redacted_by_OpenGrok";
+
     /**
-     * Build a html link to the given http url. If the URL is not an http URL
+     * If given path is a URL, return the string representation with the user-info part filtered out.
+     * @param path path to object
+     * @return either the original string or string representation of URL with the user-info part removed
+     */
+    public static String redactUrl(String path) {
+        URL url;
+        try {
+            url = new URL(path);
+        } catch (MalformedURLException e) {
+            // not an URL
+            return path;
+        }
+        if (url.getUserInfo() != null) {
+            return url.toString().replace(url.getUserInfo(),
+                    REDACTED_USER_INFO);
+        } else {
+            return url.toString();
+        }
+    }
+
+    /**
+     * Build a HTML link to the given HTTP URL. If the URL is not an http URL
      * then it is returned as it was received. This has the same effect as
      * invoking <code>linkify(url, true)</code>.
      *

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -97,7 +97,7 @@ public final class Util {
         "[^A-Za-z0-9_]");
 
     private Util() {
-        // singleton
+        // private to ensure static
     }
 
     /**
@@ -1570,7 +1570,7 @@ public final class Util {
     }
 
     /**
-     * Creates a html slider for pagination. This has the same effect as
+     * Creates a HTML slider for pagination. This has the same effect as
      * invoking <code>createSlider(offset, limit, size, null)</code>.
      *
      * @param offset start of the current page
@@ -1583,8 +1583,7 @@ public final class Util {
     }
 
     /**
-     * Creates a html slider for pagination.
-     *
+     * Creates a HTML slider for pagination.
      *
      * @param offset start of the current page
      * @param limit max number of items per page
@@ -1661,7 +1660,7 @@ public final class Util {
     }
 
     /**
-     * Check if the string is a http URL.
+     * Check if the string is a HTTP URL.
      *
      * @param string the string to check
      * @return true if it is http URL, false otherwise
@@ -1694,9 +1693,9 @@ public final class Util {
      * Build a html link to the given http URL. If the URL is not an http URL
      * then it is returned as it was received.
      *
-     * @param url the http URL
+     * @param url the HTTP URL
      * @param newTab if the link should open in a new tab
-     * @return html containing the link &lt;a&gt;...&lt;/a&gt;
+     * @return HTML code containing the link &lt;a&gt;...&lt;/a&gt;
      */
     public static String linkify(String url, boolean newTab) {
         if (isHttpUri(url)) {
@@ -1852,8 +1851,8 @@ public final class Util {
     }
 
     /**
-     * Parses the specified url and returns its query params.
-     * @param url url to retrieve the query params from
+     * Parses the specified URL and returns its query params.
+     * @param url URL to retrieve the query params from
      * @return query params of {@code url}
      */
     public static Map<String, List<String>> getQueryParams(final URL url) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1694,7 +1694,7 @@ public final class Util {
             return url.toString().replace(url.getUserInfo(),
                     REDACTED_USER_INFO);
         } else {
-            return url.toString();
+            return path;
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1675,7 +1675,7 @@ public final class Util {
         return url.getProtocol().equals("http") || url.getProtocol().equals("https");
     }
 
-    protected final static String REDACTED_USER_INFO = "redacted_by_OpenGrok";
+    protected static final String REDACTED_USER_INFO = "redacted_by_OpenGrok";
 
     /**
      * If given path is a URL, return the string representation with the user-info part filtered out.

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -351,6 +351,16 @@ public class UtilTest {
     }
 
     @Test
+    public void testRedactUrl() {
+        assertEquals("/foo/bar", Util.redactUrl("/foo/bar"));
+        assertEquals("http://foo/bar?r=xxx", Util.redactUrl("http://foo/bar?r=xxx"));
+        assertEquals("http://" + Util.REDACTED_USER_INFO + "@foo/bar?r=xxx",
+                Util.redactUrl("http://user@foo/bar?r=xxx"));
+        assertEquals("http://" + Util.REDACTED_USER_INFO + "@foo/bar?r=xxx",
+                Util.redactUrl("http://user:pass@foo/bar?r=xxx"));
+    }
+
+    @Test
     public void testLinkify() throws URISyntaxException, MalformedURLException {
         assertTrue(Util.linkify("http://www.example.com")
                 .matches("<a.*?href=\"http://www\\.example\\.com\".*?>.*?</a>"));

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -25,23 +25,14 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
 --%>
 <%@page errorPage="error.jsp" import="
 java.io.BufferedInputStream,
-java.io.BufferedReader,
 java.io.FileInputStream,
-java.io.FileReader,
-java.io.FileWriter,
 java.io.InputStream,
 java.io.InputStreamReader,
 java.io.Reader,
 java.net.URLEncoder,
 java.nio.charset.StandardCharsets,
-java.util.ArrayList,
-java.util.Arrays,
 java.util.List,
 java.util.Set,
-java.util.logging.Level,
-java.util.zip.GZIPInputStream,
-javax.servlet.http.HttpServletResponse,
-
 org.opengrok.indexer.analysis.AnalyzerGuru,
 org.opengrok.indexer.analysis.Definitions,
 org.opengrok.indexer.analysis.FileAnalyzer.Genre,

--- a/opengrok-web/src/main/webapp/projects.jspf
+++ b/opengrok-web/src/main/webapp/projects.jspf
@@ -26,11 +26,7 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 --%>
 <%@page import="
 java.net.URLEncoder,
-java.util.TreeSet,
-
-org.opengrok.indexer.web.Prefix,
-org.opengrok.indexer.web.PageConfig,
-org.opengrok.indexer.configuration.Project
+org.opengrok.indexer.web.PageConfig
 "%><%
 /* ---------------------- projects.jspf start --------------------- */
 {

--- a/opengrok-web/src/main/webapp/repos.jspf
+++ b/opengrok-web/src/main/webapp/repos.jspf
@@ -23,23 +23,15 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
 --%>
 <%@page import="java.util.TreeSet"%>
 <%@page import="java.util.Iterator"%>
-<%@page import="org.opengrok.indexer.web.Scripts"%>
 <%@page import="org.json.simple.JSONArray"%>
-<%@page import="java.util.SortedSet"%>
 <%@page import="java.util.Set"%>
-<%@page import="java.text.ParseException"%>
-<%@page import="java.util.ArrayList"%>
-<%@page import="java.util.Date"%>
 <%@page import="org.opengrok.indexer.web.Prefix"%>
 <%@page import="org.opengrok.indexer.web.ProjectHelper"%>
 <%@page import="java.util.LinkedList"%>
 <%@page import="java.util.Collections"%>
 <%@page import="java.util.Comparator"%>
-<%@page import="java.util.Collection"%>
 <%@page import="java.io.File"%>
-<%@page import="org.opengrok.indexer.configuration.RuntimeEnvironment"%>
 <%@page import="org.opengrok.indexer.history.RepositoryInfo"%>
-<%@page import="org.opengrok.indexer.history.Repository"%>
 <%@page import="org.opengrok.indexer.web.Util"%>
 <%@page import="org.opengrok.indexer.configuration.Project"%>
 <%@page import="org.opengrok.indexer.configuration.Group"%>

--- a/opengrok-web/src/main/webapp/repos.jspf
+++ b/opengrok-web/src/main/webapp/repos.jspf
@@ -171,7 +171,7 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
                         <span class="important-note important-note-rounded" data-messages='<%= messages %>'>!</span>
                     <% } %>
                                 </td><%
-                            String parent = ri.getParent();
+                            String parent = Util.redactUrl(ri.getParent());
                             if (parent == null) {
                                 parent = "N/A";
                             }
@@ -301,7 +301,7 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
                         <span class="important-note important-note-rounded" data-messages='<%= messages %>'>!</span>
                     <% } %>
                     </td><%
-                                String parent = ri.getParent();
+                                String parent = Util.redactUrl(ri.getParent());
                                 if (parent == null) {
                                     parent = "N/A";
                                 }


### PR DESCRIPTION
This change redacts the user-info part of URL for the project/repository list on the index page.