### PR TITLE
add serialVersionUID to silence lint

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -57,7 +57,7 @@ public class GitRepository extends Repository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GitRepository.class);
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -6126297612958508386L;
     /**
      * The property name used to obtain the client command for this repository.
      */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -50,6 +50,8 @@ import org.opengrok.indexer.util.Executor;
  */
 public abstract class Repository extends RepositoryInfo {
 
+    private static final long serialVersionUID = -203179700904894217L;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(Repository.class);
 
     /**
@@ -548,6 +550,8 @@ public abstract class Repository extends RepositoryInfo {
     }
 
     private class RepositoryDateFormat extends DateFormat {
+        private static final long serialVersionUID = -6951382723884436414L;
+
         private final Locale locale = Locale.ENGLISH;
         // NOTE: SimpleDateFormat is not thread-safe, lock must be held when used
         private final SimpleDateFormat[] formatters = new SimpleDateFormat[datePatterns.length];

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/OptionParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/OptionParser.java
@@ -114,6 +114,8 @@ public class OptionParser {
     private String epilogue;  // text emitted after options summary
     
     class DuplicateOptionName extends Exception {
+        private static final long serialVersionUID = -2807551057713512315L;
+
         public DuplicateOptionName(String message) {
             super(message);
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryTest.java
@@ -140,6 +140,7 @@ public class RepositoryTest {
     }
 
     private class RepositoryImplementation extends Repository {
+        private static final long serialVersionUID = 1686223058901603237L;
 
         @Override
         public boolean fileHasHistory(File file) {


### PR DESCRIPTION
The serial version UID checks resurfaces in IDEA build so it is necessary to address them.