### PR TITLE
Perforce filenames 2746

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
@@ -87,7 +87,7 @@ public class PerforceHistoryParser {
         cmd.add("p4");
         cmd.add("filelog");
         cmd.add("-lti");
-        cmd.add(file.getName() + PerforceRepository.getRevisionCmd(rev));
+        cmd.add(PerforceRepository.protectPerforceFilename(file.getName()) + PerforceRepository.getRevisionCmd(rev));
         Executor executor = new Executor(cmd, file.getCanonicalFile().getParentFile());
         executor.exec();
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Ross <cross@distal.com>.
  */
 
 package org.opengrok.indexer.history;
@@ -35,6 +36,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.opengrok.indexer.util.Executor;
+import static org.opengrok.indexer.history.PerforceRepository.protectPerforceFilename;
 
 /**
  * Parse source history for a Perforce Repository
@@ -87,7 +89,7 @@ public class PerforceHistoryParser {
         cmd.add("p4");
         cmd.add("filelog");
         cmd.add("-lti");
-        cmd.add(PerforceRepository.protectPerforceFilename(file.getName()) + PerforceRepository.getRevisionCmd(rev));
+        cmd.add(protectPerforceFilename(file.getName()) + PerforceRepository.getRevisionCmd(rev));
         Executor executor = new Executor(cmd, file.getCanonicalFile().getParentFile());
         executor.exec();
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
@@ -65,8 +65,10 @@ public class PerforceRepository extends Repository {
     public static String protectPerforceFilename(String name) {
         ArrayList<SimpleImmutableEntry<String,String>>   transmap = new ArrayList<SimpleImmutableEntry<String,String>>() {
             {
-                add(new SimpleImmutableEntry<>("#", "%23"));
+                /* NOTE: Must replace '%' first, or that translation will */
+                /* will affect the result of the others. */
                 add(new SimpleImmutableEntry<>("%", "%25"));
+                add(new SimpleImmutableEntry<>("#", "%23"));
                 add(new SimpleImmutableEntry<>("\\*", "%2A"));
                 add(new SimpleImmutableEntry<>("@", "%40"));
             }
@@ -77,8 +79,8 @@ public class PerforceRepository extends Repository {
         }
         /* Instead of iterating over a list, just force each? */
 /*
-        String t = name.replaceAll("#", "%23");
-        t = t.replaceAll("%", "%25");
+        String t = name.replaceAll("%", "%25");
+        t = t.replaceAll("#", "%23");
         t = t.replaceAll("\\*", "%2A");
         t = t.replaceAll("@", "%40");
 */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2019, Chris Ross <cross@distal.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -61,7 +62,7 @@ public class PerforceRepository extends Repository {
         ignoredFiles.add(".p4config");
     }
 
