### PR TITLE
workaround for broken javadoc in JDK 11 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,6 @@ jobs:
       before_install: dev/before_install
       before_script: dev/before
     - stage: test
-      name: Linux + Oracle JDK 9
-      os: linux
-      dist: trusty
-      sudo: required
-      jdk: oraclejdk9
-      install: true
-      script: dev/main
-      before_install: dev/before_install
-      before_script: dev/before
-    - stage: test
       name: Linux + Oracle JDK 11
       os: linux
       dist: trusty

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,13 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                 </executions>
                 <configuration>
                     <verbose>true</verbose>
+                    <!-- workaround for https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+                    <javaApiLinks>
+                        <property>
+                            <name>foo</name>
+                            <value>bar</value>
+                        </property>
+                    </javaApiLinks>
                     <sourceFileExcludes>
                         <!-- workarounds for https://github.com/jflex-de/jflex/issues/542 -->
                         <exclude>**/HistoryLineTokenizer.java</exclude>


### PR DESCRIPTION
The workaround https://bugs.openjdk.java.net/browse/JDK-8212233?focusedCommentId=14225970&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14225970 seems to be working.