### PR TITLE
use Jackson for JSON serialization of Messages

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -75,7 +75,7 @@ Besides `/suggester` and `/search` endpoints, everything is accessible from `loc
 
         {
           "tags": ["main"],
-          "cssClass": "cssClass",
+          "cssClass": "class",
           "text":"test message",
           "duration":"PT10M"
         }
@@ -98,18 +98,17 @@ Besides `/suggester` and `/search` endpoints, everything is accessible from `loc
 
         [
           {
-            "acceptedTime": "2018-06-28T17:49:01.793Z",
-            "message": {
-              "tags": ["main"],
-              "cssClass": "cssClass",
-              "text": "test message",
-              "duration": "PT10M"
-            },
-            "expirationTime": "2018-06-28T17:59:01.793Z",
-            "expired":false
+            "expired": false,
+            "created": "2019-01-23 20:39:31 CET",
+            "tags": [
+              "main"
+            ],
+            "expiration": "2019-01-23 20:49:31 CET",
+            "cssClass": "class",
+            "text": "test&nbsp;message"
           }
         ]
-        
+
 ## Projects [/projects]
 
 ### returns a list of all projects [GET]

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -88,10 +88,6 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
         </dependency>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
@@ -47,7 +47,6 @@ import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreDoc;
-import org.json.simple.JSONArray;
 import org.opengrok.indexer.analysis.Definitions;
 import org.opengrok.indexer.analysis.FileAnalyzer.Genre;
 import org.opengrok.indexer.analysis.Scopes;
@@ -60,6 +59,8 @@ import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.Prefix;
 import org.opengrok.indexer.web.SearchHelper;
 import org.opengrok.indexer.web.Util;
+
+import org.opengrok.indexer.web.messages.MessagesUtils;
 
 import static org.opengrok.indexer.web.messages.MessagesContainer.MESSAGES_MAIN_PAGE_TAG;
 
@@ -191,9 +192,10 @@ public final class Results {
                 out.write(sh.desc.get(parent));
                 out.write("</i>");
             }
