### PR TITLE
Fix #2604, add TandemFilename and TandemPath

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/GZIPAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/GZIPAnalyzer.java
@@ -27,6 +27,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
@@ -79,8 +80,7 @@ public class GZIPAnalyzer extends FileAnalyzer {
 
         StreamSource gzSrc = wrap(src);
         String path = doc.get("path");
-        if (path != null
-                && (path.endsWith(".gz") || path.endsWith(".GZ") || path.endsWith(".Gz"))) {
+        if (path != null && path.toLowerCase(Locale.ROOT).endsWith(".gz")) {
             String newname = path.substring(0, path.length() - 3);
             //System.err.println("GZIPPED OF = " + newname);
             try (InputStream gzis = gzSrc.getStream()) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -59,6 +59,7 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
 import org.opengrok.indexer.util.IOUtils;
+import org.opengrok.indexer.util.TandemPath;
 
 /*
  * Class representing file based storage of per source file history.
@@ -213,13 +214,12 @@ class FileHistoryCache implements HistoryCache {
                 sb.append(File.separator);
                 sb.append(DIRECTORY_FILE_PREFIX);
             }
-            sb.append(".gz");
         } catch (IOException e) {
             throw new HistoryException("Failed to get path relative to " +
                     "source root for " + file, e);
         }
 
-        return new File(sb.toString());
+        return new File(TandemPath.join(sb.toString(), ".gz"));
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -98,6 +98,7 @@ import org.opengrok.indexer.util.ForbiddenSymlinkException;
 import org.opengrok.indexer.util.IOUtils;
 import org.opengrok.indexer.util.ObjectPool;
 import org.opengrok.indexer.util.Statistics;
+import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.Util;
 
 import javax.ws.rs.client.ClientBuilder;
@@ -685,7 +686,8 @@ public class IndexDatabase {
     }
 
     private File whatXrefFile(String path, boolean compress) {
-        return new File(xrefDir, path + (compress ? ".gz" : ""));
+        String xrefPath = compress ? TandemPath.join(path, ".gz") : path;
+        return new File(xrefDir, xrefPath);
     }
 
     /**
@@ -1612,8 +1614,8 @@ public class IndexDatabase {
 
             // Write to a pending file for later renaming.
             String xrefAbs = xrefFile.getAbsolutePath();
-            File transientXref = new File(xrefAbs +
-                PendingFileCompleter.PENDING_EXTENSION);
+            File transientXref = new File(TandemPath.join(xrefAbs,
+                PendingFileCompleter.PENDING_EXTENSION));
             PendingFileRenaming ren = new PendingFileRenaming(xrefAbs,
                 transientXref.getAbsolutePath());
             completer.add(ren);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
@@ -44,6 +44,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.TandemPath;
 
 /**
  * Represents a tracker of pending file deletions and renamings that can later
@@ -319,7 +320,7 @@ class PendingFileCompleter {
     }
 
     private void doDelete(PendingFileDeletionExec del) throws IOException {
-        File f = new File(del.absolutePath + PENDING_EXTENSION);
+        File f = new File(TandemPath.join(del.absolutePath, PENDING_EXTENSION));
         File parent = f.getParentFile();
         del.absoluteParent = parent;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
@@ -56,6 +56,7 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.IOUtils;
+import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.Prefix;
 import org.opengrok.indexer.web.SearchHelper;
 import org.opengrok.indexer.web.Util;
@@ -116,9 +117,9 @@ public final class Results {
             int len = r.read(content);
             return new String(content, 0, len);
         } catch (Exception e) {
-            LOGGER.log(
-                    Level.WARNING, "An error reading tags from " + basedir + path
-                    + (compressed ? ".gz" : ""), e);
+            String fnm = compressed ? TandemPath.join(basedir + path, ".gz") :
+                    basedir + path;
+            LOGGER.log(Level.WARNING, "An error reading tags from " + fnm, e);
         }
         return "";
     }
@@ -127,13 +128,14 @@ public final class Results {
     private static Reader getXrefReader(
                     File basedir, String path, boolean compressed)
             throws IOException {
-        /**
+        /*
          * For backward compatibility, read the OpenGrok-produced document
          * using the system default charset.
          */
         if (compressed) {
             return new BufferedReader(IOUtils.createBOMStrippedReader(
-                    new GZIPInputStream(new FileInputStream(new File(basedir, path + ".gz")))));
+                    new GZIPInputStream(new FileInputStream(new File(basedir,
+                            TandemPath.join(path, ".gz"))))));
         } else {
             return new BufferedReader(IOUtils.createBOMStrippedReader(
                     new FileInputStream(new File(basedir, path))));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -67,6 +67,7 @@ import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.search.Summary.Fragment;
 import org.opengrok.indexer.search.context.Context;
 import org.opengrok.indexer.search.context.HistoryContext;
+import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.PageConfig;
 import org.opengrok.indexer.web.Prefix;
 import org.opengrok.indexer.web.ProjectHelper;
@@ -521,7 +522,8 @@ public class SearchEngine {
                              * default charset.
                              */
                             try (Reader r = RuntimeEnvironment.getInstance().isCompressXref()
-                                    ? new HTMLStripCharFilter(new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(data + Prefix.XREF_P + filename + ".gz")))))
+                                    ? new HTMLStripCharFilter(new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(
+                                            TandemPath.join(data + Prefix.XREF_P + filename, ".gz"))))))
                                     : new HTMLStripCharFilter(new BufferedReader(new FileReader(data + Prefix.XREF_P + filename)))) {
                                 l = r.read(content);
                             }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/TandemFilename.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/TandemFilename.java
