### PR TITLE
Vary Level for printProgress(). No redundant getFileCount().

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -497,8 +497,8 @@ public class AnalyzerGuru {
         AnalyzerFactory factory = find(in, file);
         if (factory == null) {
             AbstractAnalyzer defaultAnalyzer = getAnalyzer();
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.log(Level.FINE, "{0}: fallback {1}",
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST, "{0}: fallback {1}",
                     new Object[]{file,
                     defaultAnalyzer.getClass().getSimpleName() });
             }
@@ -878,8 +878,8 @@ public class AnalyzerGuru {
             if (dotpos > 0) {
                 factory = pre.get(path.substring(0, dotpos).toUpperCase(Locale.ROOT));
                 if (factory != null) {
-                    if (LOGGER.isLoggable(Level.FINER)) {
-                        LOGGER.log(Level.FINER, "{0}: chosen by prefix: {1}",
+                    if (LOGGER.isLoggable(Level.FINEST)) {
+                        LOGGER.log(Level.FINEST, "{0}: chosen by prefix: {1}",
                             new Object[]{file,
                             factory.getClass().getSimpleName() });
                     }
@@ -892,8 +892,8 @@ public class AnalyzerGuru {
             // cases when this does not work.
             factory = ext.get(path.substring(dotpos + 1).toUpperCase(Locale.ROOT));
             if (factory != null) {
-                if (LOGGER.isLoggable(Level.FINER)) {
-                    LOGGER.log(Level.FINER, "{0}: chosen by suffix: {1}",
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST, "{0}: chosen by suffix: {1}",
                         new Object[]{file,
                         factory.getClass().getSimpleName() });
                 }
@@ -952,8 +952,8 @@ public class AnalyzerGuru {
             if (matcher.getIsPreciseMagic()) {
                 fac = matcher.isMagic(content, in);
                 if (fac != null) {
-                    if (LOGGER.isLoggable(Level.FINER)) {
-                        LOGGER.log(Level.FINER,
+                    if (LOGGER.isLoggable(Level.FINEST)) {
+                        LOGGER.log(Level.FINEST,
                             "{0}: chosen by precise magic: {1}", new Object[]{
                             file, fac.getClass().getSimpleName() });
                     }
@@ -974,8 +974,8 @@ public class AnalyzerGuru {
             if (!matcher.getIsPreciseMagic()) {
                 fac = matcher.isMagic(content, in);
                 if (fac != null) {
-                    if (LOGGER.isLoggable(Level.FINER)) {
-                        LOGGER.log(Level.FINER,
+                    if (LOGGER.isLoggable(Level.FINEST)) {
+                        LOGGER.log(Level.FINEST,
                             "{0}: chosen by imprecise magic: {1}",
                             new Object[]{file,
                             fac.getClass().getSimpleName() });
@@ -996,8 +996,8 @@ public class AnalyzerGuru {
         String fragment = getWords(opening, 2);
         AnalyzerFactory fac = magics.get(fragment);
         if (fac != null) {
-            if (LOGGER.isLoggable(Level.FINER)) {
-                LOGGER.log(Level.FINER, "{0}: chosen by magic {2}: {1}",
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST, "{0}: chosen by magic {2}: {1}",
                     new Object[]{file, fac.getClass().getSimpleName(),
                     fragment});
             }
@@ -1008,8 +1008,8 @@ public class AnalyzerGuru {
         fragment = getWords(opening, 1);
         fac = magics.get(fragment);
         if (fac != null) {
-            if (LOGGER.isLoggable(Level.FINER)) {
-                LOGGER.log(Level.FINER, "{0}: chosen by magic {2}: {1}",
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST, "{0}: chosen by magic {2}: {1}",
                     new Object[]{file, fac.getClass().getSimpleName(),
                     fragment});
             }
@@ -1022,8 +1022,8 @@ public class AnalyzerGuru {
             String magic = entry.getKey();
             if (opening.startsWith(magic)) {
                 fac = entry.getValue();
-                if (LOGGER.isLoggable(Level.FINER)) {
-                    LOGGER.log(Level.FINER,
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST,
                         "{0}: chosen by magic(substr) {2}: {1}", new Object[]{
                         file, fac.getClass().getSimpleName(), magic});
                 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocRunner.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocRunner.java
@@ -99,13 +99,13 @@ public class MandocRunner {
             command.add("os=" + oo);
         }
 
-        if (LOGGER.isLoggable(Level.FINE)) {
+        if (LOGGER.isLoggable(Level.FINER)) {
             StringBuilder sb = new StringBuilder();
             command.forEach((s) -> {
                 sb.append(s).append(" ");
             });
             String cmd = sb.toString();
-            LOGGER.log(Level.FINE, "Executing mandoc command [{0}]", cmd);
+            LOGGER.log(Level.FINER, "Executing mandoc command [{0}]", cmd);
         }
 
         ProcessBuilder processBuilder = new ProcessBuilder(command);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
@@ -41,21 +41,25 @@ public class DefaultIndexChangedListener implements IndexChangedListener {
 
     @Override
     public void fileAdd(String path, String analyzer) {
-        LOGGER.log(Level.INFO, "Add: {0} ({1})", new Object[]{path, analyzer});
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, "Add: {0} ({1})", new Object[]{path, analyzer});
+        }
     }
 
     @Override
     public void fileRemove(String path) {
-        LOGGER.log(Level.INFO, "Remove file:{0}", path);
+        LOGGER.log(Level.FINE, "Remove file:{0}", path);
     }
     @Override
     public void fileUpdate(String path) {
-        LOGGER.log(Level.INFO, "Update: {0}", path);
+        LOGGER.log(Level.FINE, "Update: {0}", path);
     }
 
     @Override
     public void fileAdded(String path, String analyzer) {
-        LOGGER.log(Level.FINER, "Added: {0} ({1})", new Object[]{path, analyzer});
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.log(Level.FINER, "Added: {0} ({1})", new Object[]{path, analyzer});
+        }
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -241,10 +241,8 @@ public class IndexDatabase {
      *
      * @param listener where to signal the changes to the database
      * @param paths list of paths to be indexed
-     * @throws IOException if an error occurs
      */
-    public static void update(IndexChangedListener listener, List<String> paths)
-            throws IOException {
+    public static void update(IndexChangedListener listener, List<String> paths) {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         IndexerParallelizer parallelizer = env.getIndexerParallelizer();
         List<IndexDatabase> dbs = new ArrayList<>();
@@ -350,20 +348,12 @@ public class IndexDatabase {
         return false;
     }
 
-    private int getFileCount(File sourceRoot, String dir) throws IOException {
-        int file_cnt = 0;
+    private void showFileCount(
+            String dir, IndexDownArgs args, Statistics elapsed) {
         if (RuntimeEnvironment.getInstance().isPrintProgress()) {
-            IndexDownArgs args = new IndexDownArgs();
-            args.count_only = true;
-
-            Statistics elapsed = new Statistics();
-            LOGGER.log(Level.INFO, "Counting files in {0} ...", dir);
-            indexDown(sourceRoot, dir, args);
             elapsed.report(LOGGER, String.format("Need to process: %d files for %s",
                     args.cur_count, dir));
         }
-
-        return file_cnt;
     }
 
     private void markProjectIndexed(Project project) {
@@ -495,18 +485,15 @@ public class IndexDatabase {
                     // The actual indexing happens in indexParallel().
 
                     IndexDownArgs args = new IndexDownArgs();
-                    args.est_total = getFileCount(sourceRoot, dir);
-
-                    args.cur_count = 0;
                     Statistics elapsed = new Statistics();
                     LOGGER.log(Level.INFO, "Starting traversal of directory {0}", dir);
                     indexDown(sourceRoot, dir, args);
-                    elapsed.report(LOGGER, String.format("Done traversal of directory %s", dir));
+                    showFileCount(dir, args, elapsed);
 
                     args.cur_count = 0;
                     elapsed = new Statistics();
                     LOGGER.log(Level.INFO, "Starting indexing of directory {0}", dir);
-                    indexParallel(args);
+                    indexParallel(dir, args);
                     elapsed.report(LOGGER, String.format("Done indexing of directory %s", dir));
 
                     // Remove data for the trailing terms that indexDown()
@@ -804,7 +791,6 @@ public class IndexDatabase {
 
     private AbstractAnalyzer getAnalyzerFor(File file, String path)
             throws IOException {
-        AbstractAnalyzer fa;
         try (InputStream in = new BufferedInputStream(
                 new FileInputStream(file))) {
             return AnalyzerGuru.getAnalyzer(in, path);
@@ -1037,12 +1023,24 @@ public class IndexDatabase {
         return local;
     }
 
-    private void printProgress(int currentCount, int totalCount) {
-        if (RuntimeEnvironment.getInstance().isPrintProgress()
-            && totalCount > 0 && LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.log(Level.INFO, "Progress: {0} ({1}%)",
-                    new Object[]{currentCount,
-                    (currentCount * 100.0f / totalCount)});
+    private void printProgress(String dir, int currentCount, int totalCount) {
+        if (totalCount > 0 && RuntimeEnvironment.getInstance().isPrintProgress()) {
+            Level currentLevel;
+            if (currentCount <= 1 || currentCount >= totalCount ||
+                    currentCount % 100 == 0) {
+                currentLevel = Level.INFO;
+            } else if (currentCount % 50 == 0) {
+                currentLevel = Level.FINE;
+            } else if (currentCount % 10 == 0) {
+                currentLevel = Level.FINER;
+            } else {
+                currentLevel = Level.FINEST;
+            }
+            if (LOGGER.isLoggable(currentLevel)) {
+                LOGGER.log(currentLevel, "Progress: {0} ({1}%) for {2}",
+                        new Object[]{currentCount, currentCount * 100.0f /
+                                totalCount, dir});
+            }
         }
     }
 
@@ -1103,9 +1101,6 @@ public class IndexDatabase {
                     indexDown(file, path, args);
                 } else {
                     args.cur_count++;
-                    if (args.count_only) {
-                        continue;
-                    }
 
                     if (uidIter != null) {
                         path = Util.fixPathIfWindows(path);
@@ -1163,10 +1158,11 @@ public class IndexDatabase {
 
     /**
      * Executes the second, parallel stage of indexing.
+     * @param dir the parent directory (when appended to SOURCE_ROOT)
      * @param args contains a list of files to index, found during the earlier
      * stage
      */
-    private void indexParallel(IndexDownArgs args) throws IOException {
+    private void indexParallel(String dir, IndexDownArgs args) {
 
         int worksCount = args.works.size();
         if (worksCount < 1) {
@@ -1227,7 +1223,7 @@ public class IndexDatabase {
                         }
 
                         int ncount = currentCounter.incrementAndGet();
-                        printProgress(ncount, worksCount);
+                        printProgress(dir, ncount, worksCount);
                         return ret;
                     }
                 }))).get();
@@ -1820,9 +1816,7 @@ public class IndexDatabase {
     }
 
     private class IndexDownArgs {
-        boolean count_only;
         int cur_count;
-        int est_total;
         final List<IndexFileWork> works = new ArrayList<>();
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
@@ -302,8 +302,13 @@ public final class Results {
                     fargs.xrefPrefix, fargs.morePrefix, rpath, tags, true,
                     isDefSearch, null, scopes);
             } catch (IOException ex) {
-                LOGGER.log(Level.WARNING, String.format("No context for %s",
-                        sourceFile, ex));
+                String errMsg = String.format("No context for %s", sourceFile);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    // WARNING but with FINE detail
+                    LOGGER.log(Level.WARNING, errMsg, ex);
+                } else {
+                    LOGGER.log(Level.WARNING, errMsg);
+                }
             }
         }
     }


### PR DESCRIPTION
Hello,

Please consider for integration this patch to remove the redundant directory traversal while indexing and to adjust logging levels, so that `INFO` is less verbose and `FINEST` fills out.

As an example with the OpenGrok source, previously the indexing would produce logs with the following aggregate number of messages per log level:

```
FINER      3291
INFO       2828
FINEST     1499
FINE       107
WARNING    18
CONFIG     14
```

`FINER` had the most messages, with `INFO` second, and `FINE` with barely any content.

With this patch, a run will produce the aggregate levels below, with `INFO` nicely terse, `FINEST` having the largest number of messages, and `FINE` and `FINER` having about an equal number of messages.

```
FINEST     4668
FINER      1528
FINE       1468
INFO       48
WARNING    18
CONFIG     14
```
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
