### PR TITLE
add loglevel arg to tools

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/config_merge.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/config_merge.py
@@ -26,6 +26,7 @@ import logging
 import sys
 
 from .utils.java import Java, get_javaparser
+from .utils.log import print_exc_exit
 
 
 """
@@ -38,15 +39,15 @@ def main():
                                                  'configuration merging',
                                      parents=[get_javaparser()])
 
-    args = parser.parse_args()
+    try:
+        args = parser.parse_args()
+    except ValueError as e:
+        print_exc_exit(e)
 
     # Avoid using utils.log.get_console_level() since the stdout of the program
     # is interpreted as data.
-    loglevel = logging.INFO
-    if args.debug:
-        loglevel = logging.DEBUG
     logger = logging.getLogger(__name__)
-    logger.setLevel(loglevel)
+    logger.setLevel(args.loglevel)
 
     cmd = Java(args.options, classpath=args.jar, java=args.java,
                java_opts=args.java_opts, redirect_stderr=False,

--- a/opengrok-tools/src/main/python/opengrok_tools/deploy.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/deploy.py
@@ -23,12 +23,13 @@
 #
 
 import argparse
-import logging
 import os
 import tempfile
 from zipfile import ZipFile
 from shutil import copyfile
-from .utils.log import get_console_logger, get_class_basename
+from .utils.log import get_console_logger, get_class_basename, \
+    add_log_level_argument, print_exc_exit
+
 
 """
  deploy war file
@@ -98,8 +99,7 @@ def deploy_war(logger, sourceWar, targetWar, configFile=None):
 def main():
     parser = argparse.ArgumentParser(description='Deploy WAR file')
 