@@ -1,0 +1,173 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.util;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+
+/**
+ * Represents a utility class for creating a filename to operate in tandem with
+ * an original filename by adding a new file extension but limiting the length
+ * of the new filename to 255 UTF-8 encoded bytes if necessary by truncating
+ * and packing in a Base64-encoded SHA-256 hash of the original file name.
+ */
+public class TandemFilename {
+
+    private static final int MAX_BYTES = 255;
+
+    /**
+     * One fewer than {@link #MAX_BYTES} as a cap for simple concatenation to
+     * avoid the possibility of easily fabricating a collision against this
+     * algorithm. I.e., a 255 byte tandem filename will always include a
+     * computed hash and not just be the concatenation of original filename
+     * plus new extension.
+     */
+    private static final int MAX_CAT_BYTES = MAX_BYTES - 1;
+
+    /**
+     * "Instances of Base64.Encoder class are safe for use by multiple
+     * concurrent threads." --Oracle.
+     */
+    private static final Base64.Encoder encoder = Base64.getUrlEncoder();
+
+    /** private to enforce static */
+    private TandemFilename() {
+    }
+
+    /**
+     * Appends an ASCII extension to the specified {@code filename}, truncating
+     * and packing in a SHA-256 hash if the UTF-8 encoding would exceed 254
+     * bytes and arriving at a final size of 255 bytes in that special case.
+     * @param filename a defined instance
+     * @param asciiExtension a defined instance that is expected to be only
+     *                       ASCII so that its UTF-8 form is the same length
+     * @return a transformed filename whose UTF-8 encoding is not more than 255
+     * bytes.
+     * @throws IllegalArgumentException thrown if {@code filename} has a
+     * parent or if {@code asciiExtension} is too long to allow packing a
+     * SHA-256 hash in the transformation.
+     */
+    public static String join(String filename, String asciiExtension) {
+
+        File file = new File(filename);
+        if (file.getParent() != null) {
+            throw new IllegalArgumentException("filename can't have parent");
+        }
+
+        /*
+         * If the original filename length * 4 (for longest possible UTF-8
+         * encoding) plus asciiExtension length is not greater than one less
+         * than 255, then quickly return the concatenation.
+         */
+        if (filename.length() * 4 + asciiExtension.length() <= MAX_CAT_BYTES) {
+            return filename + asciiExtension;
+        }
+        return maybePackSha(filename, asciiExtension);
+    }
+
+    private static String maybePackSha(String filename, String asciiExtension) {
+
+        byte[] uFilename = filename.getBytes(StandardCharsets.UTF_8);
+        int nBytes = uFilename.length;
+        if (nBytes + asciiExtension.length() <= MAX_CAT_BYTES) {
+            // Here the UTF-8 encoding already allows for the new extension.
+            return filename + asciiExtension;
+        }
+
+        /*
+         * If filename has an ASCII extension already (of a reasonable length),
+         * shift it to the new asciiExtension so that it won't be overwritten
+         * by the packed hash.
+         */
+        int pos = filename.lastIndexOf('.');
+        int extLength = filename.length() - pos;
+        if (pos >= 0 && extLength < 30 && extLength > 1) {
+            int i;
+            for (i = pos + 1; i < filename.length(); ++i) {
+                char ch = filename.charAt(i);
+                if (!Character.isLetterOrDigit(ch) || ch > 'z') {
+                    break;
+                }
+            }
+            if (i >= filename.length()) {
+                // By this point, we affirmed a letters/numbers extension.
+                asciiExtension = filename.substring(pos) + asciiExtension;
+                filename = filename.substring(0, pos);
+                uFilename = filename.getBytes(StandardCharsets.UTF_8);
+                nBytes = uFilename.length;
+            }
+        }
+
+        // Pack the hash just before the file extension.
+        asciiExtension = sha256base64(filename) + asciiExtension;
+
+        /*
+         * Now trim the filename by code points until the full UTF-8 encoding
+         * fits within MAX_BYTES.
+         */
+        int newLength = filename.length();
+        while (nBytes + asciiExtension.length() > MAX_BYTES) {
+            int cp = filename.codePointBefore(newLength);
+            int nChars = Character.charCount(cp);
+            String c = filename.substring(newLength - nChars, newLength);
+            nBytes -= c.getBytes(StandardCharsets.UTF_8).length;
+            newLength -= nChars;
+
+            if (newLength <= 0) {
+                throw new IllegalArgumentException("asciiExtension too long");
+            }
+        }
+
+        // Pad if necessary to exactly MAX_BYTES.
+        if (nBytes + asciiExtension.length() != MAX_BYTES) {
+            char[] pad = new char[MAX_BYTES - nBytes - asciiExtension.length()];
+            Arrays.fill(pad, '_');
+            asciiExtension = new String(pad) + asciiExtension;
+        }
+
+        return filename.substring(0, newLength) + asciiExtension;
+    }
+
+    private static String sha256base64(String value) {
+
+        MessageDigest hasher;
+        try {
+            hasher = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            /*
+             * This will not happen since "Every implementation of the Java
+             * platform is required to support the following standard
+             * MessageDigest algorithms: MD5, SHA-1, SHA-256."
+             */
+            throw new RuntimeException(e);
+        }
+
+        byte[] digest = hasher.digest(value.getBytes(StandardCharsets.UTF_8));
+        return encoder.encodeToString(digest);
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/TandemPath.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/TandemPath.java
@@ -1,0 +1,61 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.util;
+
+import java.io.File;
+
+/**
+ * Represents a utility class for creating a path to operate in tandem with
+ * an original path by adding a new file extension but limiting the length
+ * of the filename component of the new path to 255 UTF-8 encoded bytes if
+ * necessary by truncating and packing in a Base64-encoded SHA-256 hash of the
+ * original file name component.
+ */
+public class TandemPath {
+
+    /** private to enforce static */
+    private TandemPath() {
+    }
+
+    /**
+     * Appends an ASCII extension to the specified {@code filePath}, truncating
+     * and packing in a SHA-256 hash if the UTF-8 encoding of the filename
+     * component of the path would exceed 254 bytes and arriving at a final
+     * size of 255 bytes in that special case.
+     * @param filePath a defined instance
+     * @param asciiExtension a defined instance that is expected to be only
+     *                       ASCII so that its UTF-8 form is the same length
+     * @return a transformed path whose filename component's UTF-8 encoding is
+     * not more than 255 bytes.
+     * @throws IllegalArgumentException {@code asciiExtension} is too long to
+     * allow packing a SHA-256 hash in the transformation.
+     */
+    public static String join(String filePath, String asciiExtension) {
+
+        File file = new File(filePath);
+        String newName = TandemFilename.join(file.getName(), asciiExtension);
+        File newFile = new File(file.getParent(), newName);
+        return newFile.getPath();
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions copyright (c) 2011 Jens Elkner.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -74,6 +74,7 @@ import org.opengrok.indexer.index.IgnoredNames;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.IOUtils;
+import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.messages.MessagesContainer.AcceptedMessage;
 import org.suigeneris.jrcs.diff.Diff;
 import org.suigeneris.jrcs.diff.DifferentiationFailedException;
@@ -873,7 +874,7 @@ public final class PageConfig {
      * Get the parameter values for the given name. Splits comma separated
      * values automatically into a list of Strings.
      *
-     * @param name name of the parameter.
+     * @param paramName name of the parameter.
      * @return a possible empty list.
      */
     private List<String> getParamVals(String paramName) {
@@ -1185,7 +1186,7 @@ public final class PageConfig {
     private File checkFile(File dir, String name, boolean compressed) {
         File f;
         if (compressed) {
-            f = new File(dir, name + ".gz");
+            f = new File(dir, TandemPath.join(name, ".gz"));
             if (f.exists() && f.isFile()
                     && f.lastModified() >= resourceFile.lastModified()) {
                 return f;
@@ -1206,7 +1207,7 @@ public final class PageConfig {
         }
         File f;
         if (compressed) {
-            f = new File(dir, name + ".gz");
+            f = new File(dir, TandemPath.join(name, ".gz"));
             if (f.exists() && f.isFile()
                     && f.lastModified() >= lresourceFile.lastModified()) {
                 return f;
@@ -1571,7 +1572,6 @@ public final class PageConfig {
     /**
      * Get basename of the path or "/" if the path is empty.
      * This is used for setting title of various pages.
-     * @param path
      * @return short version of the path
      */
     public String getShortPath(String path) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/condition/DeliberateRuntimeException.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/condition/DeliberateRuntimeException.java
@@ -17,8 +17,8 @@
  * CDDL HEADER END
  */
 
- /*
- * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+/*
+ * Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.condition;
 
@@ -29,6 +29,8 @@ package org.opengrok.indexer.condition;
  * https://stackoverflow.com/questions/1754315/how-to-create-custom-exceptions-in-java
  */
 public class DeliberateRuntimeException extends RuntimeException {
+      private static final long serialVersionUID = 7870938126523334656L;
+
       public DeliberateRuntimeException() { super(); }
       public DeliberateRuntimeException(String message) { super(message); }
       public DeliberateRuntimeException(String message, Throwable cause) { super(message, cause); }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -31,6 +32,7 @@ import org.opengrok.indexer.condition.ConditionalRunRule;
 import org.opengrok.indexer.condition.RepositoryInstalled;
 import org.opengrok.indexer.condition.UnixPresent;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.util.TestRepository;
 
 import java.io.File;
@@ -625,7 +627,7 @@ public class FileHistoryCacheTest {
         // FetchHistoryWhenNotInCache is set to false.
         File dataRoot = new File(repositories.getDataRoot(),
                 "historycache" + File.separatorChar + reponame);
-        File fileHistory = new File(dataRoot, filename + ".gz");
+        File fileHistory = new File(dataRoot, TandemPath.join(filename, ".gz"));
         assertEquals(historyFileExists, fileHistory.exists());
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -50,6 +50,7 @@ import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.history.RepositoryFactory;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.search.SearchEngine;
+import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.util.TestRepository;
 
 /**
@@ -134,7 +135,7 @@ public class IndexDatabaseTest {
 
         for (String dirName : new String[]{"historycache", IndexDatabase.XREF_DIR}) {
             File dataDir = new File(env.getDataRootFile(), dirName);
-            File dataFile = new File(dataDir, fileName + ".gz");
+            File dataFile = new File(dataDir, TandemPath.join(fileName, ".gz"));
 
             if (shouldExist) {
                 Assert.assertTrue("file " + fileName + " not found in " + dirName,
@@ -149,12 +150,9 @@ public class IndexDatabaseTest {
     /**
      * Test removal of IndexDatabase. xrefs and history index entries after
      * file has been removed from a repository.
-     *
-     * @throws Exception 
      */
     @Test
     public void testCleanupAfterIndexRemoval() throws Exception {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         final int origNumFiles;
 
         String projectName = "git";
@@ -190,7 +188,6 @@ public class IndexDatabaseTest {
     /**
      * This is a test of {@code populateDocument} so it should be rather in {@code AnalyzerGuruTest}
      * however it lacks the pre-requisite indexing phase.
-     * @throws IOException
      */
     @Test
     public void testIndexPath() throws IOException {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -66,6 +66,7 @@ import org.opengrok.indexer.history.RepositoryFactory;
 import org.opengrok.indexer.history.RepositoryInfo;
 import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.FileUtilities;
+import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.util.TestRepository;
 
 /**
@@ -306,7 +307,8 @@ public class IndexerTest {
             // followed by {@code addFile()} that will create the file again.
             if (path.equals("/mercurial/bar.txt")) {
                 RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-                File f = new File(env.getDataRootPath(), "historycache" + path + ".gz");
+                File f = new File(env.getDataRootPath(),
+                        TandemPath.join("historycache" + path, ".gz"));
                 Assert.assertTrue("history cache file should be preserved", f.exists());
             }
             removedFiles.add(path);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/TandemFilenameTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/TandemFilenameTest.java
@@ -1,0 +1,174 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ *
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TandemFilenameTest {
+
+    @Test
+    public void shouldThrowIfFilenameIncludesPath() {
+        IllegalArgumentException caughtException = null;
+        try {
+            TandemFilename.join("a/b/c", ".gz");
+        } catch (IllegalArgumentException ex) {
+            caughtException = ex;
+        }
+        assertNotNull("a/b/c is not a valid argument", caughtException);
+    }
+
+    @Test
+    public void shouldNotNeedToHashShortNames() {
+        String newName = TandemFilename.join("file1", ".gz");
+        assertEquals("file1.gz", newName);
+    }
+
+    @Test
+    public void shouldNotNeedToHash254ASCIIChars() {
+        final String extension = ".gz";
+        char[] chars = new char[254 - extension.length()];
+        Arrays.fill(chars, 'A');
+        String filename = new String(chars);
+        String newName = TandemFilename.join(filename, extension);
+        assertEquals("254 ASCII characters", filename + extension, newName);
+
+        byte[] newBytes = newName.getBytes(StandardCharsets.UTF_8);
+        assertEquals("Should use 254 bytes", 254, newBytes.length);
+    }
+
+    @Test
+    public void shouldHash255ASCIIChars() {
+        final String extension = ".zip";
+        char[] chars = new char[255 - extension.length()];
+        Arrays.fill(chars, 'B');
+        String filename = new String(chars);
+        String newName = TandemFilename.join(filename, extension);
+
+        final String expected = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "EOowLBTrxWMrXUnR2y818jr7LlP-DReUhteosu_8AoY=.zip";
+        assertEquals("255 ASCII characters", expected, newName);
+
+        byte[] newBytes = newName.getBytes(StandardCharsets.UTF_8);
+        assertEquals("Should use all 255 bytes", 255, newBytes.length);
+    }
+
+    @Test
+    public void shouldHash255ASCIICharsWithShiftedExtension() {
+        final String ext2 = ".gz";
+        final String ext1 = ".cpp";
+        char[] chars = new char[255 - ext1.length() - ext2.length()];
+        Arrays.fill(chars, 'B');
+        String filename = new String(chars) + ext1;
+        String newName = TandemFilename.join(filename, ext2);
+
+        final String expected = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "GfYhMFaQvXK2dbJeO9SXYHzWC2UFhNyDYXzWDP2a_5E=.cpp.gz";
+        assertEquals("255 ASCII characters + 2 extensions", expected, newName);
+
+        byte[] newBytes = newName.getBytes(StandardCharsets.UTF_8);
+        assertEquals("Should use all 255 bytes", 255, newBytes.length);
+    }
+
+    @Test
+    public void shouldHash255ASCIICharsWithLongOriginalExtension() {
+        final String extension = ".gz";
+        char[] chars = new char[255 - extension.length()];
+        Arrays.fill(chars, 'B');
+        chars[32] = '.';
+        String filename = new String(chars);
+        String newName = TandemFilename.join(filename, extension);
+
+        final String expected = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB.BBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "pVBqc9SOArO6qf3shKWndZ05harxS-tqnmQkev_mxmY=.gz";
+        assertEquals("256 ASCII characters + 2 extensions", expected, newName);
+
+        byte[] newBytes = newName.getBytes(StandardCharsets.UTF_8);
+        assertEquals("Should use all 255 bytes", 255, newBytes.length);
+    }
+
+    @Test
+    public void shouldNotNeedToHashUnicodeOf254UTF8Bytes() {
+        final String extension = ".gz";
+        String filename = "Лоремипсумдолорситаметаппетерепатриояуеелояуентиа" +
+                "меуяуиетомнисанималсцрипторемсеаутвидитсолутаусуЯуиеусусцип" +
+                "итеррорибусприеро1";
+        byte[] uFilename = filename.getBytes(StandardCharsets.UTF_8);
+        assertEquals(filename + " as UTF-8, length", 251, uFilename.length);
+
+        String newName = TandemFilename.join(filename, extension);
+        assertEquals("Unicode concatenation", filename + extension, newName);
+
+        byte[] newBytes = newName.getBytes(StandardCharsets.UTF_8);
+        assertEquals("Should use 254 bytes", 254, newBytes.length);
+    }
+
+    @Test
+    public void shouldHashUnicodeOf255UTF8Bytes() {
+        final String extension = ".zip";
+        String filename = "Лоремипсумдолорситаметаппетерепатриояуеелояуентиа" +
+                "меуяуиетомнисанималсцрипторемсеаутвидитсолутаусуЯуиеусусцип" +
+                "итеррорибусприер.cs";
+        byte[] uFilename = filename.getBytes(StandardCharsets.UTF_8);
+        assertEquals(filename + " as UTF-8, length", 251, uFilename.length);
+
+        String newName = TandemFilename.join(filename, extension);
+        String expected = "Лоремипсумдолорситаметаппетерепатриояуеелояуентиа" +
+                "меуяуиетомнисанималсцрипторемсеаутвидитсолутаусуЯуиеу" +
+                "8Veko6G0h8wci2kX60EisTi4ReksNP1wdTLhbuB-5Vw=.cs.zip";
+        assertEquals("Unicode + new extension", expected, newName);
+
+        byte[] newBytes = newName.getBytes(StandardCharsets.UTF_8);
+        assertEquals("Should use all 255 bytes", 255, newBytes.length);
+    }
+
+    @Test
+    public void shouldHashWithPaddingUnicodeOf256UTF8Bytes() {
+        final String extension = ".zip";
+        String filename = "Лоремипсумдолорситаметаппетерепатриояуеелояуентиа" +
+                "меуяуиетомнисанималсцрипторемсеаутвидитсолутаусуЯуиеусусцип" +
+                "итеррорибусприерер";
+        byte[] uFilename = filename.getBytes(StandardCharsets.UTF_8);
+        assertEquals(filename + " as UTF-8, length", 252, uFilename.length);
+
+        String newName = TandemFilename.join(filename, extension);
+        String expected = "Лоремипсумдолорситаметаппетерепатриояуеелояуентиа" +
+                "меуяуиетомнисанималсцрипторемсеаутвидитсолутаусуЯуиеус" +
+                "_exXOSa5o10Ll_Z1Ymf8pI1BDI9IH4io6weWi-PYPMj4=.zip";
+        assertEquals("Unicode + padding + new extension", expected, newName);
+
+        byte[] newBytes = newName.getBytes(StandardCharsets.UTF_8);
+        assertEquals("Should use all 255 bytes", 255, newBytes.length);
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/TandemPathTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/TandemPathTest.java
@@ -1,0 +1,76 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ *
+ * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.util;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class TandemPathTest {
+
+    @Test
+    public void shouldNotNeedToHashShortNames() {
+        File original = new File("dir", "file1");
+        File expected = new File("dir", "file1.gz");
+        String newName = TandemPath.join(original.toString(), ".gz");
+        assertEquals(expected.toString(), newName);
+    }
+
+    @Test
+    public void shouldHash255ASCIIChars() {
+        final String extension = ".zip";
+        char[] chars = new char[255 - extension.length()];
+        Arrays.fill(chars, 'B');
+        String filename = new String(chars);
+        File original = new File("dir", filename);
+        String newName = TandemPath.join(original.toString(), extension);
+
+        final String aNewName = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "EOowLBTrxWMrXUnR2y818jr7LlP-DReUhteosu_8AoY=.zip";
+        File expected = new File("dir", aNewName);
+        assertEquals("255 ASCII characters", expected.toString(), newName);
+    }
+
+    @Test
+    public void shouldNotNeedToHash254ASCIIChars() {
+        final String extension = ".zip";
+        char[] chars = new char[254 - extension.length()];
+        Arrays.fill(chars, 'B');
+        String filename = new String(chars);
+        File original = new File("dir", filename);
+        String newName = TandemPath.join(original.toString(), extension);
+
+        final String aNewName = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" +
+                "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB.zip";
+        File expected = new File("dir", aNewName);
+        assertEquals("254 ASCII characters", expected.toString(), newName);
+    }
+}


### PR DESCRIPTION
Hello,

Please consider for integration this patch to ensure that OpenGrok tandem filenames (i.e. filenames that operate in tandem with source files; e.g. `.gz` xref files and `.org_opengrok` interim files) do not exceed 255 byte filenames.

This is backward-compatible with existing 1.1 `DATA_ROOT` outputs* because the new algorithm is only really effective for files that could not be created due to exceeding 255 byte names.

Also:
- Do case-insensitive comparison for `.gz` in `GZIPAnalyzer`.
- Add a `serialVersionUID` to silence lint.

Thank you.

*for filesystems with 255 byte name limits, such as Linux, Windows, and macOS.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
