### PR TITLE
specify required python version

### DIFF
--- a/opengrok-tools/setup.py
+++ b/opengrok-tools/setup.py
@@ -40,6 +40,7 @@ setup(
     description='Tools for managing OpenGrok instance',
     long_description=readme(),
     test_suite='setup.my_test_suite',
+    python_requires='>=3.4, <4',
     install_requires=[
         'jsonschema==2.6.0',
         'pyyaml',

--- a/opengrok-tools/src/main/python/opengrok_tools/sync.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/sync.py
@@ -19,15 +19,11 @@
 #
 
 #
-# Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 
 """
  This script runs OpenGrok parallel project processing.
-
- It is intended to work on Unix systems. (mainly because it relies on the
- OpenGrok shell script - for the time being)
-
 """
 
 import argparse


### PR DESCRIPTION
The minimum version is set according to our internal deployment, i.e. the version it is most tested with.