### PR TITLE
Use jetty-jspc. Fix opensearch.jsp exposed error.

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -400,7 +400,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <target unless="maven.test.skip">
+                            <target unless="skipTests">
                                 <ant target="-post-compile-test"/>
                             </target>
                         </configuration>

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+CDDL HEADER START
+
+The contents of this file are subject to the terms of the
+Common Development and Distribution License (the "License").
+You may not use this file except in compliance with the License.
+
+See LICENSE.txt included in this distribution for the specific
+language governing permissions and limitations under the License.
+
+When distributing Covered Code, include this CDDL HEADER in each
+file and include the License file at LICENSE.txt.
+If applicable, add the following below this CDDL HEADER, with the
+fields enclosed by brackets "[]" replaced with your own identifying
+information: Portions Copyright [yyyy] [name of copyright owner]
+
+CDDL HEADER END
+
+Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -117,6 +140,23 @@
         <finalName>source</finalName>
 
         <plugins>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-jspc-maven-plugin</artifactId>
+                <version>9.4.14.v20181114</version>
+                <executions>
+                    <execution>
+                        <id>jspc</id>
+                        <goals>
+                            <goal>jspc</goal>
+                        </goals>
+                        <configuration>
+                            <mergeFragment>false</mergeFragment>
+                            <generatedClasses>${project.build.directory}/jspc</generatedClasses>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>

--- a/opengrok-web/src/main/webapp/opensearch.jsp
+++ b/opengrok-web/src/main/webapp/opensearch.jsp
@@ -19,12 +19,13 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
-
 Portions Copyright 2011 Jens Elkner.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 --%><%@page  session="false" errorPage="error.jsp" import="
 java.util.Set,
 
+org.opengrok.indexer.web.Prefix,
 org.opengrok.indexer.web.Util"
 %>
 <%


### PR DESCRIPTION
Hello,

Please consider for integration this patch to add a jetty-jspc step to affirm that the JSP files compile without error. One JSP, `opensearch.jsp`, had an error and is fixed.

* Set `mergeFragment=false` so pre-compiled JSP classes will not be included in the WAR.
* Also, use `skipTests` not `maven.test.skip` w.r.t. the short-circuiting the setting up of testdata.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
