### PR TITLE
deal with null entities in AuthorizationFramework

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationFramework.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationFramework.java
@@ -763,6 +763,12 @@ public final class AuthorizationFramework {
             return true;
         }
 
+        if (entity == null) {
+            LOGGER.log(Level.WARNING, "entity was null for request with parameters: {}",
+                    request.getParameterMap());
+            return false;
+        }
+
         Statistics stats = RuntimeEnvironment.getInstance().getStatistics();
 
         Boolean val;


### PR DESCRIPTION
This provides basic protection for `null` entities.