### PR TITLE
Moving repofactory to scm module

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/mirror.py
@@ -40,19 +40,16 @@ from logging.handlers import RotatingFileHandler
 
 from filelock import Timeout, FileLock
 
+from .scm.repofactory import get_repository
+from .scm.repository import RepositoryException
 from .utils.hook import run_hook
 from .utils.log import get_console_logger, get_class_basename, \
     print_exc_exit
 from .utils.opengrok import get_repos, get_config_value, get_repo_type
 from .utils.parsers import get_baseparser
 from .utils.readconfig import read_config
-from .utils.repofactory import get_repository
 from .utils.utils import is_exe, check_create_dir, get_int, diff_list, \
     is_web_uri
-
-# do not reorder this import, it must be imported after utils.
-# (for me) idea reorders the import to the top, causing an import error
-from .scm.repository import RepositoryException
 
 major_version = sys.version_info[0]
 if major_version < 3:

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/__init__.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/__init__.py
@@ -1,10 +1,11 @@
 from .cvs import CVSRepository
 from .git import GitRepository
 from .mercurial import MercurialRepository
+from .repo import RepoRepository
+from .repofactory import get_repository
 from .repository import Repository
 from .svn import SubversionRepository
 from .teamware import TeamwareRepository
-from .repo import RepoRepository
 
 __all__ = [
     'CVSRepository',
@@ -14,4 +15,5 @@ __all__ = [
     'TeamwareRepository',
     'Repository',
     'RepoRepository',
+    'get_repository',
 ]

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repofactory.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repofactory.py
@@ -21,12 +21,12 @@
 # Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 #
 
-from ..scm.cvs import CVSRepository
-from ..scm.git import GitRepository
-from ..scm.mercurial import MercurialRepository
-from ..scm.svn import SubversionRepository
-from ..scm.teamware import TeamwareRepository
-from ..scm.repo import RepoRepository
+from .cvs import CVSRepository
+from .git import GitRepository
+from .mercurial import MercurialRepository
+from .repo import RepoRepository
+from .svn import SubversionRepository
+from .teamware import TeamwareRepository
 
 
 def get_repository(logger, path, repo_type, project, commands, env, hooks,

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/__init__.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/__init__.py
@@ -4,7 +4,6 @@ from . import hook
 from . import opengrok
 from . import parsers
 from . import readconfig
-from . import repofactory
 from . import utils
 from . import webutil
 
@@ -14,7 +13,6 @@ __all__ = [
     'command',
     'commandsequence',
     'hook',
-    'repofactory',
     'webutil',
     'readconfig',
     'parsers',


### PR DESCRIPTION
depends on #2720

Removing the cross module dependency forcing the particular order of imports.