### PR TITLE
add Mellon header decoder

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationException.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationException.java
@@ -31,7 +31,7 @@ public class AuthorizationException extends RuntimeException {
         super(ex);
     }
 
-    AuthorizationException(String msg) {
+    public AuthorizationException(String msg) {
         super(msg);
     }
 

--- a/plugins/src/opengrok/auth/plugin/LdapUserPlugin.java
+++ b/plugins/src/opengrok/auth/plugin/LdapUserPlugin.java
@@ -104,7 +104,6 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
     }
 
     protected String getFilter(User user) {
-        String filter = null;
         String commonName;
 
         Matcher matcher = usernameCnPattern.matcher(user.getUsername());
@@ -113,14 +112,11 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
             LOGGER.log(Level.FINEST, "extracted common name {0} from {1}",
                 new Object[]{commonName, user.getUsername()});
         } else {
-            LOGGER.log(Level.WARNING, "cannot get common name out of {0}",
-                    user.getUsername());
-            return filter;
+            throw new AuthorizationException(String.format("cannot get common name out of %s",
+                    user.getUsername()));
         }
         
-        filter = "(&(objectclass=" + this.objectClass + ")(" + commonName + "))";
-        
-        return filter;
+        return "(&(objectclass=" + this.objectClass + ")(" + commonName + "))";
     }
     
     @Override

--- a/plugins/src/opengrok/auth/plugin/decoders/MellonHeaderDecoder.java
+++ b/plugins/src/opengrok/auth/plugin/decoders/MellonHeaderDecoder.java
@@ -1,0 +1,62 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+
+package opengrok.auth.plugin.decoders;
+
+import opengrok.auth.plugin.entity.User;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Decode basic headers coming from the
+ * <a href="https://github.com/Uninett/mod_auth_mellon">mod_auth_mellon</a> module
+ * for Apache web server.
+ *
+ * This decoder assumes that the SAML Service Provider metadata was setup with
+ * {@code <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>}
+ * i.e. that Identity Provider will send back e-mail address of the authenticated user
+ * and that the {@code mod_auth_mellon} is setup to create Apache environment variable
+ * containing the e-mail address and the {@code mod_headers} Apache module is set to
+ * pass the value of this variable in HTTP header called {@code MELLON_email}, i.e.:
+ * {@code RequestHeader set email "%{MELLON_email}e" env=MELLON_email}
+ */
+public class MellonHeaderDecoder implements IUserDecoder {
+
+    private static final Logger LOGGER = Logger.getLogger(MellonHeaderDecoder.class.getName());
+
+    static String MELLON_EMAIL_HEADER = "MELLON_email";
+
+    @Override
+    public User fromRequest(HttpServletRequest request) {
+        String username = request.getHeader(MELLON_EMAIL_HEADER);
+        if (username == null || username.isEmpty()) {
+            LOGGER.log(Level.WARNING,
+                    "Can not construct an user: username could not be extracted");
+            return null;
+        }
+
+        return new User(username);
+    }
+}

