### PR TITLE
setReadable()/canRead() does not work on Windows

### DIFF
--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.rmi.server.UnicastRemoteObject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,6 +43,7 @@ import org.opengrok.indexer.authorization.TestPlugin;
 import org.opengrok.indexer.condition.ConditionalRun;
 import org.opengrok.indexer.condition.ConditionalRunRule;
 import org.opengrok.indexer.condition.RepositoryInstalled;
+import org.opengrok.indexer.condition.UnixPresent;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.Annotation;
@@ -475,6 +477,7 @@ public class PageConfigTest {
      * @throws IOException I/O exception
      */
     @Test
+    @ConditionalRun(UnixPresent.class)
     public void testCheckSourceRootExistence4() throws IOException {
         HttpServletRequest req = new DummyHttpServletRequest();
         PageConfig cfg = PageConfig.get(req);


### PR DESCRIPTION
On Windows, `PageConfigTest#testCheckSourceRootExistence4()` calls `setReadable()` on temporary source root and expects that `checkSourceRootExistence()` will fail on the basis of `canRead()` returning false however this is not happening.

https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6203387 explains this:
> Here's the sad story of canRead() on Windows:

> The win32 API provides _access() and _waccess(), which
seem to exactly match the requirements for implementing
canRead() and canWrite().

> Unfortunately, the Windows implementers, in their infinite wisdom,
decided not to teach these functions about the new NTFS security mechanism,
and so they claim that *ALL* files are readable (because they
were so on MS-DOS) and for writing, only the one bit in the
file attributes is checked.

So, this change will make the test Unix only.