### PR TITLE
refresh repository README on Docker hub after image push

### DIFF
--- a/dev/before_install
+++ b/dev/before_install
@@ -20,7 +20,8 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 	    python3 \
 	    python3-venv \
 	    python3-pip \
-	    nodejs
+	    nodejs \
+	    jq
 	if [[ $? != 0 ]]; then
 		echo "cannot install extra packages"
 		exit 1

--- a/dev/before_install
+++ b/dev/before_install
@@ -38,7 +38,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 	brew update
 
-	brew install cvs libgit2
+	brew install cvs libgit2 jq
 	if [[ $? != 0 ]]; then
 		echo "cannot install extra packages"
 		exit 1

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -106,7 +106,7 @@ TOKEN=$(curl -s -H "Content-Type: application/json" -X POST \
     -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' \
     https://hub.docker.com/v2/users/login/ | jq -r .token)
 if [[ -z $TOKEN ]]; then
-	echo "Cannot get auth token"
+	echo "Cannot get auth token to publish the README file"
 	exit 1
 fi
 

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -48,13 +48,13 @@ docker ps -a
 
 # Travis can only work on master since it needs encrypted variables.
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-	echo "Not pushing docker image for pull requests"
+	echo "Not pushing Docker image for pull requests"
 	exit 0
 fi
 
 # The push only works on the main repository.
 if [[ "${TRAVIS_REPO_SLUG}" != "oracle/opengrok" ]]; then
-	echo "Not pushing docker image for non main repository"
+	echo "Not pushing Docker image for non main repository"
 	exit 0
 fi
 

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -58,7 +58,7 @@ if [[ "${TRAVIS_REPO_SLUG}" != "oracle/opengrok" ]]; then
 	exit 0
 fi
 
-# Allow Docker builds for release builds only.
+# Allow Docker push for release builds only.
 if [[ -z $TRAVIS_TAG ]]; then
 	echo "TRAVIS_TAG is empty"
 	exit 0

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 #
-# Build and push new image to Docker hub.
+# Build and optionally push new image to Docker hub.
 #
-# Uses the following Travis secure variables:
+# When pushing, this script uses the following Travis secure variables:
 #  - DOCKER_USERNAME
 #  - DOCKER_PASSWORD
 #

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 #
-# Build and optionally push new image to Docker hub.
+# Build and push new image to Docker hub.
 #
-# When pushing, this script uses the following Travis secure variables:
+# Uses the following Travis secure variables:
 #  - DOCKER_USERNAME
 #  - DOCKER_PASSWORD
 #
@@ -13,50 +13,15 @@
 set -x
 set -e
 
-if [[ -n $TRAVIS_TAG ]]; then
-	VERSION="$TRAVIS_TAG"
-	VERSION_SHORT=$( echo $VERSION | cut -d. -f1,2 )
-else
-	VERSION="latest"
-	VERSION_SHORT="latest"
-fi
-
-if [[ -z $VERSION ]]; then
-	echo "empty VERSION"
-	exit 1
-fi
-
-if [[ -z $VERSION_SHORT ]]; then
-	echo "empty VERSION_SHORT"
-	exit 1
-fi
-
-# Build the image.
-docker build \
-    -t opengrok/docker:$VERSION \
-    -t opengrok/docker:$VERSION_SHORT \
-    -t opengrok/docker:latest .
-
-#
-# Run the image in container. This is not strictly needed however
-# serves as additional test in automatic builds.
-#
-docker run -d opengrok/docker
-docker ps -a
+IMAGE="opengrok/docker"
 
 # Travis can only work on master since it needs encrypted variables.
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-	echo "Not publishing docker image for pull requests"
+	echo "Not building docker image for pull requests"
 	exit 0
 fi
 
-# The push only works on the main repository.
-if [[ "${TRAVIS_REPO_SLUG}" != "oracle/opengrok" ]]; then
-	echo "Not publishing docker image for non main repository"
-	exit 0
-fi
-
-# Allow Docker publish for release builds only.
+# Allow Docker builds for release builds only.
 if [[ -z $TRAVIS_TAG ]]; then
 	echo "TRAVIS_TAG is empty"
 	exit 0
@@ -72,6 +37,32 @@ if [[ -z $DOCKER_PASSWORD ]]; then
 	exit 1
 fi
 
+VERSION="$TRAVIS_TAG"
+VERSION_SHORT=$( echo $VERSION | cut -d. -f1,2 )
+
+if [[ -z $VERSION ]]; then
+	echo "empty VERSION"
+	exit 1
+fi
+
+if [[ -z $VERSION_SHORT ]]; then
+	echo "empty VERSION_SHORT"
+	exit 1
+fi
+
+# Build the image.
+docker build \
+    -t $IMAGE:$VERSION \
+    -t $IMAGE:$VERSION_SHORT \
+    -t $IMAGE:latest .
+
+#
+# Run the image in container. This is not strictly needed however
+# serves as additional test in automatic builds.
+#
+docker run -d $IMAGE
+docker ps -a
+
 # Publish the image to Docker hub.
 if [ -n "$DOCKER_PASSWORD" -a -n "$DOCKER_USERNAME" -a -n "$VERSION" ]; then
 	echo "Logging into docker"
@@ -80,6 +71,43 @@ if [ -n "$DOCKER_PASSWORD" -a -n "$DOCKER_USERNAME" -a -n "$VERSION" ]; then
 	# All the tags need to be pushed individually:
 	for tag in $VERSION $VERSION_SHORT latest; do
 		echo "Pushing docker image for tag $tag"
-		docker push opengrok/docker:$tag
+		docker push $IMAGE:$tag
 	done
 fi
+
+# Update README file in Docker hub.
+push_readme() {
+	declare -r image="${1}"
+	declare -r token="${2}"
+	declare -r input_file="${3}"
+
+	if [[ ! -r $input_file ]]; then
+		echo "file $input_file is not readable"
+		exit 1
+	fi
+
+	local code=$(jq -n --arg msg "$(<${input_file})" \
+	    '{"registry":"registry-1.docker.io","full_description": $msg }' | \
+	        curl -s -o /dev/null  -L -w "%{http_code}" \
+	           https://cloud.docker.com/v2/repositories/"${image}"/ \
+	           -d @- -X PATCH \
+	           -H "Content-Type: application/json" \
+	           -H "Authorization: JWT ${token}")
+
+	if [[ "${code}" = "200" ]]; then
+		echo "Successfully pushed README to Docker Hub"
+	else
+		printf "Unable to push README to Docker Hub, response code: %s\n" "${code}"
+		exit 1
+	fi
+}
+
+TOKEN=$(curl -s -H "Content-Type: application/json" -X POST \
+    -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' \
+    https://hub.docker.com/v2/users/login/ | jq -r .token)
+if [[ -z $TOKEN ]]; then
+	echo "Cannot get auth token"
+	exit 1
+fi
+
+push_readme "${IMAGE}" "${TOKEN}" "docker/README.md"

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -65,12 +65,12 @@ docker ps -a
 
 # Publish the image to Docker hub.
 if [ -n "$DOCKER_PASSWORD" -a -n "$DOCKER_USERNAME" -a -n "$VERSION" ]; then
-	echo "Logging into docker"
+	echo "Logging into Docker Hub"
 	echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 	# All the tags need to be pushed individually:
 	for tag in $VERSION $VERSION_SHORT latest; do
-		echo "Pushing docker image for tag $tag"
+		echo "Pushing Docker image for tag $tag"
 		docker push $IMAGE:$tag
 	done
 fi

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -48,13 +48,13 @@ docker ps -a
 
 # Travis can only work on master since it needs encrypted variables.
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-	echo "Not building docker image for pull requests"
+	echo "Not pushing docker image for pull requests"
 	exit 0
 fi
 
 # The push only works on the main repository.
 if [[ "${TRAVIS_REPO_SLUG}" != "oracle/opengrok" ]]; then
-	echo "Not publishing docker image for non main repository"
+	echo "Not pushing docker image for non main repository"
 	exit 0
 fi
 

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -52,6 +52,12 @@ if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
 	exit 0
 fi
 
+# The push only works on the main repository.
+if [[ "${TRAVIS_REPO_SLUG}" != "oracle/opengrok" ]]; then
+	echo "Not publishing docker image for non main repository"
+	exit 0
+fi
+
 # Allow Docker builds for release builds only.
 if [[ -z $TRAVIS_TAG ]]; then
 	echo "TRAVIS_TAG is empty"

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -15,30 +15,13 @@ set -e
 
 IMAGE="opengrok/docker"
 
-# Travis can only work on master since it needs encrypted variables.
-if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-	echo "Not building docker image for pull requests"
-	exit 0
+if [[ -n $TRAVIS_TAG ]]; then
+	VERSION="$TRAVIS_TAG"
+	VERSION_SHORT=$( echo $VERSION | cut -d. -f1,2 )
+else
+	VERSION="latest"
+	VERSION_SHORT="latest"
 fi
-
-# Allow Docker builds for release builds only.
-if [[ -z $TRAVIS_TAG ]]; then
-	echo "TRAVIS_TAG is empty"
-	exit 0
-fi
-
-if [[ -z $DOCKER_USERNAME ]]; then
-	echo "DOCKER_USERNAME is empty"
-	exit 1
-fi
-
-if [[ -z $DOCKER_PASSWORD ]]; then
-	echo "DOCKER_PASSWORD is empty"
-	exit 1
-fi
-
-VERSION="$TRAVIS_TAG"
-VERSION_SHORT=$( echo $VERSION | cut -d. -f1,2 )
 
 if [[ -z $VERSION ]]; then
 	echo "empty VERSION"
@@ -62,6 +45,28 @@ docker build \
 #
 docker run -d $IMAGE
 docker ps -a
+
+# Travis can only work on master since it needs encrypted variables.
+if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+	echo "Not building docker image for pull requests"
+	exit 0
+fi
+
+# Allow Docker builds for release builds only.
+if [[ -z $TRAVIS_TAG ]]; then
+	echo "TRAVIS_TAG is empty"
+	exit 0
+fi
+
+if [[ -z $DOCKER_USERNAME ]]; then
+	echo "DOCKER_USERNAME is empty"
+	exit 1
+fi
+
+if [[ -z $DOCKER_PASSWORD ]]; then
+	echo "DOCKER_PASSWORD is empty"
+	exit 1
+fi
 
 # Publish the image to Docker hub.
 if [ -n "$DOCKER_PASSWORD" -a -n "$DOCKER_USERNAME" -a -n "$VERSION" ]; then


### PR DESCRIPTION
The README file on Docker hub is not automatically refreshed. This is because the Docker image builds are performed in Travis and not on Docker hub.

Using https://stackoverflow.com/a/55082686/11582827 and https://success.docker.com/article/how-do-i-authenticate-with-the-v2-api I made this work without enabling automated builds in Docker hub. The API does not seem to be publicly documented but works.