### PR TITLE
adding --release 8 argument to JDK9+ builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,25 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
         </pluginManagement>
     </build>
 
+    <profiles>
+        <profile>
+            <id>java9plus-8-release</id>
+            <activation>
+                <jdk>[9,18]</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <release>8</release>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <reporting>
         <plugins>
             <plugin>


### PR DESCRIPTION
fixes #2820

```
[INFO] --- maven-help-plugin:3.2.0:active-profiles (default-cli) @ opengrok-top ---
[INFO] 
Active Profiles for Project 'org.opengrok:opengrok-top:pom:1.2.15':

The following profiles are active:

 - java9plus-8-release (source: org.opengrok:opengrok-top:1.2.15)



Active Profiles for Project 'org.opengrok:opengrok:jar:1.2.15':

The following profiles are active:

 - java9plus (source: org.opengrok:opengrok:1.2.15)
 - java9plus-8-release (source: org.opengrok:opengrok-top:1.2.15)



Active Profiles for Project 'org.opengrok:plugins:jar:1.2.15':

The following profiles are active:

 - java9plus (source: org.opengrok:plugins:1.2.15)
 - java9plus-8-release (source: org.opengrok:opengrok-top:1.2.15)



Active Profiles for Project 'org.opengrok:suggester:jar:1.2.15':

The following profiles are active:

 - java9plus (source: org.opengrok:suggester:1.2.15)
 - java9plus-8-release (source: org.opengrok:opengrok-top:1.2.15)



Active Profiles for Project 'org.opengrok:opengrok-web:war:1.2.15':

The following profiles are active:

 - java9plus (source: org.opengrok:opengrok-web:1.2.15)
 - java9plus-8-release (source: org.opengrok:opengrok-top:1.2.15)



Active Profiles for Project 'org.opengrok:opengrok-tools:pom:1.2.15':

The following profiles are active:

 - java9plus-8-release (source: org.opengrok:opengrok-top:1.2.15)



Active Profiles for Project 'org.opengrok:opengrok-dist:pom:1.2.15':

The following profiles are active:

 - java9plus-8-release (source: org.opengrok:opengrok-top:1.2.15)

```
