### PR TITLE
Minify js and css files

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -76,6 +76,7 @@ import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.IOUtils;
 import org.opengrok.indexer.util.TandemPath;
+import org.opengrok.indexer.web.Scripts.ScriptType;
 import org.opengrok.indexer.web.messages.MessagesContainer.AcceptedMessage;
 import org.suigeneris.jrcs.diff.Diff;
 import org.suigeneris.jrcs.diff.DifferentiationFailedException;
@@ -110,6 +111,7 @@ public final class PageConfig {
     protected static final String ALL_PROJECT_SEARCH = "searchall";
     protected static final String PROJECT_PARAM_NAME = "project";
     protected static final String GROUP_PARAM_NAME = "group";
+    private static final String DEBUG_PARAM_NAME = "debug";
 
     // TODO if still used, get it from the app context
 
@@ -1401,11 +1403,15 @@ public final class PageConfig {
      * @param name name of the script to search for
      * @return this
      *
-     * @see Scripts#addScript(java.lang.String, java.lang.String)
+     * @see Scripts#addScript(java.lang.String, java.lang.String, ScriptType)
      */
     public PageConfig addScript(String name) {
-        this.scripts.addScript(this.req.getContextPath(), name);
+        this.scripts.addScript(this.req.getContextPath(), name, isDebug() ? ScriptType.DEBUG : ScriptType.MINIFIED);
         return this;
+    }
+
+    private boolean isDebug() {
+        return Boolean.parseBoolean(req.getParameter(DEBUG_PARAM_NAME));
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -76,7 +76,6 @@ import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.IOUtils;
 import org.opengrok.indexer.util.TandemPath;
-import org.opengrok.indexer.web.Scripts.ScriptType;
 import org.opengrok.indexer.web.messages.MessagesContainer.AcceptedMessage;
 import org.suigeneris.jrcs.diff.Diff;
 import org.suigeneris.jrcs.diff.DifferentiationFailedException;
@@ -1403,10 +1402,10 @@ public final class PageConfig {
      * @param name name of the script to search for
      * @return this
      *
-     * @see Scripts#addScript(java.lang.String, java.lang.String, ScriptType)
+     * @see Scripts#addScript(String, String, Scripts.Type)
      */
     public PageConfig addScript(String name) {
-        this.scripts.addScript(this.req.getContextPath(), name, isDebug() ? ScriptType.DEBUG : ScriptType.MINIFIED);
+        this.scripts.addScript(this.req.getContextPath(), name, isDebug() ? Scripts.Type.DEBUG : Scripts.Type.MINIFIED);
         return this;
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
@@ -40,7 +40,7 @@ public class Scripts implements Iterable<Scripts.Script> {
 
     private static final String DEBUG_SUFFIX = "-debug";
 
-    enum ScriptType {
+    enum Type {
         MINIFIED, DEBUG
     }
 
@@ -109,14 +109,14 @@ public class Scripts implements Iterable<Scripts.Script> {
         SCRIPTS.put("jquery", new FileScript("js/jquery-3.4.1.min.js", 10));
         SCRIPTS.put("jquery-ui", new FileScript("js/jquery-ui-1.12.1-custom.min.js", 11));
         SCRIPTS.put("jquery-tablesorter", new FileScript("js/jquery-tablesorter-2.26.6.min.js", 12));
-        SCRIPTS.put("tablesorter-parsers", new FileScript("js/tablesorter-parsers-0.0.1-min.js", 13));
+        SCRIPTS.put("tablesorter-parsers", new FileScript("js/tablesorter-parsers-0.0.1.min.js", 13));
         SCRIPTS.put("tablesorter-parsers" + DEBUG_SUFFIX, new FileScript("js/tablesorter-parsers-0.0.1.js", 13));
         SCRIPTS.put("searchable-option-list", new FileScript("js/searchable-option-list-2.0.7.min.js", 14));
-        SCRIPTS.put("utils", new FileScript("js/utils-0.0.31-min.js", 15));
+        SCRIPTS.put("utils", new FileScript("js/utils-0.0.31.min.js", 15));
         SCRIPTS.put("utils" + DEBUG_SUFFIX, new FileScript("js/utils-0.0.31.js", 15));
-        SCRIPTS.put("repos", new FileScript("js/repos-0.0.1-min.js", 20));
+        SCRIPTS.put("repos", new FileScript("js/repos-0.0.1.min.js", 20));
         SCRIPTS.put("repos" + DEBUG_SUFFIX, new FileScript("js/repos-0.0.1.js", 20));
-        SCRIPTS.put("diff", new FileScript("js/diff-0.0.3-min.js", 20));
+        SCRIPTS.put("diff", new FileScript("js/diff-0.0.3.min.js", 20));
         SCRIPTS.put("diff" + DEBUG_SUFFIX, new FileScript("js/diff-0.0.3.js", 20));
         SCRIPTS.put("jquery-caret", new FileScript("js/jquery.caret-1.5.2.min.js", 25));
     }
@@ -193,9 +193,9 @@ public class Scripts implements Iterable<Scripts.Script> {
      * @param type type of the script to add
      * @return true if script was added; false otherwise
      */
-    public boolean addScript(String contextPath, String scriptName, ScriptType type) {
+    public boolean addScript(String contextPath, String scriptName, Type type) {
         contextPath = contextPath == null || contextPath.isEmpty() ? "/" : contextPath + "/";
-        if (type == ScriptType.DEBUG && SCRIPTS.containsKey(scriptName + DEBUG_SUFFIX)) {
+        if (type == Type.DEBUG && SCRIPTS.containsKey(scriptName + DEBUG_SUFFIX)) {
             addScript(contextPath, scriptName + DEBUG_SUFFIX);
             return true;
         } else if (SCRIPTS.containsKey(scriptName)) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
@@ -38,6 +38,12 @@ import java.util.TreeSet;
  */
 public class Scripts implements Iterable<Scripts.Script> {
 
+    private static final String DEBUG_SUFFIX = "-debug";
+
+    enum ScriptType {
+        MINIFIED, DEBUG
+    }
+
     /**
      * A script wrapper.
      */
@@ -103,11 +109,15 @@ public class Scripts implements Iterable<Scripts.Script> {
         SCRIPTS.put("jquery", new FileScript("js/jquery-3.4.1.min.js", 10));
         SCRIPTS.put("jquery-ui", new FileScript("js/jquery-ui-1.12.1-custom.min.js", 11));
         SCRIPTS.put("jquery-tablesorter", new FileScript("js/jquery-tablesorter-2.26.6.min.js", 12));
-        SCRIPTS.put("tablesorter-parsers", new FileScript("js/tablesorter-parsers-0.0.1.js", 13));
+        SCRIPTS.put("tablesorter-parsers", new FileScript("js/tablesorter-parsers-0.0.1-min.js", 13));
+        SCRIPTS.put("tablesorter-parsers" + DEBUG_SUFFIX, new FileScript("js/tablesorter-parsers-0.0.1.js", 13));
         SCRIPTS.put("searchable-option-list", new FileScript("js/searchable-option-list-2.0.7.min.js", 14));
-        SCRIPTS.put("utils", new FileScript("js/utils-0.0.31.js", 15));
-        SCRIPTS.put("repos", new FileScript("js/repos-0.0.1.js", 20));
-        SCRIPTS.put("diff", new FileScript("js/diff-0.0.3.js", 20));
+        SCRIPTS.put("utils", new FileScript("js/utils-0.0.31-min.js", 15));
+        SCRIPTS.put("utils" + DEBUG_SUFFIX, new FileScript("js/utils-0.0.31.js", 15));
+        SCRIPTS.put("repos", new FileScript("js/repos-0.0.1-min.js", 20));
+        SCRIPTS.put("repos" + DEBUG_SUFFIX, new FileScript("js/repos-0.0.1.js", 20));
+        SCRIPTS.put("diff", new FileScript("js/diff-0.0.3-min.js", 20));
+        SCRIPTS.put("diff" + DEBUG_SUFFIX, new FileScript("js/diff-0.0.3.js", 20));
         SCRIPTS.put("jquery-caret", new FileScript("js/jquery.caret-1.5.2.min.js", 25));
     }
 
@@ -180,18 +190,24 @@ public class Scripts implements Iterable<Scripts.Script> {
      *
      * @param contextPath given context path for the used URL
      * @param scriptName  name of the script
+     * @param type type of the script to add
      * @return true if script was added; false otherwise
      */
-    public boolean addScript(String contextPath, String scriptName) {
+    public boolean addScript(String contextPath, String scriptName, ScriptType type) {
         contextPath = contextPath == null || contextPath.isEmpty() ? "/" : contextPath + "/";
-        if (SCRIPTS.containsKey(scriptName)) {
-            this.addScript(
-                    // put the context path end append the script path
-                    new FileScript(contextPath + SCRIPTS.get(scriptName).getScriptData(),
-                            SCRIPTS.get(scriptName).getPriority()));
+        if (type == ScriptType.DEBUG && SCRIPTS.containsKey(scriptName + DEBUG_SUFFIX)) {
+            addScript(contextPath, scriptName + DEBUG_SUFFIX);
+            return true;
+        } else if (SCRIPTS.containsKey(scriptName)) {
+            addScript(contextPath, scriptName);
             return true;
         }
         return false;
+    }
+
+    private void addScript(String contextPath, String scriptName) {
+        this.addScript(new FileScript(contextPath + SCRIPTS.get(scriptName).getScriptData(),
+                SCRIPTS.get(scriptName).getPriority()));
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/ScriptsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/ScriptsTest.java
@@ -33,7 +33,6 @@ import java.util.Map.Entry;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengrok.indexer.web.Scripts.Script;
-import org.opengrok.indexer.web.Scripts.ScriptType;
 
 /**
  *
@@ -110,10 +109,10 @@ public class ScriptsTest {
 
     @Test
     public void testLookup() {
-        scripts.addScript("", "utils", ScriptType.MINIFIED);
-        scripts.addScript("", "jquery", ScriptType.MINIFIED);
-        scripts.addScript("", "diff", ScriptType.MINIFIED);
-        scripts.addScript("", "jquery-tablesorter", ScriptType.MINIFIED);
+        scripts.addScript("", "utils", Scripts.Type.MINIFIED);
+        scripts.addScript("", "jquery", Scripts.Type.MINIFIED);
+        scripts.addScript("", "diff", Scripts.Type.MINIFIED);
+        scripts.addScript("", "jquery-tablesorter", Scripts.Type.MINIFIED);
 
         assertEquals(4, scripts.size());
 
@@ -145,10 +144,10 @@ public class ScriptsTest {
     @Test
     public void testLookupWithContextPath() {
         String contextPath = "/source";
-        scripts.addScript(contextPath, "utils", ScriptType.MINIFIED);
-        scripts.addScript(contextPath, "jquery", ScriptType.MINIFIED);
-        scripts.addScript(contextPath, "diff", ScriptType.MINIFIED);
-        scripts.addScript(contextPath, "jquery-tablesorter", ScriptType.MINIFIED);
+        scripts.addScript(contextPath, "utils", Scripts.Type.MINIFIED);
+        scripts.addScript(contextPath, "jquery", Scripts.Type.MINIFIED);
+        scripts.addScript(contextPath, "diff", Scripts.Type.MINIFIED);
+        scripts.addScript(contextPath, "jquery-tablesorter", Scripts.Type.MINIFIED);
 
         assertEquals(4, scripts.size());
 
@@ -179,13 +178,13 @@ public class ScriptsTest {
 
     @Test
     public void testAddMinified() {
-        scripts.addScript("", "utils", ScriptType.MINIFIED);
+        scripts.addScript("", "utils", Scripts.Type.MINIFIED);
         assertTrue(scripts.iterator().next().scriptData.endsWith("min.js"));
     }
 
     @Test
     public void testAddDebug() {
-        scripts.addScript("", "utils", ScriptType.DEBUG);
+        scripts.addScript("", "utils", Scripts.Type.DEBUG);
         assertFalse(scripts.iterator().next().scriptData.endsWith("min.js"));
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/ScriptsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/ScriptsTest.java
@@ -23,6 +23,7 @@
 package org.opengrok.indexer.web;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -32,6 +33,7 @@ import java.util.Map.Entry;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengrok.indexer.web.Scripts.Script;
+import org.opengrok.indexer.web.Scripts.ScriptType;
 
 /**
  *
@@ -108,10 +110,10 @@ public class ScriptsTest {
 
     @Test
     public void testLookup() {
-        scripts.addScript("", "utils");
-        scripts.addScript("", "jquery");
-        scripts.addScript("", "diff");
-        scripts.addScript("", "jquery-tablesorter");
+        scripts.addScript("", "utils", ScriptType.MINIFIED);
+        scripts.addScript("", "jquery", ScriptType.MINIFIED);
+        scripts.addScript("", "diff", ScriptType.MINIFIED);
+        scripts.addScript("", "jquery-tablesorter", ScriptType.MINIFIED);
 
         assertEquals(4, scripts.size());
 
@@ -143,10 +145,10 @@ public class ScriptsTest {
     @Test
     public void testLookupWithContextPath() {
         String contextPath = "/source";
-        scripts.addScript(contextPath, "utils");
-        scripts.addScript(contextPath, "jquery");
-        scripts.addScript(contextPath, "diff");
-        scripts.addScript(contextPath, "jquery-tablesorter");
+        scripts.addScript(contextPath, "utils", ScriptType.MINIFIED);
+        scripts.addScript(contextPath, "jquery", ScriptType.MINIFIED);
+        scripts.addScript(contextPath, "diff", ScriptType.MINIFIED);
+        scripts.addScript(contextPath, "jquery-tablesorter", ScriptType.MINIFIED);
 
         assertEquals(4, scripts.size());
 
@@ -174,4 +176,17 @@ public class ScriptsTest {
                                     + " data-priority=\"" + s.getValue().getPriority() + "\"></script>"));
         }
     }
+
+    @Test
+    public void testAddMinified() {
+        scripts.addScript("", "utils", ScriptType.MINIFIED);
+        assertTrue(scripts.iterator().next().scriptData.endsWith("min.js"));
+    }
+
+    @Test
+    public void testAddDebug() {
+        scripts.addScript("", "utils", ScriptType.DEBUG);
+        assertFalse(scripts.iterator().next().scriptData.endsWith("min.js"));
+    }
+
 }

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -213,6 +213,7 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                     </execution>
                 </executions>
                 <configuration>
+                    <suffix>.min</suffix>
                     <excludes>
                         <exclude>**/*min.js</exclude>
                         <exclude>**/*min.css</exclude>

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 -->
@@ -201,6 +201,25 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>yuicompressor-maven-plugin</artifactId>
+                <version>1.5.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jslint</goal>
+                            <goal>compress</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*min.js</exclude>
+                        <exclude>**/*min.css</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
@@ -233,5 +252,13 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
             </build>
         </profile>
     </profiles>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <name>oss.sonatype.org</name>
+            <id>oss.sonatype.org</id>
+            <url>http://oss.sonatype.org/content/groups/public</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/opengrok-web/src/main/webapp/httpheader.jspf
+++ b/opengrok-web/src/main/webapp/httpheader.jspf
@@ -43,8 +43,8 @@ org.opengrok.indexer.web.PageConfig"
     PageConfig cfg = PageConfig.get(request);
     String styleDir = cfg.getCssDir();
     String ctxPath = request.getContextPath();
-    String dstyle = styleDir + '/' + "style-min.css";
-    String pstyle = styleDir + '/' + "print-min.css";
+    String dstyle = styleDir + '/' + "style.min.css";
+    String pstyle = styleDir + '/' + "print.min.css";
 %><!DOCTYPE html>
 <html lang="en"
       class="<%= request.getServletPath().length() > 0 ? request.getServletPath().substring(1) : "" %>">
@@ -58,13 +58,13 @@ org.opengrok.indexer.web.PageConfig"
     title="Default" href="<%= dstyle %>" />
 <link rel="alternate stylesheet" type="text/css" media="all"
     title="Paper White" href="<%= pstyle %>" />
-<link rel="stylesheet" type="text/css" href="<%=styleDir%>/mandoc-min.css" media="all" />
-<link rel="stylesheet" type="text/css" href="<%=styleDir%>/print-min.css" media="print" />
+<link rel="stylesheet" type="text/css" href="<%=styleDir%>/mandoc.min.css" media="all" />
+<link rel="stylesheet" type="text/css" href="<%=styleDir%>/print.min.css" media="print" />
 <link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery-ui-1.12.1-custom.min.css" />
 <link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery-ui-1.12.1-custom.structure.min.css" />
 <link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery-ui-1.12.1-custom.theme.min.css" />
-<link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery.tooltip-min.css" />
-<link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery.tablesorter-min.css" />
+<link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery.tooltip.min.css" />
+<link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery.tablesorter.min.css" />
 <link rel="stylesheet" type="text/css" href="<%=styleDir%>/searchable-option-list-2.0.3.min.css" />
 
 <%

--- a/opengrok-web/src/main/webapp/httpheader.jspf
+++ b/opengrok-web/src/main/webapp/httpheader.jspf
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
 
@@ -43,8 +43,8 @@ org.opengrok.indexer.web.PageConfig"
     PageConfig cfg = PageConfig.get(request);
     String styleDir = cfg.getCssDir();
     String ctxPath = request.getContextPath();
-    String dstyle = styleDir + '/' + "style.css";
-    String pstyle = styleDir + '/' + "print.css";
+    String dstyle = styleDir + '/' + "style-min.css";
+    String pstyle = styleDir + '/' + "print-min.css";
 %><!DOCTYPE html>
 <html lang="en"
       class="<%= request.getServletPath().length() > 0 ? request.getServletPath().substring(1) : "" %>">
@@ -58,13 +58,13 @@ org.opengrok.indexer.web.PageConfig"
     title="Default" href="<%= dstyle %>" />
 <link rel="alternate stylesheet" type="text/css" media="all"
     title="Paper White" href="<%= pstyle %>" />
-<link rel="stylesheet" type="text/css" href="<%=styleDir%>/mandoc.css" media="all" />
-<link rel="stylesheet" type="text/css" href="<%=styleDir%>/print.css" media="print" />
+<link rel="stylesheet" type="text/css" href="<%=styleDir%>/mandoc-min.css" media="all" />
+<link rel="stylesheet" type="text/css" href="<%=styleDir%>/print-min.css" media="print" />
 <link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery-ui-1.12.1-custom.min.css" />
 <link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery-ui-1.12.1-custom.structure.min.css" />
 <link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery-ui-1.12.1-custom.theme.min.css" />
-<link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery.tooltip.css" />
-<link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery.tablesorter.css" />
+<link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery.tooltip-min.css" />
+<link rel="stylesheet" type="text/css" href="<%=styleDir%>/jquery.tablesorter-min.css" />
 <link rel="stylesheet" type="text/css" href="<%=styleDir%>/searchable-option-list-2.0.3.min.css" />
 
 <%

--- a/opengrok-web/src/main/webapp/js/utils-0.0.31.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.31.js
@@ -1846,14 +1846,14 @@ function initAutocompleteForField(inputId, field, config, dataFunction, errorEle
                 });
                 if (config.showTime) {
                     $("<li>", {
-                        class: "ui-state-disabled",
+                        "class": "ui-state-disabled",
                         style: 'padding-left: 5px;',
                         text: time + ' ms'
                     }).appendTo(ul);
                 }
                 if (partialResult) {
                     $("<li>", {
-                        class: "ui-state-disabled",
+                        "class": "ui-state-disabled",
                         style: 'padding-left: 5px;',
                         text: 'Partial result due to timeout'
                     }).appendTo(ul);
@@ -1934,7 +1934,7 @@ function showError(errorText, errorElem) {
     var span = parent.find('#autocomplete-error')[0];
     if (!span) {
         span = $("<span>", {
-            class: "important-note important-note-rounded",
+            "class": "important-note important-note-rounded",
             style: "right: -10px; position: absolute; top: 0px;",
             text: "!",
             id: 'autocomplete-error'
@@ -1966,17 +1966,17 @@ function hideError(errorElem) {
 function getSuggestionListItem(itemData, config) {
     if (itemData.selectable === false) {
         return $("<li>", {
-            class: "ui-state-disabled",
+            "class": "ui-state-disabled",
             text: itemData.phrase
         });
     }
 
     var listItem = $("<li>", {
-        class: "ui-menu-item",
+        "class": "ui-menu-item",
         style: "display: block;"
     });
     var listItemChild = $("<div>", {
-        class: "ui-menu-item-wrapper",
+        "class": "ui-menu-item-wrapper",
         style: "height: 20px; padding: 0;",
         tabindex: "-1"
     });


### PR DESCRIPTION
Hi,

I've added maven plugin which minifies `js` and `css` files. I don't think there will be a noticable improvement since our js and css files are quite small.

`jslint` produces a few warnings so I will create an issue for that as soon as this is merged.

If there is a need to debug the `js` code, then simply `debug=true` query param can be appended to the URL.

Changes in the `util.js` file fixed errors where `class` should be enclosed in `"` -> the same can be seen on jQuery page as well: https://api.jquery.com/jQuery/#creating-new-elements

Thanks :)
