### PR TITLE
perform hook executable tests only on Unix systems

### DIFF
--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -81,6 +81,7 @@ def test_invalid_project_config_hooknames():
         assert not check_project_configuration(config, hookdir=tmpdir)
 
 
+@pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")
 def test_invalid_project_config_nonexec_hook():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "foo.sh"), 'w+') as tmpfile:


### PR DESCRIPTION
Recently the Windows tests in AppVeyor started failing with:

```
================================== FAILURES ===================================
__________________ test_invalid_project_config_nonexec_hook ___________________
    def test_invalid_project_config_nonexec_hook():
        with tempfile.TemporaryDirectory() as tmpdir:
            with open(os.path.join(tmpdir, "foo.sh"), 'w+') as tmpfile:
                tmpfile.write("foo\n")
                config = {"foo": {HOOKS_PROPERTY: {"pre": "foo.sh"}}}
>               assert not check_project_configuration(config, hookdir=tmpdir)
E               AssertionError: assert not True
E                +  where True = check_project_configuration({'foo': {'hooks': {'pre': 'foo.sh'}}}, hookdir='C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\tmpxsvor572')
```

given the `test_valid_project_config_hook()` is already Unix only, let's make the "default" version behave the same.