### PR TITLE
Extract xref test code--customizable for odd duck, Troff

### DIFF
--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/XrefTestBase.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/XrefTestBase.java
@@ -1,0 +1,136 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.analysis;
+
+import org.opengrok.indexer.util.StreamUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
+import static org.opengrok.indexer.util.StreamUtils.readerFromResource;
+
+/**
+ * Represents an abstract base class for language-specific xref test classes.
+ */
+public abstract class XrefTestBase {
+
+    /**
+     * Tests the XREF result of a specified factory and arguments.
+     * @param factory a defined instance
+     * @param sourceResource a defined resource name for source code
+     * @param resultResource a defined resource name for expected XREF result
+     * @param defs an optional instance
+     * @param expectedLOC the number of expected LOC
+     * @throws IOException thrown if an I/O error occurs
+     */
+    protected void writeAndCompare(
+            AnalyzerFactory factory, String sourceResource,
+            String resultResource, Definitions defs, int expectedLOC)
+            throws IOException {
+
+        try (Reader sourceRes = readerFromResource(sourceResource);
+             Reader resultRes = readerFromResource(resultResource)) {
+            writeAndCompare(factory, sourceRes, resultRes, defs, expectedLOC);
+        }
+    }
+
+    /**
+     * Tests the XREF result of a specified factory and arguments.
+     * @param factory a defined instance
+     * @param source a defined instance for source code
+     * @param result a defined instance for expected XREF result
+     * @param defs an optional instance
+     * @param expectedLOC the number of expected LOC
+     * @throws IOException thrown if an I/O error occurs
+     */
+    protected void writeAndCompare(
+            AnalyzerFactory factory, Reader source, Reader result,
+            Definitions defs, int expectedLOC) throws IOException {
+
+        ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
+
+        int actLOC = writeXref(new PrintStream(outBytes), factory, source, defs);
+        outBytes.close();
+        String outStr = new String(outBytes.toByteArray(), StandardCharsets.UTF_8);
+        String[] gotten = outStr.split("\n");
+
+        String expStr = StreamUtils.readToEnd(result);
+        String[] expected = expStr.split("\n");
+
+        String messagePrefix = factory.getClass().getName();
+        assertLinesEqual(messagePrefix + " xref", expected, gotten);
+        assertEquals(messagePrefix + " LOC", expectedLOC, actLOC);
+    }
+
+    private int writeXref(
+            PrintStream oss, AnalyzerFactory factory, Reader in,
+            Definitions defs) throws IOException {
+
+        oss.print(getHtmlBegin());
+
+        Writer out = new StringWriter();
+        AbstractAnalyzer analyzer = factory.getAnalyzer();
+        analyzer.setScopesEnabled(true);
+        analyzer.setFoldingEnabled(true);
+
+        WriteXrefArgs writeArgs = new WriteXrefArgs(in, out);
+        writeArgs.setDefs(defs);
+
+        Xrefer xref = analyzer.writeXref(writeArgs);
+        oss.print(out.toString());
+
+        oss.print(getHtmlEnd());
+        return xref.getLOC();
+    }
+
+    /**
+     * Subclasses can override if the XREF is non-standard.
+     * @return default HTML document header
+     */
+    protected String getHtmlBegin() {
+        return "<!DOCTYPE html>\n" +
+                "<html lang=\"en\">\n" +
+                "<head>\n" +
+                "<meta charset=\"UTF-8\">\n" +
+                "<title>sampleFile - OpenGrok cross reference" +
+                " for /sampleFile</title></head><body>\n";
+    }
+
+    /**
+     * Subclasses can override if the XREF is non-standard.
+     * @return default HTML document footer
+     */
+    protected String getHtmlEnd() {
+        return "</body>\n" +
+                "</html>\n";
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ada/AdaXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ada/AdaXrefTest.java
@@ -19,84 +19,24 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.ada;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
 
 /**
  * Tests the {@link AdaXref} class.
  */
-public class AdaXrefTest {
+public class AdaXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/ada/sample.adb");
-        assertNotNull("though sample.adb should stream,", res);
-        int actLOC = writeAdaXref(res, new PrintStream(baos));
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            "analysis/ada/ada_xrefres.html");
-        assertNotNull("ada_xrefres.html should stream,", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String estr = new String(expbytes, "UTF-8");
-        assertLinesEqual("Ada xref", estr, ostr);
-        assertEquals("Ada LOC", 19, actLOC);
-    }
-
-    private int writeAdaXref(InputStream iss, PrintStream oss)
-            throws IOException {
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        AdaAnalyzerFactory fac = new AdaAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        Xrefer xref = analyzer.writeXref(wargs);
-
-        oss.print(sw.toString());
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new AdaAnalyzerFactory(),
+                "analysis/ada/sample.adb",
+                "analysis/ada/ada_xrefres.html", null, 19);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CXrefTest.java
@@ -19,107 +19,27 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.c;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
 
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link CXref} class.
  */
-public class CXrefTest {
+public class CXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/c/sample.c");
-        assertNotNull("though sample.c should stream,", res);
-        int actLOC = writeCXref(res, new PrintStream(baos));
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            "analysis/c/c_xrefres.html");
-        assertNotNull("c_xrefres.html should stream,", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String estr = new String(expbytes, "UTF-8");
-        assertLinesEqual("C xref", estr, ostr);
-        assertEquals("C LOC", 69, actLOC);
-    }
-
-    private int writeCXref(InputStream iss, PrintStream oss)
-        throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        CAnalyzerFactory fac = new CAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(getTagsDefinitions());
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        Xrefer xref = analyzer.writeXref(wargs);
-
-        oss.print(sw.toString());
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/c/sampletags_c");
-        assertNotNull("though sampletags_c should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new CAnalyzerFactory(),
+                "analysis/c/sample.c",
+                "analysis/c/c_xrefres.html",
+                readTagsFromResource("analysis/c/sampletags_c"), 69);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CxxXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CxxXrefTest.java
@@ -19,106 +19,27 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.c;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
 
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link CxxXref} class.
  */