-    public static String protectPerforceFilename(String name) {
+    static String protectPerforceFilename(String name) {
         /* For each of the [four] special characters, replace them with */
         /* the recognized escape sequence for perforce. */
         /* NOTE: Must replace '%' first, or that translation would */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.AbstractMap.SimpleImmutableEntry;
 
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -63,29 +62,16 @@ public class PerforceRepository extends Repository {
     }
 
     public static String protectPerforceFilename(String name) {
-        ArrayList<SimpleImmutableEntry<String,String>>   transmap = new ArrayList<SimpleImmutableEntry<String,String>>() {
-            {
-                /* NOTE: Must replace '%' first, or that translation will */
-                /* will affect the result of the others. */
-                add(new SimpleImmutableEntry<>("%", "%25"));
-                add(new SimpleImmutableEntry<>("#", "%23"));
-                add(new SimpleImmutableEntry<>("\\*", "%2A"));
-                add(new SimpleImmutableEntry<>("@", "%40"));
-            }
-        };
-        String t = name;   /* XXX remove? */
-        for (SimpleImmutableEntry<String,String> ent : transmap) {
-            t = t.replaceAll(ent.getKey(), ent.getValue());
-        }
-        /* Instead of iterating over a list, just force each? */
-/*
+        /* For each of the [four] special characters, replace them with */
+        /* the recognized escape sequence for perforce. */
+        /* NOTE: Must replace '%' first, or that translation would */
+        /* affect the output of the others. */
         String t = name.replaceAll("%", "%25");
         t = t.replaceAll("#", "%23");
         t = t.replaceAll("\\*", "%2A");
         t = t.replaceAll("@", "%40");
-*/
         if (name != t) {
-            LOGGER.log(Level.INFO,
+            LOGGER.log(Level.FINEST,
                        "protectPerforceFilename: replaced ''{0}'' with ''{1}''",
                        new Object[]{name, t});
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2019, Chris Ross <cross@distal.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -110,19 +111,17 @@ public class PerforceRepositoryTest {
 
     @Test
     public void testProtectFilename() throws Exception {
-        ArrayList<SimpleImmutableEntry<String,String>>   testmap = new ArrayList<SimpleImmutableEntry<String,String>>() {
-            {
-                add(new SimpleImmutableEntry<>("Testfile 34", "Testfile 34"));
-                add(new SimpleImmutableEntry<>("Test%52", "Test%2552"));
-                add(new SimpleImmutableEntry<>("Test*4+2", "Test%2A4+2"));
-                add(new SimpleImmutableEntry<>("Test@", "Test%40"));
-                add(new SimpleImmutableEntry<>("@seventeen", "%40seventeen"));
-                add(new SimpleImmutableEntry<>("upNdown(", "upNdown("));
-                add(new SimpleImmutableEntry<>("tst#99", "tst%2399"));
-                add(new SimpleImmutableEntry<>("#File*Three%trig", "%23File%2AThree%25trig"));
-                add(new SimpleImmutableEntry<>("Two%and5#3#4", "Two%25and5%233%234"));
-            }
-        };
+        ArrayList<SimpleImmutableEntry<String,String>>   testmap = new ArrayList<>();
+        testmap.add(new SimpleImmutableEntry<>("Testfile 34", "Testfile 34"));
+        testmap.add(new SimpleImmutableEntry<>("Test%52", "Test%2552"));
+        testmap.add(new SimpleImmutableEntry<>("Test*4+2", "Test%2A4+2"));
+        testmap.add(new SimpleImmutableEntry<>("Test@", "Test%40"));
+        testmap.add(new SimpleImmutableEntry<>("@seventeen", "%40seventeen"));
+        testmap.add(new SimpleImmutableEntry<>("upNdown(", "upNdown("));
+        testmap.add(new SimpleImmutableEntry<>("tst#99", "tst%2399"));
+        testmap.add(new SimpleImmutableEntry<>("#File*Three%trig", "%23File%2AThree%25trig"));
+        testmap.add(new SimpleImmutableEntry<>("Two%and5#3#4", "Two%25and5%233%234"));
+
         // XXX: We don't need an instance here, to unit-test a static function?
         PerforceRepository instance = new PerforceRepository();
         for (SimpleImmutableEntry<String,String> ent : testmap) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
@@ -118,11 +118,12 @@ public class PerforceRepositoryTest {
                 add(new SimpleImmutableEntry<>("Test@", "Test%40"));
                 add(new SimpleImmutableEntry<>("@seventeen", "%40seventeen"));
                 add(new SimpleImmutableEntry<>("upNdown(", "upNdown("));
+                add(new SimpleImmutableEntry<>("tst#99", "tst%2399"));
             }
         };
         for (SimpleImmutableEntry<String,String> ent : testmap) {
             String prot = instance.protectPerforceFilename(ent.getKey());
-            assertEquals("Improper protected filename, "+prot+" != "+ent.getValue(), prot, ent.getValue());
+            assertEquals("Improper protected filename, "+prot+" != "+ent.getValue(), ent.getValue(), prot);
         }
 //        instance.update();
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
@@ -41,6 +41,7 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import static org.opengrok.indexer.history.PerforceRepository.protectPerforceFilename;
 
 /**
  * Do basic testing of the Perforce support
@@ -122,10 +123,8 @@ public class PerforceRepositoryTest {
         testmap.add(new SimpleImmutableEntry<>("#File*Three%trig", "%23File%2AThree%25trig"));
         testmap.add(new SimpleImmutableEntry<>("Two%and5#3#4", "Two%25and5%233%234"));
 
-        // XXX: We don't need an instance here, to unit-test a static function?
-        PerforceRepository instance = new PerforceRepository();
         for (SimpleImmutableEntry<String,String> ent : testmap) {
-            String prot = instance.protectPerforceFilename(ent.getKey());
+            String prot = protectPerforceFilename(ent.getKey());
             assertEquals("Improper protected filename, "+prot+" != "+ent.getValue(), ent.getValue(), prot);
         }
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
@@ -35,8 +35,9 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.AbstractMap.SimpleImmutableEntry;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
 /**
@@ -104,5 +105,25 @@ public class PerforceRepositoryTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testProtectFilename() throws Exception {
+        PerforceRepository instance = new PerforceRepository();
+        ArrayList<SimpleImmutableEntry<String,String>>   testmap = new ArrayList<SimpleImmutableEntry<String,String>>() {
+            {
+                add(new SimpleImmutableEntry<>("Testfile 34", "Testfile 34"));
+                add(new SimpleImmutableEntry<>("Test%52", "Test%2552"));
+                add(new SimpleImmutableEntry<>("Test*4+2", "Test%2A4+2"));
+                add(new SimpleImmutableEntry<>("Test@", "Test%40"));
+                add(new SimpleImmutableEntry<>("@seventeen", "%40seventeen"));
+                add(new SimpleImmutableEntry<>("upNdown(", "upNdown("));
+            }
+        };
+        for (SimpleImmutableEntry<String,String> ent : testmap) {
+            String prot = instance.protectPerforceFilename(ent.getKey());
+            assertEquals("Improper protected filename, "+prot+" != "+ent.getValue(), prot, ent.getValue());
+        }
+//        instance.update();
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
@@ -37,7 +37,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.AbstractMap.SimpleImmutableEntry;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
 /**
@@ -109,7 +110,6 @@ public class PerforceRepositoryTest {
 
     @Test
     public void testProtectFilename() throws Exception {
-        PerforceRepository instance = new PerforceRepository();
         ArrayList<SimpleImmutableEntry<String,String>>   testmap = new ArrayList<SimpleImmutableEntry<String,String>>() {
             {
                 add(new SimpleImmutableEntry<>("Testfile 34", "Testfile 34"));
@@ -119,12 +119,15 @@ public class PerforceRepositoryTest {
                 add(new SimpleImmutableEntry<>("@seventeen", "%40seventeen"));
                 add(new SimpleImmutableEntry<>("upNdown(", "upNdown("));
                 add(new SimpleImmutableEntry<>("tst#99", "tst%2399"));
+                add(new SimpleImmutableEntry<>("#File*Three%trig", "%23File%2AThree%25trig"));
+                add(new SimpleImmutableEntry<>("Two%and5#3#4", "Two%25and5%233%234"));
             }
         };
+        // XXX: We don't need an instance here, to unit-test a static function?
+        PerforceRepository instance = new PerforceRepository();
         for (SimpleImmutableEntry<String,String> ent : testmap) {
             String prot = instance.protectPerforceFilename(ent.getKey());
             assertEquals("Improper protected filename, "+prot+" != "+ent.getValue(), ent.getValue(), prot);
         }
-//        instance.update();
     }
 }


### PR DESCRIPTION
<!-- OCA submitted April 29, 2019.  -->

This avoids the errors from perforce when using filenames containing reserved characters, and will fix issue #2746 .

I am not a java developer so much, so I'm happy to adjust the code to match core opinions of how it should be implemented.  Let me know.