### PR TITLE
Replace demo link with link to docker image

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
                 <a href="https://github.com/oracle/opengrok/releases">Download <strong>TAR Ball</strong></a>
             </li>
             <li>
-                <a href="http://demo.opengrok.org">Check out <strong>Demo</strong></a>
+                <a href="https://hub.docker.com/r/opengrok/docker/">Pull <strong>Docker image</strong></a>
             </li>
         </ul>
 


### PR DESCRIPTION
Hi,

I've noticed that the web page still contains link to the demo which is no longer working. I've replaced it with the link to Docker image.

Please let me know if you would like to change the wording or replace it with something else.

Thanks :)
