### PR TITLE
Replace RAMDirectory with ByteBuffersDirectory in tests

### DIFF
--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterProjectDataTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterProjectDataTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest;
 
@@ -30,6 +30,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.suggest.Lookup;
+import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.hamcrest.Matchers;
@@ -66,9 +67,8 @@ public class SuggesterProjectDataTest {
     private SuggesterProjectData data;
 
     @Before
-    @SuppressWarnings("deprecation") // for RAMDirectory
     public void setUp() throws IOException {
-        dir = new org.apache.lucene.store.RAMDirectory();
+        dir = new ByteBuffersDirectory();
         tempDir = Files.createTempDirectory("test");
     }
 
@@ -262,9 +262,8 @@ public class SuggesterProjectDataTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation") // for RAMDirectory
     public void testRemove() throws IOException {
-        Directory dir = new org.apache.lucene.store.RAMDirectory();
+        Directory dir = new ByteBuffersDirectory();
         Path tempDir = Files.createTempDirectory("test");
 
         try (IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig())) {

--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterSearcherTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterSearcherTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest;
 
@@ -31,6 +31,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.junit.AfterClass;
@@ -58,9 +59,8 @@ public class SuggesterSearcherTest {
     private static SuggesterSearcher searcher;
 
     @BeforeClass
-    @SuppressWarnings("deprecation") // for RAMDirectory
     public static void setUpClass() throws IOException {
-        dir = new org.apache.lucene.store.RAMDirectory();
+        dir = new ByteBuffersDirectory();
 
         try (IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig())) {
             Document doc1 = new Document();

--- a/suggester/src/test/java/org/opengrok/suggest/query/customized/CustomSloppyPhraseScorerTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/query/customized/CustomSloppyPhraseScorerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest.query.customized;
 
@@ -35,6 +35,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.junit.Test;
 import org.opengrok.suggest.query.PhraseScorer;
@@ -47,7 +48,6 @@ import java.util.Set;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertThat;
 
-@SuppressWarnings("deprecation") // for RAMDirectory
 public class CustomSloppyPhraseScorerTest {
 
     @SuppressWarnings("unchecked") // for contains()
@@ -57,7 +57,7 @@ public class CustomSloppyPhraseScorerTest {
             final String[] terms,
             final Integer[] expectedPositions
     ) throws IOException {
-        Directory dir = new org.apache.lucene.store.RAMDirectory();
+        Directory dir = new ByteBuffersDirectory();
 
         try (IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig())) {
             Document doc = new Document();


### PR DESCRIPTION
fixes #2454

From https://lucene.apache.org/core/7_6_0/core/org/apache/lucene/store/ByteBuffersDirectory.html :
> A heap-based directory like this one can have the advantage in case of ephemeral, small, short-lived indexes when disk syncs provide an additional overhead.

which I think is exactly what we need for tests.

Thanks :)
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