-public class CxxXrefTest {
+public class CxxXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/c/sample.cc");
-        assertNotNull("though sample.cc should stream,", res);
-        int actLOC = writeCxxXref(res, new PrintStream(baos));
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            "analysis/c/cc_xrefres.html");
-        assertNotNull("cc_xrefres.html should stream,", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String estr = new String(expbytes, "UTF-8");
-        assertLinesEqual("Cxx xref", estr, ostr);
-        assertEquals("Cxx LOC", 199, actLOC);
-    }
-
-    private int writeCxxXref(InputStream iss, PrintStream oss)
-        throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        CxxAnalyzerFactory fac = new CxxAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(getTagsDefinitions());
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        Xrefer xref = analyzer.writeXref(wargs);
-
-        oss.print(sw.toString());
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/c/sampletags_cc");
-        assertNotNull("though sampletags_cc should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new CxxAnalyzerFactory(),
+                "analysis/c/sample.cc",
+                "analysis/c/cc_xrefres.html",
+                readTagsFromResource("analysis/c/sampletags_cc"), 199);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/clojure/ClojureXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/clojure/ClojureXrefTest.java
@@ -19,123 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.clojure;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link ClojureXref} class.
  */
-public class ClojureXrefTest {
+public class ClojureXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/clojure/sample.clj",
-            "analysis/clojure/sample_xref.html",
-            getTagsDefinitions(), 40);
+        writeAndCompare(new ClojureAnalyzerFactory(),
+                "analysis/clojure/sample.clj",
+                "analysis/clojure/sample_xref.html",
+                readTagsFromResource("analysis/clojure/sampletags"), 40);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/clojure/truncated.clj",
-            "analysis/clojure/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeClojureXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Clojure xref", expected, gotten);
-        assertEquals("Clojure LOC", expLOC, actLOC);
-    }
-
-    private int writeClojureXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        ClojureAnalyzerFactory fac = new ClojureAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/clojure/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new ClojureAnalyzerFactory(),
+                "analysis/clojure/truncated.clj",
+                "analysis/clojure/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/csharp/CSharpXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/csharp/CSharpXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.csharp;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link CSharpXref} class.
  */
-public class CSharpXrefTest {
+public class CSharpXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/csharp/sample.cs",
-            "analysis/csharp/sample_xref.html",
-            getTagsDefinitions(), 209);
+        writeAndCompare(new CSharpAnalyzerFactory(),
+                "analysis/csharp/sample.cs",
+                "analysis/csharp/sample_xref.html",
+                readTagsFromResource("analysis/csharp/sampletags"), 209);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/csharp/truncated.cs",
-            "analysis/csharp/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeCsharpXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("CSharp xref", expected, gotten);
-        assertEquals("CSharp LOC", expLOC, actLOC);
-    }
-
-    private int writeCsharpXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        CSharpAnalyzerFactory fac = new CSharpAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/csharp/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new CSharpAnalyzerFactory(),
+                "analysis/csharp/truncated.cs",
+                "analysis/csharp/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/document/TroffXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/document/TroffXrefTest.java
@@ -19,90 +19,29 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.document;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
 
 /**
  * Tests the {@link TroffXref} class.
  */
