### PR TITLE
Replace "q" query param name with "full"

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -330,7 +330,7 @@ with a colon. If the type cannot be determined "N/A" is returned.
 + Request (application/json)
   + Body
 
-            ["http://localhost:8080/source/search?project=kotlin&q=text"]
+            ["http://localhost:8080/source/search?project=kotlin&full=text"]
 
 + Response 204
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/JFlexXref.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/JFlexXref.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
  * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
@@ -315,7 +315,7 @@ public class JFlexXref implements Xrefer, SymbolMatchedListener,
                 case QUERY:
                     out.write("<a href=\"");
                     out.write(urlPrefix);
-                    out.write("q=");
+                    out.write("full=");
                     Util.qurlencode(lstr, out);
                     JFlexXrefUtils.appendProject(out, project);
                     out.write("\">");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/QueryBuilder.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/QueryBuilder.java
@@ -18,7 +18,7 @@
  */
 
 /* 
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
  * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
@@ -72,7 +72,7 @@ public class QueryBuilder {
     public static final String OBJSER = "objser"; // object serialized
     public static final String OBJVER = "objver"; // object version
 
-    public static final List<String> searchFields = Arrays.asList("q", DEFS, REFS, PATH, HIST);
+    public static final List<String> searchFields = Arrays.asList(FULL, DEFS, REFS, PATH, HIST);
 
     /** Used for paths, so SHA-1 is completely sufficient */
     private static final String DIRPATH_HASH_ALGORITHM = "SHA-1";

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
@@ -18,14 +18,9 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
- */
-
-/**
- * This is supposed to get the matching lines from sourcefile.
- * since lucene does not easily give the match context.
  */
 package org.opengrok.indexer.search.context;
 
@@ -55,6 +50,10 @@ import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.IOUtils;
 import org.opengrok.indexer.web.Util;
 
+/**
+ * This is supposed to get the matching lines from sourcefile.
+ * since lucene does not easily give the match context.
+ */
 public class Context {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Context.class);
