### PR TITLE
project path needs to use /

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -50,6 +50,9 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
         ClassUtil.remarkTransientFields(Project.class);
     }
 
+    /**
+     * Path relative to source root. Uses the '/' separator on all platforms.
+     */
     private String path;
 
     /**
@@ -175,15 +178,13 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     }
 
     /**
-     * Set the path (relative from source root) this project is located It seems
-     * that you should ALWAYS prefix the path with current file.separator ,
-     * current environment should always have it set up
+     * Set the path (relative from source root) this project is located.
      *
      * @param path the relative path from source root where this project is
-     * located.
+     * located, starting with path separator.
      */
     public void setPath(String path) {
-        this.path = path;
+        this.path = Util.fixPathIfWindows(path);
     }
 
     public void setIndexed(boolean flag) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -940,7 +940,7 @@ public final class Indexer {
             // Add a project for each top-level directory in source root.
             for (File file : files) {
                 String name = file.getName();
-                String path = File.separator + name;
+                String path = '/' + name;
                 if (oldProjects.containsKey(name)) {
                     // This is an existing object. Reuse the old project,
                     // possibly with customizations, instead of creating a


### PR DESCRIPTION
There was one place which still used native path separator for project path, breaking some tests on Windows.