-public class TroffXrefTest {
+public class TroffXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/document/sync.1m",
-            "analysis/document/sync_xref.html",
-            null, 20);
+        writeAndCompare(new TroffAnalyzerFactory(),
+                "analysis/document/sync.1m",
+                "analysis/document/sync_xref.html", null, 20);
     }
 
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeTroffXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Troff xref", expected, gotten);
-        assertEquals("Troff LOC", expLOC, actLOC);
-    }
-
-    private int writeTroffXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        TroffAnalyzerFactory fac = new TroffAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private static String getHtmlBegin() {
+    @Override
+    protected String getHtmlBegin() {
         return "<!DOCTYPE html>\n" +
             "<html lang=\"en\">\n" +
             "<head>\n" +
@@ -111,7 +50,8 @@ public class TroffXrefTest {
             " for /sampleFile</title></head><body><pre>\n";
     }
 
-    private static String getHtmlEnd() {
+    @Override
+    protected String getHtmlEnd() {
         return "</pre></body>\n" +
             "</html>\n";
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/eiffel/EiffelXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/eiffel/EiffelXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.eiffel;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link EiffelXref} class.
  */
-public class EiffelXrefTest {
+public class EiffelXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/eiffel/sample.e",
-            "analysis/eiffel/sample_xref.html",
-            getTagsDefinitions(), 498);
+        writeAndCompare(new EiffelAnalyzerFactory(),
+                "analysis/eiffel/sample.e",
+                "analysis/eiffel/sample_xref.html",
+                readTagsFromResource("analysis/eiffel/sampletags"), 498);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/eiffel/truncated.e",
-            "analysis/eiffel/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        int actLOC = writeEiffelXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expraw = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expraw, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Eiffel xref", expected, gotten);
-        assertEquals("Eiffel LOC", expLOC, actLOC);
-    }
-
-    private int writeEiffelXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        EiffelAnalyzerFactory fac = new EiffelAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/eiffel/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new EiffelAnalyzerFactory(),
+                "analysis/eiffel/truncated.e",
+                "analysis/eiffel/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/erlang/ErlangXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/erlang/ErlangXrefTest.java
@@ -19,123 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.erlang;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link ErlangXref} class.
  */
-public class ErlangXrefTest {
+public class ErlangXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/erlang/sample.erl",
-            "analysis/erlang/sample_xref.html",
-            getTagsDefinitions(), 37);
+        writeAndCompare(new ErlangAnalyzerFactory(),
+                "analysis/erlang/sample.erl",
+                "analysis/erlang/sample_xref.html",
+                readTagsFromResource("analysis/erlang/sampletags"), 37);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/erlang/truncated.erl",
-            "analysis/erlang/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeErlangXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Erlang xref", expected, gotten);
-        assertEquals("Erlang LOC", expLOC, actLOC);
-    }
-
-    private int writeErlangXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        ErlangAnalyzerFactory fac = new ErlangAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/erlang/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new ErlangAnalyzerFactory(),
+                "analysis/erlang/truncated.erl",
+                "analysis/erlang/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/fortran/FortranXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/fortran/FortranXrefTest.java
@@ -19,121 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.fortran;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link FortranXref} class.
  */
-public class FortranXrefTest {
+public class FortranXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/fortran/sample.f",
-            "analysis/fortran/sample_xref.html",
-            getTagsDefinitions(), 28);
+        writeAndCompare(new FortranAnalyzerFactory(),
+                "analysis/fortran/sample.f",
+                "analysis/fortran/sample_xref.html",
+                readTagsFromResource("analysis/fortran/sampletags"), 28);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/fortran/truncated.f",
-            "analysis/fortran/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeFortranXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String estr = new String(expbytes, "UTF-8");
-        assertLinesEqual("Fortran xref", estr, ostr);
-        assertEquals("Fortran LOC", expLOC, actLOC);
-    }
-
-    private int writeFortranXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        FortranAnalyzerFactory fac = new FortranAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/fortran/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new FortranAnalyzerFactory(),
+                "analysis/fortran/truncated.f",
+                "analysis/fortran/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/golang/GolangXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/golang/GolangXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.golang;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link GolangXref} class.
  */
-public class GolangXrefTest {
+public class GolangXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/golang/sample.go",
-            "analysis/golang/sample_xref.html",
-            getTagsDefinitions(), 101);
+        writeAndCompare(new GolangAnalyzerFactory(),
+                "analysis/golang/sample.go",
+                "analysis/golang/sample_xref.html",
+                readTagsFromResource("analysis/golang/sampletags"), 101);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/golang/truncated.go",
-            "analysis/golang/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeGolangXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Golang xref", expected, gotten);
-        assertEquals("Golang LOC", expLOC, actLOC);
-    }
-
-    private int writeGolangXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        GolangAnalyzerFactory fac = new GolangAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/golang/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new GolangAnalyzerFactory(),
+                "analysis/golang/truncated.go",
+                "analysis/golang/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/java/JavaXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/java/JavaXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.java;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link JavaXref} class.
  */
