### PR TITLE
deal with newlines for tests utilizing Mercurial running on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ install:
   - cmd: mvn --version
   - cmd: java -version
   - cmd: python --version
+  - cmd: hg --version
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\uctags" )) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.opengrok.indexer.condition.ConditionalRun;
 import org.opengrok.indexer.condition.ConditionalRunRule;
 import org.opengrok.indexer.condition.RepositoryInstalled;
+import org.opengrok.indexer.condition.UnixPresent;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.TestRepository;
 
@@ -230,6 +231,7 @@ public class FileHistoryCacheTest {
     /**
      * Basic tests for the {@code store()} and {@code get()} methods.
      */
+    @ConditionalRun(UnixPresent.class)
     @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
     @Test
     public void testStoreAndGet() throws Exception {
@@ -353,6 +355,7 @@ public class FileHistoryCacheTest {
      * - change+rename the file again
      * - incremental reindex
      */
+    @ConditionalRun(UnixPresent.class)
     @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
     @Test
     public void testRenameFileThenDoIncrementalReindex() throws Exception {
@@ -480,6 +483,7 @@ public class FileHistoryCacheTest {
      * (i.e. there should not be history entries from the default branch made
      * there after the branch was created).
      */
+    @ConditionalRun(UnixPresent.class)
     @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
     @Test
     public void testRenamedFilePlusChangesBranched() throws Exception {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/FileUtilities.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/FileUtilities.java
@@ -33,7 +33,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.index.IgnoredNames;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Various filesystem utilities used by the different test setups
@@ -53,7 +54,7 @@ public class FileUtilities {
             if (ze.isDirectory()) {
                 file.mkdirs();
             } else {
-                try (InputStream in = zipfile.getInputStream(ze); FileOutputStream out = new FileOutputStream(file)) {
+                try (InputStream in = zipfile.getInputStream(ze); OutputStream out = new FileOutputStream(file)) {
                     if (in == null) {
                         throw new IOException("Cannot get InputStream for " + ze);
                     }

--- a/testdata/repositories/mercurial/hg/hgrc
+++ b/testdata/repositories/mercurial/hg/hgrc
@@ -1,0 +1,6 @@
+[extensions]
+eol =
+
+[eol]
+native = LF
+only-consistent = True


### PR DESCRIPTION
This was originally root caused by @Orviss. The problem with the failing `FileHistoryCacheTest` tests on Windows were newlines. In particular, the `ZipFile` extraction performed by `FileUtilities` and used by `TestRepository` seems to be extracting the files from `repositories.zip` with CR LF as newlines on Windows even though the files therein were originally created on Unix.

This leads to Mercurial repository to become "dirty" right after extraction. Originally, I wanted to solve this with something like:
```java
package org.opengrok.indexer.history;
import java.io.FilterOutputStream;
import java.io.IOException;
import java.io.OutputStream;
/**
 * Convert CR LF bytes in the stream to the LF byte.
 */
public class LFOutputStream extends FilterOutputStream {
    public LFOutputStream(OutputStream out) {
        super(out);
    }
    private enum Seen { INIT, CR, LF };
    public synchronized void write(byte buffer[], int offset, int length)
            throws IOException {
        Seen last = Seen.INIT;
        for (int i = offset; i < length + offset; i++) {
            switch (buffer[i]) {
                case '\r':
                    last = Seen.CR;
                    break;
                case '\n':
                    out.write('\n');
                    last = Seen.LF;
                    break;
                default:
                    if (last == Seen.CR) {
                        out.write('\r');
                        last = Seen.INIT;
                    }
                    out.write(buffer[i]);
                    break;
            }
        }
    }
} 
```
and using it like so:
```java
try (InputStream in = zipfile.getInputStream(ze);
                     OutputStream out = Util.isWindows() ?
                             new LFOutputStream(new FileOutputStream(file)) : new FileOutputStream(file)) {
```
however even though this is trying to be as non-invasive as possible (by preserving standalone CR) this corrupts some files (namely the Bazaar repository files).

The solution for Mercurial seems to be the https://www.mercurial-scm.org/wiki/EolExtension which fixes the problem when running the tests locally in my Win7 test environment however AppVeyor still fails because after:
```java
        // Import changesets which rename one of the files in the repository.
        MercurialRepositoryTest.runHgCommand(reposRoot, "import",
            Paths.get(getClass().getResource("/history/hg-export-renamed.txt").toURI()).toString());
```
the `main2.c` file (that `main.c` got renamed to) contained one less newline than it should:
```
--- local.txt	2018-11-28 10:36:39.015766197 +0100
+++ appveyor.txt	2018-11-28 10:37:28.128477911 +0100
@@ -1,4 +1,4 @@
-/tmp/source2568971285070305602/mercurial/main.c
+C:\Users\appveyor\AppData\Local\Temp\1\source1209084693523932817\mercurial\main.c
 23 69 6e 63 6c 75 64 65 20 22 68 65 61 64 65 72
 2e 68 22 0a 0a 69 6e 74 20 6d 61 69 6e 28 69 6e
 74 20 61 72 67 63 2c 20 63 68 61 72 20 2a 2a 61
@@ -16,7 +16,7 @@
 29 70 72 69 6e 74 66 28 22 5c 6e 22 29 3b 0a 0a
 20 20 20 72 65 74 75 72 6e 20 45 58 49 54 5f 53
 55 43 43 45 53 53 3b 0a 7d 0a
-/tmp/source2568971285070305602/mercurial/main2.c
+C:\Users\appveyor\AppData\Local\Temp\1\source1209084693523932817\mercurial\main2.c
 23 69 6e 63 6c 75 64 65 20 22 68 65 61 64 65 72
 2e 68 22 0a 0a 69 6e 74 20 6d 61 69 6e 28 69 6e
 74 20 61 72 67 63 2c 20 63 68 61 72 20 2a 2a 61
@@ -31,8 +31,8 @@
 20 20 20 28 76 6f 69 64 29 70 72 69 6e 74 66 28
 22 5b 25 73 5d 20 22 2c 20 61 72 67 76 5b 69 5d
 29 3b 0a 20 20 20 7d 0a 20 20 20 28 76 6f 69 64
-29 70 72 69 6e 74 66 28 22 5c 6e 22 29 3b 0a 0a
-20 20 20 72 65 74 75 72 6e 20 61 72 67 63 20 3d
-3d 20 31 20 3f 20 45 58 49 54 5f 53 55 43 43 45
-53 53 20 3a 20 45 58 49 54 5f 46 41 49 4c 55 52
-45 3b 0a 7d 0a
+29 70 72 69 6e 74 66 28 22 5c 6e 22 29 3b 0a 20
+20 20 72 65 74 75 72 6e 20 61 72 67 63 20 3d 3d
+20 31 20 3f 20 45 58 49 54 5f 53 55 43 43 45 53
+53 20 3a 20 45 58 49 54 5f 46 41 49 4c 55 52 45
+3b 0a 7d 0a
```
This single byte difference made the test fail:
```
FileHistoryCacheTest.testRenameFileThenDoIncrementalReindex:477->assertSameEntries:105->assertSameEntry:120 expected:<13:e[55a793086da]> but was:<13:e[71041216828]>
```
This is because the file contents are fed into the SHA1 (https://www.mercurial-scm.org/wiki/Nodeid) that is the Mercurial node ID.

The `hg import` somehow applied the patch without the empty newline.

The hex dump routine BTW:
```java
/**
     * Print file contents to stdout in hexa bytes.
     * @param file file object
     * @throws IOException
     */
    private static void debugPrintFile(File file) throws IOException {
        int nr;
        byte array[] = new byte[16];

        try (FileInputStream input = new FileInputStream(file)) {
            System.out.println(file.toString());
            while ((nr = input.read(array)) > 0) {
                for (int i = 0; i < nr; i++) {
                    System.out.print(String.format("%02x ", array[i]));
                }
                System.out.println();
            }
        }
    }
```

The AppVeyor currently runs Windows server 2012 r2. The other difference is that my Win7 environment has Mercurial 4.7.1 while AppVeyor has 4.1.1.