### PR TITLE
avoid returning null objects from getIndexSearcher()

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1715,27 +1715,21 @@ public final class RuntimeEnvironment {
      * to the SearcherManager. This is done with returnIndexSearcher().
      * The return of the IndexSearcher should happen only after the search result data are read fully.
      *
-     * @param proj project
+     * @param projectName project
      * @return SearcherManager for given project
      * @throws IOException I/O exception
      */
-    public SuperIndexSearcher getIndexSearcher(String proj) throws IOException {
-        SearcherManager mgr = searcherManagerMap.get(proj);
-        SuperIndexSearcher searcher = null;
+    public SuperIndexSearcher getIndexSearcher(String projectName) throws IOException {
+        SearcherManager mgr = searcherManagerMap.get(projectName);
+        SuperIndexSearcher searcher;
 
         if (mgr == null) {
             File indexDir = new File(getDataRootPath(), IndexDatabase.INDEX_DIR);
-
-            try {
-                Directory dir = FSDirectory.open(new File(indexDir, proj).toPath());
-                mgr = new SearcherManager(dir, new ThreadpoolSearcherFactory());
-                searcherManagerMap.put(proj, mgr);
-                searcher = (SuperIndexSearcher) mgr.acquire();
-                searcher.setSearcherManager(mgr);
-            } catch (IOException ex) {
-                LOGGER.log(Level.SEVERE,
-                    "cannot construct IndexSearcher for project " + proj, ex);
-            }
+            Directory dir = FSDirectory.open(new File(indexDir, projectName).toPath());
+            mgr = new SearcherManager(dir, new ThreadpoolSearcherFactory());
+            searcherManagerMap.put(projectName, mgr);
+            searcher = (SuperIndexSearcher) mgr.acquire();
+            searcher.setSearcherManager(mgr);
         } else {
             searcher = (SuperIndexSearcher) mgr.acquire();
             searcher.setSearcherManager(mgr);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -469,8 +469,7 @@ public class SearchHelper {
             Suggestion s = new Suggestion(proj);
             try {
                 if (!closeOnDestroy) {
-                    SuperIndexSearcher searcher;
-                    searcher = RuntimeEnvironment.getInstance().getIndexSearcher(proj);
+                    SuperIndexSearcher searcher = RuntimeEnvironment.getInstance().getIndexSearcher(proj);
                     searcherList.add(searcher);
                     ir = searcher.getIndexReader();
                 } else {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -503,7 +503,7 @@ public class SearchHelper {
                 }
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Got exception while getting "
-                        + "spelling suggestions for project " + proj + " :", e);
+                        + "spelling suggestions for project " + proj + ":", e);
             } finally {
                 if (ir != null && closeOnDestroy) {
                     try {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -469,7 +469,15 @@ public class SearchHelper {
             Suggestion s = new Suggestion(proj);
             try {
                 if (!closeOnDestroy) {
-                    SuperIndexSearcher searcher = RuntimeEnvironment.getInstance().getIndexSearcher(proj);
+                    SuperIndexSearcher searcher;
+                    try {
+                        searcher = RuntimeEnvironment.getInstance().getIndexSearcher(proj);
+                    } catch (IOException ex) {
+                        LOGGER.log(Level.SEVERE,
+                                "cannot construct IndexSearcher for project " + proj, ex);
+                        return res;
+                    }
+
                     searcherList.add(searcher);
                     ir = searcher.getIndexReader();
                 } else {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -470,14 +470,7 @@ public class SearchHelper {
             try {
                 if (!closeOnDestroy) {
                     SuperIndexSearcher searcher;
-                    try {
-                        searcher = RuntimeEnvironment.getInstance().getIndexSearcher(proj);
-                    } catch (IOException ex) {
-                        LOGGER.log(Level.SEVERE,
-                                "cannot construct IndexSearcher for project " + proj, ex);
-                        return res;
-                    }
-
+                    searcher = RuntimeEnvironment.getInstance().getIndexSearcher(proj);
                     searcherList.add(searcher);
                     ir = searcher.getIndexReader();
                 } else {
@@ -511,7 +504,7 @@ public class SearchHelper {
                 }
             } catch (IOException e) {
                 LOGGER.log(Level.WARNING, "Got exception while getting "
-                        + "spelling suggestions: ", e);
+                        + "spelling suggestions for project " + proj + " :", e);
             } finally {
                 if (ir != null && closeOnDestroy) {
                     try {


### PR DESCRIPTION
This change corrects the semantics of the outcome of getIndexSearcher() - it should either raise exception or return null but now both.