### PR TITLE
indenting only real subrepositories of the project

### DIFF
--- a/opengrok-web/src/main/webapp/repos.jspf
+++ b/opengrok-web/src/main/webapp/repos.jspf
@@ -21,21 +21,21 @@ CDDL HEADER END
 Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
 
 --%>
-<%@page import="java.util.TreeSet"%>
-<%@page import="java.util.Iterator"%>
-<%@page import="java.util.Set"%>
-<%@page import="org.opengrok.indexer.web.Prefix"%>
-<%@page import="org.opengrok.indexer.web.ProjectHelper"%>
-<%@page import="java.util.LinkedList"%>
+<%@page import="java.io.File"%>
 <%@page import="java.util.Collections"%>
 <%@page import="java.util.Comparator"%>
-<%@page import="java.io.File"%>
-<%@page import="org.opengrok.indexer.history.RepositoryInfo"%>
-<%@page import="org.opengrok.indexer.web.Util"%>
-<%@page import="org.opengrok.indexer.configuration.Project"%>
-<%@page import="org.opengrok.indexer.configuration.Group"%>
+<%@page import="java.util.Iterator"%>
+<%@page import="java.util.LinkedList"%>
 <%@page import="java.util.List"%>
+<%@page import="java.util.Set"%>
+<%@page import="java.util.TreeSet"%>
+<%@page import="org.opengrok.indexer.configuration.Group"%>
+<%@page import="org.opengrok.indexer.configuration.Project"%>
+<%@page import="org.opengrok.indexer.history.RepositoryInfo"%>
 <%@page import="org.opengrok.indexer.web.PageConfig"%>
+<%@page import="org.opengrok.indexer.web.Prefix"%>
+<%@page import="org.opengrok.indexer.web.ProjectHelper"%>
+<%@page import="org.opengrok.indexer.web.Util"%>
 <%@ page import="static org.opengrok.indexer.web.messages.MessagesUtils.printMessages" %>
 <%@ page import="static org.opengrok.indexer.web.messages.MessagesUtils.messagesToJson" %>
 <%
@@ -158,7 +158,7 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
                                 continue;
 
                             boolean subrepository = !ri.getDirectoryNameRelative().equals(project.getPath());
-                            if(subrepository && cnt == 0) {
+                            if (subrepository && cnt == 0) {
                             %>
                                 <tr>
                                     <td class="name repository" colspan="3">
@@ -303,7 +303,7 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
                                     // discard repositories without a parent url
                                     continue;
                                 boolean subrepository = !ri.getDirectoryNameRelative().equals(proj.getPath());
-                                if(subrepository && cnt == 0) {
+                                if (subrepository && cnt == 0) {
                                     %>
                                         <tr>
                                             <td class="name repository" colspan="3">

--- a/opengrok-web/src/main/webapp/repos.jspf
+++ b/opengrok-web/src/main/webapp/repos.jspf
@@ -156,13 +156,28 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
                             if (cnt > 0 && ri.getParent() == null)
                                 // discard repositories without a parent url
                                 continue;
-                            if (cnt != 0) {
+
+                            boolean subrepository = !ri.getDirectoryNameRelative().equals(project.getPath());
+                            if(subrepository && cnt == 0) {
+                            %>
+                                <tr>
+                                    <td class="name repository" colspan="3">
+                                        <a href="<%= request.getContextPath() + Prefix.XREF_P + "/" + projDesc %>"
+                                           title="Xref for project <%= Util.htmlize(projDesc) %>">
+                                            <%= Util.htmlize(projDesc) %>
+                                        </a>
+                                    </td>
+                                </tr>
+                            <%
+                            }
+
+                            if (subrepository) {
                                 projDesc = ri.getDirectoryName()
                                              .replace(cfg.getSourceRootPath() + File.separator, "");
                             }
                             %>
                             <tr>
-                                <td class="name <%= cnt > 0 ? "subrepository" : "repository" %>">
+                                <td class="name <%= subrepository ? "subrepository" : "repository" %>">
                     <a href="<%= request.getContextPath() + Prefix.XREF_P + "/" + projDesc%>"
                        title="Xref for project <%= Util.htmlize(projDesc) %>">
                         <%= Util.htmlize(projDesc) %>
@@ -287,12 +302,26 @@ Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
                                 if (cnt > 0 && ri.getParent() == null)
                                     // discard repositories without a parent url
                                     continue;
-                                if (cnt != 0) {
+                                boolean subrepository = !ri.getDirectoryNameRelative().equals(proj.getPath());
+                                if(subrepository && cnt == 0) {
+                                    %>
+                                        <tr>
+                                            <td class="name repository" colspan="3">
+                                                <a href="<%= request.getContextPath() + Prefix.XREF_P + "/" + projDesc %>"
+                                                   title="Xref for project <%= Util.htmlize(projDesc) %>">
+                                                    <%= Util.htmlize(projDesc) %>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    <%
+                                }
+
+                                if (subrepository) {
                                     projDesc = ri.getDirectoryName()
                                                  .replace(cfg.getSourceRootPath() + File.separator, "");
                                 }
                                 %>
-                                <tr><td class="name <%= cnt > 0 ? "subrepository" : "repository" %>">
+                                <tr><td class="name <%= subrepository ? "subrepository" : "repository" %>">
                     <a href="<%= request.getContextPath() + Prefix.XREF_P + "/" + projDesc %>"
                        title="Xref for project <%= Util.htmlize(projDesc) %>">
                         <%= Util.htmlize(projDesc) %>


### PR DESCRIPTION
fixes #2672

## With groups and the project is itself a repository:
<img width="669" alt="screenshot 2019-02-16 at 15 02 17" src="https://user-images.githubusercontent.com/6997160/52900890-6c4cc180-31fc-11e9-8247-a092b939d13f.png">

## Without groups and the project is itself a repository:
<img width="989" alt="screenshot 2019-02-16 at 15 02 48" src="https://user-images.githubusercontent.com/6997160/52900891-6c4cc180-31fc-11e9-8ff5-4f063b2978d0.png">

## With groups and the project itself is not a repository:
<img width="1009" alt="screenshot 2019-02-16 at 15 03 26" src="https://user-images.githubusercontent.com/6997160/52900892-6c4cc180-31fc-11e9-9a01-11d79f86e73a.png">

## Without groups and the project itself is not a repository:
<img width="720" alt="screenshot 2019-02-16 at 15 03 53" src="https://user-images.githubusercontent.com/6997160/52900893-6c4cc180-31fc-11e9-9e8e-bfcf9abd7eac.png">