-public class JavaXrefTest {
+public class JavaXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/java/Sample.jav",
-            "analysis/java/sample_xref.html",
-            getTagsDefinitions(), 32);
+        writeAndCompare(new JavaAnalyzerFactory(),
+                "analysis/java/Sample.jav",
+                "analysis/java/sample_xref.html",
+                readTagsFromResource("analysis/java/sampletags"), 32);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/java/truncated.jav",
-            "analysis/java/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeJavaXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Java xref", expected, gotten);
-        assertEquals("Java LOC", expLOC, actLOC);
-    }
-
-    private int writeJavaXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        JavaAnalyzerFactory fac = new JavaAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/java/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new JavaAnalyzerFactory(),
+                "analysis/java/truncated.jav",
+                "analysis/java/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/javascript/JavaScriptXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/javascript/JavaScriptXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.javascript;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link JavaScriptXref} class.
  */
-public class JavaScriptXrefTest {
+public class JavaScriptXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/javascript/sample.js",
-            "analysis/javascript/sample_xref.html",
-            getTagsDefinitions(), 206);
+        writeAndCompare(new JavaScriptAnalyzerFactory(),
+                "analysis/javascript/sample.js",
+                "analysis/javascript/sample_xref.html",
+                readTagsFromResource("analysis/javascript/sampletags"), 206);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/javascript/truncated.js",
-            "analysis/javascript/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeJavaScriptXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("JavaScript xref", expected, gotten);
-        assertEquals("JavaScript LOC", expLOC, actLOC);
-    }
-
-    private int writeJavaScriptXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        JavaScriptAnalyzerFactory fac = new JavaScriptAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/javascript/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new JavaScriptAnalyzerFactory(),
+                "analysis/javascript/truncated.js",
+                "analysis/javascript/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/json/JsonXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/json/JsonXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.json;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link JsonXref} class.
  */
-public class JsonXrefTest {
+public class JsonXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/json/sample.json",
-            "analysis/json/sample_xref.html",
-            getTagsDefinitions(), 27);
+        writeAndCompare(new JsonAnalyzerFactory(),
+                "analysis/json/sample.json",
+                "analysis/json/sample_xref.html",
+                readTagsFromResource("analysis/json/sampletags"), 27);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/json/truncated.json",
-            "analysis/json/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeJsonXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Json xref", expected, gotten);
-        assertEquals("Json LOC", expLOC, actLOC);
-    }
-
-    private int writeJsonXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        JsonAnalyzerFactory fac = new JsonAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/json/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new JsonAnalyzerFactory(),
+                "analysis/json/truncated.json",
+                "analysis/json/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/kotlin/KotlinXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/kotlin/KotlinXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.kotlin;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link KotlinXref} class.
  */
-public class KotlinXrefTest {
+public class KotlinXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/kotlin/sample.kt",
+        writeAndCompare(new KotlinAnalyzerFactory(),
+                "analysis/kotlin/sample.kt",
                 "analysis/kotlin/sample_xref.html",
-            getTagsDefinitions(), 105);
+                readTagsFromResource("analysis/kotlin/sampletags"), 105);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/kotlin/truncated.kt",
-                "analysis/kotlin/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeKotlinXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Kotlin xref", expected, gotten);
-        assertEquals("Kotlin LOC", expLOC, actLOC);
-    }
-
-    private int writeKotlinXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        KotlinAnalyzerFactory fac = new KotlinAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-                "analysis/kotlin/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new KotlinAnalyzerFactory(),
+                "analysis/kotlin/truncated.kt",
+                "analysis/kotlin/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/lisp/LispXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/lisp/LispXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.lisp;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link LispXref} class.
  */
-public class LispXrefTest {
+public class LispXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/lisp/sample.lsp",
-            "analysis/lisp/sample_xref.html",
-            getTagsDefinitions(), 55);
+        writeAndCompare(new LispAnalyzerFactory(),
+                "analysis/lisp/sample.lsp",
+                "analysis/lisp/sample_xref.html",
+                readTagsFromResource("analysis/lisp/sampletags"), 55);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/lisp/truncated.lsp",
-            "analysis/lisp/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeLispXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Lisp xref", expected, gotten);
-        assertEquals("Lisp LOC", expLOC, actLOC);
-    }
-
-    private int writeLispXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        LispAnalyzerFactory fac = new LispAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/lisp/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new LispAnalyzerFactory(),
+                "analysis/lisp/truncated.lsp",
+                "analysis/lisp/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/lua/LuaXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/lua/LuaXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.lua;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link LuaXref} class.
  */
