### PR TITLE
fix ThreadLocal leaks in webapp

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -507,6 +507,15 @@ public class AnalyzerGuru {
     }
 
     /**
+     * Free resources associated with all registered analyzers.
+     */
+    public static void returnAnalyzers() {
+        for (FileAnalyzerFactory analyzer : factories) {
+            analyzer.returnAnalyzer();
+        }
+    }
+
+    /**
      * Populate a Lucene document with the required fields.
      *
      * @param doc The document to populate

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzerFactory.java
@@ -205,6 +205,9 @@ public class FileAnalyzerFactory {
         return fa;
     }
 
+    /**
+     * Free thread-local data.
+     */
     public void returnAnalyzer() {
         cachedAnalyzer.remove();
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzerFactory.java
@@ -205,6 +205,10 @@ public class FileAnalyzerFactory {
         return fa;
     }
 
+    public void returnAnalyzer() {
+        cachedAnalyzer.remove();
+    }
+
     /**
      * Create a new analyzer.
      * @return an analyzer

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -33,6 +33,7 @@ import javax.servlet.ServletRequestEvent;
 import javax.servlet.ServletRequestListener;
 import org.json.simple.parser.ParseException;
 import org.opengrok.indexer.Info;
+import org.opengrok.indexer.analysis.plain.PlainAnalyzerFactory;
 import org.opengrok.indexer.authorization.AuthorizationFramework;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -135,6 +136,9 @@ public final class WebappListener
         if (sh != null) {
             sh.destroy();
         }
+
+        PlainAnalyzerFactory fac = PlainAnalyzerFactory.DEFAULT_INSTANCE;
+        fac.returnAnalyzer();
     }
 
     /**

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -22,24 +22,25 @@
  */
 package org.opengrok.web;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-import javax.servlet.ServletRequestEvent;
-import javax.servlet.ServletRequestListener;
 import org.json.simple.parser.ParseException;
 import org.opengrok.indexer.Info;
-import org.opengrok.indexer.analysis.plain.PlainAnalyzerFactory;
+import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.authorization.AuthorizationFramework;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.web.PageConfig;
 import org.opengrok.indexer.web.SearchHelper;
 import org.opengrok.web.api.v1.suggester.provider.service.SuggesterServiceFactory;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletRequestEvent;
+import javax.servlet.ServletRequestListener;
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.opengrok.indexer.util.StatisticsUtils.loadStatistics;
 import static org.opengrok.indexer.util.StatisticsUtils.saveStatistics;
@@ -137,7 +138,7 @@ public final class WebappListener
             sh.destroy();
         }
 
-        PlainAnalyzerFactory.DEFAULT_INSTANCE.returnAnalyzer();
+        AnalyzerGuru.returnAnalyzers();
     }
 
     /**

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -137,8 +137,7 @@ public final class WebappListener
             sh.destroy();
         }
 
-        PlainAnalyzerFactory fac = PlainAnalyzerFactory.DEFAULT_INSTANCE;
-        fac.returnAnalyzer();
+        PlainAnalyzerFactory.DEFAULT_INSTANCE.returnAnalyzer();
     }
 
     /**

--- a/opengrok-web/src/test/java/org/opengrok/web/WebappListenerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/WebappListenerTest.java
@@ -1,0 +1,25 @@
+package org.opengrok.web;
+
+import org.junit.Test;
+import org.opengrok.indexer.web.DummyHttpServletRequest;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRequestEvent;
+
+import static org.mockito.Mockito.mock;
+
+public class WebappListenerTest {
+    /**
+     * simple smoke test for WebappListener request handling
+     */
+    @Test
+    public void testRequest() {
+        WebappListener wl = new WebappListener();
+        DummyHttpServletRequest req = new DummyHttpServletRequest();
+        final ServletContext servletContext = mock(ServletContext.class);
+        ServletRequestEvent event = new ServletRequestEvent(servletContext, req);
+
+        wl.requestInitialized(event);
+        wl.requestDestroyed(event);
+    }
+}

