### PR TITLE
Close streams while extracting archive

### DIFF
--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/FileUtilities.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/FileUtilities.java
@@ -53,11 +53,12 @@ public class FileUtilities {
             if (ze.isDirectory()) {
                 file.mkdirs();
             } else {
-                InputStream in = zipfile.getInputStream(ze);
-                assertNotNull(in);
-                FileOutputStream out = new FileOutputStream(file);
-                assertNotNull(out);
-                copyFile(in, out);
+                try (InputStream in = zipfile.getInputStream(ze); FileOutputStream out = new FileOutputStream(file)) {
+                    if (in == null) {
+                        throw new IOException("Cannot get InputStream for " + ze);
+                    }
+                    copyFile(in, out);
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

While looking at the failing Windows tests @tarzanek found out that these streams are not closed properly.

Note: `assertNotNull(out);` was redundant since constructor will never return `null`

Thanks :)