### PR TITLE
Fix #1999 : REFS aren't indexed if DEFS is empty

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ada/AdaAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ada/AdaAnalyzer.java
@@ -51,11 +51,11 @@ public class AdaAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CAnalyzer.java
@@ -52,11 +52,11 @@ public class CAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CxxAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CxxAnalyzer.java
@@ -50,11 +50,11 @@ public class CxxAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzer.java
@@ -41,11 +41,11 @@ public class ClojureAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzer.java
@@ -45,11 +45,11 @@ public class CSharpAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/eiffel/EiffelAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/eiffel/EiffelAnalyzer.java
@@ -48,11 +48,11 @@ public class EiffelAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/erlang/ErlangAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/erlang/ErlangAnalyzer.java
@@ -46,11 +46,11 @@ public class ErlangAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/fortran/FortranAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/fortran/FortranAnalyzer.java
@@ -40,7 +40,18 @@ public class FortranAnalyzer extends AbstractSourceCodeAnalyzer {
         super(factory, new JFlexTokenizer(new FortranSymbolTokenizer(
             FileAnalyzer.dummyReader)));
     }
-    
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20180208_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20180208_00; // Edit comment above too!
+    }
+
     /**
      * Creates a wrapped {@link FortranXref} instance.
      * @param reader the data to produce xref for

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/golang/GolangAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/golang/GolangAnalyzer.java
@@ -50,11 +50,11 @@ public class GolangAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/haskell/HaskellAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/haskell/HaskellAnalyzer.java
@@ -50,11 +50,11 @@ public class HaskellAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/JavaAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/JavaAnalyzer.java
@@ -49,11 +49,11 @@ public class JavaAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/javascript/JavaScriptAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/javascript/JavaScriptAnalyzer.java
@@ -50,11 +50,11 @@ public class JavaScriptAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20180118_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20180118_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/json/JsonAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/json/JsonAnalyzer.java
@@ -50,11 +50,11 @@ public class JsonAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/kotlin/KotlinAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/kotlin/KotlinAnalyzer.java
@@ -49,11 +49,11 @@ public class KotlinAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lisp/LispAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lisp/LispAnalyzer.java
@@ -45,11 +45,11 @@ public class LispAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lua/LuaAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lua/LuaAnalyzer.java
@@ -50,11 +50,11 @@ public class LuaAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzer.java
@@ -49,11 +49,11 @@ public class PascalAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20180125_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20180125_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/perl/PerlAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/perl/PerlAnalyzer.java
@@ -49,11 +49,11 @@ public class PerlAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/php/PhpAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/php/PhpAnalyzer.java
@@ -49,11 +49,11 @@ public class PhpAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzer.java
@@ -73,11 +73,11 @@ public class PlainAnalyzer extends TextAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20180112_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20180112_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**
@@ -108,15 +108,18 @@ public class PlainAnalyzer extends TextAnalyzer {
             defs = ctags.doCtags(fullpath);
             if (defs != null && defs.numberOfSymbols() > 0) {
                 tryAddingDefs(doc, defs, src, fullpath);
-                //this is to explicitly use appropriate analyzers tokenstream to workaround #1376 symbols search works like full text search 
-                OGKTextField ref = new OGKTextField(QueryBuilder.REFS,
-                    this.symbolTokenizer);
-                this.symbolTokenizer.setReader(getReader(src.getStream()));
-                doc.add(ref);
                 byte[] tags = defs.serialize();
                 doc.add(new StoredField(QueryBuilder.TAGS, tags));                
             }
         }
+        /*
+         * This is to explicitly use appropriate analyzer's token stream to
+         * work around #1376: symbols search works like full text search.
+         */
+        OGKTextField ref = new OGKTextField(QueryBuilder.REFS,
+                this.symbolTokenizer);
+        this.symbolTokenizer.setReader(getReader(src.getStream()));
+        doc.add(ref);
         
         if (scopesEnabled && xrefOut == null) {
             /*

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/powershell/PowershellAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/powershell/PowershellAnalyzer.java
@@ -50,11 +50,11 @@ public class PowershellAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/python/PythonAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/python/PythonAnalyzer.java
@@ -49,11 +49,11 @@ public class PythonAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/RubyAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/RubyAnalyzer.java
@@ -50,11 +50,11 @@ public class RubyAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/rust/RustAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/rust/RustAnalyzer.java
@@ -52,11 +52,11 @@ public class RustAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/scala/ScalaAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/scala/ScalaAnalyzer.java
@@ -49,11 +49,11 @@ public class ScalaAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sh/ShAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sh/ShAnalyzer.java
@@ -50,11 +50,11 @@ public class ShAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/PLSQLAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/PLSQLAnalyzer.java
@@ -38,11 +38,11 @@ public class PLSQLAnalyzer extends PlainAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/SQLAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/SQLAnalyzer.java
@@ -38,11 +38,11 @@ public class SQLAnalyzer extends PlainAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/SwiftAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/SwiftAnalyzer.java
@@ -49,11 +49,11 @@ public class SwiftAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/tcl/TclAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/tcl/TclAnalyzer.java
@@ -45,11 +45,11 @@ public class TclAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/vb/VBAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/vb/VBAnalyzer.java
@@ -49,11 +49,11 @@ public class VBAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20171218_00
+     * @return 20180208_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20171218_00; // Edit comment above too!
+        return 20180208_00; // Edit comment above too!
     }
 
     /**


### PR DESCRIPTION
Hello,

Please consider for integration this patch to index REFS independently from DEFS and to bump the affected analyzers' specialized version numbers.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
