### PR TITLE
remove stale comment and cleanup pool of workers on KeyboardInterrupt

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/sync.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/sync.py
@@ -153,8 +153,6 @@ def main():
                                  "opengrok-sync.lock"))
     try:
         with lock.acquire(timeout=0):
-            pool = Pool(processes=int(args.workers))
-
             if args.projects:
                 dirs_to_process = args.projects
                 logger.debug("Processing directories: {}".
@@ -186,10 +184,12 @@ def main():
                 cmds_base.append(cmd_base)
 
             # Map the commands into pool of workers so they can be processed.
+            pool = Pool(processes=int(args.workers))
             try:
                 cmds_base_results = pool.map(worker, cmds_base, 1)
             except KeyboardInterrupt:
-                # XXX lock.release() or return 1 ?
+                pool.close()
+                pool.terminate()
                 sys.exit(1)
             else:
                 for cmds_base in cmds_base_results:


### PR DESCRIPTION
When adding locking to `sync.py` I was not sure whether the lock needs to be released on `sys.exit()` so a comment was added there. I made a trivial program that mimicks `sync.py` to verify no explicit cleanup is actually needed:

``` python
#!/usr/bin/env python

import os
import sys
import tempfile
from filelock import FileLock, Timeout
import time

tmpfile = os.path.join(tempfile.gettempdir(), "foo.lock")
print(tmpfile)
lock = FileLock(tmpfile)

print(os.getpid())

with lock.acquire(timeout=0):
	print("foo!")
	try:
	    time.sleep(30)
	except KeyboardInterrupt:
	    print("Interrupted")
	    sys.exit(1)

time.sleep(30)
print("done")
```

Running the program:

```
$ ./foo.py 
/var/folders/_d/2m97zqf92nlfyp17tnstfq540000gn/T/foo.lock
39196
foo!
^CInterrupted
```
while observing with dtruss:
```
$ sudo dtruss -p 39196
dtrace: system integrity protection is on, some features will not be available

SYSCALL(args) 		 = return
sigreturn(0x7FFEE1C64250, 0x1E, 0x0)		 = 0 Err#-2
dtrace: error on enabled probe ID 2172 (ID 161: syscall::write:return): invalid kernel access in action #12 at DIF offset 68
flock(0x3, 0x8, 0x0)		 = 0 0
close(0x3)		 = 0 0
sigaction(0x2, 0x7FFEE1C64528, 0x7FFEE1C64568)		 = 0 0
madvise(0x10E353000, 0x20000, 0x9)		 = 0 0
madvise(0x10E313000, 0x20000, 0x9)		 = 0 0
madvise(0x10E333000, 0x20000, 0x9)		 = 0 0
sigaltstack(0x0, 0x7FFEE1C64598, 0x0)		 = 0 0
madvise(0x10E2B2000, 0x20000, 0x9)		 = 0 0
^C
```
confirms as `0x8` argument of `flock` is `LOCK_UN` (unlock) and double confirming by looking into `filelock`'s `UnixFileLock` class (which is the implementation used on my system) does `fcntlt()` followed by `close()` in `_release()`.

Also, as part of the exit I added cleanup for the process pool.