### PR TITLE
Page config test updates

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -25,6 +25,8 @@
 
 package org.opengrok.indexer.web;
 
+import static org.opengrok.indexer.index.Indexer.PATH_SEPARATOR;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -63,8 +65,6 @@ import org.opengrok.indexer.history.Annotation;
 import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.logger.LoggerFactory;
-
-import static org.opengrok.indexer.index.Indexer.PATH_SEPARATOR;
 
 /**
  * Class for useful functions.
@@ -848,22 +848,37 @@ public final class Util {
         return path;
     }
 
+    /**
+     * Determine the operation system name.
+     *
+     * @return the name in lowercase, {@code null} if unknown
+     */
     public static String getOsName() {
         if (OS == null) {
-            OS = System.getProperty("os.name");
+            OS = System.getProperty("os.name").toLowerCase(Locale.ROOT);
         }
         return OS;
     }
 
+    /**
+     * Determine if the current platform is Windows.
+     *
+     * @return true if windows, false when not windows or we can not determine
+     */
     public static boolean isWindows() {
         String osname = getOsName();
-        return osname != null ? osname.startsWith("Windows") : false;
+        return osname != null ? osname.startsWith("windows") : false;
     }
 
+    /**
+     * Determine if the current platform is Unix.
+     *
+     * @return true if unix, false when not unix or we can not determine
+     */
     public static boolean isUnix() {
         String osname = getOsName();
-        return osname != null ? (osname.startsWith("Linux") || osname.startsWith("Solaris") ||
-                osname.contains("bsd") || osname.startsWith("mac")): false;
+        return osname != null ? (osname.startsWith("linux") || osname.startsWith("solaris") ||
+                osname.contains("bsd") || osname.startsWith("mac")) : false;
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -485,7 +486,8 @@ public class PageConfigTest {
         File temp = File.createTempFile("opengrok", "-test-file.tmp");
         Files.delete(temp.toPath());
         Files.createDirectories(temp.toPath());
-        temp.setReadable(false);
+        // skip the test if the implementation does not permit setting permissions
+        Assume.assumeTrue(temp.setReadable(false));
         RuntimeEnvironment.getInstance().setSourceRoot(temp.getAbsolutePath());
         try {
             cfg.checkSourceRootExistence();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigTest.java
@@ -22,11 +22,17 @@
  */
 package org.opengrok.indexer.web;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.rmi.server.UnicastRemoteObject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,8 +56,6 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.Annotation;
 import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.util.TestRepository;
-
-import static org.junit.Assert.*;
 
 /**
  * Unit tests for the {@code PageConfig} class.
@@ -105,8 +109,8 @@ public class PageConfigTest {
         }
     }
 
-    @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
     @Test
+    @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
     public void canProcessHistory() {
         // Expect no redirection (that is, empty string is returned) for a
         // file that exists.
@@ -246,6 +250,7 @@ public class PageConfigTest {
     }
 
     @Test
+    @ConditionalRun(RepositoryInstalled.GitInstalled.class)
     public void testGetLatestRevisionValid() {
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
             @Override
@@ -261,6 +266,7 @@ public class PageConfigTest {
     }
 
     @Test
+    @ConditionalRun(RepositoryInstalled.GitInstalled.class)
     public void testGetRevisionLocation() {
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
             @Override
@@ -287,6 +293,7 @@ public class PageConfigTest {
     }
 
     @Test
+    @ConditionalRun(RepositoryInstalled.GitInstalled.class)
     public void testGetRevisionLocationNullQuery() {
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
             @Override
@@ -313,6 +320,7 @@ public class PageConfigTest {
     }
 
     @Test
+    @ConditionalRun(RepositoryInstalled.GitInstalled.class)
     public void testGetLatestRevisionNotValid() {
         DummyHttpServletRequest req2 = new DummyHttpServletRequest() {
             @Override


### PR DESCRIPTION
1. Using assume to skip tests of the platform does not allow read permissions for files.
2. Fix the isUnix() for macosx platform

approaches #2661
fixes #2662