-public class LuaXrefTest {
+public class LuaXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/lua/sample.lua",
-            "analysis/lua/sample_xref.html",
-            getTagsDefinitions(), 108);
+        writeAndCompare(new LuaAnalyzerFactory(),
+                "analysis/lua/sample.lua",
+                "analysis/lua/sample_xref.html",
+                readTagsFromResource("analysis/lua/sampletags"), 108);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/lua/truncated.lua",
-            "analysis/lua/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeLuaXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("lua xref", expected, gotten);
-        assertEquals("lua LOC", expLOC, actLOC);
-    }
-
-    private int writeLuaXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        LuaAnalyzerFactory fac = new LuaAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/lua/sampletags");
-        assertNotNull("though sampletags luaould stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new LuaAnalyzerFactory(),
+                "analysis/lua/truncated.lua",
+                "analysis/lua/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/pascal/PascalXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/pascal/PascalXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.pascal;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link PascalXref} class.
  */
-public class PascalXrefTest {
+public class PascalXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/pascal/sample.pas",
-            "analysis/pascal/sample_xref.html",
-            getTagsDefinitions(), 423);
+        writeAndCompare(new PascalAnalyzerFactory(),
+                "analysis/pascal/sample.pas",
+                "analysis/pascal/sample_xref.html",
+                readTagsFromResource("analysis/pascal/sampletags"), 423);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/pascal/truncated.pas",
-            "analysis/pascal/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writePascalXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Pascal xref", expected, gotten);
-        assertEquals("Pascal LOC", expLOC, actLOC);
-    }
-
-    private int writePascalXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        PascalAnalyzerFactory fac = new PascalAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/pascal/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new PascalAnalyzerFactory(),
+                "analysis/pascal/truncated.pas",
+                "analysis/pascal/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/perl/PerlXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/perl/PerlXrefTest.java
@@ -19,98 +19,31 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.perl;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
 
 /**
  * Tests the {@link PerlXref} class.
  */
-public class PerlXrefTest {
+public class PerlXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/perl/sample.pl",
-            "analysis/perl/samplexrefres.html", 258);
+        writeAndCompare(new PerlAnalyzerFactory(),
+                "analysis/perl/sample.pl",
+                "analysis/perl/samplexrefres.html", null, 258);
     }
 
     @Test
     public void shouldCloseTruncateStringSpan() throws IOException {
-        writeAndCompare("analysis/perl/truncated.pl",
-            "analysis/perl/truncated_xrefres.html",
-            1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writePerlXref(res, new PrintStream(baos));
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String estr = new String(expbytes, "UTF-8");
-        assertLinesEqual("Perl xref", estr, ostr);
-        assertEquals("Perl LOC", expLOC, actLOC);
-    }
-
-    private int writePerlXref(InputStream iss, PrintStream oss)
-        throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        PerlAnalyzerFactory fac = new PerlAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        Xrefer xref = analyzer.writeXref(new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw));
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleTest.pl - OpenGrok cross reference" +
-            " for /sampleTest.pl</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new PerlAnalyzerFactory(),
+                "analysis/perl/truncated.pl",
+                "analysis/perl/truncated_xrefres.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/powershell/PoshXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/powershell/PoshXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.powershell;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link PoshXref} class.
  */
-public class PoshXrefTest {
+public class PoshXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/powershell/sample.psm1",
-            "analysis/powershell/sample_xref.html",
-            getTagsDefinitions(), 338);
+        writeAndCompare(new PowershellAnalyzerFactory(),
+                "analysis/powershell/sample.psm1",
+                "analysis/powershell/sample_xref.html",
+                readTagsFromResource("analysis/powershell/sampletags"), 338);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/powershell/truncated.ps1",
-            "analysis/powershell/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writePowerShellXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("PowerShell xref", expected, gotten);
-        assertEquals("PowerShell LOC", expLOC, actLOC);
-    }
-
-    private int writePowerShellXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        PowershellAnalyzerFactory fac = new PowershellAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/powershell/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new PowershellAnalyzerFactory(),
+                "analysis/powershell/truncated.ps1",
+            "analysis/powershell/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/python/PythonXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/python/PythonXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.python;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link PythonXref} class.
  */
-public class PythonXrefTest {
+public class PythonXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/python/sample.py",
-            "analysis/python/sample_xref.html",
-            getTagsDefinitions(), 101);
+        writeAndCompare(new PythonAnalyzerFactory(),
+                "analysis/python/sample.py",
+                "analysis/python/sample_xref.html",
+                readTagsFromResource("analysis/python/sampletags"), 101);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/python/truncated.py",
-            "analysis/python/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writePythonXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Python xref", expected, gotten);
-        assertEquals("Python LOC", expLOC, actLOC);
-    }
-
-    private int writePythonXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        PythonAnalyzerFactory fac = new PythonAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/python/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new PythonAnalyzerFactory(),
+                "analysis/python/truncated.py",
+                "analysis/python/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ruby/RubyXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ruby/RubyXrefTest.java
@@ -19,60 +19,33 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.ruby;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
+import org.junit.Test;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import org.opengrok.indexer.analysis.JFlexXref;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.io.Writer;
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.JFlexXref;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
-import org.opengrok.indexer.analysis.Xrefer;
 import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link RubyXref} class.
  */
