### PR TITLE
testIndexVersionOldIndex fails on Windows

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexVersion.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexVersion.java
@@ -24,7 +24,6 @@
 package org.opengrok.indexer.index;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -74,7 +73,7 @@ public class IndexVersion {
                 LOGGER.log(Level.FINER,
                         "Checking Lucene index version in project {0}",
                         projectName);
-                checkDir(getDirectory(new File(indexRoot, projectName)));
+                checkDir(new File(indexRoot, projectName));
             }
         } else {
             if (env.isProjectsEnabled()) {
@@ -82,20 +81,14 @@ public class IndexVersion {
                     LOGGER.log(Level.FINER,
                             "Checking Lucene index version in project {0}",
                             projectName);
-                    checkDir(getDirectory(new File(indexRoot, projectName)));
+                    checkDir(new File(indexRoot, projectName));
                 }
             } else {
                 LOGGER.log(Level.FINER, "Checking Lucene index version in {0}",
                         indexRoot);
-                checkDir(getDirectory(indexRoot));
+                checkDir(indexRoot);
             }
         }
-    }
-    
-    private static Directory getDirectory(File indexDir) throws IOException {
-        LockFactory lockfact = NativeFSLockFactory.INSTANCE;
-        FSDirectory indexDirectory = FSDirectory.open(indexDir.toPath(), lockfact);
-        return indexDirectory;
     }
 
     /**
@@ -105,13 +98,21 @@ public class IndexVersion {
      * @param dir directory with index
      * @thows IOException if the directory cannot be opened
      */
-    private static void checkDir(Directory dir) throws IOException, Exception {
+    private static void checkDir(File dir) throws Exception {
+        LockFactory lockfact = NativeFSLockFactory.INSTANCE;
         int segVersion;
-        try {
-            segVersion = SegmentInfos.readLatestCommit(dir).getIndexCreatedVersionMajor();
-        } catch (IndexNotFoundException e) {
-            return;
+
+        try (Directory indexDirectory = FSDirectory.open(dir.toPath(), lockfact)) {
+           SegmentInfos segInfos = null;
+
+            try {
+                segInfos = SegmentInfos.readLatestCommit(indexDirectory);
+                segVersion = segInfos.getIndexCreatedVersionMajor();
+            } catch (IndexNotFoundException e) {
+                return;
+            }
         }
+
         if (segVersion != Version.LATEST.major) {
             throw new IndexVersionException(
                 String.format("Directory %s has index of version %d and Lucene has %d",


### PR DESCRIPTION
`testIndexVersionOldIndex` fails on Windows with:

```
[ERROR] testIndexVersionOldIndex(org.opengrok.indexer.index.IndexVersionTest)  Time elapsed: 0.156 s  <<< ERROR!
java.nio.file.FileSystemException: 
C:\Users\appveyor\AppData\Local\Temp\1\data6096978419951074269\index\segments_3: The process cannot access the file because it is being used by another process.
	at org.opengrok.indexer.index.IndexVersionTest.tearDown(IndexVersionTest.java:82)
[INFO] Running org.opengrok.indexer.search.context.ContextFormatterTest
```

Line 82 is recursive directory removal. The file/directory needs to be closed in `IndexVersionTest`.