### PR TITLE
log environment with Level.FINER

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -34,6 +34,7 @@ import java.io.Reader;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Level;
@@ -165,9 +166,14 @@ public class Executor {
             dir_str = cwd.toString();
         }
 
+        String env_str = "";
+        if (LOGGER.isLoggable(Level.FINER)) {
+            Map<String,String> env_map = processBuilder.environment();
+            env_str = " with environment: " + env_map.toString();
+        }
         LOGGER.log(Level.FINE,
-                "Executing command {0} in directory {1}",
-                new Object[] {cmd_str,dir_str});
+                "Executing command {0} in directory {1}{2}",
+                new Object[] {cmd_str, dir_str, env_str});
 
         Process process = null;
         try {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -224,8 +224,8 @@ public class Executor {
             ret = process.waitFor();
             
             LOGGER.log(Level.FINE,
-                "Finished command {0} in directory {1}",
-                new Object[] {cmd_str,dir_str});
+                "Finished command {0} in directory {1} with exit code {2}",
+                new Object[] {cmd_str, dir_str, ret});
 
             // Wait for the stderr read-out thread to finish the processing and
             // only after that read the data.


### PR DESCRIPTION
example of log entry:
```
2019-06-17 15:13:49.834+0200 FINE t1 Executor.exec: Executing command [git, log, --format=commit:%H%nDate:%at, -n, 1, 2.4] in directory /var/opengrok/src/jna with environment: {PATH=/home/vkotal/bin:/home/vkotal/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/lib/jvm/java-8-oracle/bin:/usr/lib/jvm/java-8-oracle/db/bin:/usr/lib/jvm/java-8-oracle/jre/bin, XAUTHORITY=/run/user/1000/gdm/Xauthority, LC_MEASUREMENT=en_US.UTF-8, LC_TELEPHONE=en_US.UTF-8, ...}
```