### PR TITLE
fail mirroring if incoming check raises exception

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/mirror.py
@@ -368,7 +368,8 @@ def main():
                             break
                     except RepositoryException:
                         logger.error('Cannot determine incoming changes for '
-                                     'repository {}, driving on'.format(repo))
+                                     'repository {}'.format(repo))
+                        sys.exit(1)
 
                 if not got_incoming:
                     logger.info('No incoming changes for repositories in '

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -109,7 +109,7 @@ class MercurialRepository(Repository):
         cmd.execute()
         self.logger.debug(cmd.getoutputstr())
         retcode = cmd.getretcode()
-        if cmd.getstate() != Command.FINISHED or retcode not in [0,1]:
+        if cmd.getstate() != Command.FINISHED or retcode not in [0, 1]:
             cmd.log_error("failed to perform incoming")
             raise RepositoryException('failed to perform incoming command '
                                       'for repository {}'.format(self))

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -108,12 +108,13 @@ class MercurialRepository(Repository):
                               env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.debug(cmd.getoutputstr())
-        if cmd.getstate() != Command.FINISHED:
+        retcode = cmd.getretcode()
+        if cmd.getstate() != Command.FINISHED or retcode not in [0,1]:
             cmd.log_error("failed to perform incoming")
             raise RepositoryException('failed to perform incoming command '
                                       'for repository {}'.format(self))
 
-        if cmd.getretcode() == 0:
+        if retcode == 0:
             return True
         else:
             return False


### PR DESCRIPTION
One of our Mercurial projects failed to sync and this was not noticed in the logs because the `opengrok-mirror` script was run with `-I`. One problem is that incoming check failures are treated as soft, second problem is that Mercurial exit codes are not interpreted correctly - in this case `hg incoming` exits with 255 due to authentication failure.