### PR TITLE
Fixing git viewing renamed revision

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -215,10 +215,14 @@ public class GitRepository extends Repository {
              * not exist or internal git error occured.
              */
             result.success = (status == 0);
-        } catch (Exception exp) {
+        } catch (Exception exception) {
             LOGGER.log(Level.SEVERE,
-                    "Failed to get history for file {0} in revision {1}: ",
-                        new Object[]{fullpath, rev, exp.getClass().toString(), exp});
+                    String.format(
+                            "Failed to get history for file %s in revision %s:",
+                            fullpath, rev
+                    ),
+                    exception
+            );
         }
         return result;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -299,12 +299,14 @@ public class GitRepository extends Repository {
     }
 
     /**
-     * Get the name of file in given revision.
+     * Get the name of file in given revision. The returned file name is relative
+     * to the repository root.
      *
-     * @param fullpath file path
+     * @param fullpath  file path
      * @param changeset changeset
      * @return original filename relative to the repository root
      * @throws java.io.IOException if I/O exception occurred
+     * @see #getPathRelativeToRepositoryRoot(String)
      */
     protected String findOriginalName(String fullpath, String changeset)
             throws IOException {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
  */
 package org.opengrok.indexer.history;
 


### PR DESCRIPTION
I noticed that viewing revision of renamed files was broken. The getHistory expects a full path file while the find renamed name returns the name relative to the repository directory. This leads that for renamed files the revision was never found as the filename after renaming was invalid.