-            JSONArray messages;
-            if ((p = Project.getProject(parent)) != null
-                    && (messages = Util.messagesToJson(p, MESSAGES_MAIN_PAGE_TAG)).size() > 0) {
+
+            p = Project.getProject(parent);
+            String messages = MessagesUtils.messagesToJson(p, MESSAGES_MAIN_PAGE_TAG);
+            if (p != null && !messages.isEmpty()) {
                 out.write(" <a href=\"" + xrefPrefix + "/" + p.getName() + "\">");
                 out.write("<span class=\"important-note important-note-rounded\" data-messages='" + messages + "'>!</span>");
                 out.write("</a>");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
@@ -126,7 +126,7 @@ public class Scripts implements Iterable<Scripts.Script> {
         SCRIPTS.put("jquery-tablesorter", new FileScript("js/jquery-tablesorter-2.26.6.min.js", 12));
         SCRIPTS.put("tablesorter-parsers", new FileScript("js/tablesorter-parsers-0.0.1.js", 13));
         SCRIPTS.put("searchable-option-list", new FileScript("js/searchable-option-list-2.0.6.js", 14));
-        SCRIPTS.put("utils", new FileScript("js/utils-0.0.26.js", 15));
+        SCRIPTS.put("utils", new FileScript("js/utils-0.0.27.js", 15));
         SCRIPTS.put("repos", new FileScript("js/repos-0.0.1.js", 20));
         SCRIPTS.put("diff", new FileScript("js/diff-0.0.3.js", 20));
         SCRIPTS.put("jquery-caret", new FileScript("js/jquery.caret-1.5.2.min.js", 25));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/JSONable.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/JSONable.java
@@ -42,9 +42,10 @@ public interface JSONable {
         try {
             return mapper.writeValueAsString(this);
         } catch (JsonProcessingException e) {
-            LoggerFactory.getLogger(JSONable.class).log(Level.WARNING, "failed to convert object of class {0} to JSON: {1}",
-                    new Object[]{this.getClass().toString(), this});
-            return "";
+            LoggerFactory.getLogger(JSONable.class).log(Level.WARNING,
+                    String.format("failed to convert object of class {0} to JSON: {1}",
+                    this.getClass().toString(), this), e);
+            return EMPTY;
         }
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/JSONable.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/JSONable.java
@@ -31,7 +31,7 @@ import java.util.logging.Level;
 
 public interface JSONable {
 
-    public static final String EMPTY = "";
+    String EMPTY = "";
 
     /**
      * convert object to JSON

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/JSONable.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/JSONable.java
@@ -31,6 +31,8 @@ import java.util.logging.Level;
 
 public interface JSONable {
 
+    public static final String EMPTY = "";
+
     /**
      * convert object to JSON
      * @return JSON string or empty string on error

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/JSONable.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/JSONable.java
@@ -1,0 +1,48 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.web.messages;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opengrok.indexer.logger.LoggerFactory;
+
+import java.util.logging.Level;
+
+public interface JSONable {
+
+    /**
+     * convert object to JSON
+     * @return JSON string or empty string on error
+     */
+    default String toJSON() {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            LoggerFactory.getLogger(JSONable.class).log(Level.WARNING, "failed to convert object of class {0} to JSON: {1}",
+                    new Object[]{this.getClass().toString(), this});
+            return "";
+        }
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/JSONable.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/JSONable.java
@@ -43,7 +43,7 @@ public interface JSONable {
             return mapper.writeValueAsString(this);
         } catch (JsonProcessingException e) {
             LoggerFactory.getLogger(JSONable.class).log(Level.WARNING,
-                    String.format("failed to convert object of class {0} to JSON: {1}",
+                    String.format("failed to convert object of class %s to JSON: %s",
                     this.getClass().toString(), this), e);
             return EMPTY;
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/Message.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/Message.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.NotEmpty;
+import org.opengrok.indexer.web.Util;
 import org.opengrok.indexer.web.api.constraints.PositiveDuration;
 
 import java.io.IOException;
@@ -44,7 +45,7 @@ import java.util.TreeSet;
 
 import static org.opengrok.indexer.web.messages.MessagesContainer.MESSAGES_MAIN_PAGE_TAG;
 
-public class Message implements Comparable<Message> {
+public class Message implements Comparable<Message>, JSONable {
 
     @NotEmpty(message = "tags cannot be empty")
     private Set<String> tags = Collections.singleton(MESSAGES_MAIN_PAGE_TAG);
@@ -52,6 +53,7 @@ public class Message implements Comparable<Message> {
     private String cssClass = "info";
 
     @NotBlank(message = "text cannot be empty")
+    @JsonSerialize(using = HTMLSerializer.class)
     private String text;
 
     @PositiveDuration(message = "duration must be positive")
@@ -190,4 +192,29 @@ public class Message implements Comparable<Message> {
         }
     }
 
+    protected static class HTMLSerializer extends StdSerializer<String> {
+
+        private static final long serialVersionUID = -2843900664165513923L;
+
+        HTMLSerializer() {
+            this(null);
+        }
+
+        HTMLSerializer(final Class<String> cl) {
+            super(cl);
+        }
+
+        @Override
+        public void serialize(
+                final String string,
+                final JsonGenerator jsonGenerator,
+                final SerializerProvider serializerProvider
+        ) throws IOException {
+            if (string != null) {
+                jsonGenerator.writeString(Util.encode(string));
+            } else {
+                jsonGenerator.writeNull();
+            }
+        }
+    }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/MessagesContainer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/MessagesContainer.java
@@ -22,16 +22,21 @@
  */
 package org.opengrok.indexer.web.messages;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.hibernate.validator.constraints.NotBlank;
 
 import java.io.IOException;
+import java.text.DateFormat;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -223,19 +228,39 @@ public class MessagesContainer {
         return toRet == null ? new TreeSet<>() : toRet;
     }
 
-    public static class AcceptedMessage implements Comparable<AcceptedMessage> {
+    public static class AcceptedMessage implements Comparable<AcceptedMessage>, JSONable {
 
         private final Instant acceptedTime = Instant.now();
 
+        // The message member is ignored so that it can be flattened using the getters specified below.
+        @JsonIgnore
         private final Message message;
+
+        @JsonProperty("text")
+        @NotBlank(message = "text cannot be empty")
+        @JsonSerialize(using = Message.HTMLSerializer.class)
+        public String getText() {
+            return message.getText();
+        }
+
+        @JsonProperty("cssClass")
+        public String getCssClass() {
+            return message.getCssClass();
+        }
 
         private AcceptedMessage(final Message message) {
             this.message = message;
         }
 
+        @JsonProperty("created")
         @JsonSerialize(using = InstantSerializer.class)
         public Instant getAcceptedTime() {
             return acceptedTime;
+        }
+
+        @JsonProperty("tags")
+        public Set<String> getTags() {
+            return message.getTags();
         }
 
         public Message getMessage() {
@@ -246,6 +271,7 @@ public class MessagesContainer {
             return getExpirationTime().isBefore(Instant.now());
         }
 
+        @JsonProperty("expiration")
         @JsonSerialize(using = InstantSerializer.class)
         public Instant getExpirationTime() {
             return acceptedTime.plus(message.getDuration());
@@ -297,7 +323,8 @@ public class MessagesContainer {
                     final SerializerProvider serializerProvider
             ) throws IOException {
                 if (instant != null) {
-                    jsonGenerator.writeString(instant.toString());
+                    DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG, Locale.ROOT);
+                    jsonGenerator.writeString(formatter.format(Date.from(instant)));
                 } else {
                     jsonGenerator.writeNull();
                 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/MessagesUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/MessagesUtils.java
@@ -1,0 +1,235 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.web.messages;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opengrok.indexer.configuration.Group;
+import org.opengrok.indexer.configuration.Project;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.web.Util;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.sql.Date;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class MessagesUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MessagesUtils.class);
+
+    private void MessageUtils() {
+        // private to ensure static
+    }
+
+    private static final String EMPTY = "";
+
+    static final class TaggedMessagesContainer implements JSONable {
+
+        private final String tag;
+        private final SortedSet<MessagesContainer.AcceptedMessage> messages;
+
+        TaggedMessagesContainer(String tag, SortedSet<MessagesContainer.AcceptedMessage> messages) {
+            this.tag = tag;
+            this.messages = messages;
+        }
+
+        public String getTag() {
+            return tag;
+        }
+
+        public SortedSet<MessagesContainer.AcceptedMessage> getMessages() {
+            return messages;
+        }
+    }
+
+    /**
+     * Print list of messages into output
+     *
+     * @param out output
+     * @param set set of messages
+     */
+    public static void printMessages(Writer out, SortedSet<MessagesContainer.AcceptedMessage> set) {
+        printMessages(out, set, false);
+    }
+
+    /**
+     * Print set of messages into output
+     * @param out output
+     * @param set set of messages
+     * @param limited if the container should be limited
+     */
+    private static void printMessages(Writer out, SortedSet<MessagesContainer.AcceptedMessage> set, boolean limited) {
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
+        if (!set.isEmpty()) {
+            try {
+                out.write("<ul class=\"message-group");
+                if (limited) {
+                    out.write(" limited");
+                }
+                out.write("\">\n");
+                for (MessagesContainer.AcceptedMessage m : set) {
+                    out.write("<li class=\"message-group-item ");
+                    out.write(Util.encode(m.getMessage().getCssClass()));
+                    out.write("\" title=\"Expires on ");
+                    out.write(Util.encode(df.format(Date.from(m.getExpirationTime()))));
+                    out.write("\">");
+                    out.write(Util.encode(df.format(Date.from(m.getAcceptedTime()))));
+                    out.write(": ");
+                    out.write(m.getMessage().getText());
+                    out.write("</li>");
+                }
+                out.write("</ul>");
+            } catch (IOException ex) {
+                LOGGER.log(Level.WARNING,
+                        "An error occurred for a group of messages", ex);
+            }
+        }
+    }
+
+    /**
+     * Print set of tagged messages into JSON object.
+     *
+     * @return JSON string or empty string
+     */
+    private static String taggedMessagesToJson(Set<TaggedMessagesContainer> messages) {
+        if (messages.isEmpty()) {
+            return EMPTY;
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        try {
+            return mapper.writeValueAsString(messages);
+        } catch (JsonProcessingException e) {
+            LOGGER.log(Level.WARNING, "failed to encode {0} to JSON", messages);
+            return EMPTY;
+        }
+    }
+
+    /**
+     * Print messages for given tags into JSON array
+     *
+     * @param tags list of tags
+     * @return JSON array of the messages (the same as the parameter)
+     */
+    public static String messagesToJson(String... tags) {
+        Set<TaggedMessagesContainer> messages = new HashSet<>();
+
+        for (String tag : tags) {
+            SortedSet<MessagesContainer.AcceptedMessage> messagesWithTag = RuntimeEnvironment.getInstance().getMessages(tag);
+            if (messagesWithTag.isEmpty()) {
+                continue;
+            }
+
+            TaggedMessagesContainer container = new TaggedMessagesContainer(tag, messagesWithTag);
+            messages.add(container);
+        }
+
+        return taggedMessagesToJson(messages);
+    }
+
+    /**
+     * Print messages for given tags into JSON array
+     *
+     * @param tags list of tags
+     * @return json array of the messages
+     * @see #messagesToJson(String...)
+     */
+    private static String messagesToJson(List<String> tags) {
+        return messagesToJson(tags.toArray(new String[0]));
+    }
+
+    /**
+     * Print messages for given project into JSON. These messages are
+     * tagged by project description or tagged by any of the project's group name.
+     *
+     * @param project the project
+     * @param additionalTags additional list of tags
+     * @return JSON string
+     * @see #messagesToJson(String...)
+     */
+    public static String messagesToJson(Project project, String... additionalTags) {
+        if (project == null) {
+            return EMPTY;
+        }
+
+        List<String> tags = new ArrayList<>();
+        tags.addAll(Arrays.asList(additionalTags));
+        tags.add(project.getName());
+        project.getGroups().stream().map(Group::getName).forEach(tags::add);
+
+        return messagesToJson(tags);
+    }
+
+    /**
+     * Print messages for given project into JSON array. These messages are
+     * tagged by project description or tagged by any of the project's group
+     * name.
+     *
+     * @param project the project
+     * @return the json array
+     * @see #messagesToJson(Project, String...)
+     */
+    public static String messagesToJson(Project project) {
+        return messagesToJson(project, new String[0]);
+    }
+
+    /**
+     * Print messages for given group into JSON.
+     *
+     * @param group the group
+     * @param additionalTags additional list of tags
+     * @return JSON string
+     * @see #messagesToJson(java.util.List)
+     */
+    private static String messagesToJson(Group group, String... additionalTags) {
+        List<String> tags = new ArrayList<>();
+
+        tags.add(group.getName());
+        tags.addAll(Arrays.asList(additionalTags));
+
+        return messagesToJson(tags);
+    }
+
+    /**
+     * Convert messages for given group into JSON.
+     *
+     * @param group the group
+     * @return JSON string
+     * @see #messagesToJson(Group, String...)
+     */
+    public static String messagesToJson(Group group) {
+        return messagesToJson(group, new String[0]);
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/MessagesUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/MessagesUtils.java
@@ -52,8 +52,6 @@ public final class MessagesUtils {
         // private to ensure static
     }
 
-    private static final String EMPTY = "";
-
     static final class TaggedMessagesContainer implements JSONable {
 
         private final String tag;
@@ -124,7 +122,7 @@ public final class MessagesUtils {
      */
     private static String taggedMessagesToJson(Set<TaggedMessagesContainer> messages) {
         if (messages.isEmpty()) {
-            return EMPTY;
+            return JSONable.EMPTY;
         }
 
         ObjectMapper mapper = new ObjectMapper();
@@ -133,7 +131,7 @@ public final class MessagesUtils {
             return mapper.writeValueAsString(messages);
         } catch (JsonProcessingException e) {
             LOGGER.log(Level.WARNING, "failed to encode {0} to JSON", messages);
-            return EMPTY;
+            return JSONable.EMPTY;
         }
     }
 
@@ -181,7 +179,7 @@ public final class MessagesUtils {
      */
     public static String messagesToJson(Project project, String... additionalTags) {
         if (project == null) {
-            return EMPTY;
+            return JSONable.EMPTY;
         }
 
         List<String> tags = new ArrayList<>();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/MessagesUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/MessagesUtils.java
@@ -130,7 +130,7 @@ public final class MessagesUtils {
         try {
             return mapper.writeValueAsString(messages);
         } catch (JsonProcessingException e) {
-            LOGGER.log(Level.WARNING, "failed to encode {0} to JSON", messages);
+            LOGGER.log(Level.WARNING, String.format("failed to encode '%s' to JSON: ", messages), e);
             return JSONable.EMPTY;
         }
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/messages/JSONUtils.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/messages/JSONUtils.java
@@ -1,0 +1,64 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.web.messages;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+public final class JSONUtils {
+    private JSONUtils() {
+        // private to ensure static
+    }
+
+    protected static Set<String> getTopLevelJSONFields(String jsonString) throws IOException {
+        Set<String> fields = new HashSet<>();
+        JsonFactory jfactory = new JsonFactory();
+        JsonParser jParser = jfactory.createParser(jsonString);
+
+        Assert.assertNotNull(jParser);
+
+        JsonToken token;
+        jParser.nextToken(); // skip the initial START_OBJECT
+        while ((token = jParser.nextToken()) != JsonToken.END_OBJECT) {
+            if (token == JsonToken.START_OBJECT) {
+                while (jParser.nextToken() != JsonToken.END_OBJECT) {
+                }
+            }
+
+            if (token != JsonToken.FIELD_NAME)
+                continue;
+
+            fields.add(jParser.getCurrentName());
+        }
+        jParser.close();
+
+        return fields;
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/messages/MessageTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/messages/MessageTest.java
@@ -24,8 +24,14 @@ package org.opengrok.indexer.web.messages;
 
 import org.junit.Test;
 
+import java.io.IOException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.opengrok.indexer.web.messages.JSONUtils.getTopLevelJSONFields;
 
 public class MessageTest {
 
@@ -59,4 +65,11 @@ public class MessageTest {
         new Message("test", Collections.emptySet(), null, Duration.ofMinutes(1));
     }
 
+    @Test
+    public void messageToJSON() throws IOException {
+        Message m = new Message("test", Collections.singleton("test"), "foo", Duration.ofMinutes(1));
+        String jsonString = m.toJSON();
+        assertEquals(new HashSet<>(Arrays.asList("cssClass", "duration", "text", "tags")),
+                getTopLevelJSONFields(jsonString));
+    }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/messages/MessagesContainerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/messages/MessagesContainerTest.java
@@ -26,16 +26,20 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.opengrok.indexer.web.messages.JSONUtils.getTopLevelJSONFields;
 
 public class MessagesContainerTest {
 
@@ -144,4 +148,18 @@ public class MessagesContainerTest {
         container.getMessages(null);
     }
 
+    /**
+     * tests serialization of MessagesContainer.AcceptedMessage
+     */
+    @Test
+    public void testJSON() throws IOException {
+        Message m = new Message("testJSON", Collections.singleton("testJSON"), "info", Duration.ofMinutes(10));
+
+        container.addMessage(m);
+
+        MessagesContainer.AcceptedMessage am = container.getMessages("testJSON").first();
+        String jsonString = am.toJSON();
+        assertEquals(new HashSet<>(Arrays.asList("tags", "expired", "created", "expiration", "cssClass", "text")),
+                getTopLevelJSONFields(jsonString));
+    }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/messages/MessagesUtilsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/messages/MessagesUtilsTest.java
@@ -1,0 +1,57 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.web.messages;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opengrok.indexer.configuration.Project;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class MessagesUtilsTest {
+    RuntimeEnvironment env;
+
+    @Before
+    public void setUp() {
+        env = RuntimeEnvironment.getInstance();
+    }
+
+    @Test
+    public void testGetMessagesForNonExistentProject() {
+        String projectName = "nonexistent";
+        Project foo = new Project(projectName, "/doesnotexist");
+        HashMap<String, Project> projects = new HashMap<>();
+        projects.put(projectName, foo);
+        env.setProjectsEnabled(true);
+        env.setProjects(projects);
+
+        String jsonString = MessagesUtils.messagesToJson(projectName);
+        assertNotNull(jsonString);
+        assertEquals("", jsonString);
+    }
+}

--- a/opengrok-web/src/main/webapp/js/utils-0.0.27.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.27.js
@@ -1117,7 +1117,7 @@
                             $ul.append(
                                     $('<li>')
                                     .addClass('message-group-item')
-                                    .addClass(tag.messages[j].cssclass)
+                                    .addClass(tag.messages[j].cssClass)
                                     .attr('title', 'Expires on ' + tag.messages[j].expiration)
                                     .html(tag.messages[j].created + ': ' + tag.messages[j].text)
                                     )

--- a/opengrok-web/src/main/webapp/js/utils-0.0.27.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.27.js
@@ -1117,7 +1117,7 @@
                             $ul.append(
                                     $('<li>')
                                     .addClass('message-group-item')
-                                    .addClass(tag.messages[j].class)
+                                    .addClass(tag.messages[j].cssclass)
                                     .attr('title', 'Expires on ' + tag.messages[j].expiration)
                                     .html(tag.messages[j].created + ': ' + tag.messages[j].text)
                                     )

--- a/opengrok-web/src/main/webapp/mast.jsp
+++ b/opengrok-web/src/main/webapp/mast.jsp
@@ -28,19 +28,13 @@ After include you are here: /body/div#page/div#content/
 
 --%>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@page import="org.json.simple.JSONArray"%>
-<%@page import="java.util.SortedSet"%>
 <%@page import="org.opengrok.indexer.web.messages.MessagesContainer"%>
 <%@ page session="false" errorPage="error.jsp" import="
-java.io.File,
-java.io.IOException,
-
-org.opengrok.indexer.configuration.Project,
-org.opengrok.indexer.history.HistoryGuru,
-org.opengrok.indexer.web.EftarFileReader,
 org.opengrok.indexer.web.PageConfig,
 org.opengrok.indexer.web.Prefix,
-org.opengrok.indexer.web.Util"%><%
+org.opengrok.indexer.web.Util"%>
+<%@ page import="org.opengrok.indexer.web.messages.MessagesUtils" %>
+<%
 /* ---------------------- mast.jsp start --------------------- */
 {
     PageConfig cfg = PageConfig.get(request);
@@ -97,9 +91,9 @@ include file="pageheader.jspf"
     String context = request.getContextPath();
     String rev = cfg.getRequestedRevision();
 
-    JSONArray messages = new JSONArray();
+    String messages = "";
     if (cfg.getProject() != null) {
-        messages = Util.messagesToJson(cfg.getProject(),
+        messages = MessagesUtils.messagesToJson(cfg.getProject(),
                     MessagesContainer.MESSAGES_MAIN_PAGE_TAG);
     }
     %>

--- a/opengrok-web/src/main/webapp/menu.jspf
+++ b/opengrok-web/src/main/webapp/menu.jspf
@@ -22,11 +22,9 @@ Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
 
 Portions Copyright 2011 Jens Elkner.
 
---%><%@page import="org.json.simple.JSONArray"%>
-<%@page import="org.opengrok.indexer.configuration.RuntimeEnvironment"%>
+--%>
 <%@page import="java.util.TreeSet"%>
 <%@page import="java.util.Set"%>
-<%@page import="java.util.LinkedList"%>
 <%@page import="org.opengrok.indexer.configuration.Group"%>
 <%@page import="org.opengrok.indexer.web.ProjectHelper"%>
 <%@page import="org.opengrok.indexer.web.SearchHelper"%>
@@ -34,22 +32,20 @@ Portions Copyright 2011 Jens Elkner.
 <%@page import="
 java.util.SortedSet,
 java.util.TreeMap,
-java.util.Map.Entry,
-java.util.List,
-java.util.HashMap,
-java.util.ArrayList,
 
 org.opengrok.indexer.configuration.Project,
 org.opengrok.indexer.search.QueryBuilder,
 org.opengrok.indexer.web.PageConfig,
-org.opengrok.indexer.web.Prefix,
+org.opengrok.indexer.web.messages.MessagesUtils,
 org.opengrok.indexer.web.Util"
-%><%
+%>
+<%@ page import="org.opengrok.indexer.web.messages.Message" %>
+<%
 /* ---------------------- menu.jspf start --------------------- */
 {
     PageConfig cfg = PageConfig.get(request);
     ProjectHelper ph = ProjectHelper.getInstance(cfg);
-    JSONArray messages;
+    String messages;
     Set<Project> projects = ph.getAllProjects();
     if (projects == null) {
         projects = new TreeSet<>();
@@ -107,7 +103,7 @@ document.domReady.push(function() { domReadyMenu(); });
                     if (pRequested.contains(p.getName())) {
                         %> selected="selected"<%
                     }
-                    if (!(messages = Util.messagesToJson(p)).isEmpty()) {
+                    if (!(messages = MessagesUtils.messagesToJson(p)).isEmpty()) {
                     %> data-messages='<%= messages %>' <%
                         }
                     %>><%= Util.formQuoteEscape(p.getName()) %></option><%
@@ -128,7 +124,7 @@ document.domReady.push(function() { domReadyMenu(); });
             if (pRequested.contains(p.getName())) {
                 %> selected="selected"<%
             }
-            if (!(messages = Util.messagesToJson(p)).isEmpty()) {
+            if (!(messages = MessagesUtils.messagesToJson(p)).isEmpty()) {
                 %> data-messages='<%= messages %>' <%
             }
             %>><%= Util.formQuoteEscape(p.getName()) %></option><%

--- a/opengrok-web/src/main/webapp/repos.jspf
+++ b/opengrok-web/src/main/webapp/repos.jspf
@@ -23,7 +23,6 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
 --%>
 <%@page import="java.util.TreeSet"%>
 <%@page import="java.util.Iterator"%>
-<%@page import="org.json.simple.JSONArray"%>
 <%@page import="java.util.Set"%>
 <%@page import="org.opengrok.indexer.web.Prefix"%>
 <%@page import="org.opengrok.indexer.web.ProjectHelper"%>
@@ -37,13 +36,15 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
 <%@page import="org.opengrok.indexer.configuration.Group"%>
 <%@page import="java.util.List"%>
 <%@page import="org.opengrok.indexer.web.PageConfig"%>
+<%@ page import="static org.opengrok.indexer.web.messages.MessagesUtils.printMessages" %>
+<%@ page import="static org.opengrok.indexer.web.messages.MessagesUtils.messagesToJson" %>
 <%
 {
     PageConfig cfg = PageConfig.get(request);
     cfg.addScript("repos");
-    JSONArray messages;
+    String messages;
 
-    Util.printMessages(out, cfg.getMessages());
+    printMessages(out, cfg.getMessages());
 
     Comparator<RepositoryInfo> comparatorRepo = new Comparator<RepositoryInfo>() {
         public int compare(RepositoryInfo r1, RepositoryInfo r2) {
@@ -110,7 +111,7 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
                             <span class="pull-left">
                                 <span class="name"><%= Util.htmlize(group.getName())%></span>
                                 <%
-                                if (!(messages = Util.messagesToJson(group)).isEmpty()) { %>
+                                if (!(messages = MessagesUtils.messagesToJson(group)).isEmpty()) { %>
                                     <span class="important-note important-note-rounded" data-messages='<%= messages %>'>!</span>
                                 <% } %>
                                 <small>
@@ -167,7 +168,7 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
                         <%= Util.htmlize(projDesc) %>
                     </a>
                     <%
-                    if (!(messages = Util.messagesToJson(project)).isEmpty()) { %>
+                    if (!(messages = MessagesUtils.messagesToJson(project)).isEmpty()) { %>
                         <span class="important-note important-note-rounded" data-messages='<%= messages %>'>!</span>
                     <% } %>
                                 </td><%
@@ -246,7 +247,7 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
                                 <span class="pull-left">
                                     <span class="name">Other</span>
                                     <%
-                                    if (!(messages = Util.messagesToJson("other")).isEmpty()) { %>
+                                    if (!(messages = messagesToJson("other")).isEmpty()) { %>
                                         <span class="important-note important-note-rounded" data-messages='<%= messages %>'>!</span>
                                     <% } %>
                                     <small>
@@ -297,7 +298,7 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
                         <%= Util.htmlize(projDesc) %>
                     </a>
                     <%
-                    if (!(messages = Util.messagesToJson(proj)).isEmpty()) { %>
+                    if (!(messages = messagesToJson(proj)).isEmpty()) { %>
                         <span class="important-note important-note-rounded" data-messages='<%= messages %>'>!</span>
                     <% } %>
                     </td><%

--- a/opengrok-web/src/main/webapp/search.jsp
+++ b/opengrok-web/src/main/webapp/search.jsp
@@ -32,6 +32,7 @@ org.opengrok.indexer.web.SortOrder,
 org.opengrok.indexer.web.Suggestion"
 %>
 <%@ page import="org.opengrok.web.api.v1.suggester.provider.service.SuggesterServiceFactory" %>
+<%@ page import="java.util.List" %>
 <%
 {
     PageConfig cfg = PageConfig.get(request);

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/MessagesControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/MessagesControllerTest.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -58,10 +59,12 @@ public class MessagesControllerTest extends JerseyTest {
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
     private static class AcceptedMessageModel {
-        public String acceptedTime;
-        public String expirationTime;
+        public String created;
+        public String expiration;
         public boolean expired;
-        public Message message;
+        public String text;
+        public String cssClass;
+        public Set<String> tags;
     }
 
     @Override
@@ -94,7 +97,7 @@ public class MessagesControllerTest extends JerseyTest {
 
         AcceptedMessage msg = env.getMessages().first();
 
-        assertEquals("test message", msg.getMessage().getText());
+        assertEquals("test&nbsp;message", msg.getMessage().getText());
     }
 
     private void addMessage(String text, String... tags) {
@@ -221,9 +224,9 @@ public class MessagesControllerTest extends JerseyTest {
                 .get(messagesType);
 
         assertEquals(1, messages.size());
-        assertEquals("text", messages.get(0).message.getText());
+        assertEquals("text", messages.get(0).text);
 
-        assertThat(messages.get(0).message.getTags(), contains("info"));
+        assertThat(messages.get(0).tags, contains("info"));
     }
 
     @Test


### PR DESCRIPTION
This change converts Message handling to use Jackson for JSON handling and finally shoves JSON-simple out of the door. The JSON format of the Message changed a bit to accommodate easier serialization.

Tested with:
  1. `curl -X POST --data '{ "tags": [ "foo" ], "cssClass": "class", "text": "test message", "duration": "PT10M" }' -H 'Content-Type:application/json' http://localhost:8080/source/api/v1/messages`
  1. `curl -X GET http://localhost:8080/source/api/v1/messages`
  1. check the UI