### PR TITLE
Suppressing the double render problem on error

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
@@ -23,13 +23,13 @@
  */
 package org.opengrok.indexer.web;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * A list-like container for javascripts in the page.
@@ -111,11 +111,14 @@ public class Scripts implements Iterable<Scripts.Script> {
         SCRIPTS.put("jquery-caret", new FileScript("js/jquery.caret-1.5.2.min.js", 25));
     }
 
+    private final static Comparator<Script> SCRIPTS_COMPARATOR = Comparator
+            .comparingInt(Script::getPriority)
+            .thenComparing(Script::getScriptData);
+
     /**
-     * Scripts which will be written to the page. We assume that the length
-     * could be the same as for {@link #SCRIPTS}.
+     * Scripts which will be written to the page.
      */
-    private final List<Script> outputScripts = new ArrayList<>(SCRIPTS.size());
+    private final NavigableSet<Script> outputScripts = new TreeSet<>(SCRIPTS_COMPARATOR);
 
     /**
      * Convert the page scripts into HTML.
@@ -134,7 +137,6 @@ public class Scripts implements Iterable<Scripts.Script> {
      * Return the HTML representation of the page scripts.
      *
      * @return the HTML
-     *
      * @see #toHtml()
      */
     @Override
@@ -146,7 +148,6 @@ public class Scripts implements Iterable<Scripts.Script> {
      * Return the size of the page scripts.
      *
      * @return the size
-     *
      * @see List#size()
      */
     public int size() {
@@ -157,7 +158,6 @@ public class Scripts implements Iterable<Scripts.Script> {
      * Check if there is any script for this page.
      *
      * @return true if there is not; false otherwise
-     *
      * @see List#isEmpty()
      */
     public boolean isEmpty() {
@@ -179,7 +179,7 @@ public class Scripts implements Iterable<Scripts.Script> {
      * Add a script which is identified by the name.
      *
      * @param contextPath given context path for the used URL
-     * @param scriptName name of the script
+     * @param scriptName  name of the script
      * @return true if script was added; false otherwise
      */
     public boolean addScript(String contextPath, String scriptName) {
@@ -195,46 +195,11 @@ public class Scripts implements Iterable<Scripts.Script> {
     }
 
     /**
-     * Add a script to the page, taking the script priority into account. The
-     * position is determined as the upper bound for the given priority.
+     * Add a script to the page, taking the script priority into account.
      *
      * @param script the script
      */
     public void addScript(Script script) {
-        int index = Collections.binarySearch(outputScripts, script, new Comparator<Script>() {
-            @Override
-            public int compare(Script a, Script b) {
-                return a.getPriority() - b.getPriority();
-            }
-        });
-        if (index < 0) {
-            /**
-             * Key is not found in the list the index<br>
-             * equals to -(insertion index) - 1.
-             */
-            this.outputScripts.add(Math.abs(index + 1), script);
-        } else {
-            /**
-             * Key found in the list, append it after the last element with the
-             * same priority => insert it at the upper bound index.
-             */
-            while (index < this.outputScripts.size()
-                    && this.outputScripts.get(index).getPriority() == script.getPriority()) {
-                index++;
-            }
-            this.outputScripts.add(index, script);
-        }
-    }
-
-    /**
-     * Get the page script by the index
-     *
-     * @param index index of the script
-     * @return the script
-     *
-     * @see List#get(int)
-     */
-    public Script get(int index) {
-        return outputScripts.get(index);
+        this.outputScripts.add(script);
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
@@ -111,7 +111,7 @@ public class Scripts implements Iterable<Scripts.Script> {
         SCRIPTS.put("jquery-caret", new FileScript("js/jquery.caret-1.5.2.min.js", 25));
     }
 
-    private final static Comparator<Script> SCRIPTS_COMPARATOR = Comparator
+    private static final Comparator<Script> SCRIPTS_COMPARATOR = Comparator
             .comparingInt(Script::getPriority)
             .thenComparing(Script::getScriptData);
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/ScriptsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/ScriptsTest.java
@@ -18,7 +18,7 @@
  */
 
  /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.web;
 
@@ -26,8 +26,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map.Entry;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.opengrok.indexer.web.Scripts.Script;
@@ -53,12 +54,15 @@ public class ScriptsTest {
 
         assertEquals(3, scripts.size());
 
-        assertEquals(scripts.get(0).getScriptData(), "http://example.com/main1.js");
-        assertEquals(scripts.get(0).getPriority(), 0);
-        assertEquals(scripts.get(1).getScriptData(), "http://example.com/main2.js");
-        assertEquals(scripts.get(1).getPriority(), 0);
-        assertEquals(scripts.get(2).getScriptData(), "http://example.com/main3.js");
-        assertEquals(scripts.get(2).getPriority(), 0);
+        List<Script> listScripts = new ArrayList<>();
+        scripts.forEach(listScripts::add);
+
+        assertEquals(listScripts.get(0).getScriptData(), "http://example.com/main1.js");
+        assertEquals(listScripts.get(0).getPriority(), 0);
+        assertEquals(listScripts.get(1).getScriptData(), "http://example.com/main2.js");
+        assertEquals(listScripts.get(1).getPriority(), 0);
+        assertEquals(listScripts.get(2).getScriptData(), "http://example.com/main3.js");
+        assertEquals(listScripts.get(2).getPriority(), 0);
     }
 
     @Test
@@ -69,12 +73,15 @@ public class ScriptsTest {
 
         assertEquals(3, scripts.size());
 
-        assertEquals(scripts.get(0).getScriptData(), "http://example.com/main2.js");
-        assertEquals(scripts.get(0).getPriority(), 1);
-        assertEquals(scripts.get(1).getScriptData(), "http://example.com/main3.js");
-        assertEquals(scripts.get(1).getPriority(), 2);
-        assertEquals(scripts.get(2).getScriptData(), "http://example.com/main1.js");
-        assertEquals(scripts.get(2).getPriority(), 3);
+        List<Script> listScripts = new ArrayList<>();
+        scripts.forEach(listScripts::add);
+
+        assertEquals(listScripts.get(0).getScriptData(), "http://example.com/main2.js");
+        assertEquals(listScripts.get(0).getPriority(), 1);
+        assertEquals(listScripts.get(1).getScriptData(), "http://example.com/main3.js");
+        assertEquals(listScripts.get(1).getPriority(), 2);
+        assertEquals(listScripts.get(2).getScriptData(), "http://example.com/main1.js");
+        assertEquals(listScripts.get(2).getPriority(), 3);
     }
 
     @Test


### PR DESCRIPTION
Using set instead of lists does not add the same record twice.

The records were doubled because (assume we get an exception on index.jsp page):
1. we partially render the index.jsp
2. it includes httpheader.jspf which registers the scripts into PageConfig
3. exception occurs, the error page is being rendered instead
4. error page calls httpheader.jspf again and it adds the script again to the same PageConfig (because the request has not changed)
5. error page renders the scripts twice