### PR TITLE
logger must cover all levels

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/utils/log.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/log.py
@@ -117,7 +117,7 @@ def get_console_logger(name, level=logging.INFO, format='%(message)s'):
     stdout_handler.setFormatter(formatter)
 
     stderr_handler.addFilter(lambda rec: rec.levelno >= logging.ERROR)
-    stdout_handler.addFilter(lambda rec: rec.levelno <= logging.INFO)
+    stdout_handler.addFilter(lambda rec: rec.levelno < logging.ERROR)
 
     logger = logging.getLogger(name)
     logger.setLevel(level)


### PR DESCRIPTION
Running `opengrok-sync` while another was in progress did not result in the `Already running` message. This is due to the filters in `get_console_logger()` missing the `logging.WARNING` range.