### PR TITLE
JSTL vs Paths

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1752,6 +1752,11 @@ public final class PageConfig {
         return false;
     }
 
+    /**
+     * @param root root path
+     * @param path path
+     * @return path relative to root
+     */
     public static String getRelativePath(String root, String path) {
         return Paths.get(root).relativize(Paths.get(path)).toString();
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1749,5 +1750,9 @@ public final class PageConfig {
         // return 200 OK
         response.setHeader(HttpHeaders.ETAG, currentEtag);
         return false;
+    }
+
+    public static String getRelativePath(String root, String path) {
+        return Paths.get(root).relativize(Paths.get(path)).toString();
     }
 }

--- a/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
+++ b/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
@@ -42,7 +42,7 @@ Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
 
 <c:if test="${isSubrepository}">
     <c:set var="name"
-           value="${Paths.get(pageConfig.sourceRootPath).relativize(Paths.get(repositoryInfo.directoryName))}"/>
+           value="${pageConfig.getRelativePath(pageConfig.sourceRootPath, repositoryInfo.directoryName)}"/>
 </c:if>
 
 <c:if test="${isSubrepository && isFirst}">

--- a/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
+++ b/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
@@ -19,7 +19,6 @@ CDDL HEADER END
 Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
 --%>
-<%@ tag import="java.nio.file.Paths" %>
 <%@ tag import="org.apache.commons.lang3.ObjectUtils" %>
 <%@ tag import="org.opengrok.indexer.web.Prefix" %>
 <%@ tag import="org.opengrok.indexer.web.Util" %>


### PR DESCRIPTION
correctly displays subrepository path on the index page