-public class RubyXrefTest {
+public class RubyXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/ruby/sample.rb");
-        assertNotNull("though sample.rb should stream,", res);
-        int actLOC = writeRubyXref(res, new PrintStream(baos));
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            "analysis/ruby/ruby_xrefres.html");
-        assertNotNull("ruby_xrefres.html should stream,", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String estr = new String(expbytes, "UTF-8");
-        assertLinesEqual("Ruby xref", estr, ostr);
-        assertEquals("Ruby LOC", 159, actLOC);
+        writeAndCompare(new RubyAnalyzerFactory(),
+                "analysis/ruby/sample.rb",
+                "analysis/ruby/ruby_xrefres.html",
+                readTagsFromResource("analysis/ruby/sampletags"), 159);
     }
 
     @Test
@@ -96,52 +69,5 @@ public class RubyXrefTest {
             "<a class=\"l\" name=\"2\" href=\"#2\">2</a>\n";
         assertLinesEqual("Ruby colon-quote", xexpected, xout);
         assertEquals("Ruby colon-quote LOC", 1, actLOC);
-    }
-
-    private int writeRubyXref(InputStream iss, PrintStream oss)
-            throws IOException {
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        RubyAnalyzerFactory fac = new RubyAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(getTagsDefinitions());
-        Xrefer xref = analyzer.writeXref(wargs);
-
-        oss.print(sw.toString());
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/ruby/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/rust/RustXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/rust/RustXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.rust;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link RustXref} class.
  */
-public class RustXrefTest {
+public class RustXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/rust/sample.rs",
-            "analysis/rust/sample_xref.html",
-            getTagsDefinitions(), 107);
+        writeAndCompare(new RustAnalyzerFactory(),
+                "analysis/rust/sample.rs",
+                "analysis/rust/sample_xref.html",
+                readTagsFromResource("analysis/rust/sampletags"), 107);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/rust/truncated.rs",
-            "analysis/rust/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeRustXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Rust xref", expected, gotten);
-        assertEquals("Rust LOC", expLOC, actLOC);
-    }
-
-    private int writeRustXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        RustAnalyzerFactory fac = new RustAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/rust/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new RustAnalyzerFactory(),
+                "analysis/rust/truncated.rs",
+                "analysis/rust/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/scala/ScalaXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/scala/ScalaXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.scala;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link ScalaXref} class.
  */
-public class ScalaXrefTest {
+public class ScalaXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/scala/sample.scala",
-            "analysis/scala/sample_xref.html",
-            getTagsDefinitions(), 196);
+        writeAndCompare(new ScalaAnalyzerFactory(),
+                "analysis/scala/sample.scala",
+                "analysis/scala/sample_xref.html",
+                readTagsFromResource("analysis/scala/sampletags"), 196);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/scala/truncated.scala",
-            "analysis/scala/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeScalaXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Scala xref", expected, gotten);
-        assertEquals("Scala LOC", expLOC, actLOC);
-    }
-
-    private int writeScalaXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        ScalaAnalyzerFactory fac = new ScalaAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/scala/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new ScalaAnalyzerFactory(),
+                "analysis/scala/truncated.scala",
+                "analysis/scala/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sh/ShXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sh/ShXrefTest.java
@@ -19,121 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.sh;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link ShXref} class.
  */
-public class ShXrefTest {
+public class ShXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/sh/sample.sh",
-            "analysis/sh/sample_xref.html",
-            getTagsDefinitions(), 157);
+        writeAndCompare(new ShAnalyzerFactory(),
+                "analysis/sh/sample.sh",
+                "analysis/sh/sample_xref.html",
+                readTagsFromResource("analysis/sh/sampletags"), 157);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/sh/truncated.sh",
-            "analysis/sh/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeShXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String estr = new String(expbytes, "UTF-8");
-        assertLinesEqual("sh xref", estr, ostr);
-        assertEquals("sh LOC", expLOC, actLOC);
-    }
-
-    private int writeShXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        ShAnalyzerFactory fac = new ShAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/sh/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new ShAnalyzerFactory(),
+                "analysis/sh/truncated.sh",
+            "analysis/sh/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sql/PLSQLXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sql/PLSQLXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.sql;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link PLSQLXref} class.
  */
