### PR TITLE
Bump AnalyzerGuru version after Verilog addition

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -319,16 +319,17 @@ public class AnalyzerGuru {
 
     /**
      * Gets a version number to be used to tag documents examined by the guru so
-     * that analysis can be re-done later if a stored version number is
-     * different from the current implementation or if customization has been
-     * done by the user to change the {@link AnalyzerGuru} operation.
+     * that {@link AbstractAnalyzer} selection can be re-done later if a stored
+     * version number is different from the current implementation or if guru
+     * factory registrations are modified by the user to change the guru
+     * operation.
      * <p>
      * The static part of the version is bumped in a release when e.g. new
      * {@link FileAnalyzerFactory} subclasses are registered or when existing
      * {@link FileAnalyzerFactory} subclasses are revised to target more or
      * different files.
      * @return a value whose lower 32-bits are a static value
-     * 20171230_00
+     * 20190211_00
      * for the current implementation and whose higher-32 bits are non-zero if
      * {@link #addExtension(java.lang.String, AnalyzerFactory)}
      * or
@@ -336,7 +337,7 @@ public class AnalyzerGuru {
      * has been called.
      */
     public static long getVersionNo() {
-        final int ver32 = 20171230_00; // Edit comment above too!
+        final int ver32 = 20190211_00; // Edit comment above too!
         long ver = ver32;
         if (customizationHashCode != 0) {
             ver |= (long)customizationHashCode << 32;


### PR DESCRIPTION
Hello,

Please consider for integration this fix to bump the `AnalyzerGuru` version, which I forgot to do after having added the `VerilogAnalyzer`.

Thank you.
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
