### PR TITLE
escaping extra html in annotate tooltip

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
@@ -105,7 +105,7 @@ public class Scripts implements Iterable<Scripts.Script> {
         SCRIPTS.put("jquery-tablesorter", new FileScript("js/jquery-tablesorter-2.26.6.min.js", 12));
         SCRIPTS.put("tablesorter-parsers", new FileScript("js/tablesorter-parsers-0.0.1.js", 13));
         SCRIPTS.put("searchable-option-list", new FileScript("js/searchable-option-list-2.0.6.js", 14));
-        SCRIPTS.put("utils", new FileScript("js/utils-0.0.28.js", 15));
+        SCRIPTS.put("utils", new FileScript("js/utils-0.0.29.js", 15));
         SCRIPTS.put("repos", new FileScript("js/repos-0.0.1.js", 20));
         SCRIPTS.put("diff", new FileScript("js/diff-0.0.3.js", 20));
         SCRIPTS.put("jquery-caret", new FileScript("js/jquery.caret-1.5.2.min.js", 25));

--- a/opengrok-web/src/main/webapp/js/utils-0.0.29.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.29.js
@@ -1703,7 +1703,7 @@ function domReadyMast() {
                     $("<dt>").text(definitions.shift().trim()).appendTo($el);
                     var $dd = $("<dd>");
                     $.each(definitions.join(":").split("<br/>"), function (i, el) {
-                        $dd.append(el.trim());
+                        $dd.append(escapeHtml(el.trim()));
                         $dd.append($("<br/>"));
                     });
                     $dd.appendTo($el);


### PR DESCRIPTION
fixes #2671

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
