### PR TITLE
initialization of Junit 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,7 @@ pmd.bat
 .project
 .settings/
 .vscode/
-*/.project
-*/.settings
-*/.classpath
 */bin/
+.classpath
+.checkstyle
 

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -112,8 +112,13 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
             <version>${jersey.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- TODO: remove! (moving Messages to web module) -->

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -118,9 +118,13 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -47,9 +47,13 @@ Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
+                    <trimStackTrace>false</trimStackTrace>
                 </configuration>
                 <version>${maven-surefire.version}</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
         <!-- Jackson version needs to match the version of Jackson Jersey depends on otherwise weird things will happen. -->
         <jackson.version>2.8.10</jackson.version>
         <junit.version>5.4.2</junit.version>
+        <maven-surefire.version>2.22.2</maven-surefire.version>
     </properties>
 
     <dependencyManagement>
@@ -219,7 +220,7 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                 </configuration>
-                <version>2.22.0</version>
+                <version>${maven-surefire.version}</version>
                 <executions>
                     <execution>
                         <id>run-unit-tests</id>
@@ -388,7 +389,7 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.20</version>
+                <version>${maven-surefire.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,14 +68,20 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
         <jersey.version>2.27</jersey.version>
         <!-- Jackson version needs to match the version of Jackson Jersey depends on otherwise weird things will happen. -->
         <jackson.version>2.8.10</jackson.version>
+        <junit.version>5.4.2</junit.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.bcel</groupId>

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -58,8 +58,14 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Hi guys,

I was looking on test coverage and I thought that I will improve it little bit, by writing new JUnit tests.
Then I realized that it would be perfect way to learn/use new tricks from JUnit5.

So I thought that it would make sense to first to update OpenGrok to using JUnit 5 and then start changing/adding tests.

What do you think?

Tested by:
```bash
./mvnw test
...

========================== 54 passed in 18.41 seconds ==========================
[INFO] 
[INFO] ---------------------< org.opengrok:opengrok-dist >---------------------
[INFO] Building Distribution 1.2.8                                        [7/7]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-maven) @ opengrok-dist ---
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.2:prepare-agent (pre-unit-test) @ opengrok-dist ---
[INFO] surefireArgLine set to -javaagent:/home/dalibor/.m2/repository/org/jacoco/org.jacoco.agent/0.8.2/org.jacoco.agent-0.8.2-runtime.jar=destfile=/media/truecrypt1/repo/github/opengrok/distribution/target/jacoco.exec
[INFO] 
[INFO] --- maven-surefire-plugin:3.0.0-M3:test (run-unit-tests) @ opengrok-dist ---
[INFO] No tests to run.
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.2:report (post-unit-test) @ opengrok-dist ---
[INFO] Skipping JaCoCo execution due to missing execution data file.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for OpenGrok 1.2.8:
[INFO] 
[INFO] OpenGrok ........................................... SUCCESS [  1.796 s]
[INFO] OpenGrok Indexer ................................... SUCCESS [ 19.060 s]
[INFO] OpenGrok authorization plugins ..................... SUCCESS [  0.540 s]
[INFO] OpenGrok Suggester ................................. SUCCESS [ 53.471 s]
[INFO] OpenGrok Web ....................................... SUCCESS [03:19 min]
[INFO] OpenGrok tools ..................................... SUCCESS [ 24.490 s]
[INFO] Distribution ....................................... SUCCESS [  0.040 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:59 min
[INFO] Finished at: 2019-06-01T01:30:26-07:00
[INFO] ------------------------------------------------------------------------

```

Thanks,
D.
