### PR TITLE
convert Statistics to use Jackson for JSON processing

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -178,6 +178,11 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -173,6 +173,11 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StatisticsUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StatisticsUtils.java
@@ -78,7 +78,7 @@ public class StatisticsUtils {
     }
 
     /**
-     * Load statistics fromJson JSON file specified in configuration.
+     * Load statistics from JSON file specified in configuration.
      *
      * @throws IOException
      * @throws ParseException
@@ -92,7 +92,7 @@ public class StatisticsUtils {
     }
 
     /**
-     * Load statistics fromJson JSON file.
+     * Load statistics from JSON file.
      *
      * @param in the file with json
      * @throws IOException
@@ -108,7 +108,7 @@ public class StatisticsUtils {
     }
 
     /**
-     * Load statistics fromJson an input stream.
+     * Load statistics from an input stream.
      *
      * @param in the file with json
      * @throws IOException

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StatisticsUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StatisticsUtils.java
@@ -24,7 +24,6 @@
 package org.opengrok.indexer.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.json.simple.parser.ParseException;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.web.Statistics;
 
@@ -81,9 +80,8 @@ public class StatisticsUtils {
      * Load statistics from JSON file specified in configuration.
      *
      * @throws IOException
-     * @throws ParseException
      */
-    public static void loadStatistics() throws IOException, ParseException {
+    public static void loadStatistics() throws IOException {
         String path = RuntimeEnvironment.getInstance().getStatisticsFilePath();
         if (path == null) {
             throw new FileNotFoundException("Statistics file is not set (null)");
@@ -96,9 +94,8 @@ public class StatisticsUtils {
      *
      * @param in the file with json
      * @throws IOException
-     * @throws ParseException
      */
-    public static void loadStatistics(File in) throws IOException, ParseException {
+    public static void loadStatistics(File in) throws IOException {
         if (in == null) {
             throw new FileNotFoundException("Statistics file is not set (null)");
         }
@@ -112,9 +109,8 @@ public class StatisticsUtils {
      *
      * @param in the file with json
      * @throws IOException
-     * @throws ParseException
      */
-    public static void loadStatistics(InputStream in) throws IOException, ParseException {
+    public static void loadStatistics(InputStream in) throws IOException {
         try (Reader iReader = new InputStreamReader(in, "UTF-8")) {
             StringBuilder outputString = new StringBuilder();
             final char[] buf = new char[1024];

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Statistics.java
@@ -26,7 +26,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.glassfish.jersey.server.JSONP;
 
 import java.io.IOException;
 import java.util.Calendar;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Statistics.java
@@ -300,16 +300,16 @@ public class Statistics {
     }
 
     /**
-     * Convert this statistics object into JSON
+     * Convert this {@code Statistics} object into JSON
      *
-     * @return the JSON object
+     * @return the JSON string
      */
     public String toJson() throws JsonProcessingException {
         return toJson(this);
     }
 
     /**
-     * Convert JSON object into statistics.
+     * Convert JSON into {@code Statistics} object.
      *
      * @param jsonString String with JSON
      * @return the {@code Statistics} object

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Statistics.java
@@ -22,8 +22,11 @@
  */
 package org.opengrok.indexer.web;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.glassfish.jersey.server.JSONP;
 
 import java.io.IOException;
 import java.util.Calendar;
@@ -53,20 +56,35 @@ public class Statistics {
     protected static final String STATISTIC_DAY_HISTOGRAM = "day_histogram";
     protected static final String STATISTIC_MONTH_HISTOGRAM = "month_histogram";
 
+    @JsonProperty(STATISTIC_REQUEST_CATEGORIES)
     private Map<String, Long> requestCategories = new TreeMap<>();
+    @JsonProperty(STATISTIC_TIMING)
     private Map<String, Long> timing = new TreeMap<>();
+    @JsonProperty(STATISTIC_TIMING_MIN)
     private Map<String, Long> timingMin = new TreeMap<>();
+    @JsonProperty(STATISTIC_TIMING_MAX)
     private Map<String, Long> timingMax = new TreeMap<>();
+    @JsonProperty(STATISTIC_TIMING_AVG)
     private Map<String, Double> timingAvg = new TreeMap<>();
+    @JsonProperty(STATISTIC_DAY_HISTOGRAM)
     private long[] dayHistogram = new long[24];
+    @JsonProperty(STATISTIC_MONTH_HISTOGRAM)
     private long[] monthHistogram = new long[31];
-    private long timeStart = System.currentTimeMillis();
+    @JsonProperty(STATISTIC_REQUESTS)
     private long requests = 0;
+    @JsonProperty(STATISTIC_MINUTES)
     private long minutes = 1;
+    @JsonProperty(STATISTIC_REQUESTS_PER_MINUTE)
     private long requestsPerMinute = 0;
+    @JsonProperty(STATISTIC_REQUESTS_PER_MINUTE_MIN)
     private long requestsPerMinuteMin = Long.MAX_VALUE;
+    @JsonProperty(STATISTIC_REQUESTS_PER_MINUTE_MAX)
     private long requestsPerMinuteMax = Long.MIN_VALUE;
+    @JsonProperty(STATISTIC_REQUESTS_PER_MINUTE_AVG)
     private double requestsPerMinuteAvg = 0;
+
+    @JsonIgnore
+    private long timeStart = System.currentTimeMillis();
 
     /**
      * Adds a single request into all requests.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Statistics.java
@@ -171,11 +171,9 @@ public class Statistics {
         timingMin.put(category, min);
         timingMax.put(category, max);
 
-        // TODO recompute for given category only
-        for (Map.Entry<String, Long> entry : timing.entrySet()) {
-            timingAvg.put(entry.getKey(), entry.getValue().doubleValue()
-                    / requestCategories.get(entry.getKey()));
-        }
+        // Recompute the average for given category.
+        timingAvg.put(category,
+                timing.get(category).doubleValue() / requestCategories.get(category));
     }
 
     public Map<String, Long> getRequestCategories() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1462,26 +1462,6 @@ public final class Util {
     }
 
     /**
-     * Convert statistics object into JSONObject.
-     *
-     * @param stats object containing statistics
-     * @return the json object
-     */
-    public static JSONObject statisticToJson(Statistics stats) {
-        return stats.toJson();
-    }
-
-    /**
-     * Convert JSONObject object into statistics.
-     *
-     * @param input object containing statistics
-     * @return the statistics object
-     */
-    public static Statistics jsonToStatistics(JSONObject input) {
-        return Statistics.from(input);
-    }
-
-    /**
      * Print a row in an HTML table.
      *
      * @param out destination for the HTML output

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
@@ -687,7 +687,7 @@ public class RuntimeEnvironmentTest {
         assertEquals(pluginConfiguration.getStack().get(0), plugin.getSetup().get("plugin"));
 
         /**
-         * Fourth element is a stack slightly changed from the previous stack.
+         * Fourth element is a stack slightly changed fromJson the previous stack.
          * Only the setup for the particular plugin is changed.
          */
         assertTrue(pluginConfiguration.getStack().get(3) instanceof AuthorizationStack);
@@ -980,7 +980,7 @@ public class RuntimeEnvironmentTest {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             saveStatistics(out);
             Assert.assertNotEquals("{}", out.toString());
-            Assert.assertEquals(env.getStatistics().toJson().toJSONString(), out.toString());
+            Assert.assertEquals(env.getStatistics().toJson(), out.toString());
         }
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
@@ -687,7 +687,7 @@ public class RuntimeEnvironmentTest {
         assertEquals(pluginConfiguration.getStack().get(0), plugin.getSetup().get("plugin"));
 
         /**
-         * Fourth element is a stack slightly changed fromJson the previous stack.
+         * Fourth element is a stack slightly changed from the previous stack.
          * Only the setup for the particular plugin is changed.
          */
         assertTrue(pluginConfiguration.getStack().get(3) instanceof AuthorizationStack);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
@@ -49,7 +49,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.tools.ant.filters.StringInputStream;
-import org.json.simple.parser.ParseException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -876,7 +875,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testLoadEmptyStatistics() throws IOException, ParseException {
+    public void testLoadEmptyStatistics() throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         String json = "{}";
         try (InputStream in = new StringInputStream(json)) {
@@ -886,7 +885,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testLoadStatistics() throws IOException, ParseException {
+    public void testLoadStatistics() throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         String json = "{"
             + "\"requests_per_minute_max\":3,"
@@ -950,22 +949,12 @@ public class RuntimeEnvironmentTest {
         Assert.assertEquals(createMap(new Object[][]{{"*", 2235L}, {"xref", 48L}, {"root", 2235L}}), stats.getTimingMax());
     }
 
-    @Test(expected = ParseException.class)
-    public void testLoadInvalidStatistics() throws ParseException, IOException {
+    @Test(expected = IOException.class)
+    public void testLoadInvalidStatistics() throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         String json = "{ malformed json with missing bracket";
         try (InputStream in = new StringInputStream(json)) {
             loadStatistics(in);
-        }
-    }
-
-    @Test
-    public void testSaveEmptyStatistics() throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        env.setStatistics(new Statistics());
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            saveStatistics(out);
-            Assert.assertEquals("{}", out.toString());
         }
     }
 
@@ -996,13 +985,13 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test(expected = IOException.class)
-    public void testLoadNullStatistics() throws IOException, ParseException {
+    public void testLoadNullStatistics() throws IOException {
         RuntimeEnvironment.getInstance().setStatisticsFilePath(null);
         loadStatistics();
     }
 
     @Test(expected = IOException.class)
-    public void testLoadNullStatisticsFile() throws IOException, ParseException {
+    public void testLoadNullStatisticsFile() throws IOException {
         loadStatistics((File) null);
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
@@ -30,13 +30,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.opengrok.indexer.util.StatisticsUtils.loadStatistics;
-import static org.opengrok.indexer.util.StatisticsUtils.saveStatistics;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.file.Files;
@@ -45,10 +41,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.TreeSet;
-import org.apache.tools.ant.filters.StringInputStream;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -61,7 +54,7 @@ import org.opengrok.indexer.authorization.AuthorizationStack;
 import org.opengrok.indexer.history.RepositoryInfo;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
 import org.opengrok.indexer.util.IOUtils;
-import org.opengrok.indexer.web.Statistics;
+
 
 /**
  * Test the RuntimeEnvironment class
@@ -858,141 +851,6 @@ public class RuntimeEnvironmentTest {
 
         env.setChattyStatusPage(false);
         assertFalse(env.isChattyStatusPage());
-    }
-
-    /**
-     * Creates a map of String key and Long values.
-     *
-     * @param input double array containing the pairs
-     * @return the map
-     */
-    protected Map<String, Long> createMap(Object[][] input) {
-        Map<String, Long> map = new TreeMap<>();
-        for (int i = 0; i < input.length; i++) {
-            map.put((String) input[i][0], (Long) input[i][1]);
-        }
-        return map;
-    }
-
-    @Test
-    public void testLoadEmptyStatistics() throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        String json = "{}";
-        try (InputStream in = new StringInputStream(json)) {
-            loadStatistics(in);
-        }
-        Assert.assertEquals(new Statistics().toJson(), env.getStatistics().toJson());
-    }
-
-    @Test
-    public void testLoadStatistics() throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        String json = "{"
-            + "\"requests_per_minute_max\":3,"
-            + "\"timing\":{"
-                + "\"*\":2288,"
-                + "\"xref\":53,"
-                + "\"root\":2235"
-            + "},"
-            + "\"minutes\":756,"
-            + "\"timing_min\":{"
-                + "\"*\":2,"
-                + "\"xref\":2,"
-                + "\"root\":2235"
-            + "},"
-            + "\"timing_avg\":{"
-                + "\"*\":572.0,"
-                + "\"xref\":17.666666666666668,"
-                + "\"root\":2235.0"
-            + "},"
-            + "\"request_categories\":{"
-                + "\"*\":4,"
-                + "\"xref\":3,"
-                + "\"root\":1"
-            + "},"
-            + "\"day_histogram\":[0,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,0,0,0,0,0,0,0,1],"
-            + "\"requests\":4,"
-            + "\"requests_per_minute_min\":1,"
-            + "\"requests_per_minute\":3,"
-            + "\"requests_per_minute_avg\":0.005291005291005291,"
-            + "\"month_histogram\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,3,0],"
-            + "\"timing_max\":{"
-                + "\"*\":2235,"
-                + "\"xref\":48,"
-                + "\"root\":2235"
-            + "}"
-        + "}";
-        try (InputStream in = new StringInputStream(json)) {
-            loadStatistics(in);
-        }
-        Statistics stats = env.getStatistics();
-        Assert.assertNotNull(stats);
-        Assert.assertEquals(756, stats.getMinutes());
-        Assert.assertEquals(4, stats.getRequests());
-        Assert.assertEquals(3, stats.getRequestsPerMinute());
-        Assert.assertEquals(1, stats.getRequestsPerMinuteMin());
-        Assert.assertEquals(3, stats.getRequestsPerMinuteMax());
-        Assert.assertEquals(0.005291005291005291, stats.getRequestsPerMinuteAvg(), 0.00005);
-
-        Assert.assertArrayEquals(new long[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 3, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 1}, stats.getDayHistogram());
-        Assert.assertArrayEquals(new long[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 1, 3,
-            0}, stats.getMonthHistogram());
-
-        Assert.assertEquals(createMap(new Object[][]{{"*", 4L}, {"xref", 3L}, {"root", 1L}}), stats.getRequestCategories());
-
-        Assert.assertEquals(createMap(new Object[][]{{"*", 2288L}, {"xref", 53L}, {"root", 2235L}}), stats.getTiming());
-        Assert.assertEquals(createMap(new Object[][]{{"*", 2L}, {"xref", 2L}, {"root", 2235L}}), stats.getTimingMin());
-        Assert.assertEquals(createMap(new Object[][]{{"*", 2235L}, {"xref", 48L}, {"root", 2235L}}), stats.getTimingMax());
-    }
-
-    @Test(expected = IOException.class)
-    public void testLoadInvalidStatistics() throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        String json = "{ malformed json with missing bracket";
-        try (InputStream in = new StringInputStream(json)) {
-            loadStatistics(in);
-        }
-    }
-
-    @Test
-    public void testSaveStatistics() throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        env.setStatistics(new Statistics());
-        env.getStatistics().addRequest();
-        env.getStatistics().addRequest("root");
-        env.getStatistics().addRequestTime("root", 10L);
-
-        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            saveStatistics(out);
-            Assert.assertNotEquals("{}", out.toString());
-            Assert.assertEquals(env.getStatistics().toJson(), out.toString());
-        }
-    }
-
-    @Test(expected = IOException.class)
-    public void testSaveNullStatistics() throws IOException {
-        RuntimeEnvironment.getInstance().setStatisticsFilePath(null);
-        saveStatistics();
-    }
-
-    @Test(expected = IOException.class)
-    public void testSaveNullStatisticsFile() throws IOException {
-        saveStatistics((File) null);
-    }
-
-    @Test(expected = IOException.class)
-    public void testLoadNullStatistics() throws IOException {
-        RuntimeEnvironment.getInstance().setStatisticsFilePath(null);
-        loadStatistics();
-    }
-
-    @Test(expected = IOException.class)
-    public void testLoadNullStatisticsFile() throws IOException {
-        loadStatistics((File) null);
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/StatisticsUtilsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/StatisticsUtilsTest.java
@@ -1,0 +1,154 @@
+package org.opengrok.indexer.util;
+
+import org.apache.tools.ant.filters.StringInputStream;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.web.Statistics;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.opengrok.indexer.util.StatisticsUtils.loadStatistics;
+import static org.opengrok.indexer.util.StatisticsUtils.saveStatistics;
+
+public class StatisticsUtilsTest {
+    /**
+     * Creates a map of String key and Long values.
+     *
+     * @param input double array containing the pairs
+     * @return the map
+     */
+    private Map<String, Long> createMap(Object[][] input) {
+        Map<String, Long> map = new TreeMap<>();
+        for (int i = 0; i < input.length; i++) {
+            map.put((String) input[i][0], (Long) input[i][1]);
+        }
+        return map;
+    }
+
+    @Test
+    public void testLoadEmptyStatistics() throws IOException {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        String json = "{}";
+        try (InputStream in = new StringInputStream(json)) {
+            loadStatistics(in);
+        }
+        Assert.assertEquals(new org.opengrok.indexer.web.Statistics().toJson(), env.getStatistics().toJson());
+    }
+
+    @Test
+    public void testLoadStatistics() throws IOException {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        String json = "{"
+                + "\"requests_per_minute_max\":3,"
+                + "\"timing\":{"
+                + "\"*\":2288,"
+                + "\"xref\":53,"
+                + "\"root\":2235"
+                + "},"
+                + "\"minutes\":756,"
+                + "\"timing_min\":{"
+                + "\"*\":2,"
+                + "\"xref\":2,"
+                + "\"root\":2235"
+                + "},"
+                + "\"timing_avg\":{"
+                + "\"*\":572.0,"
+                + "\"xref\":17.666666666666668,"
+                + "\"root\":2235.0"
+                + "},"
+                + "\"request_categories\":{"
+                + "\"*\":4,"
+                + "\"xref\":3,"
+                + "\"root\":1"
+                + "},"
+                + "\"day_histogram\":[0,0,0,0,0,0,0,0,0,0,0,0,3,0,0,0,0,0,0,0,0,0,0,1],"
+                + "\"requests\":4,"
+                + "\"requests_per_minute_min\":1,"
+                + "\"requests_per_minute\":3,"
+                + "\"requests_per_minute_avg\":0.005291005291005291,"
+                + "\"month_histogram\":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,3,0],"
+                + "\"timing_max\":{"
+                + "\"*\":2235,"
+                + "\"xref\":48,"
+                + "\"root\":2235"
+                + "}"
+                + "}";
+        try (InputStream in = new StringInputStream(json)) {
+            loadStatistics(in);
+        }
+        org.opengrok.indexer.web.Statistics stats = env.getStatistics();
+        Assert.assertNotNull(stats);
+        Assert.assertEquals(756, stats.getMinutes());
+        Assert.assertEquals(4, stats.getRequests());
+        Assert.assertEquals(3, stats.getRequestsPerMinute());
+        Assert.assertEquals(1, stats.getRequestsPerMinuteMin());
+        Assert.assertEquals(3, stats.getRequestsPerMinuteMax());
+        Assert.assertEquals(0.005291005291005291, stats.getRequestsPerMinuteAvg(), 0.00005);
+
+        Assert.assertArrayEquals(new long[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 3, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1}, stats.getDayHistogram());
+        Assert.assertArrayEquals(new long[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 1, 3,
+                0}, stats.getMonthHistogram());
+
+        Assert.assertEquals(createMap(new Object[][]{{"*", 4L}, {"xref", 3L}, {"root", 1L}}), stats.getRequestCategories());
+
+        Assert.assertEquals(createMap(new Object[][]{{"*", 2288L}, {"xref", 53L}, {"root", 2235L}}), stats.getTiming());
+        Assert.assertEquals(createMap(new Object[][]{{"*", 2L}, {"xref", 2L}, {"root", 2235L}}), stats.getTimingMin());
+        Assert.assertEquals(createMap(new Object[][]{{"*", 2235L}, {"xref", 48L}, {"root", 2235L}}), stats.getTimingMax());
+    }
+
+    @Test(expected = IOException.class)
+    public void testLoadInvalidStatistics() throws IOException {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        String json = "{ malformed json with missing bracket";
+        try (InputStream in = new StringInputStream(json)) {
+            loadStatistics(in);
+        }
+    }
+
+    @Test
+    public void testSaveStatistics() throws IOException {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setStatistics(new Statistics());
+        env.getStatistics().addRequest();
+        env.getStatistics().addRequest("root");
+        env.getStatistics().addRequestTime("root", 10L);
+
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            saveStatistics(out);
+            Assert.assertNotEquals("{}", out.toString());
+            Assert.assertEquals(env.getStatistics().toJson(), out.toString());
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void testSaveNullStatistics() throws IOException {
+        RuntimeEnvironment.getInstance().setStatisticsFilePath(null);
+        saveStatistics();
+    }
+
+    @Test(expected = IOException.class)
+    public void testSaveNullStatisticsFile() throws IOException {
+        saveStatistics((File) null);
+    }
+
+    @Test(expected = IOException.class)
+    public void testLoadNullStatistics() throws IOException {
+        RuntimeEnvironment.getInstance().setStatisticsFilePath(null);
+        loadStatistics();
+    }
+
+    @Test(expected = IOException.class)
+    public void testLoadNullStatisticsFile() throws IOException {
+        loadStatistics((File) null);
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/StatisticsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/StatisticsTest.java
@@ -242,7 +242,7 @@ public class StatisticsTest {
         Assert.assertEquals(10L, stat.getMinutes());
         Assert.assertEquals(100L, stat.getRequests());
         Assert.assertEquals(543L, stat.getRequestsPerMinute());
-        Assert.assertEquals(10.0, stat.getRequestsPerMinuteAvg(), 0.000001);
+        Assert.assertEquals(54312.0, stat.getRequestsPerMinuteAvg(), 0.000001);
         Assert.assertEquals(49L, stat.getRequestsPerMinuteMin());
         Assert.assertEquals(4753L, stat.getRequestsPerMinuteMax());
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/StatisticsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/StatisticsTest.java
@@ -265,24 +265,33 @@ public class StatisticsTest {
         });
     }
 
-    private Object getJsonField(String jsonString, String name) throws IOException {
+    private Long getJsonLongField(String jsonString, String name) throws IOException {
         JsonFactory jfactory = new JsonFactory();
         JsonParser jParser = jfactory.createParser(jsonString);
-        Object parsedName = null;
+        Long value = null;
 
         Assert.assertNotNull(jParser);
 
-        while (jParser.nextToken() != JsonToken.END_OBJECT) {
-            String fieldname = jParser.getCurrentName();
+        JsonToken token;
+        while ((token = jParser.nextToken()) != JsonToken.END_OBJECT) {
+            if (token == JsonToken.START_OBJECT) {
+                while (jParser.nextToken() != JsonToken.END_OBJECT) {
+                }
+            }
 
+            if (token != JsonToken.FIELD_NAME)
+                continue;
+
+            String fieldname = jParser.getCurrentName();
             if (name.equals(fieldname)) {
                 jParser.nextToken();
-                parsedName = jParser.getText();
+                value = jParser.getLongValue();
+                break;
             }
         }
         jParser.close();
 
-        return parsedName;
+        return value;
     }
 
     protected void checkToJson(Function<Statistics, String> callback) throws IOException {
@@ -295,15 +304,15 @@ public class StatisticsTest {
         String result = callback.apply(stats);
         Assert.assertNotNull(result);
 
-        Assert.assertNotNull(getJsonField(result, Statistics.STATISTIC_MINUTES));
-        Assert.assertEquals(-325L, (long) getJsonField(result, Statistics.STATISTIC_MINUTES));
-        Assert.assertNotNull(getJsonField(result, Statistics.STATISTIC_REQUESTS));
-        Assert.assertEquals(145L, (long) getJsonField(result, Statistics.STATISTIC_REQUESTS));
-        Assert.assertNotNull(getJsonField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE));
-        Assert.assertEquals(1000L, (long) getJsonField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE));
-        Assert.assertNotNull(getJsonField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE_MIN));
-        Assert.assertEquals(107L, (long) getJsonField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE_MIN));
-        Assert.assertNotNull(getJsonField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE_MAX));
-        Assert.assertEquals(106L, (long) getJsonField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE_MAX));
+        Assert.assertNotNull(getJsonLongField(result, Statistics.STATISTIC_MINUTES));
+        Assert.assertEquals(-325L, (long) getJsonLongField(result, Statistics.STATISTIC_MINUTES));
+        Assert.assertNotNull(getJsonLongField(result, Statistics.STATISTIC_REQUESTS));
+        Assert.assertEquals(145L, (long) getJsonLongField(result, Statistics.STATISTIC_REQUESTS));
+        Assert.assertNotNull(getJsonLongField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE));
+        Assert.assertEquals(1000L, (long) getJsonLongField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE));
+        Assert.assertNotNull(getJsonLongField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE_MIN));
+        Assert.assertEquals(107L, (long) getJsonLongField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE_MIN));
+        Assert.assertNotNull(getJsonLongField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE_MAX));
+        Assert.assertEquals(106L, (long) getJsonLongField(result, Statistics.STATISTIC_REQUESTS_PER_MINUTE_MAX));
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/StatisticsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/StatisticsTest.java
@@ -86,8 +86,8 @@ public class StatisticsTest {
             Statistics stat = new Statistics();
             Assert.assertEquals(1, stat.getMinutes());
             stat.setTimeStart(start - tests[i]);
-
             Assert.assertEquals(stat.getTimeStart(), start - tests[i]);
+            stat.maybeRefresh();
             Assert.assertEquals((tests[i] + 60 * 1000) / (60 * 1000), stat.getMinutes());
         }
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/StatisticsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/StatisticsTest.java
@@ -22,8 +22,18 @@
  */
 package org.opengrok.indexer.web;
 
-import com.fasterxml.jackson.core.*;
-import org.junit.*;
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/StatisticsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/StatisticsTest.java
@@ -207,8 +207,8 @@ public class StatisticsTest {
             public String apply(Statistics t) {
                 try {
                     return t.toJson();
-                } catch (IOException e) {
-                    e.printStackTrace();
+                } catch (JsonProcessingException e) {
+                    Assert.fail(e.toString());
                 }
                 return null;
             }
@@ -258,7 +258,7 @@ public class StatisticsTest {
                 try {
                     return Statistics.toJson(t);
                 } catch (JsonProcessingException e) {
-                    e.printStackTrace();
+                    Assert.fail(e.toString());
                 }
                 return null;
             }

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -22,7 +22,6 @@
  */
 package org.opengrok.web;
 
-import org.json.simple.parser.ParseException;
 import org.opengrok.indexer.Info;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.authorization.AuthorizationFramework;

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -89,8 +89,6 @@ public final class WebappListener
             loadStatistics();
         } catch (IOException ex) {
             LOGGER.log(Level.INFO, "Could not load statistics from a file.", ex);
-        } catch (ParseException ex) {
-            LOGGER.log(Level.SEVERE, "Could not parse statistics from a file.", ex);
         }
 
         String pluginDirectory = env.getPluginDirectory();
@@ -104,8 +102,6 @@ public final class WebappListener
             loadStatistics();
         } catch (IOException ex) {
             LOGGER.log(Level.INFO, "Could not load statistics from a file.", ex);
-        } catch (ParseException ex) {
-            LOGGER.log(Level.SEVERE, "Could not parse statistics from a file.", ex);
         }
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/StatsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/StatsController.java
@@ -44,8 +44,8 @@ public class StatsController {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String get() {
-        return Util.statisticToJson(env.getStatistics()).toJSONString();
+    public Statistics get() {
+        return env.getStatistics();
     }
 
     @DELETE
@@ -58,5 +58,4 @@ public class StatsController {
     public void reload() throws IOException, ParseException {
         loadStatistics();
     }
-
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/StatsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/StatsController.java
@@ -22,10 +22,8 @@
  */
 package org.opengrok.web.api.v1.controller;
 
-import org.json.simple.parser.ParseException;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.web.Statistics;
-import org.opengrok.indexer.web.Util;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -55,7 +53,7 @@ public class StatsController {
 
     @PUT
     @Path("reload")
-    public void reload() throws IOException, ParseException {
+    public void reload() throws IOException {
         loadStatistics();
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatsControllerTest.java
@@ -63,7 +63,7 @@ public class StatsControllerTest extends JerseyTest {
     }
 
     @Test
-    public void testGetClean() {
+    public void testGetClean() throws IOException {
         target("stats")
                 .request()
                 .delete();
@@ -72,7 +72,11 @@ public class StatsControllerTest extends JerseyTest {
                 .request()
                 .get(String.class);
 
-        Assert.assertEquals("{}", output);
+        Statistics stats = Statistics.fromJson(output);
+        assertEquals(0, stats.getRequests());
+        Assert.assertEquals(1, stats.getMinutes());
+        Assert.assertEquals(0, stats.getRequestCategories().size());
+        Assert.assertEquals(0, stats.getTiming().size());
     }
 
     @Test

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatsControllerTest.java
@@ -24,9 +24,6 @@ package org.opengrok.web.api.v1.controller;
 
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -35,6 +32,7 @@ import org.opengrok.indexer.web.Statistics;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -78,7 +76,7 @@ public class StatsControllerTest extends JerseyTest {
     }
 
     @Test
-    public void testGet() throws ParseException {
+    public void testGet() throws IOException {
         target("stats")
                 .request()
                 .delete();
@@ -89,9 +87,7 @@ public class StatsControllerTest extends JerseyTest {
                 .request()
                 .get(String.class);
 
-        JSONParser parser = new JSONParser();
-
-        Statistics stats = Statistics.from((JSONObject) parser.parse(output));
+        Statistics stats = Statistics.fromJson(output);
         assertEquals(1, stats.getRequests());
         Assert.assertEquals(1, stats.getMinutes());
         Assert.assertEquals(0, stats.getRequestCategories().size());

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
         <compileTarget>1.8</compileTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jersey.version>2.27</jersey.version>
+        <!-- Jackson version needs to match the version of Jackson Jersey depends on otherwise weird things will happen. -->
+        <jackson.version>2.8.10</jackson.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This change gets rid of the JSON simple library in favor of Jackson.

There were couple of notable decisions I had to do:
  - empty/initial Statistics will be encoded into full JSON (avoiding the special case)
  - the averages are recomputed with each request so that getters/setters can be clean
  - no JSON object passing around anymore - just strings
  - StatsController converts the Statistics to JSON implicitly