### PR TITLE
use yaml.safe_load() to replace deprecated yaml.load()

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/utils/readconfig.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/readconfig.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 
 import logging
@@ -26,7 +26,7 @@ import json
 import yaml
 import sys
 
-# The following is to make the json parsing work on Python 3.4.
+# The following is to make the JSON parsing work on Python 3.4.
 try:
     from json.decoder import JSONDecodeError
 except ImportError:
@@ -58,7 +58,7 @@ def read_config(logger, inputfile):
 
             try:
                 logger.debug("trying YAML")
-                cfg = yaml.load(data)
+                cfg = yaml.safe_load(data)
             except AttributeError:
                 # Not a valid YAML file.
                 logger.debug("got exception {}".format(sys.exc_info()[0]))


### PR DESCRIPTION
This is done to satisfy https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation to avoid the warning message when running scripts like `opengrok-mirror`.

This should be harmless as the tools do not use any special YAML features.