--- a/opengrok-web/src/test/java/org/opengrok/web/WebappListenerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/WebappListenerTest.java
@@ -1,12 +1,13 @@
 package org.opengrok.web;
 
 import org.junit.Test;
-import org.opengrok.indexer.web.DummyHttpServletRequest;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRequestEvent;
+import javax.servlet.http.HttpServletRequest;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class WebappListenerTest {
     /**
@@ -15,8 +16,9 @@ public class WebappListenerTest {
     @Test
     public void testRequest() {
         WebappListener wl = new WebappListener();
-        DummyHttpServletRequest req = new DummyHttpServletRequest();
+        final HttpServletRequest req = mock(HttpServletRequest.class);
         final ServletContext servletContext = mock(ServletContext.class);
+        when(req.getServletContext()).thenReturn(servletContext);
         ServletRequestEvent event = new ServletRequestEvent(servletContext, req);
 
         wl.requestInitialized(event);


### PR DESCRIPTION
This change fixes the majority of memory leaks reported by Tomcat when redeploying the webapp.

To trigger the leaks it was sufficient to perform all project search in my staging environment and then restart/redeploy the webapp to see Tomcat report the leaks.

Before:
```
10-Dec-2018 12:57:23.277 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@4050fe0d]) and a value of type [org.opengrok.indexer.analysis.scala.ScalaAnalyzer] (value [org.opengrok.indexer.analysis.scala.ScalaAnalyzer@7de08937]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.277 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@7e6c6643]) and a value of type [org.opengrok.indexer.analysis.c.CxxAnalyzer] (value [org.opengrok.indexer.analysis.c.CxxAnalyzer@161ad1a7]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.277 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@51fde5ff]) and a value of type [org.opengrok.indexer.analysis.eiffel.EiffelAnalyzer] (value [org.opengrok.indexer.analysis.eiffel.EiffelAnalyzer@282d77c6]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.277 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@356e52fe]) and a value of type [org.opengrok.indexer.analysis.json.JsonAnalyzer] (value [org.opengrok.indexer.analysis.json.JsonAnalyzer@75392a1d]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.277 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@4b55fb58]) and a value of type [org.opengrok.indexer.analysis.FileAnalyzer] (value [org.opengrok.indexer.analysis.FileAnalyzer@88526b3]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.278 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@736edec7]) and a value of type [org.opengrok.indexer.analysis.fortran.FortranAnalyzer] (value [org.opengrok.indexer.analysis.fortran.FortranAnalyzer@170564c9]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.278 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@36947824]) and a value of type [org.opengrok.indexer.analysis.FileAnalyzer] (value [org.opengrok.indexer.analysis.FileAnalyzer@22dc368d]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.278 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@27414cf7]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@1bde47fa]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.278 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@e9e59fd]) and a value of type [org.opengrok.indexer.analysis.php.PhpAnalyzer] (value [org.opengrok.indexer.analysis.php.PhpAnalyzer@4d357efd]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.278 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@603ea558]) and a value of type [org.opengrok.indexer.analysis.c.CAnalyzer] (value [org.opengrok.indexer.analysis.c.CAnalyzer@9b6df32]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.279 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@759b3e48]) and a value of type [org.opengrok.indexer.analysis.pascal.PascalAnalyzer] (value [org.opengrok.indexer.analysis.pascal.PascalAnalyzer@13bf6490]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.279 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@63e07da]) and a value of type [org.opengrok.indexer.analysis.javascript.JavaScriptAnalyzer] (value [org.opengrok.indexer.analysis.javascript.JavaScriptAnalyzer@39ce0760]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.279 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@150b076f]) and a value of type [org.opengrok.indexer.analysis.document.TroffAnalyzer] (value [org.opengrok.indexer.analysis.document.TroffAnalyzer@7df87aba]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.279 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@b0ea208]) and a value of type [org.opengrok.indexer.analysis.clojure.ClojureAnalyzer] (value [org.opengrok.indexer.analysis.clojure.ClojureAnalyzer@4232410e]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.279 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@f4f0658]) and a value of type [org.opengrok.indexer.analysis.erlang.ErlangAnalyzer] (value [org.opengrok.indexer.analysis.erlang.ErlangAnalyzer@31dc80a1]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.279 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@4f3c6a70]) and a value of type [org.opengrok.indexer.analysis.python.PythonAnalyzer] (value [org.opengrok.indexer.analysis.python.PythonAnalyzer@1fd668a8]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.279 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@68dcc0cc]) and a value of type [org.opengrok.indexer.analysis.executables.JarAnalyzer] (value [org.opengrok.indexer.analysis.executables.JarAnalyzer@3d508cfe]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.280 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@33f8dab5]) and a value of type [org.opengrok.indexer.analysis.haskell.HaskellAnalyzer] (value [org.opengrok.indexer.analysis.haskell.HaskellAnalyzer@af69748]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.280 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@31a9db6]) and a value of type [org.opengrok.indexer.analysis.uue.UuencodeAnalyzer] (value [org.opengrok.indexer.analysis.uue.UuencodeAnalyzer@5b55ddee]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.280 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@2e8d9943]) and a value of type [org.opengrok.indexer.analysis.archive.BZip2Analyzer] (value [org.opengrok.indexer.analysis.archive.BZip2Analyzer@107f070d]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.280 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@47dfcf99]) and a value of type [org.opengrok.indexer.analysis.lisp.LispAnalyzer] (value [org.opengrok.indexer.analysis.lisp.LispAnalyzer@3210c021]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.280 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@701510a1]) and a value of type [org.opengrok.indexer.analysis.csharp.CSharpAnalyzer] (value [org.opengrok.indexer.analysis.csharp.CSharpAnalyzer@183a26c1]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.281 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@21a09158]) and a value of type [org.opengrok.indexer.analysis.ada.AdaAnalyzer] (value [org.opengrok.indexer.analysis.ada.AdaAnalyzer@15855c85]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.281 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@4d4dc68c]) and a value of type [org.opengrok.indexer.analysis.kotlin.KotlinAnalyzer] (value [org.opengrok.indexer.analysis.kotlin.KotlinAnalyzer@408fdca]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.281 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@21879642]) and a value of type [org.opengrok.indexer.analysis.executables.ELFAnalyzer] (value [org.opengrok.indexer.analysis.executables.ELFAnalyzer@1e598783]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.281 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@3d834b62]) and a value of type [org.opengrok.indexer.analysis.sql.SQLAnalyzer] (value [org.opengrok.indexer.analysis.sql.SQLAnalyzer@7ea607b5]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.281 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@638eaba5]) and a value of type [org.opengrok.indexer.analysis.sh.ShAnalyzer] (value [org.opengrok.indexer.analysis.sh.ShAnalyzer@31b94dc8]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.282 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@1646d8c6]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@5813fe14]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.282 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@4e56a530]) and a value of type [org.opengrok.indexer.analysis.rust.RustAnalyzer] (value [org.opengrok.indexer.analysis.rust.RustAnalyzer@35fa663f]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.282 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@15da18ae]) and a value of type [org.opengrok.indexer.analysis.archive.ZipAnalyzer] (value [org.opengrok.indexer.analysis.archive.ZipAnalyzer@52fea75f]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.282 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@29fae715]) and a value of type [org.opengrok.indexer.analysis.golang.GolangAnalyzer] (value [org.opengrok.indexer.analysis.golang.GolangAnalyzer@4f57a78b]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.282 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@a8dc9a7]) and a value of type [org.opengrok.indexer.analysis.archive.GZIPAnalyzer] (value [org.opengrok.indexer.analysis.archive.GZIPAnalyzer@2d6e53f6]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.282 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@53d2db01]) and a value of type [org.opengrok.indexer.analysis.plain.XMLAnalyzer] (value [org.opengrok.indexer.analysis.plain.XMLAnalyzer@21cb450f]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.283 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@456f7060]) and a value of type [org.opengrok.indexer.analysis.tcl.TclAnalyzer] (value [org.opengrok.indexer.analysis.tcl.TclAnalyzer@1ac16ad8]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.283 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@5f0eb052]) and a value of type [org.opengrok.indexer.analysis.vb.VBAnalyzer] (value [org.opengrok.indexer.analysis.vb.VBAnalyzer@24967581]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.283 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@1a44fd03]) and a value of type [org.opengrok.indexer.analysis.ruby.RubyAnalyzer] (value [org.opengrok.indexer.analysis.ruby.RubyAnalyzer@bc2d339]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.283 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@21e46e33]) and a value of type [org.opengrok.indexer.analysis.swift.SwiftAnalyzer] (value [org.opengrok.indexer.analysis.swift.SwiftAnalyzer@36c92df3]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.283 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@bd862cc]) and a value of type [org.opengrok.indexer.analysis.executables.JavaClassAnalyzer] (value [org.opengrok.indexer.analysis.executables.JavaClassAnalyzer@161e3395]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.284 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@14895293]) and a value of type [org.opengrok.indexer.analysis.sql.PLSQLAnalyzer] (value [org.opengrok.indexer.analysis.sql.PLSQLAnalyzer@6b504344]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.284 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@23d682e0]) and a value of type [org.opengrok.indexer.analysis.powershell.PowershellAnalyzer] (value [org.opengrok.indexer.analysis.powershell.PowershellAnalyzer@44b39f94]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.284 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@1af0505b]) and a value of type [org.opengrok.indexer.analysis.FileAnalyzer] (value [org.opengrok.indexer.analysis.FileAnalyzer@73536a22]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.284 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@6405272a]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@3c124b01]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.284 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@2478a650]) and a value of type [org.opengrok.indexer.analysis.perl.PerlAnalyzer] (value [org.opengrok.indexer.analysis.perl.PerlAnalyzer@4c92ca87]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.284 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@1638848]) and a value of type [org.opengrok.indexer.analysis.archive.TarAnalyzer] (value [org.opengrok.indexer.analysis.archive.TarAnalyzer@2f079126]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.284 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@4e2ce8b0]) and a value of type [org.opengrok.indexer.analysis.lua.LuaAnalyzer] (value [org.opengrok.indexer.analysis.lua.LuaAnalyzer@1430c500]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.285 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@98c2e06]) and a value of type [org.opengrok.indexer.analysis.java.JavaAnalyzer] (value [org.opengrok.indexer.analysis.java.JavaAnalyzer@1a9110b0]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.285 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@3351123a]) and a value of type [org.opengrok.indexer.analysis.document.MandocAnalyzer] (value [org.opengrok.indexer.analysis.document.MandocAnalyzer@21dbd995]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.285 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@1646d8c6]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@49cf3fb6]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.285 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@27414cf7]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@5b49a2af]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.285 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@6405272a]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@1f5ac1cc]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.286 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@1646d8c6]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@2fd86f1e]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.286 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@6405272a]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@4c8c5bc7]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 12:57:23.286 SEVERE [localhost-startStop-1] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@27414cf7]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@591b73b]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
```

After:
```
10-Dec-2018 13:09:33.301 SEVERE [localhost-startStop-3] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@ed0c738]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@4cc9403f]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 13:09:33.301 SEVERE [localhost-startStop-3] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@29b72fb4]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@6623efb1]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 13:09:33.301 SEVERE [localhost-startStop-3] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@6e420d4a]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@680c6005]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 13:09:33.302 SEVERE [localhost-startStop-3] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@ed0c738]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@74a02063]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 13:09:33.302 SEVERE [localhost-startStop-3] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@6e420d4a]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@3dfee918]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
10-Dec-2018 13:09:33.302 SEVERE [localhost-startStop-3] org.apache.catalina.loader.WebappClassLoaderBase.checkThreadLocalMapForLeaks The web application [source] created a ThreadLocal with key of type [java.lang.ThreadLocal] (value [java.lang.ThreadLocal@29b72fb4]) and a value of type [net.openhft.chronicle.hash.impl.ContextHolder] (value [net.openhft.chronicle.hash.impl.ContextHolder@704cbaad]) but failed to remove it when the web application was stopped. Threads are going to be renewed over time to try and avoid a probable memory leak.
```