### PR TITLE
actually use the tomcat properties

### DIFF
--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -171,8 +171,8 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                 <artifactId>tomcat7-maven-plugin</artifactId>
                 <version>2.2</version>
                 <configuration>
-                    <url>http://localhost:8080/manager/text</url>
-                    <server>OpenGrok</server>
+                    <url>${tomcat.url}</url>
+                    <server>${tomcat.server.id}</server>
                     <path>/${project.build.finalName}</path>
                 </configuration>
             </plugin>


### PR DESCRIPTION
While retrying the redeploy using Tomcat plugin as per PR #2711 I noticed the Maven Tomcat plugin hardcodes the properties even though they are present in the POM file. This change remedies that.