### PR TITLE
disallow repository path equal to source root

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -414,6 +414,9 @@ public final class HistoryGuru {
                 } catch (IllegalAccessException iae) {
                     LOGGER.log(Level.WARNING, "Could not create repository for '"
                             + file + "', missing access rights.", iae);
+                } catch (ForbiddenSymlinkException e) {
+                    LOGGER.log(Level.WARNING, "Could not create repository for '"
+                            + file + "', path traversal issues.", e);
                 }
                 if (repository == null) {
                     // Not a repository, search its sub-dirs.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
@@ -114,7 +114,7 @@ public final class RepositoryFactory {
             if (rep.isRepositoryFor(file, interactive)) {
                 repo = rep.getClass().getDeclaredConstructor().newInstance();
 
-                if (env.isProjectsEnabled() && env.getPathRelativeToSourceRoot(file).isEmpty()) {
+                if (env.isProjectsEnabled() && env.getPathRelativeToSourceRoot(file).equals(File.separator)) {
                     LOGGER.log(Level.WARNING, "{0} was detected as {1} repository however with directory " +
                             "matching source root. This is invalid because projects are enabled. Ignoring this " +
                             "repository.",

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
@@ -55,7 +55,7 @@ public class RepositoryFactoryTest {
     }
     
     /*
-     * There is no conditonal run based on whether given repository is installed because
+     * There is no conditional run based on whether given repository is installed because
      * this test is not supposed to have working Mercurial anyway.
      */
     private void testNotWorkingRepository(String repoPath, String propName)

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
@@ -23,11 +23,13 @@
 package org.opengrok.indexer.history;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertFalse;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.opengrok.indexer.util.ForbiddenSymlinkException;
 import org.opengrok.indexer.util.TestRepository;
 
 /**
@@ -56,8 +58,9 @@ public class RepositoryFactoryTest {
      * There is no conditonal run based on whether given repository is installed because
      * this test is not supposed to have working Mercurial anyway.
      */
-    private void testNotWorkingRepository(String repoPath, String propName) 
-            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+    private void testNotWorkingRepository(String repoPath, String propName)
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException,
+            IOException, ForbiddenSymlinkException {
         
         String origPropValue = System.setProperty(propName, "/foo/bar/nonexistent");
         File root = new File(repository.getSourceRoot(), repoPath);
@@ -69,14 +72,16 @@ public class RepositoryFactoryTest {
     }
     
     @Test
-    public void testNotWorkingMercurialRepository() 
-            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+    public void testNotWorkingMercurialRepository()
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException,
+            IOException, ForbiddenSymlinkException {
         testNotWorkingRepository("mercurial", MercurialRepository.CMD_PROPERTY_KEY);
     }
     
     @Test
-    public void testNotWorkingBitkeeperRepository() 
-            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+    public void testNotWorkingBitkeeperRepository()
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException,
+            IOException, ForbiddenSymlinkException {
         testNotWorkingRepository("bitkeeper", BitKeeperRepository.CMD_PROPERTY_KEY);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/TestRepository.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/TestRepository.java
@@ -126,8 +126,8 @@ public class TestRepository {
      * @param filename a required instance
      * @param in a required instance
      * @param project an optional project name
-     * @return
-     * @throws IOException
+     * @return file object
+     * @throws IOException I/O exception
      */
     public File addAdhocFile(String filename, InputStream in, String project)
             throws IOException {


### PR DESCRIPTION
The detection of most repository types relies on the existence of special directory/file (e.g. the `.git` directory for Git). Perforce runs external command to detect whether given directory belongs to a repository. When misconfigured this could lead to strange indexing behavior.

This should help to detect+prevent cases as described in #2798.