### PR TITLE
try to change to maven box

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,4 @@
-# This references an OpenJDK container from the
-# Docker Hub https://hub.docker.com/_/openjdk/
-box: openjdk:8-jdk
+box: maven:3.5.3-jdk-8
 
 # This should switch to Oracle JDK however does not work:
 #box:


### PR DESCRIPTION
Recently our Wercker builds have started failing with:
```
[ERROR] ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /pipeline/source/opengrok-indexer && /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -javaagent:/pipeline/cache/.m2/org/jacoco/org.jacoco.agent/0.8.1/org.jacoco.agent-0.8.1-runtime.jar=destfile=/pipeline/source/opengrok-indexer/target/jacoco.exec -jar /pipeline/source/opengrok-indexer/target/surefire/surefirebooter8023426895010125981.jar /pipeline/source/opengrok-indexer/target/surefire 2018-10-31T10-37-24_565-jvmRun1 surefire580312577885706607tmp surefire_96852007418474470112tmp
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 1
```
On internal Wercker Slack channel I was advised to try changing the `box` to one having different Maven version.