### PR TITLE
do not fail if git info cannot be retrieved

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -210,6 +210,7 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
                     <includeOnlyProperties>
                         <includeOnlyProperty>^git.commit.id</includeOnlyProperty>
                     </includeOnlyProperties>
+		    <failOnNoGitDirectory>false</failOnNoGitDirectory>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Changes the configuration of `git-commit-id` Maven plugin not to fail if git info cannot be retrieved (using a property as described on https://github.com/git-commit-id/maven-git-commit-id-plugin/blob/master/docs/using-the-plugin.md). This is handy when building from release source archives. Thanks to how `Info.java` works the missing properties will be set to "unknown":

```
$ java -jar ./distribution/target/dist/opengrok-1.2.8.jar -V
Jun 03, 2019 12:15:48 PM org.opengrok.indexer.index.Indexer parseOptions
INFO: Indexer options: [-V]
OpenGrok v1.2.8 rev unknown
```

This will be fixed in source code archives starting from 1.2.9.