### PR TITLE
Support ctags for historical revisions

### DIFF
--- a/dev/checkstyle/suppressions.xml
+++ b/dev/checkstyle/suppressions.xml
@@ -1,5 +1,27 @@
 <?xml version="1.0"?>
+<!--
 
+CDDL HEADER START
+
+The contents of this file are subject to the terms of the
+Common Development and Distribution License (the "License").
+You may not use this file except in compliance with the License.
+
+See LICENSE.txt included in this distribution for the specific
+language governing permissions and limitations under the License.
+
+When distributing Covered Code, include this CDDL HEADER in each
+file and include the License file at LICENSE.txt.
+If applicable, add the following below this CDDL HEADER, with the
+fields enclosed by brackets "[]" replaced with your own identifying
+information: Portions Copyright [yyyy] [name of copyright owner]
+
+CDDL HEADER END
+
+Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+
+-->
 <!DOCTYPE suppressions PUBLIC
         "-//Checkstyle//DTD SuppressionFilter Configuration 1.1//EN"
         "https://checkstyle.org/dtds/suppressions_1_1.dtd">
@@ -9,7 +31,8 @@
         |CustomExactPhraseScorer\.java|PhrasePositions\.java|PhraseQueue\.java|Summarizer\.java|
         |Summary\.java|OGKUnifiedHighlighter\.java|ResponseHeaderFilter\.java|BoundedBlockingObjectPool\.java|
         |ObjectPool\.java|ObjectValidator\.java|ObjectFactory\.java|AbstractObjectPool\.java|
