### PR TITLE
make cleanup a list in CommandSequence

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/utils/commandsequence.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/commandsequence.py
@@ -48,6 +48,9 @@ class CommandSequenceBase:
         self.failed = False
         self.retcodes = {}
         self.outputs = {}
+        if cleanup and not isinstance(cleanup, list):
+            raise Exception("cleanup is not a list of commands")
+
         self.cleanup = cleanup
         self.loglevel = loglevel
         self.driveon = driveon
@@ -173,13 +176,17 @@ class CommandSequence(CommandSequenceBase):
 
     def run_cleanup(self):
         """
-        Call cleanup in case the sequence failed or termination was requested.
+        Call cleanup sequence in case the command sequence failed
+        or termination was requested.
         """
-        if self.cleanup:
-            if is_web_uri(self.cleanup.get("command")[0]):
-                self.call_rest_api(self.cleanup)
+        if self.cleanup is None:
+            return
+
+        for cleanup_cmd in self.cleanup:
+            if is_web_uri(cleanup_cmd.get("command")[0]):
+                self.call_rest_api(cleanup_cmd)
             else:
-                command_args = self.cleanup.get("command")
+                command_args = cleanup_cmd.get("command")
                 self.logger.debug("Running cleanup command '{}'".
                                   format(command_args))
                 cmd = Command(command_args,

--- a/opengrok-tools/src/test/python/test_command_sequence.py
+++ b/opengrok-tools/src/test/python/test_command_sequence.py
@@ -138,6 +138,7 @@ def test_cleanup():
         file_foo = os.path.join(tmpdir, "foo")
         file_bar = os.path.join(tmpdir, "bar")
         cleanup_list = [{"command": ["/usr/bin/touch", file_foo]},
+                        {"command": ["/bin/cat", "/totallynonexistent"]},
                         {"command": ["/usr/bin/touch", file_bar]}]
         # Running 'cat' on non-existing entry causes it to return 1.
         cmd_list = [{"command": ["/bin/cat", "/foobar"]}]

--- a/opengrok-tools/src/test/python/test_command_sequence.py
+++ b/opengrok-tools/src/test/python/test_command_sequence.py
@@ -141,11 +141,13 @@ def test_cleanup():
                         {"command": ["/bin/cat", "/totallynonexistent"]},
                         {"command": ["/usr/bin/touch", file_bar]}]
         # Running 'cat' on non-existing entry causes it to return 1.
-        cmd_list = [{"command": ["/bin/cat", "/foobar"]}]
+        cmd = ["/bin/cat", "/foobar"]
+        cmd_list = [{"command": cmd}]
         commands = CommandSequence(CommandSequenceBase("test-cleanup-list",
                                                        cmd_list,
                                                        cleanup=cleanup_list))
         assert commands is not None
         commands.run()
+        assert list(commands.retcodes.values()) == [1]
         assert os.path.isfile(file_foo)
         assert os.path.isfile(file_bar)

--- a/opengrok-tools/src/test/python/test_command_sequence.py
+++ b/opengrok-tools/src/test/python/test_command_sequence.py
@@ -116,3 +116,10 @@ def test_project_subst():
     cmds.run()
 
     assert cmds.outputs['/bin/echo test-subst'] == ['test-subst\n']
+
+
+def test_cleanup():
+    cleanup_list = [{"cleanup": ["/bin/echo", CommandSequence.PROJECT_SUBST]}]
+    cmds = CommandSequence(CommandSequenceBase("test-cleanup-list", None,
+                                               cleanup=cleanup_list))
+    assert cmds is not None


### PR DESCRIPTION
Allows to have multiple cleanup "commands" in `opengrok-sync` configuration:

Sample config:
```yml
commands:
  # returns 1
  - command: [cat, '/foo']
cleanup:
  - command: [ls, '/etc']
  - command: [echo, 'cleanup']
```
Even if any of the cleanup commands fail, the execution continues, unlike what is done for the main sequence of commands.