### PR TITLE
print index directory on exception

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -226,7 +226,9 @@ public class IndexDatabase {
                     try {
                         db.update(parallelizer);
                     } catch (Throwable e) {
-                        LOGGER.log(Level.SEVERE, "Problem updating lucene index database: ", e);
+                        LOGGER.log(Level.SEVERE,
+                                String.format("Problem updating index database in directory %s: ",
+                                        db.indexDirectory.getDirectory()), e);
                     }
                 }
             });


### PR DESCRIPTION
As noticed in the log files supplied in #2647, the exception logging is missing index directory name so it is not clear which project's index was incomplete.