-        |BlockingObjectPool\.java|OGKTextVecField\.java|OGKTextField\.java" />
+        |BlockingObjectPool\.java|OGKTextVecField\.java|OGKTextField\.java|
+        |LazilyInstantiate\.java" />
 
     <suppress checks="ParameterNumber" files="CtagsReader\.java|Definitions\.java|PerlLexHelper\.java|
         |JFlexXrefUtils\.java|RubyLexHelper\.java|FileAnalyzerFactory\.java|SearchController\.java|

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -107,6 +107,7 @@ public final class Configuration {
      * Path to {@code ctags} binary.
      */
     private String ctags;
+    private boolean webappCtags;
 
     /**
      * A defined value to specify the mandoc binary or else null so that mandoc
@@ -475,6 +476,7 @@ public final class Configuration {
         // unconditionally later.
         setUserPageSuffix("");
         setWebappLAF("default");
+        // webappCtags is default(boolean)
     }
 
     public String getRepoCmd(String clazzName) {
@@ -981,6 +983,20 @@ public final class Configuration {
 
     public void setWebappLAF(String webappLAF) {
         this.webappLAF = webappLAF;
+    }
+
+    /**
+     * Gets a value indicating if the web app should run ctags as necessary.
+     */
+    public boolean isWebappCtags() {
+        return webappCtags;
+    }
+
+    /**
+     * Sets a value indicating if the web app should run ctags as necessary.
+     */
+    public void setWebappCtags(boolean value) {
+        this.webappCtags = value;
     }
 
     public RemoteSCM getRemoteScmSupported() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarRepository.java
@@ -25,7 +25,6 @@ package org.opengrok.indexer.history;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
@@ -106,9 +105,7 @@ public class BazaarRepository extends Repository {
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
             String[] argv = {RepoCommand, "cat", "-r", rev, filename};
             process = Runtime.getRuntime().exec(argv, null, directory);
-            try (InputStream in = process.getInputStream()) {
-                copyBytes(sink, in);
-            }
+            copyBytes(sink, process.getInputStream());
             return true;
         } catch (Exception exp) {
             LOGGER.log(Level.SEVERE,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarRepository.java
@@ -19,12 +19,10 @@
 
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,6 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.BufferSink;
 import org.opengrok.indexer.util.Executor;
 
 /**
@@ -96,11 +95,10 @@ public class BazaarRepository extends Repository {
     }
 
     @Override
-    public InputStream getHistoryGet(String parent, String basename, String rev) {
-        InputStream ret = null;
+    boolean getHistoryGet(
+            BufferSink sink, String parent, String basename, String rev) {
 
         File directory = new File(getDirectoryName());
-
         Process process = null;
         try {
             String filename = (new File(parent, basename)).getCanonicalPath()
@@ -108,19 +106,10 @@ public class BazaarRepository extends Repository {
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
             String[] argv = {RepoCommand, "cat", "-r", rev, filename};
             process = Runtime.getRuntime().exec(argv, null, directory);
-
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            byte[] buffer = new byte[32 * 1024];
-            InputStream in = process.getInputStream();
-            int len;
-
-            while ((len = in.read(buffer)) != -1) {
-                if (len > 0) {
-                    out.write(buffer, 0, len);
-                }
+            try (InputStream in = process.getInputStream()) {
+                copyBytes(sink, in);
             }
-
-            ret = new ByteArrayInputStream(out.toByteArray());
+            return true;
         } catch (Exception exp) {
             LOGGER.log(Level.SEVERE,
                     "Failed to get history: " + exp.getClass().toString(), exp);
@@ -136,7 +125,7 @@ public class BazaarRepository extends Repository {
             }
         }
 
-        return ret;
+        return false;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/ClearCaseRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/ClearCaseRepository.java
@@ -19,16 +19,14 @@
 
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,6 +36,7 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.BufferSink;
 import org.opengrok.indexer.util.Executor;
 
 /**
@@ -91,8 +90,8 @@ public class ClearCaseRepository extends Repository {
     }
 
     @Override
-    public InputStream getHistoryGet(String parent, String basename, String rev) {
-        InputStream ret = null;
+    boolean getHistoryGet(
+            BufferSink sink, String parent, String basename, String rev) {
 
         File directory = new File(getDirectoryName());
 
@@ -117,28 +116,26 @@ public class ClearCaseRepository extends Repository {
             if (status != 0) {
                 LOGGER.log(Level.SEVERE, "Failed to get history: {0}",
                         executor.getErrorString());
-                return null;
+                return false;
             }
 
-            ret = new BufferedInputStream(new FileInputStream(tmp)) {
-
-                @Override
-                public void close() throws IOException {
-                    super.close();
-                    // delete the temporary file on close
-                    if (!tmp.delete()) {
-                        // failed, lets do the next best thing then ..
-                        // delete it on JVM exit
-                        tmp.deleteOnExit();
-                    }
+            try (FileInputStream in = new FileInputStream(tmp)) {
+                copyBytes(sink, in);
+            } finally {
+                // delete the temporary file on close
+                if (!tmp.delete()) {
+                    // failed, lets do the next best thing then ..
+                    // delete it on JVM exit
+                    tmp.deleteOnExit();
                 }
-            };
+            }
+            return true;
         } catch (Exception exp) {
             LOGGER.log(Level.WARNING,
                     "Failed to get history: " + exp.getClass().toString(), exp);
         }
 
-        return ret;
+        return false;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -333,7 +333,7 @@ class FileHistoryCache implements HistoryCache {
     /**
      * Store history object (encoded as XML and compressed with gzip) in a file.
      *
-     * @param history history object to store
+     * @param histNew history object to store
      * @param file file to store the history object into
      * @param repo repository for the file
      * @param mergeHistory whether to merge the history with existing or
@@ -536,9 +536,7 @@ class FileHistoryCache implements HistoryCache {
         final CountDownLatch latch = new CountDownLatch(renamed_map.size());
         AtomicInteger renamedFileHistoryCount = new AtomicInteger();
         for (final Map.Entry<String, List<HistoryEntry>> map_entry : renamed_map.entrySet()) {
-            RuntimeEnvironment.getHistoryRenamedExecutor().submit(new Runnable() {
-                @Override
-                public void run() {
+            env.getIndexerParallelizer().getHistoryRenamedExecutor().submit(() -> {
                     try {
                         doFileHistory(map_entry.getKey(), map_entry.getValue(),
                             env, repositoryF,
@@ -552,7 +550,6 @@ class FileHistoryCache implements HistoryCache {
                     } finally {
                         latch.countDown();
                     }
-                }
             });
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -27,9 +27,11 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.Reader;
 import java.nio.file.Paths;
 import java.text.ParseException;
@@ -46,6 +48,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.BufferSink;
 import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.StringUtils;
 
@@ -171,14 +174,18 @@ public class GitRepository extends Repository {
     /**
      * Try to get file contents for given revision.
      *
+     * @param sink a required target sink
+     * @param outIterations a required out array for storing the number of calls
+     * made to {@code sink}
      * @param fullpath full pathname of the file
      * @param rev revision
-     * @return contents of the file in revision rev
+     * @return {@code true} if any contents were found
      */
-    private InputStream getHistoryRev(String fullpath, String rev) {
-        InputStream ret = null;
-        File directory = new File(getDirectoryName());
+    private boolean getHistoryRev(BufferSink sink, int[] outIterations,
+            String fullpath, String rev) {
 
+        outIterations[0] = 0;
+        File directory = new File(getDirectoryName());
         try {
             /*
              * Be careful, git uses only forward slashes in its command and output (not in file path).
@@ -197,13 +204,13 @@ public class GitRepository extends Repository {
                     RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
             int status = executor.exec();
 
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
             byte[] buffer = new byte[32 * 1024];
             try (InputStream in = executor.getOutputStream()) {
                 int len;
                 while ((len = in.read(buffer)) != -1) {
                     if (len > 0) {
-                        out.write(buffer, 0, len);
+                        outIterations[0]++;
+                        sink.write(buffer, 0, len);
                     }
                 }
             }
@@ -212,22 +219,48 @@ public class GitRepository extends Repository {
              * If exit value of the process was not 0 then the file did
              * not exist or internal git error occured.
              */
-            if (status == 0) {
-                ret = new ByteArrayInputStream(out.toByteArray());
-            } else {
-                ret = null;
-            }
+            return status == 0;
         } catch (Exception exp) {
             LOGGER.log(Level.SEVERE,
                     "Failed to get history for file {0} in revision {1}: ",
                         new Object[]{fullpath, rev, exp.getClass().toString(), exp});
+            return false;
         }
+    }
 
-        return ret;
+    /**
+     * Gets the contents of a specific version of a named file into the
+     * specified target without a full, in-memory buffer.
+     *
+     * @param target a required target file which will be overwritten
+     * @param parent the name of the directory containing the file
+     * @param basename the name of the file to get
+     * @param rev the revision to get
+     * @return {@code true} if contents were found
+     * @throws java.io.IOException if an I/O error occurs
+     */
+    @Override
+    public boolean getHistoryGet(File target, String parent, String basename,
+            String rev) throws IOException {
+        try (OutputStream out = new FileOutputStream(target)) {
+            return getHistoryGet((buf, offset, n) -> out.write(buf, offset, n),
+                    parent, basename, rev);
+        }
     }
 
     @Override
-    public InputStream getHistoryGet(String parent, String basename, String rev) {
+    public InputStream getHistoryGet(String parent, String basename,
+            String rev) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        if (getHistoryGet((buf, offset, n) -> out.write(buf, offset, n),
+                parent, basename, rev)) {
+            return new ByteArrayInputStream(out.toByteArray());
+        }
+        return null;
+    }
+
+    protected boolean getHistoryGet(BufferSink sink, String parent,
+            String basename, String rev) {
         String fullpath;
         try {
             fullpath = new File(parent, basename).getCanonicalPath();
@@ -238,12 +271,13 @@ public class GitRepository extends Repository {
                     return String.format("Failed to get canonical path: %s/%s", parent, basename);
                 }
             });
-            return null;
+            return false;
         }
 
-        InputStream ret = getHistoryRev(fullpath, rev);
-
-        if (ret == null) {
+        int[] iterations = new int[1];
+        boolean ret = getHistoryRev((buf, offset, n) -> sink.write(buf, offset,
+                n), iterations, fullpath, rev);
+        if (!ret && iterations[0] < 1) {
             /*
              * If we failed to get the contents it might be that the file was
              * renamed so we need to find its original name in that revision
@@ -259,10 +293,10 @@ public class GitRepository extends Repository {
                         return String.format("Failed to get original revision: %s/%s (revision %s)", parent, basename, rev);
                     }
                 });
-                return null;
+                return false;
             }
             if (origpath != null) {
-                ret = getHistoryRev(origpath, rev);
+                ret = getHistoryRev(sink, iterations, origpath, rev);
             }
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -175,16 +175,16 @@ public class GitRepository extends Repository {
      * Try to get file contents for given revision.
      *
      * @param sink a required target sink
-     * @param outIterations a required out array for storing the number of calls
-     * made to {@code sink}
      * @param fullpath full pathname of the file
      * @param rev revision
-     * @return {@code true} if any contents were found
+     * @return a defined instance with {@code success} == {@code true} if no
+     * error occurred and with non-zero {@code iterations} if some data was
+     * transferred
      */
-    private boolean getHistoryRev(BufferSink sink, int[] outIterations,
-            String fullpath, String rev) {
+    private HistoryRevResult getHistoryRev(
+            BufferSink sink, String fullpath, String rev) {
 
-        outIterations[0] = 0;
+        HistoryRevResult result = new HistoryRevResult();
         File directory = new File(getDirectoryName());
         try {
             /*
@@ -203,29 +203,19 @@ public class GitRepository extends Repository {
             Executor executor = new Executor(Arrays.asList(argv), directory,
                     RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
             int status = executor.exec();
-
-            byte[] buffer = new byte[32 * 1024];
-            try (InputStream in = executor.getOutputStream()) {
-                int len;
-                while ((len = in.read(buffer)) != -1) {
-                    if (len > 0) {
-                        outIterations[0]++;
-                        sink.write(buffer, 0, len);
-                    }
-                }
-            }
+            result.iterations = transferExecutorOutput(sink, executor);
 
             /*
              * If exit value of the process was not 0 then the file did
              * not exist or internal git error occured.
              */
-            return status == 0;
+            result.success = (status == 0);
         } catch (Exception exp) {
             LOGGER.log(Level.SEVERE,
                     "Failed to get history for file {0} in revision {1}: ",
                         new Object[]{fullpath, rev, exp.getClass().toString(), exp});
-            return false;
         }
+        return result;
     }
 
     /**
@@ -274,10 +264,8 @@ public class GitRepository extends Repository {
             return false;
         }
 
-        int[] iterations = new int[1];
-        boolean ret = getHistoryRev((buf, offset, n) -> sink.write(buf, offset,
-                n), iterations, fullpath, rev);
-        if (!ret && iterations[0] < 1) {
+        HistoryRevResult result = getHistoryRev(sink::write, fullpath, rev);
+        if (!result.success && result.iterations < 1) {
             /*
              * If we failed to get the contents it might be that the file was
              * renamed so we need to find its original name in that revision
@@ -296,11 +284,11 @@ public class GitRepository extends Repository {
                 return false;
             }
             if (origpath != null) {
-                ret = getHistoryRev(sink, iterations, origpath, rev);
+                result = getHistoryRev(sink, origpath, rev);
             }
         }
 
-        return ret;
+        return result.success;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -24,14 +24,9 @@
 package org.opengrok.indexer.history;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -234,7 +229,7 @@ public class MercurialRepository extends Repository {
             Executor executor = new Executor(Arrays.asList(argv), directory,
                     RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
             int status = executor.exec();
-            result.iterations = transferExecutorOutput(sink, executor);
+            result.iterations = copyBytes(sink, executor.getOutputStream());
 
             /*
              * If exit value of the process was not 0 then the file did
@@ -245,37 +240,6 @@ public class MercurialRepository extends Repository {
             LOGGER.log(Level.SEVERE, "Failed to get history", exp);
         }
         return result;
-    }
-
-    /**
-     * Gets the contents of a specific version of a named file into the
-     * specified target without a full, in-memory buffer.
-     *
-     * @param target a required target file which will be overwritten
-     * @param parent the name of the directory containing the file
-     * @param basename the name of the file to get
-     * @param rev the revision to get
-     * @return {@code true} if contents were found
-     * @throws java.io.IOException if an I/O error occurs
-     */
-    @Override
-    public boolean getHistoryGet(File target, String parent, String basename,
-            String rev) throws IOException {
-        try (OutputStream out = new FileOutputStream(target)) {
-            return getHistoryGet((buf, offset, n) -> out.write(buf, offset, n),
-                    parent, basename, rev);
-        }
-    }
-
-    @Override
-    public InputStream getHistoryGet(String parent, String basename,
-            String rev) {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        if (getHistoryGet((buf, offset, n) -> out.write(buf, offset, n),
-                parent, basename, rev)) {
-            return new ByteArrayInputStream(out.toByteArray());
-        }
-        return null;
     }
 
     /**
@@ -376,10 +340,11 @@ public class MercurialRepository extends Repository {
         return (fullpath.substring(0, getDirectoryName().length() + 1) + file);
     }
 
-    protected boolean getHistoryGet(BufferSink sink, String parent,
-            String basename, String rev) {
-        String fullpath;
+    @Override
+    boolean getHistoryGet(
+            BufferSink sink, String parent, String basename, String rev) {
 
+        String fullpath;
         try {
             fullpath = new File(parent, basename).getCanonicalPath();
         } catch (IOException exp) {
@@ -404,7 +369,7 @@ public class MercurialRepository extends Repository {
                         exp.getClass().toString());
                 return false;
             }
-            if (origpath != null) {
+            if (origpath != null && !origpath.equals(fullpath)) {
                 result = getHistoryRev(sink, origpath, rev);
             }
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -27,9 +27,11 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -41,6 +43,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.BufferSink;
 import org.opengrok.indexer.util.Executor;
 
 /**
@@ -206,15 +209,19 @@ public class MercurialRepository extends Repository {
     /**
      * Try to get file contents for given revision.
      *
+     * @param sink a required target sink
+     * @param outIterations a required out array for storing the number of calls
+     * made to {@code sink}
      * @param fullpath full pathname of the file
      * @param rev revision
-     * @return contents of the file in revision rev
+     * @return {@code true} if any contents were found
      */
-    private InputStream getHistoryRev(String fullpath, String rev) {
+    private boolean getHistoryRev(BufferSink sink, int[] outIterations,
+            String fullpath, String rev) {
         InputStream ret = null;
 
+        outIterations[0] = 0;
         File directory = new File(getDirectoryName());
-
         String revision = rev;
 
         if (rev.indexOf(':') != -1) {
@@ -229,14 +236,13 @@ public class MercurialRepository extends Repository {
                     RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
             int status = executor.exec();
 
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
             byte[] buffer = new byte[32 * 1024];
             try (InputStream in = executor.getOutputStream()) {
                 int len;
-
                 while ((len = in.read(buffer)) != -1) {
                     if (len > 0) {
-                        out.write(buffer, 0, len);
+                        outIterations[0]++;
+                        sink.write(buffer, 0, len);
                     }
                 }
             }
@@ -245,14 +251,42 @@ public class MercurialRepository extends Repository {
              * If exit value of the process was not 0 then the file did
              * not exist or internal hg error occured.
              */
-            if (status == 0) {
-                ret = new ByteArrayInputStream(out.toByteArray());
-            }
+            return status == 0;
         } catch (Exception exp) {
             LOGGER.log(Level.SEVERE, "Failed to get history", exp);
+            return false;
         }
+    }
 
-        return ret;
+    /**
+     * Gets the contents of a specific version of a named file into the
+     * specified target without a full, in-memory buffer.
+     *
+     * @param target a required target file which will be overwritten
+     * @param parent the name of the directory containing the file
+     * @param basename the name of the file to get
+     * @param rev the revision to get
+     * @return {@code true} if contents were found
+     * @throws java.io.IOException if an I/O error occurs
+     */
+    @Override
+    public boolean getHistoryGet(File target, String parent, String basename,
+            String rev) throws IOException {
+        try (OutputStream out = new FileOutputStream(target)) {
+            return getHistoryGet((buf, offset, n) -> out.write(buf, offset, n),
+                    parent, basename, rev);
+        }
+    }
+
+    @Override
+    public InputStream getHistoryGet(String parent, String basename,
+            String rev) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        if (getHistoryGet((buf, offset, n) -> out.write(buf, offset, n),
+                parent, basename, rev)) {
+            return new ByteArrayInputStream(out.toByteArray());
+        }
+        return null;
     }
 
     /**
@@ -353,8 +387,8 @@ public class MercurialRepository extends Repository {
         return (fullpath.substring(0, getDirectoryName().length() + 1) + file);
     }
 
-    @Override
-    public InputStream getHistoryGet(String parent, String basename, String rev) {
+    protected boolean getHistoryGet(BufferSink sink, String parent,
+            String basename, String rev) {
         String fullpath;
 
         try {
@@ -362,11 +396,13 @@ public class MercurialRepository extends Repository {
         } catch (IOException exp) {
             LOGGER.log(Level.SEVERE,
                     "Failed to get canonical path: {0}", exp.getClass().toString());
-            return null;
+            return false;
         }
 
-        InputStream ret = getHistoryRev(fullpath, rev);
-        if (ret == null) {
+        int[] iterations = new int[1];
+        boolean ret = getHistoryRev((buf, offset, n) -> sink.write(buf, offset,
+                n), iterations, fullpath, rev);
+        if (!ret && iterations[0] < 1) {
             /*
              * If we failed to get the contents it might be that the file was
              * renamed so we need to find its original name in that revision
@@ -379,10 +415,10 @@ public class MercurialRepository extends Repository {
                 LOGGER.log(Level.SEVERE,
                         "Failed to get original revision: {0}",
                         exp.getClass().toString());
-                return null;
+                return false;
             }
             if (origpath != null) {
-                ret = getHistoryRev(origpath, rev);
+                ret = getHistoryRev(sink, iterations, origpath, rev);
             }
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MonotoneRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MonotoneRepository.java
@@ -19,17 +19,13 @@
 
 /*
  * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.BufferSink;
 import org.opengrok.indexer.util.Executor;
 
 /**
@@ -67,38 +64,25 @@ public class MonotoneRepository extends Repository {
     }
 
     @Override
-    public InputStream getHistoryGet(String parent, String basename, String rev) {
-        InputStream ret = null;
-        File directory = new File(getDirectoryName());
-        String revision = rev;
+    boolean getHistoryGet(
+            BufferSink sink, String parent, String basename, String rev) {
 
+        File directory = new File(getDirectoryName());
         try {
             String filename = (new File(parent, basename)).getCanonicalPath()
                     .substring(getDirectoryName().length() + 1);
             ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
-            String[] argv = {RepoCommand, "cat", "-r", revision, filename};
+            String[] argv = {RepoCommand, "cat", "-r", rev, filename};
             Executor executor = new Executor(Arrays.asList(argv), directory,
                     RuntimeEnvironment.getInstance().getInteractiveCommandTimeout());
-
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            byte[] buffer = new byte[32 * 1024];
-            try (InputStream in = executor.getOutputStream()) {
-                int len;
-
-                while ((len = in.read(buffer)) != -1) {
-                    if (len > 0) {
-                        out.write(buffer, 0, len);
-                    }
-                }
-            }
-
-            ret = new BufferedInputStream(new ByteArrayInputStream(out.toByteArray()));
+            copyBytes(sink, executor.getOutputStream());
+            return true;
         } catch (Exception exp) {
             LOGGER.log(Level.SEVERE,
                     "Failed to get history: {0}", exp.getClass().toString());
         }
 
-        return ret;
+        return false;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepoRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepoRepository.java
@@ -19,17 +19,17 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- */
-/*
  * Copyright (c) 2010, Trond Norbye <trond.norbye@gmail.com>. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.opengrok.indexer.util.BufferSink;
 import org.opengrok.indexer.util.Executor;
 
 /**
@@ -108,7 +108,8 @@ public class RepoRepository extends Repository {
     }
 
     @Override
-    InputStream getHistoryGet(String parent, String basename, String rev) {
+    boolean getHistoryGet(
+            BufferSink sink, String parent, String basename, String rev) {
         throw new UnsupportedOperationException("Should never be called!");
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -608,7 +608,7 @@ public abstract class Repository extends RepositoryInfo {
         return iterations;
     }
 
-    class HistoryRevResult {
+    static class HistoryRevResult {
         public boolean success;
         public int iterations;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -145,7 +146,6 @@ public class IndexDatabase {
     private List<String> directories;
     private LockFactory lockfact;
     private final BytesRef emptyBR = new BytesRef("");
-    private IndexerParallelizer parallelizer;
 
     // Directory where we store indexes
     public static final String INDEX_DIR = "index";
@@ -184,23 +184,20 @@ public class IndexDatabase {
      * Update the index database for all of the projects. Print progress to
      * standard out.
      *
-     * @param parallelizer a defined instance
      * @throws IOException if an error occurs
      */
-    public static void updateAll(IndexerParallelizer parallelizer)
-            throws IOException {
-        updateAll(parallelizer, null);
+    public static void updateAll() throws IOException {
+        updateAll(null);
     }
 
     /**
      * Update the index database for all of the projects
      *
-     * @param parallelizer a defined instance
      * @param listener where to signal the changes to the database
      * @throws IOException if an error occurs
      */
-    static void updateAll(IndexerParallelizer parallelizer,
-        IndexChangedListener listener) throws IOException {
+    static CountDownLatch updateAll(IndexChangedListener listener)
+            throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         List<IndexDatabase> dbs = new ArrayList<>();
 
@@ -212,6 +209,9 @@ public class IndexDatabase {
             dbs.add(new IndexDatabase());
         }
 
+        IndexerParallelizer parallelizer = RuntimeEnvironment.getInstance().
+                getIndexerParallelizer();
+        CountDownLatch latch = new CountDownLatch(dbs.size());
         for (IndexDatabase d : dbs) {
             final IndexDatabase db = d;
             if (listener != null) {
@@ -222,28 +222,31 @@ public class IndexDatabase {
                 @Override
                 public void run() {
                     try {
-                        db.update(parallelizer);
+                        db.update();
                     } catch (Throwable e) {
                         LOGGER.log(Level.SEVERE,
                                 String.format("Problem updating index database in directory %s: ",
                                         db.indexDirectory.getDirectory()), e);
+                    } finally {
+                        latch.countDown();
                     }
                 }
             });
         }
+        return latch;
     }
 
     /**
      * Update the index database for a number of sub-directories
      *
-     * @param parallelizer a defined instance
      * @param listener where to signal the changes to the database
      * @param paths list of paths to be indexed
      * @throws IOException if an error occurs
      */
-    public static void update(IndexerParallelizer parallelizer,
-        IndexChangedListener listener, List<String> paths) throws IOException {
+    public static void update(IndexChangedListener listener, List<String> paths)
+            throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        IndexerParallelizer parallelizer = env.getIndexerParallelizer();
         List<IndexDatabase> dbs = new ArrayList<>();
 
         for (String path : paths) {
@@ -284,7 +287,7 @@ public class IndexDatabase {
                     @Override
                     public void run() {
                         try {
-                            db.update(parallelizer);
+                            db.update();
                         } catch (Throwable e) {
                             LOGGER.log(Level.SEVERE, "An error occurred while updating index", e);
                         }
@@ -396,11 +399,9 @@ public class IndexDatabase {
     /**
      * Update the content of this index database
      *
-     * @param parallelizer a defined instance
      * @throws IOException if an error occurs
      */
-    public void update(IndexerParallelizer parallelizer)
-            throws IOException {
+    public void update() throws IOException {
         synchronized (lock) {
             if (running) {
                 throw new IOException("Indexer already running!");
@@ -409,7 +410,6 @@ public class IndexDatabase {
             interrupted = false;
         }
 
-        this.parallelizer = parallelizer;
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
         reader = null;
@@ -572,13 +572,12 @@ public class IndexDatabase {
     /**
      * Optimize all index databases
      *
-     * @param parallelizer a defined instance
      * @throws IOException if an error occurs
      */
-    static void optimizeAll(IndexerParallelizer parallelizer)
-            throws IOException {
+    static CountDownLatch optimizeAll() throws IOException {
         List<IndexDatabase> dbs = new ArrayList<>();
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        IndexerParallelizer parallelizer = env.getIndexerParallelizer();
         if (env.hasProjects()) {
             for (Project project : env.getProjectList()) {
                 dbs.add(new IndexDatabase(project));
@@ -587,6 +586,7 @@ public class IndexDatabase {
             dbs.add(new IndexDatabase());
         }
 
+        CountDownLatch latch = new CountDownLatch(dbs.size());
         for (IndexDatabase d : dbs) {
             final IndexDatabase db = d;
             if (db.isDirty()) {
@@ -594,15 +594,18 @@ public class IndexDatabase {
                     @Override
                     public void run() {
                         try {
-                            db.update(parallelizer);
+                            db.update();
                         } catch (Throwable e) {
                             LOGGER.log(Level.SEVERE,
                                 "Problem updating lucene index database: ", e);
+                        } finally {
+                            latch.countDown();
                         }
                     }
                 });
             }
         }
+        return latch;
     }
 
     /**
@@ -1173,6 +1176,8 @@ public class IndexDatabase {
         AtomicInteger successCounter = new AtomicInteger();
         AtomicInteger currentCounter = new AtomicInteger();
         AtomicInteger alreadyClosedCounter = new AtomicInteger();
+        IndexerParallelizer parallelizer = RuntimeEnvironment.getInstance().
+                getIndexerParallelizer();
         ObjectPool<Ctags> ctagsPool = parallelizer.getCtagsPool();
 
         Map<Boolean, List<IndexFileWork>> bySuccess = null;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/BoundedBlockingObjectPool.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/BoundedBlockingObjectPool.java
@@ -4,16 +4,15 @@
  * http://javawithswaranga.blogspot.com/2011/10/generic-and-concurrent-object-pool.html
  * https://dzone.com/articles/generic-and-concurrent-object : "Feel free to use
  * it, change it, add more implementations. Happy coding!"
- * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.util;
 
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -35,11 +34,11 @@ public final class BoundedBlockingObjectPool<T> extends AbstractObjectPool<T>
         BoundedBlockingObjectPool.class);
 
     private final int size;
-    private final BlockingQueue<T> objects;
+    private final LinkedBlockingDeque<T> objects;
     private final ObjectValidator<T> validator;
     private final ObjectFactory<T> objectFactory;
     private final ExecutorService executor = Executors.newCachedThreadPool();
-
+    private volatile boolean puttingLast;
     private volatile boolean shutdownCalled;
 
     public BoundedBlockingObjectPool(int size, ObjectValidator<T> validator,
@@ -49,20 +48,27 @@ public final class BoundedBlockingObjectPool<T> extends AbstractObjectPool<T>
         this.size = size;
         this.validator = validator;
 
-        objects = new LinkedBlockingQueue<>(size);
+        objects = new LinkedBlockingDeque<>(size);
         initializeObjects();
     }
 
     @Override
     public T get(long timeOut, TimeUnit unit) {
         if (!shutdownCalled) {
+            T ret = null;
             try {
-                return objects.poll(timeOut, unit);
+                ret = objects.pollFirst(timeOut, unit);
+                /*
+                 * When the queue first empties, switch to a strategy of putting
+                 * returned objects last instead of first.
+                 */
+                if (!puttingLast && objects.size() < 1) {
+                    puttingLast = true;
+                }
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
             }
-
-            return null;
+            return ret;
         }
         throw new IllegalStateException("Object pool is already shutdown");
     }
@@ -70,13 +76,20 @@ public final class BoundedBlockingObjectPool<T> extends AbstractObjectPool<T>
     @Override
     public T get() {
         if (!shutdownCalled) {
+            T ret = null;
             try {
-                return objects.take();
+                ret = objects.takeFirst();
+                /*
+                 * When the queue first empties, switch to a strategy of putting
+                 * returned objects last instead of first.
+                 */
+                if (!puttingLast && objects.size() < 1) {
+                    puttingLast = true;
+                }
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
             }
-
-            return null;
+            return ret;
         }
         throw new IllegalStateException("Object pool is already shutdown");
     }
@@ -97,7 +110,7 @@ public final class BoundedBlockingObjectPool<T> extends AbstractObjectPool<T>
     @Override
     protected void returnToPool(T t) {
         if (validator.isValid(t)) {
-            executor.submit(new ObjectReturner<T>(objects, t));
+            executor.submit(new ObjectReturner<>(objects, t, puttingLast));
         }
     }
 
@@ -112,7 +125,7 @@ public final class BoundedBlockingObjectPool<T> extends AbstractObjectPool<T>
         }
 
         t = objectFactory.createNew();
-        executor.submit(new ObjectReturner<T>(objects, t));
+        executor.submit(new ObjectReturner<>(objects, t, puttingLast));
     }
 
     @Override
@@ -127,19 +140,25 @@ public final class BoundedBlockingObjectPool<T> extends AbstractObjectPool<T>
     }
 
     private class ObjectReturner<E> implements Callable<Void> {
-        private final BlockingQueue<E> queue;
+        private final LinkedBlockingDeque<E> queue;
         private final E e;
+        private final boolean puttingLast;
 
-        ObjectReturner(BlockingQueue<E> queue, E e) {
+        ObjectReturner(LinkedBlockingDeque<E> queue, E e, boolean puttingLast) {
             this.queue = queue;
             this.e = e;
+            this.puttingLast = puttingLast;
         }
 
         @Override
         public Void call() {
             while (true) {
                 try {
-                    queue.put(e);
+                    if (puttingLast) {
+                        queue.putLast(e);
+                    } else {
+                        queue.putFirst(e);
+                    }
                     break;
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/BufferSink.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/BufferSink.java
@@ -1,0 +1,34 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.util;
+
+import java.io.IOException;
+
+/**
+ * Represents a functional interface for accepting buffers.
+ */
+@FunctionalInterface
+public interface BufferSink {
+    void write(byte[] buf, int offset, int n) throws IOException;
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/LazilyInstantiate.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/LazilyInstantiate.java
@@ -1,0 +1,111 @@
+/*
+ * The contents of this file are Copyright (c) 2014,
+ * https://programmingideaswithjake.wordpress.com/about/ made available under
+ * free license,
+ * https://programmingideaswithjake.wordpress.com/2014/10/05/java-functional-lazy-instantiation/
+ * https://github.com/EZGames/functional-java/blob/master/LICENSE :
+ * "There is no license on this code.
+ * It's true open-ware.  Do what you want with it.
+ * It's only meant to be helpful
+ * I'd prefer that you don't take credit for it, though.  You don't have to give
+ * credit; just don't take it."
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+package org.opengrok.indexer.util;
+
+import java.util.function.Supplier;
+
+/**
+ * {@code LazilyInstantiate} is a quick class to make lazily instantiating
+ * objects easy. All you need to know for working with this class is its two
+ * public methods: one static factory for creating the object, and another for
+ * initiating the instantiation and retrieval of the object.
+ * <p>
+ * Also, another benefit is that it's thread safe, but only blocks when
+ * initially instantiating the object. After that, it stops blocking and removes
+ * unnecessary checks for whether the object is instantiated.
+ * <p>
+ * Here's an example of it being used for implementing a singleton:
+ * <code>
+ * public class Singleton<br>
+ * {<br>
+ * &nbsp; &nbsp; private static Supplier&lt;Singleton&gt; instance =
+ * LazilyInstantiate.using(() -&gt; new Singleton());<br>
+ * &nbsp; &nbsp; //other fields<br>
+ * <br>
+ * &nbsp; &nbsp; public static getInstance()<br>
+ * &nbsp; &nbsp; {<br>
+ * &nbsp; &nbsp; &nbsp; &nbsp; instance.get();<br>
+ * &nbsp; &nbsp; }<br>
+ * <br>
+ * &nbsp; &nbsp; //other methods<br>
+ * <br>
+ * &nbsp; &nbsp; private Singleton()<br>
+ * &nbsp; &nbsp; {<br>
+ * &nbsp; &nbsp; &nbsp; &nbsp; //contructor stuff<br>
+ * &nbsp; &nbsp; }<br>
+ * }<br>
+ * </code>
+ * <p>
+ * So, here are the changes you'll need to apply in your code:
+ * <ul>
+ * <li>Change the type of the lazily instantiated object to a {@code Supplier}
+ * of that <i>type</i>
+ * <li>Have it set to LazilyInstantiate.using() where the argument is
+ * {@code () -> <instantiation code>} You could also use a method reference,
+ * which, for the example above, would be {@code Singleton::new} instead of
+ * {@code () -> new Singleton()}</li>
+ * <li>Whatever asks for the object, asks for the {@code Supplier} object, then
+ * {@code .get()}</li>
+ * </ul>
+ *
+ * @param <T> the type of object that you're trying to lazily instantiate
+ */
+public class LazilyInstantiate<T> implements Supplier<T> {
+
+    private final Supplier<T> supplier;
+    private Supplier<T> current;
+
+    public static <T> LazilyInstantiate<T> using(Supplier<T> supplier) {
+        return new LazilyInstantiate<>(supplier);
+    }
+
+    /**
+     * Executes the {@link #using(java.util.function.Supplier)} supplier in a
+     * thread-safe manner if it has not yet been executed, and keeps the result
+     * to provide to every caller of this method.
+     * @return the result of {@code supplier}
+     */
+    @Override
+    public T get() {
+        return current.get();
+    }
+
+    private LazilyInstantiate(Supplier<T> supplier) {
+        this.supplier = supplier;
+        this.current = () -> swapper();
+    }
+
+    //swaps the itself out for a supplier of an instantiated object
+    private synchronized T swapper() {
+        if (!Factory.class.isInstance(current)) {
+            T obj = supplier.get();
+            current = new Factory<>(obj);
+        }
+        return current.get();
+    }
+
+    private class Factory<T> implements Supplier<T> {
+
+        private final T obj;
+
+        Factory(T obj) {
+            this.obj = obj;
+        }
+
+        @Override
+        public T get() {
+            return obj;
+        }
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryTest.java
@@ -19,17 +19,17 @@
 
 /*
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
+import org.opengrok.indexer.util.BufferSink;
 
 /**
  *
@@ -158,8 +158,9 @@ public class RepositoryTest {
         }
 
         @Override
-        public InputStream getHistoryGet(String parent, String basename, String rev) {
-            return null;
+        boolean getHistoryGet(
+                BufferSink sink, String parent, String basename, String rev) {
+            return false;
         }
 
         @Override

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -60,7 +60,6 @@ import org.opengrok.indexer.util.TestRepository;
 public class IndexDatabaseTest {
 
     private static TestRepository repository;
-    private static IndexerParallelizer parallelizer;
 
     @ClassRule
     public static ConditionalRunRule rule = new ConditionalRunRule();
@@ -79,8 +78,6 @@ public class IndexDatabaseTest {
         env.setProjectsEnabled(true);
         RepositoryFactory.initializeIgnoredNames(env);
 
-        parallelizer = new IndexerParallelizer(env);
-
         // Note that all tests in this class share the index created below.
         // Ergo, if they need to modify it, this has to be done in such a way
         // so that it does not affect other tests, no matter in which order
@@ -96,11 +93,6 @@ public class IndexDatabaseTest {
     @AfterClass
     public static void tearDownClass() throws Exception {
         repository.destroy();
-
-        if (parallelizer != null) {
-            parallelizer.close();
-            parallelizer = null;
-        }
     }
 
     @Test
@@ -179,7 +171,7 @@ public class IndexDatabaseTest {
         File file = new File(repository.getSourceRoot(), projectName + File.separator + fileName);
         file.delete();
         Assert.assertFalse("file " + fileName + " not removed", file.exists());
-        idb.update(parallelizer);
+        idb.update();
 
         // Check that the data for the file has been removed.
         checkDataExistence(projectName + File.separator + fileName, false);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -77,7 +77,6 @@ import org.opengrok.indexer.util.TestRepository;
 public class IndexerTest {
 
     TestRepository repository;
-    private static IndexerParallelizer parallelizer;
 
     @Rule
     public ConditionalRunRule rule = new ConditionalRunRule();
@@ -86,16 +85,6 @@ public class IndexerTest {
     public static void setUpClass() {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         RepositoryFactory.initializeIgnoredNames(env);
-
-        parallelizer = new IndexerParallelizer(env);
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-        if (parallelizer != null) {
-            parallelizer.close();
-            parallelizer = null;
-        }
     }
 
     @Before
@@ -257,14 +246,14 @@ public class IndexerTest {
             assertNotNull(idb);
             MyIndexChangeListener listener = new MyIndexChangeListener();
             idb.addIndexChangedListener(listener);
-            idb.update(parallelizer);
+            idb.update();
             assertEquals(2, listener.files.size());
             repository.purgeData();
             RuntimeEnvironment.getInstance().setIndexVersionedFilesOnly(true);
             idb = new IndexDatabase(project);
             listener = new MyIndexChangeListener();
             idb.addIndexChangedListener(listener);
-            idb.update(parallelizer);
+            idb.update();
             assertEquals(1, listener.files.size());
             RuntimeEnvironment.getInstance().setIndexVersionedFilesOnly(false);
         } else {
@@ -340,7 +329,7 @@ public class IndexerTest {
         assertNotNull(idb);
         RemoveIndexChangeListener listener = new RemoveIndexChangeListener();
         idb.addIndexChangedListener(listener);
-        idb.update(parallelizer);
+        idb.update();
         Assert.assertEquals(5, listener.filesToAdd.size());
         listener.reset();
 
@@ -356,7 +345,7 @@ public class IndexerTest {
         fw.close();
 
         // reindex
-        idb.update(parallelizer);
+        idb.update();
         // Make sure that the file was actually processed.
         assertEquals(1, listener.removedFiles.size());
         assertEquals(1, listener.filesToAdd.size());
@@ -396,7 +385,7 @@ public class IndexerTest {
         assertNotNull(idb);
         MyIndexChangeListener listener = new MyIndexChangeListener();
         idb.addIndexChangedListener(listener);
-        idb.update(parallelizer);
+        idb.update();
         assertEquals(1, listener.files.size());
     }
 
@@ -416,14 +405,14 @@ public class IndexerTest {
         assertNotNull(idb);
         MyIndexChangeListener listener = new MyIndexChangeListener();
         idb.addIndexChangedListener(listener);
-        idb.update(parallelizer);
+        idb.update();
         assertEquals(1, listener.files.size());
         listener.reset();
         repository.addDummyFile(ppath);
-        idb.update(parallelizer);
+        idb.update();
         assertEquals("No new file added", 1, listener.files.size());
         repository.removeDummyFile(ppath);
-        idb.update(parallelizer);
+        idb.update();
         assertEquals("(added)files changed unexpectedly", 1, listener.files.size());
         assertEquals("Didn't remove the dummy file", 1, listener.removedFiles.size());
         assertEquals("Should have added then removed the same file",
@@ -462,7 +451,7 @@ public class IndexerTest {
             MyIndexChangeListener listener = new MyIndexChangeListener();
             idb.addIndexChangedListener(listener);
             System.out.println("Trying to index a special file - FIFO in this case.");
-            idb.update(parallelizer);
+            idb.update();
             assertEquals(0, listener.files.size());
 
         } else {

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web;
 
@@ -109,8 +110,10 @@ public final class WebappListener
      */
     @Override
     public void contextDestroyed(final ServletContextEvent servletContextEvent) {
-        RuntimeEnvironment.getInstance().watchDog.stop();
-        RuntimeEnvironment.getInstance().stopExpirationTimer();
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.getIndexerParallelizer().bounce();
+        env.watchDog.stop();
+        env.stopExpirationTimer();
         try {
             saveStatistics();
         } catch (IOException ex) {


### PR DESCRIPTION
Hello,

Please consider for integration this patch to support running ctags for historical revisions.

- Add `webappCtags` configuration flag, with `--webappCtags` switch, to indicate if the webapp is eligible to run ctags.
- Add `Repository.getHistoryGet()` override to allow sub-classes to override to avoid a full in-memory version; and override for Git and Mercurial.
- Revise `BoundedBlockingObjectPool` as LIFO-to-FIFO so the webapp does not start extraneous
  instances; Indexer switches to FIFO performance when the queue pool is emptied.
- make `IndexerParallelizer` a lazy property of `RuntimeEnvironment`, and make the executors of `IndexerParallelizer` also lazy properties. Move the history-related executors into `IndexerParallelizer` so the lifecycle of all indexing/history executors are controlled in the same class.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
