### PR TITLE
always use absolute path for webapp config file

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/deploy.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/deploy.py
@@ -81,6 +81,9 @@ def deploy_war(logger, sourceWar, targetWar, configFile=None):
     tmpWar = None
     DEFAULT_CONFIG_FILE = '/var/opengrok/etc/configuration.xml'
     if configFile and configFile != DEFAULT_CONFIG_FILE:
+        # Resolve the path to be absolute so that webapp can find the file.
+        configFile = os.path.abspath(configFile)
+
         with tempfile.NamedTemporaryFile(prefix='OpenGroktmpWar',
                                          suffix='.war',
                                          delete=False) as tmpWar:


### PR DESCRIPTION
Yesterday I was lazy typing the full path of config file when deploying with the `opengrok-deploy` script and the result was non-functional webapp because it could not find the config file. This change fixes that.