### PR TITLE
Re-enable checkstyle in web module

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       name: OpenGrok/OpenGrok
       description: Build submitted via Travis CI
       branch_pattern: coverity_scan
-      build_command: mvn -DskipTests=true -Dmaven.javadoc.skip=false -B -V compile
+      build_command: ./mvnw -DskipTests=true -Dmaven.javadoc.skip=false -B -V compile
   sonarcloud:
     organization: opengrok
     token:
@@ -85,7 +85,7 @@ jobs:
     services:
     - docker
     before_install: dev/before_install
-    before_script: mvn -DskipTests=true -Dmaven.javadoc.skip=true -B -V package
+    before_script: ./mvnw -DskipTests=true -Dmaven.javadoc.skip=true -B -V package
     script: dev/docker.sh
   - stage: javadoc
     name: Upload javadocs to Github pages

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,15 @@
 version: '{build}'
 skip_tags: true
 environment:
-  MAVEN_VERSION: 3.6.0
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
       PYTHON: C:\Python35
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\maven" )) {
-        Write-Host "Downloading Maven $env:MAVEN_VERSION"
-        (new-object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/org/apache/maven/apache-maven/$env:MAVEN_VERSION/apache-maven-$env:MAVEN_VERSION-bin.zip", 'C:\maven-bin.zip')
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
-      }
-  - cmd: SET M2_HOME=C:\maven\apache-maven-%MAVEN_VERSION%
   # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
-  - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PYTHON%;%PATH:C:\Ruby193\bin;=%;
-  - cmd: mvn --version
+  - cmd: SET PATH=%JAVA_HOME%\bin;%PYTHON%;%PATH:C:\Ruby193\bin;=%;
+  - cmd: mvnw.cmd --version
   - cmd: java -version
   - cmd: python --version
   - cmd: hg --version
@@ -30,7 +23,6 @@ install:
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\uctags-bin.zip", "C:\uctags")
       }
 build_script:
-    - mvn -B -V -Dorg.opengrok.indexer.analysis.Ctags=c:\uctags\ctags.exe clean verify
+    - mvnw.cmd -B -V -Dorg.opengrok.indexer.analysis.Ctags=c:\uctags\ctags.exe clean verify
 cache:
-  - C:\maven\ -> appveyor.yml
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/dev/javadoc.sh
+++ b/dev/javadoc.sh
@@ -11,7 +11,7 @@ fi
 
 echo -e "Publishing javadoc...\n"
 
-mvn -DskipTests=true site
+./mvnw -DskipTests=true site
 
 git config --global user.email "travis@travis-ci.org"
 git config --global user.name "travis-ci"

--- a/dev/main
+++ b/dev/main
@@ -24,6 +24,6 @@ if [ "x$TRAVIS_REPO_SLUG" == "xoracle/opengrok" ]; then
 fi
 
 ret=0
-mvn -B -V verify $extra_args || ret=1
+./mvnw -B -V verify $extra_args || ret=1
 node dev/parse.js || ret=1
 exit $ret

--- a/dev/pre-deploy.sh
+++ b/dev/pre-deploy.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Create distribution that will be uploaded to Github release.
-mvn -DskipTests=true -Dmaven.javadoc.skip=false -B -V package
+./mvnw -DskipTests=true -Dmaven.javadoc.skip=false -B -V package

--- a/dev/release.sh
+++ b/dev/release.sh
@@ -36,7 +36,7 @@ if [[ $ver == $VERSION ]]; then
 fi
 
 git pull --ff-only
-mvn versions:set -DgenerateBackupPoms=false "-DnewVersion=$VERSION"
+./mvnw versions:set -DgenerateBackupPoms=false "-DnewVersion=$VERSION"
 git commit pom.xml '**/pom.xml' -m "$VERSION"
 git push
 git tag "$VERSION"

--- a/docker/README.md
+++ b/docker/README.md
@@ -125,7 +125,7 @@ docker run -d \
 
 If you want to do your own development, you can build the image yourself:
 
-    mvn -DskipTests=true clean package && \
+    ./mvnw -DskipTests=true clean package && \
         docker build -t opengrok-dev .
 
 Then run the container:

--- a/opengrok-tools/README.md
+++ b/opengrok-tools/README.md
@@ -129,7 +129,7 @@ python3 -m pip uninstall opengrok_tools
 
 ```bash
 python setup.py install test
-mvn test
+./mvnw test
 ```
 
 ## Cleanup

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -200,6 +200,10 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                     </argLine>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,7 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                                 <failsOnError>true</failsOnError>
                                 <suppressionsLocation>/dev/checkstyle/suppressions.xml</suppressionsLocation>
                                 <headerLocation>/dev/checkstyle/fileheader.txt</headerLocation>
+                                <sourceDirectories>${project.build.sourceDirectory}</sourceDirectories>
                             </configuration>
                             <goals>
                                 <goal>check</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -296,14 +296,7 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.0.0</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.puppycrawl.tools</groupId>
-                            <artifactId>checkstyle</artifactId>
-                            <version>8.17</version>
-                        </dependency>
-                    </dependencies>
+                    <version>3.1.0</version>
                     <executions>
                         <execution>
                             <id>checkstyle</id>
@@ -315,7 +308,6 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
                                 <failsOnError>true</failsOnError>
                                 <suppressionsLocation>/dev/checkstyle/suppressions.xml</suppressionsLocation>
                                 <headerLocation>/dev/checkstyle/fileheader.txt</headerLocation>
-                                <sourceDirectories>${project.build.sourceDirectory}</sourceDirectories>
                             </configuration>
                             <goals>
                                 <goal>check</goal>


### PR DESCRIPTION
Hi,

fixes #2792 

I've noticed that there is a new version of `maven-checkstyle-plugin` so I've tried re-enabling it in web module -> `./mvnw clean compile` works without issues on my Mac and Fedora.

Also, I've updated `mvnw` to newer version and rewritten CI scripts to use it as well. I'm not sure if `appveyor` and `wercker` will work properly since I don't have them enabled in my fork.

Thanks :)