-public class PLSQLXrefTest {
+public class PLSQLXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/sql/sample.pls",
-            "analysis/sql/samplepls_xref.html",
-            getTagsDefinitions(), 284);
+        writeAndCompare(new PLSQLAnalyzerFactory(),
+                "analysis/sql/sample.pls",
+                "analysis/sql/samplepls_xref.html",
+                readTagsFromResource("analysis/sql/sampleplstags"), 284);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/sql/truncated.pls",
-            "analysis/sql/truncatedpls_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writePLSQLXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("PL/SQL xref", expected, gotten);
-        assertEquals("PL/SQL LOC", expLOC, actLOC);
-    }
-
-    private int writePLSQLXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        PLSQLAnalyzerFactory fac = new PLSQLAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/sql/sampleplstags");
-        assertNotNull("though sampleplstags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new PLSQLAnalyzerFactory(),
+                "analysis/sql/truncated.pls",
+                "analysis/sql/truncatedpls_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sql/SQLXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sql/SQLXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.sql;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link SQLXref} class.
  */
-public class SQLXrefTest {
+public class SQLXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/sql/sample.sql",
-            "analysis/sql/samplesql_xref.html",
-            getTagsDefinitions(), 1127);
+        writeAndCompare(new SQLAnalyzerFactory(),
+                "analysis/sql/sample.sql",
+                "analysis/sql/samplesql_xref.html",
+                readTagsFromResource("analysis/sql/samplesqltags"), 1127);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/sql/truncated.sql",
-            "analysis/sql/truncatedsql_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeSQLXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("SQL xref", expected, gotten);
-        assertEquals("SQL LOC", expLOC, actLOC);
-    }
-
-    private int writeSQLXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        SQLAnalyzerFactory fac = new SQLAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/sql/samplesqltags");
-        assertNotNull("though samplesqltags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new SQLAnalyzerFactory(),
+                "analysis/sql/truncated.sql",
+                "analysis/sql/truncatedsql_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/swift/SwiftXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/swift/SwiftXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.swift;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link SwiftXref} class.
  */
-public class SwiftXrefTest {
+public class SwiftXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/swift/sample.swift",
-            "analysis/swift/sample_xref.html",
-            getTagsDefinitions(), 111);
+        writeAndCompare(new SwiftAnalyzerFactory(),
+                "analysis/swift/sample.swift",
+                "analysis/swift/sample_xref.html",
+                readTagsFromResource("analysis/swift/sampletags"), 111);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/swift/truncated.swift",
-            "analysis/swift/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeSwiftXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Swift xref", expected, gotten);
-        assertEquals("Swift LOC", expLOC, actLOC);
-    }
-
-    private int writeSwiftXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        SwiftAnalyzerFactory fac = new SwiftAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/swift/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new SwiftAnalyzerFactory(),
+                "analysis/swift/truncated.swift",
+                "analysis/swift/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/tcl/TclXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/tcl/TclXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.tcl;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link TclXref} class.
  */
-public class TclXrefTest {
+public class TclXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/tcl/sample.tcl",
-            "analysis/tcl/sample_xref.html",
-            getTagsDefinitions(), 163);
+        writeAndCompare(new TclAnalyzerFactory(),
+                "analysis/tcl/sample.tcl",
+                "analysis/tcl/sample_xref.html",
+                readTagsFromResource("analysis/tcl/sampletags"), 163);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/tcl/truncated.tcl",
-            "analysis/tcl/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeTclXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("Tcl xref", expected, gotten);
-        assertEquals("Tcl LOC", expLOC, actLOC);
-    }
-
-    private int writeTclXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        TclAnalyzerFactory fac = new TclAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/tcl/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new TclAnalyzerFactory(),
+                "analysis/tcl/truncated.tcl",
+                "analysis/tcl/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/vb/VBXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/vb/VBXrefTest.java
@@ -19,125 +19,34 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.vb;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.CtagsReader;
-import org.opengrok.indexer.analysis.Definitions;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
  * Tests the {@link VBXref} class.
  */
-public class VBXrefTest {
+public class VBXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/vb/sample.cls",
-            "analysis/vb/sample_xref.html",
-            getTagsDefinitions(), 209);
+        writeAndCompare(new VBAnalyzerFactory(),
+                "analysis/vb/sample.cls",
+                "analysis/vb/sample_xref.html",
+                readTagsFromResource("analysis/vb/sampletags"), 209);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/vb/truncated.cls",
-            "analysis/vb/truncated_xref.html",
-            null, 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        Definitions defs, int expLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeVBXref(new PrintStream(baos), res, defs);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("VB xref", expected, gotten);
-        assertEquals("VB LOC", expLOC, actLOC);
-    }
-
-    private int writeVBXref(PrintStream oss, InputStream iss,
-        Definitions defs) throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        VBAnalyzerFactory fac = new VBAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        wargs.setDefs(defs);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private Definitions getTagsDefinitions() throws IOException {
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            "analysis/vb/sampletags");
-        assertNotNull("though sampletags should stream,", res);
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-            res, "UTF-8"));
-
-        CtagsReader rdr = new CtagsReader();
-        String line;
-        while ((line = in.readLine()) != null) {
-            rdr.readLine(line);
-        }
-        return rdr.getDefinitions();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new VBAnalyzerFactory(),
+                "analysis/vb/truncated.cls",
+                "analysis/vb/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/xml/XMLXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/xml/XMLXrefTest.java
@@ -19,104 +19,32 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.xml;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.io.StringWriter;
-import java.io.Writer;
-
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.opengrok.indexer.analysis.Xrefer;
+import org.opengrok.indexer.analysis.XrefTestBase;
 import org.opengrok.indexer.analysis.plain.XMLAnalyzerFactory;