--- a/plugins/src/opengrok/auth/plugin/decoders/MellonHeaderDecoder.java
+++ b/plugins/src/opengrok/auth/plugin/decoders/MellonHeaderDecoder.java
@@ -47,7 +47,7 @@ public class MellonHeaderDecoder implements IUserDecoder {
 
     private static final Logger LOGGER = Logger.getLogger(MellonHeaderDecoder.class.getName());
 
-    static String MELLON_EMAIL_HEADER = "MELLON_email";
+    static final String MELLON_EMAIL_HEADER = "MELLON_email";
 
     @Override
     public User fromRequest(HttpServletRequest request) {

--- a/plugins/src/opengrok/auth/plugin/decoders/MellonHeaderDecoder.java
+++ b/plugins/src/opengrok/auth/plugin/decoders/MellonHeaderDecoder.java
@@ -26,6 +26,7 @@ package opengrok.auth.plugin.decoders;
 import opengrok.auth.plugin.entity.User;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -53,7 +54,9 @@ public class MellonHeaderDecoder implements IUserDecoder {
         String username = request.getHeader(MELLON_EMAIL_HEADER);
         if (username == null || username.isEmpty()) {
             LOGGER.log(Level.WARNING,
-                    "Can not construct an user: username could not be extracted");
+                    "Can not construct User object: header ''{1}'' not found in request headers: {0}",
+                    new Object[]{String.join(",", Collections.list(request.getHeaderNames())),
+                            MELLON_EMAIL_HEADER});
             return null;
         }
 

--- a/plugins/src/opengrok/auth/plugin/decoders/OSSOHeaderDecoder.java
+++ b/plugins/src/opengrok/auth/plugin/decoders/OSSOHeaderDecoder.java
@@ -22,6 +22,7 @@
  */
 package opengrok.auth.plugin.decoders;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -57,13 +58,15 @@ public class OSSOHeaderDecoder implements IUserDecoder {
         
         if (username == null || username.isEmpty()) {
             LOGGER.log(Level.WARNING,
-                    "Can not construct an user: username could not be extracted");
+                    "Can not construct an user: username could not be extracted from headers: {0}",
+                    String.join(",", Collections.list(request.getHeaderNames())));
             return null;
         }
         
         if (userguid == null || userguid.isEmpty()) {
             LOGGER.log(Level.WARNING,
-                    "Can not construct an user: userguid could not be extracted");
+                    "Can not construct an user: userguid could not be extracted from headers: {0}",
+                    String.join(",", Collections.list(request.getHeaderNames())));
             return null;
         }
 
@@ -74,8 +77,8 @@ public class OSSOHeaderDecoder implements IUserDecoder {
             cookieTimestamp = Timestamp.decodeTimeCookie(timestamp);
         } catch (NumberFormatException ex) {
             LOGGER.log(Level.WARNING,
-                    String.format("Unparseable timestamp cookie \"%s\" for user \"%s\"", timestamp, username),
-                    ex);
+                    String.format("Unparseable timestamp cookie \"%s\" for user \"%s\"",
+                            timestamp, username), ex);
         }
 
         /**
@@ -89,7 +92,8 @@ public class OSSOHeaderDecoder implements IUserDecoder {
         user.setAttribute("subscriber", request.getHeader(OSSO_SUBSCRIBER_HEADER));
 
         if (user.isTimeouted()) {
-            LOGGER.log(Level.WARNING, "Can not construct an user \"{0}\": header is timeouted", username);
+            LOGGER.log(Level.WARNING, "Can not construct an user \"{0}\": header is timeouted",
+                    username);
             return null;
         }
 

--- a/plugins/src/opengrok/auth/plugin/entity/User.java
+++ b/plugins/src/opengrok/auth/plugin/entity/User.java
@@ -34,6 +34,10 @@ public class User {
     private boolean timeouted;
     private final Map<String, Object> attrs = new HashMap<>();
 
+    public User(String username) {
+        this.username = username;
+    }
+
     public User(String username, String id, Date cookieTimestamp, boolean timeouted) {
         this.id = id;
         this.username = username;

--- a/plugins/test/opengrok/auth/plugin/decoders/MellonDecoderTest.java
+++ b/plugins/test/opengrok/auth/plugin/decoders/MellonDecoderTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static opengrok.auth.plugin.decoders.MellonHeaderDecoder.MELLON_EMAIL_HEADER;
+import static org.junit.Assert.assertNull;
 
 public class MellonDecoderTest {
     DummyHttpServletRequestUser dummyRequest;
@@ -47,7 +48,12 @@ public class MellonDecoderTest {
 
         Assert.assertNotNull(result);
         Assert.assertEquals("foo@bar.cz", result.getUsername());
-        Assert.assertNull(result.getId());
+        assertNull(result.getId());
         Assert.assertFalse(result.isTimeouted());
+    }
+
+    @Test
+    public void testMissingHeader() {
+        assertNull(decoder.fromRequest(new DummyHttpServletRequestUser()));
     }
 }

--- a/plugins/test/opengrok/auth/plugin/decoders/MellonDecoderTest.java
+++ b/plugins/test/opengrok/auth/plugin/decoders/MellonDecoderTest.java
@@ -1,0 +1,53 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ */
+
+package opengrok.auth.plugin.decoders;
+
+import opengrok.auth.plugin.entity.User;
+import opengrok.auth.plugin.util.DummyHttpServletRequestUser;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static opengrok.auth.plugin.decoders.MellonHeaderDecoder.MELLON_EMAIL_HEADER;
+
+public class MellonDecoderTest {
+    DummyHttpServletRequestUser dummyRequest;
+    MellonHeaderDecoder decoder = new MellonHeaderDecoder();
+
+    @Before
+    public void setUp() {
+        dummyRequest = new DummyHttpServletRequestUser();
+        dummyRequest.setHeader(MELLON_EMAIL_HEADER, "foo@bar.cz");
+    }
+
+    @Test
+    public void testAll() {
+        User result = decoder.fromRequest(dummyRequest);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals("foo@bar.cz", result.getUsername());
+        Assert.assertNull(result.getId());
+        Assert.assertFalse(result.isTimeouted());
+    }
+}

--- a/plugins/test/opengrok/auth/plugin/util/DummyHttpServletRequestUser.java
+++ b/plugins/test/opengrok/auth/plugin/util/DummyHttpServletRequestUser.java
@@ -172,7 +172,7 @@ public class DummyHttpServletRequestUser implements HttpServletRequest {
 
     @Override
     public Enumeration<String> getHeaderNames() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return Collections.enumeration(headers.keySet());
     }
 
     @Override


### PR DESCRIPTION
This is a simple decoder for the https://github.com/UNINETT/mod_auth_mellon SAML implementation.

Needs `mod_headers` to convert the email Apache environment variable from `mod_auth_mellon` to HTTP header. In Apache config it looks like this:

```
        RequestHeader unset MELLON_email
        RequestHeader set MELLON_email "%{MELLON_email}e" env=MELLON_email
```

Also, makes some of the error messages more informative.