### PR TITLE
Add support for getting CurrentVersion of PerforceRepository

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
@@ -272,6 +272,24 @@ public class PerforceRepository extends Repository {
 
     @Override
     String determineCurrentVersion(boolean interactive) throws IOException {
-        return null;
+        File directory = new File(getDirectoryName());
+        List<String> cmd = new ArrayList<>();
+
+        ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
+        cmd.add(RepoCommand);
+        cmd.add("changes");
+        cmd.add("-t");
+        cmd.add("-m");
+        cmd.add("1");
+        cmd.add("...#have");
+
+        Executor executor = new Executor(cmd, directory, interactive ?
+                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
+                RuntimeEnvironment.getInstance().getCommandTimeout());
+        if (executor.exec(false) != 0) {
+            throw new IOException(executor.getErrorString());
+        }
+
+        return executor.getOutputString().trim();
     }
 }


### PR DESCRIPTION
Implement determineCurrentVersion() for PerforceRepository

note, I tested this and it works.  However, I've found that after loading the root in the Web U/I, then updating one of the perforce repositories, the web U/I doesn't refresh.  It is still showing the version test of that repository when I first loaded the page.  Shift-refresh doesn't help, and waiting an hour didn't help.

Have I missed something to make this know it needs to recheck via determineCurrentVersion()?