-import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
-import static org.opengrok.indexer.util.StreamUtils.copyStream;
+import java.io.IOException;
 
 /**
  * Tests the {@code XMLXref} class.
  */
-public class XMLXrefTest {
+public class XMLXrefTest extends XrefTestBase {
 
     @Test
     public void sampleTest() throws IOException {
-        writeAndCompare("analysis/xml/sample.xml",
-            "analysis/xml/sample_xref.html", 229);
+        writeAndCompare(new XMLAnalyzerFactory(),
+                "analysis/xml/sample.xml",
+                "analysis/xml/sample_xref.html", null, 229);
     }
 
     @Test
     public void shouldCloseTruncatedStringSpan() throws IOException {
-        writeAndCompare("analysis/xml/truncated.xml",
-            "analysis/xml/truncated_xref.html", 1);
-    }
-
-    private void writeAndCompare(String sourceResource, String resultResource,
-        int expectedLOC) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        InputStream res = getClass().getClassLoader().getResourceAsStream(
-            sourceResource);
-        assertNotNull(sourceResource + " should get-as-stream", res);
-        int actLOC = writeXMLXref(new PrintStream(baos), res);
-        res.close();
-
-        InputStream exp = getClass().getClassLoader().getResourceAsStream(
-            resultResource);
-        assertNotNull(resultResource + " should get-as-stream", exp);
-        byte[] expbytes = copyStream(exp);
-        exp.close();
-        baos.close();
-
-        String ostr = new String(baos.toByteArray(), "UTF-8");
-        String gotten[] = ostr.split("\n");
-
-        String estr = new String(expbytes, "UTF-8");
-        String expected[] = estr.split("\n");
-
-        assertLinesEqual("XML xref", expected, gotten);
-        assertEquals("XML LOC", expectedLOC, actLOC);
-    }
-
-    private int writeXMLXref(PrintStream oss, InputStream iss)
-            throws IOException {
-
-        oss.print(getHtmlBegin());
-
-        Writer sw = new StringWriter();
-        XMLAnalyzerFactory fac = new XMLAnalyzerFactory();
-        AbstractAnalyzer analyzer = fac.getAnalyzer();
-        analyzer.setScopesEnabled(true);
-        analyzer.setFoldingEnabled(true);
-        WriteXrefArgs wargs = new WriteXrefArgs(
-            new InputStreamReader(iss, "UTF-8"), sw);
-        Xrefer xref = analyzer.writeXref(wargs);
-        oss.print(sw.toString());
-
-        oss.print(getHtmlEnd());
-        return xref.getLOC();
-    }
-
-    private static String getHtmlBegin() {
-        return "<!DOCTYPE html>\n" +
-            "<html lang=\"en\">\n" +
-            "<head>\n" +
-            "<meta charset=\"UTF-8\">\n" +
-            "<title>sampleFile - OpenGrok cross reference" +
-            " for /sampleFile</title></head><body>\n";
-    }
-
-    private static String getHtmlEnd() {
-        return "</body>\n" +
-            "</html>\n";
+        writeAndCompare(new XMLAnalyzerFactory(),
+                "analysis/xml/truncated.xml",
+                "analysis/xml/truncated_xref.html", null, 1);
     }
 }

--- a/opengrok-indexer/src/test/resources/analysis/perl/samplexrefres.html
+++ b/opengrok-indexer/src/test/resources/analysis/perl/samplexrefres.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>sampleTest.pl - OpenGrok cross reference for /sampleTest.pl</title></head><body>
+<title>sampleFile - OpenGrok cross reference for /sampleFile</title></head><body>
 <a class="l" name="1" href="#1">1</a><span class="c">#!/<a href="/source/s?path=/usr/">usr</a>/<a href="/source/s?path=/usr/bin/">bin</a>/<a href="/source/s?path=/usr/bin/perl">perl</a></span>
 <a class="l" name="2" href="#2">2</a>
 <a class="l" name="3" href="#3">3</a><span class="c">#</span>

--- a/opengrok-indexer/src/test/resources/analysis/perl/truncated_xrefres.html
+++ b/opengrok-indexer/src/test/resources/analysis/perl/truncated_xrefres.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>sampleTest.pl - OpenGrok cross reference for /sampleTest.pl</title></head><body>
+<title>sampleFile - OpenGrok cross reference for /sampleFile</title></head><body>
 <a class="l" name="1" href="#1">1</a><span class="c">#!/<a href="/source/s?path=/usr/">usr</a>/<a href="/source/s?path=/usr/bin/">bin</a>/<a href="/source/s?path=/usr/bin/perl">perl</a></span>
 <a class="l" name="2" href="#2">2</a>
 <a class="l" name="3" href="#3">3</a><span class="c">#</span>


### PR DESCRIPTION
Hello,

Please consider for integration this maintenance patch for xref test classes to remove some redundancy.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