-    parser.add_argument('-D', '--debug', action='store_true',
-                        help='Enable debug prints')
+    add_log_level_argument(parser)
     parser.add_argument('-c', '--config',
                         help='Path to OpenGrok configuration file')
     parser.add_argument('source_war', nargs=1,
@@ -107,12 +107,12 @@ def main():
     parser.add_argument('target_war', nargs=1,
                         help='Path where to deploy source war file to')
 
-    args = parser.parse_args()
+    try:
+        args = parser.parse_args()
+    except ValueError as e:
+        print_exc_exit(e)
 
-    loglevel = logging.INFO
-    if args.debug:
-        loglevel = logging.DEBUG
-    logger = get_console_logger(get_class_basename(), loglevel)
+    logger = get_console_logger(get_class_basename(), args.loglevel)
 
     deploy_war(logger, args.source_war[0], args.target_war[0], args.config)
 

--- a/opengrok-tools/src/main/python/opengrok_tools/groups.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/groups.py
@@ -22,11 +22,10 @@
 #
 
 import argparse
-import logging
 import sys
 
 from .utils.java import Java, get_javaparser
-from .utils.log import get_console_logger, get_class_basename
+from .utils.log import get_console_logger, get_class_basename, print_exc_exit
 
 
 """
@@ -39,12 +38,12 @@ def main():
                                                  'group manipulation',
                                      parents=[get_javaparser()])
 
-    args = parser.parse_args()
+    try:
+        args = parser.parse_args()
+    except ValueError as e:
+        print_exc_exit(e)
 
-    loglevel = logging.INFO
-    if args.debug:
-        loglevel = logging.DEBUG
-    logger = get_console_logger(get_class_basename(), loglevel)
+    logger = get_console_logger(get_class_basename(), args.loglevel)
 
     cmd = Java(args.options, classpath=args.jar, java=args.java,
                java_opts=args.java_opts, redirect_stderr=False,

--- a/opengrok-tools/src/main/python/opengrok_tools/indexer.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/indexer.py
@@ -24,12 +24,11 @@
 
 
 import argparse
-import logging
 import sys
 
 from .utils.indexer import FindCtags, Indexer
 from .utils.java import get_javaparser
-from .utils.log import get_console_logger, get_class_basename
+from .utils.log import get_console_logger, get_class_basename, print_exc_exit
 
 """
   opengrok.jar wrapper
@@ -44,12 +43,12 @@ def main():
     parser.add_argument('-C', '--no_ctags_check', action='store_true',
                         default=False, help='Suppress checking for ctags')
 
-    args = parser.parse_args()
+    try:
+        args = parser.parse_args()
+    except ValueError as e:
+        print_exc_exit(e)
 
-    loglevel = logging.INFO
-    if args.debug:
-        loglevel = logging.DEBUG
-    logger = get_console_logger(get_class_basename(), loglevel)
+    logger = get_console_logger(get_class_basename(), args.loglevel)
 
     #
     # Since it is not possible to tell what kind of action is performed,

--- a/opengrok-tools/src/main/python/opengrok_tools/java.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/java.py
@@ -23,11 +23,10 @@
 #
 
 import argparse
-import logging
 import sys
 
 from .utils.java import Java, get_javaparser
-from .utils.log import get_console_logger, get_class_basename
+from .utils.log import get_console_logger, get_class_basename, print_exc_exit
 
 
 def main():
@@ -36,12 +35,12 @@ def main():
     parser.add_argument('-m', '--mainclass', required=True,
                         help='Main class')
 
-    args = parser.parse_args()
+    try:
+        args = parser.parse_args()
+    except ValueError as e:
+        print_exc_exit(e)
 
-    loglevel = logging.INFO
-    if args.debug:
-        loglevel = logging.DEBUG
-    logger = get_console_logger(get_class_basename(), loglevel)
+    logger = get_console_logger(get_class_basename(), args.loglevel)
 
     java = Java(args.options, logger=logger, java=args.java,
                 jar=args.jar, java_opts=args.java_opts,

--- a/opengrok-tools/src/main/python/opengrok_tools/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/mirror.py
@@ -39,7 +39,8 @@ from logging.handlers import RotatingFileHandler
 from filelock import Timeout, FileLock
 
 from .utils.hook import run_hook
-from .utils.log import get_console_logger, get_class_basename
+from .utils.log import get_console_logger, get_class_basename, \
+    add_log_level_argument, print_exc_exit
 from .utils.opengrok import get_repos, get_config_value, get_repo_type
 from .utils.readconfig import read_config
 from .utils.repofactory import get_repository
@@ -53,7 +54,7 @@ if major_version < 3:
     print("Need Python 3, you are running {}".format(major_version))
     sys.exit(1)
 
-__version__ = "0.5"
+__version__ = "0.6"
 
 # "constants"
 HOOK_TIMEOUT_PROPERTY = 'hook_timeout'
@@ -120,8 +121,7 @@ def main():
     parser = argparse.ArgumentParser(description='project mirroring')
 
     parser.add_argument('project')
-    parser.add_argument('-D', '--debug', action='store_true',
-                        help='Enable debug prints')
+    add_log_level_argument(parser)
     parser.add_argument('-c', '--config',
                         help='config file in JSON/YAML format')
     parser.add_argument('-U', '--uri', default='http://localhost:8080/source',
@@ -133,12 +133,12 @@ def main():
     parser.add_argument('-I', '--incoming', action='store_true',
                         help='Check for incoming changes, terminate the '
                              'processing if not found.')
-    args = parser.parse_args()
+    try:
+        args = parser.parse_args()
+    except ValueError as e:
+        print_exc_exit(e)
 
-    loglevel = logging.INFO
-    if args.debug:
-        loglevel = logging.DEBUG
-    logger = get_console_logger(get_class_basename(), loglevel)
+    logger = get_console_logger(get_class_basename(), args.loglevel)
 
     if args.config:
         config = read_config(logger, args.config)

--- a/opengrok-tools/src/main/python/opengrok_tools/reindex_project.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/reindex_project.py
@@ -23,14 +23,13 @@
 
 
 import argparse
-import logging
 import os
 import sys
 import tempfile
 
 from .utils.indexer import Indexer
 from .utils.java import get_javaparser
-from .utils.log import get_console_logger, get_class_basename
+from .utils.log import get_console_logger, get_class_basename, print_exc_exit
 from .utils.opengrok import get_configuration
 
 """
@@ -85,12 +84,12 @@ def main():
     parser.add_argument('-U', '--uri', default='http://localhost:8080/source',
                         help='URI of the webapp with context path')
 
-    args = parser.parse_args()
+    try:
+        args = parser.parse_args()
+    except ValueError as e:
+        print_exc_exit(e)
 
-    loglevel = logging.INFO
-    if args.debug:
-        loglevel = logging.DEBUG
-    logger = get_console_logger(get_class_basename(), loglevel)
+    logger = get_console_logger(get_class_basename(), args.loglevel)
 
     # Make sure the log directory exists.
     if not os.path.isdir(args.directory):

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/java.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/java.py
@@ -25,6 +25,7 @@
 import platform
 from .command import Command
 from .utils import is_exe
+from .log import add_log_level_argument
 import os
 import argparse
 
@@ -111,8 +112,7 @@ class Java(Command):
 
 def get_javaparser():
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument('-D', '--debug', action='store_true',
-                        help='Enable debug prints')
+    add_log_level_argument(parser)
     parser.add_argument('-j', '--java',
                         help='path to java binary')
     parser.add_argument('-J', '--java_opts',

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/log.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/log.py
@@ -54,7 +54,7 @@ class LogLevelAction(argparse.Action):
         if val:
             setattr(namespace, self.dest, val)
         else:
-            raise ValueError("need valid log level")
+            raise ValueError("invalid log level '{}'".format(values))
 
 
 def get_log_level(level):

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/log.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/log.py
@@ -47,6 +47,7 @@ class LogLevelAction(argparse.Action):
         if nargs is not None:
             raise ValueError("nargs not allowed")
         super(LogLevelAction, self).__init__(option_strings, dest, **kwargs)
+
     def __call__(self, parser, namespace, values, option_string=None):
         # print('%r %r %r' % (namespace, values, option_string))
         val = get_log_level(values)

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/log.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/log.py
@@ -23,6 +23,52 @@
 
 import logging
 import sys
+import argparse
+
+
+def print_exc_exit(e):
+    """
+    Print exception and exit
+    :param e: exception
+    :return: nothing
+    """
+    print(e, file=sys.stderr)
+    sys.exit(1)
+
+
+def add_log_level_argument(parser):
+    parser.add_argument('-l', '--loglevel', action=LogLevelAction,
+                        help='Set log level (e.g. \"ERROR\")',
+                        default=logging.INFO)
+
+
+class LogLevelAction(argparse.Action):
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+        super(LogLevelAction, self).__init__(option_strings, dest, **kwargs)
+    def __call__(self, parser, namespace, values, option_string=None):
+        # print('%r %r %r' % (namespace, values, option_string))
+        val = get_log_level(values)
+        if val:
+            setattr(namespace, self.dest, val)
+        else:
+            raise ValueError("need valid log level")
+
+
+def get_log_level(level):
+    """
+    :param level: expressed in string (upper or lower case)
+    :return: integer representation of the log level or None
+    """
+    try:
+        value = getattr(logging, level.upper())
+        if type(value) is int:
+            return value
+        else:
+            return None
+    except AttributeError:
+        return None
 
 
 def get_class_basename():
@@ -39,6 +85,9 @@ def get_console_logger(name, level=logging.INFO, format='%(message)s'):
     :param format: format string to use
     :return: logger
     """
+    if level is None:
+        level = logging.INFO
+
     if level == logging.DEBUG:
         format = '%(asctime)s %(levelname)8s %(name)s | %(message)s'
 


### PR DESCRIPTION
adds -l/--loglevel to all tools. Replaces -D.

This is how it looks like:
```
$ opengrok-mirror -l xxx foo
invalid log level 'xxx'
$ opengrok-mirror -l debug foo
2018-11-06 22:46:18,578    DEBUG opengrok_tools | web application URI = http://localhost:8080/source
2018-11-06 22:46:18,584    DEBUG opengrok_tools | Source root = /var/opengrok/src
2018-11-06 22:46:18,589    DEBUG opengrok_tools | Repository path = /foo
2018-11-06 22:46:18,596    DEBUG opengrok_tools | Repository type = Mercurial
2018-11-06 22:46:18,596    DEBUG opengrok_tools | Constructing repo object for path /var/opengrok/src/foo
2018-11-06 22:46:18,597     INFO opengrok_tools | Synchronizing repository /var/opengrok/src/foo
...
```