### PR TITLE
enforce minimum Maven version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,26 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                  <execution>
+                    <id>enforce-maven</id>
+                    <goals>
+                      <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                      <rules>
+                        <requireMavenVersion>
+                          <version>3.0.5</version>
+                        </requireMavenVersion>
+                      </rules>
+                    </configuration>
+                  </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>


### PR DESCRIPTION
When running `mvn versions:display-plugin-updates` to display available plugin updates, Maven was complaining that no minimum Maven version is enforced. This should fix this.