@@ -245,9 +244,6 @@ public class Context {
         for (Map.Entry<String, String> entry : subqueries.entrySet()) {
             String field = entry.getKey();
             String queryText = entry.getValue();
-            if (QueryBuilder.FULL.equals(field)) {
-                field = "q"; // bah - search query params should be consistent!
-            }
             sb.append(field).append("=").append(Util.URIEncode(queryText))
                 .append('&');
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions copyright (c) 2011 Jens Elkner.
  * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
@@ -597,7 +597,7 @@ public final class PageConfig {
      */
     public QueryBuilder getQueryBuilder() {
         if (queryBuilder == null) {
-            queryBuilder = new QueryBuilder().setFreetext(req.getParameter("q"))
+            queryBuilder = new QueryBuilder().setFreetext(req.getParameter(QueryBuilder.FULL))
                     .setDefs(req.getParameter(QueryBuilder.DEFS))
                     .setRefs(req.getParameter(QueryBuilder.REFS))
                     .setPath(req.getParameter(QueryBuilder.PATH))
@@ -1600,10 +1600,10 @@ public final class PageConfig {
      * @return string used for setting page title of search results page
      */
     public String getSearchTitle() {
-        String title = new String();
+        String title = "";
 
-        if (req.getParameter("q") != null && !req.getParameter("q").isEmpty()) {
-            title += req.getParameter("q") + " (full)";
+        if (req.getParameter(QueryBuilder.FULL) != null && !req.getParameter(QueryBuilder.FULL).isEmpty()) {
+            title += req.getParameter(QueryBuilder.FULL) + " (full)";
         }
         if (req.getParameter(QueryBuilder.DEFS) != null && !req.getParameter(QueryBuilder.DEFS).isEmpty()) {
             title = addTitleDelimiter(title);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/JFlexXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/JFlexXrefTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
  */
 
@@ -434,7 +434,7 @@ public class JFlexXrefTest {
         assertLinesEqual("UuencodeXref truncated",
                 "<a class=\"l\" name=\"1\" href=\"#1\">1</a>"
                 + "<strong>begin</strong> <em>644</em> "
-                + "<a href=\"/source/s?q=%22test.txt%22\">test.txt</a>"
+                + "<a href=\"/source/s?full=%22test.txt%22\">test.txt</a>"
                 + "<span class=\"c\">\n"
                 + "<a class=\"l\" name=\"2\" href=\"#2\">2</a></span>",
                 out.toString());

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SuggesterController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SuggesterController.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.controller;
 
@@ -181,7 +181,7 @@ public final class SuggesterController {
      * Initializes the search data used by suggester to perform most popular completion. The passed {@code urls} are
      * decomposed into single terms which search counts are then increased by 1.
      * @param urls list of URLs in JSON format, e.g.
-     * {@code ["http://demo.opengrok.org/search?project=opengrok&q=test"]}
+     * {@code ["http://demo.opengrok.org/search?project=opengrok&full=test"]}
      */
     @POST
     @Path("/init/queries")
@@ -227,7 +227,7 @@ public final class SuggesterController {
         QueryBuilder builder = new QueryBuilder();
 
         switch (field) {
-            case "q":
+            case QueryBuilder.FULL:
                 builder.setFreetext(value);
                 break;
             case QueryBuilder.DEFS:

--- a/opengrok-web/src/main/webapp/help.jsp
+++ b/opengrok-web/src/main/webapp/help.jsp
@@ -16,7 +16,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
@@ -61,27 +61,27 @@ include file="menu.jspf"
 <pre class="example">
 
 To find where setResourceMonitors is defined:
-<a href="search?q=&amp;defs=setResourceMonitors">defs:setResourceMonitors</a>
+<a href="search?full=&amp;defs=setResourceMonitors">defs:setResourceMonitors</a>
 
 To find files that use sprintf in usr/src/cmd/cmd-inet/usr.sbin/:
 <a href="search?refs=sprintf&amp;path=usr%2Fsrc%2Fcmd%2Fcmd-inet%2Fusr.sbin%2F"
 >refs:sprintf path:usr/src/cmd/cmd-inet/usr.sbin</a>
 
 To find assignments to variable foo:
-<a href="search?q=%22foo+%3D%22">"foo ="</a>
+<a href="search?full=%22foo+%3D%22">"foo ="</a>
 
 To find Makefiles where pstack binary is being built:
-<a href="search?q=pstack&amp;path=Makefile">pstack path:Makefile</a>
+<a href="search?full=pstack&amp;path=Makefile">pstack path:Makefile</a>
 
 to search for phrase "Bill Joy":
-<a href="search?q=%22Bill+Joy%22">"Bill Joy"</a>
+<a href="search?full=%22Bill+Joy%22">"Bill Joy"</a>
 
 To find perl files that do not use /usr/bin/perl but something else:
-<a href="search?q=-%22%2Fusr%2Fbin%2Fperl%22+%2B%22%2Fbin%2Fperl%22"
+<a href="search?full=-%22%2Fusr%2Fbin%2Fperl%22+%2B%22%2Fbin%2Fperl%22"
 >-"/usr/bin/perl" +"/bin/perl"</a>
 
 To find all strings beginning with foo use the wildcard:
-<a href="search?q=foo*">foo*</a>
+<a href="search?full=foo*">foo*</a>
 
 To find all files which have . c in their name (dot is a token!):
 <a href="search?path=%22. c%22">". c"</a>
@@ -90,7 +90,7 @@ To find all files which start with "ma" and then have only alphabet characters d
 <a href="search?path=/ma[a-zA-Z]*/">path:/ma[a-zA-Z]*/</a>
 
 To find all main methods in all files analyzed by C analyzer (so .c, .h, ...) do:
-<a href="search?q=main&type=c">main type:c</a>
+<a href="search?full=main&type=c">main type:c</a>
 </pre>
 
 <h4>More info:</h4>

--- a/opengrok-web/src/main/webapp/js/utils-0.0.28.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.28.js
@@ -803,7 +803,7 @@
             return $.intelliWindow = $window.create($.extend({
                 title: 'Intelligence window',
                 selector: 'a.intelliWindow-symbol',
-                google_url: 'https://www.google.com/search?full=',
+                google_url: 'https://www.google.com/search?q=',
                 project: undefined,
                 init: function ($window) {
                     var $highlight, $unhighlight, $unhighlightAll, $prev, $next

--- a/opengrok-web/src/main/webapp/js/utils-0.0.28.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.28.js
@@ -803,7 +803,7 @@
             return $.intelliWindow = $window.create($.extend({
                 title: 'Intelligence window',
                 selector: 'a.intelliWindow-symbol',
-                google_url: 'https://www.google.com/search?q=',
+                google_url: 'https://www.google.com/search?full=',
                 project: undefined,
                 init: function ($window) {
                     var $highlight, $unhighlight, $unhighlightAll, $prev, $next
@@ -945,7 +945,7 @@
 
                     this.$search_defs.attr('href', this.getSearchLink('defs'));
                     this.$search_refs.attr('href', this.getSearchLink('refs'));
-                    this.$search_full.attr('href', this.getSearchLink('q'));
+                    this.$search_full.attr('href', this.getSearchLink('full'));
                     this.$search_files.attr('href', this.getSearchLink('path'));
                     this.$search_google.attr('href', this.options.google_url + this.symbol)
                 },
@@ -1745,7 +1745,7 @@ function initAutocomplete(config, minisearch) {
     if (minisearch) {
         initMinisearchAutocomplete(config);
     } else {
-        initAutocompleteForField("q", "full", config);
+        initAutocompleteForField("full", "full", config);
         initAutocompleteForField("defs", "defs", config);
         initAutocompleteForField("refs", "refs", config);
         initAutocompleteForField("path", "path", config);
@@ -1799,7 +1799,7 @@ function initAutocompleteForField(inputId, field, config, dataFunction, errorEle
         dataFunction = getAutocompleteMenuData;
     }
     if (!errorElemId) {
-        errorElemId = 'q';
+        errorElemId = 'full';
     }
     var errorElem = $('#' + errorElemId);
 
@@ -1909,7 +1909,7 @@ function getAutocompleteMenuData(input, field) {
     return {
         projects: getSelectedProjectNames(),
         field: field,
-        full: $('#q').val(),
+        full: $('#full').val(),
         defs: $('#defs').val(),
         refs: $('#refs').val(),
         path: $('#path').val(),

--- a/opengrok-web/src/main/webapp/menu.jspf
+++ b/opengrok-web/src/main/webapp/menu.jspf
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
 
 Portions Copyright 2011 Jens Elkner.
 
@@ -156,8 +156,8 @@ document.domReady.push(function() { domReadyMenu(); });
     %>
     <tbody>
     <tr>
-        <td><label for="q" title="The text token(s) or other fields to be found (lucene query, this is not full text!)">Full&nbsp;Search</label></td>
-        <td colspan="2"><input tabindex="1" class="q" name="q" id="q" type="text" value="<%=
+        <td><label for="full" title="The text token(s) or other fields to be found (lucene query, this is not full text!)">Full&nbsp;Search</label></td>
+        <td colspan="2"><input tabindex="1" class="q" name="full" id="full" type="text" value="<%=
                 Util.formQuoteEscape(queryParams.getFreetext()) %>"/></td>
     </tr>
     <tr>

--- a/opengrok-web/src/main/webapp/minisearch.jspf
+++ b/opengrok-web/src/main/webapp/minisearch.jspf
@@ -16,7 +16,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
 
 --%>
 <%@ page session="false" errorPage="error.jsp" import="
@@ -96,7 +96,7 @@ org.opengrok.indexer.web.Util"%><%
             %>"><span id="download"></span>Download</a></li>
 	<%
     }
-        %><li><input type="text" id="search" name="q" class="q" /></li>
+        %><li><input type="text" id="search" name="full" class="q" /></li>
             <li><input type="submit" value="Search" class="submit" /></li><%
     Project proj = cfg.getProject();
     String[] vals = cfg.getSearchOnlyIn();

--- a/opengrok-web/src/main/webapp/opensearch.jsp
+++ b/opengrok-web/src/main/webapp/opensearch.jsp
@@ -87,7 +87,7 @@ include file="projects.jspf"
     <InputEncoding>UTF-8</InputEncoding>
     <Image height="16" width="16" type="image/png"><%= imgurl %></Image>
 <%-- <Url type="application/x-suggestions+json" template="suggestionURL"/>--%>
-    <Url template="<%= url.toString() %>&amp;q={searchTerms}" type="text/html"/>
+    <Url template="<%= url.toString() %>&amp;full={searchTerms}" type="text/html"/>
 </OpenSearchDescription>
 <%
 }

--- a/opengrok-web/src/main/webapp/search.jsp
+++ b/opengrok-web/src/main/webapp/search.jsp
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
 
@@ -52,7 +52,7 @@ include file="projects.jspf"
             Util.appendQuery(url, "sort", sh.order.toString());
         }
         if (qb != null) {
-            Util.appendQuery(url, "q", qb.getFreetext());
+            Util.appendQuery(url, "full", qb.getFreetext());
             Util.appendQuery(url, "defs", qb.getDefs());
             Util.appendQuery(url, "refs", qb.getRefs());
             Util.appendQuery(url, "path", qb.getPath());
@@ -170,7 +170,7 @@ include file="menu.jspf"
         %><p class="suggestions"><font color="#cc0000">Did you mean (for <%= hint.name %>)</font>:<%
 	  if (hint.freetext!=null) { 
 	    for (String word : hint.freetext) {
-            %> <a href="search?q=<%= Util.URIEncode(word) %>"><%=
+            %> <a href="search?full=<%= Util.URIEncode(word) %>"><%=
                 Util.htmlize(word) %></a> &nbsp; <%
 	    }
 	  }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.controller;
 
@@ -413,9 +413,9 @@ public class SuggesterControllerTest extends JerseyTest {
         // terms for prefix t: "text", "texttrim", "tell", "teach", "trimmargin"
 
         List<String> queries = Arrays.asList(
-                "http://localhost:8080/source/search?project=kotlin&q=text",
-                "http://localhost:8080/source/search?project=kotlin&q=text",
-                "http://localhost:8080/source/search?project=kotlin&q=teach"
+                "http://localhost:8080/source/search?project=kotlin&full=text",
+                "http://localhost:8080/source/search?project=kotlin&full=text",
+                "http://localhost:8080/source/search?project=kotlin&full=teach"
         );
 
         target(SuggesterController.PATH)


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

I've wanted to do this for a very long time :D

Only reason why I think it might be good to keep the name is backwards compatibility. However, it does not correspond to the index name as other fields (`refs,defs,…`) and is just plainly confusing.

Caveats: complete reindex needed (because of the xrefs) and old links will not work.

If you do not like this change then feel free to close this ;)

Thanks :)