### PR TITLE
enforce timeout for file processing in ctags

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -207,7 +207,7 @@ public final class Configuration {
     private int tabSize;
     private int commandTimeout; // in seconds
     private int interactiveCommandTimeout; // in seconds
-    private int ctagsTimeout; // in seconds
+    private long ctagsTimeout; // in seconds
     private boolean scopesEnabled;
     private boolean projectsEnabled;
     private boolean foldingEnabled;
@@ -377,7 +377,7 @@ public final class Configuration {
         this.interactiveCommandTimeout = commandTimeout;
     }
 
-    public int getCtagsTimeout() {
+    public long getCtagsTimeout() {
         return ctagsTimeout;
     }
 
@@ -387,7 +387,7 @@ public final class Configuration {
      * @param timeout the new value
      * @throws IllegalArgumentException when the timeout is negative
      */
-    public void setCtagsTimeout(int timeout) throws IllegalArgumentException {
+    public void setCtagsTimeout(long timeout) throws IllegalArgumentException {
         if (commandTimeout < 0) {
             throw new IllegalArgumentException(
                     String.format(NEGATIVE_NUMBER_ERROR, "ctagsTimeout", timeout));
@@ -446,7 +446,7 @@ public final class Configuration {
         setContextLimit((short) 10);
         //contextSurround is default(short)
         //ctags is default(String)
-        setCtagsTimeout(30);
+        setCtagsTimeout(10);
         setCurrentIndexedCollapseThreshold(27);
         setDataRoot(null);
         setDisplayRepositories(true);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -207,6 +207,7 @@ public final class Configuration {
     private int tabSize;
     private int commandTimeout; // in seconds
     private int interactiveCommandTimeout; // in seconds
+    private int ctagsTimeout; // in seconds
     private boolean scopesEnabled;
     private boolean projectsEnabled;
     private boolean foldingEnabled;
@@ -376,6 +377,24 @@ public final class Configuration {
         this.interactiveCommandTimeout = commandTimeout;
     }
 
+    public int getCtagsTimeout() {
+        return ctagsTimeout;
+    }
+
+    /**
+     * Set the ctags timeout to a new value.
+     *
+     * @param timeout the new value
+     * @throws IllegalArgumentException when the timeout is negative
+     */
+    public void setCtagsTimeout(int timeout) throws IllegalArgumentException {
+        if (commandTimeout < 0) {
+            throw new IllegalArgumentException(
+                    String.format(NEGATIVE_NUMBER_ERROR, "ctagsTimeout", timeout));
+        }
+        this.ctagsTimeout = timeout;
+    }
+
     public String getStatisticsFilePath() {
         return statisticsFilePath;
     }
@@ -411,13 +430,10 @@ public final class Configuration {
     }
 
     /**
-     * Creates a new instance of Configuration.
+     * Creates a new instance of Configuration with default values.
      */
     public Configuration() {
-        /**
-         * This list of calls is sorted alphabetically so please keep it.
-         */
-        // defaults for an opengrok instance configuration
+        // This list of calls is sorted alphabetically so please keep it.
         cmds = new HashMap<>();
         setAllowedSymlinks(new HashSet<>());
         setAuthorizationWatchdogEnabled(false);
@@ -430,6 +446,7 @@ public final class Configuration {
         setContextLimit((short) 10);
         //contextSurround is default(short)
         //ctags is default(String)
+        setCtagsTimeout(30);
         setCurrentIndexedCollapseThreshold(27);
         setDataRoot(null);
         setDisplayRepositories(true);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationHelp.java
@@ -140,6 +140,8 @@ public class ConfigurationHelp {
             return "user-specified-value";
         } else if (paramType == int.class) {
             return 1 + (int) defaultValue;
+        } else if (paramType == long.class) {
+            return 1 + (long) defaultValue;
         } else if (paramType == short.class) {
             return (short) (1 + (short) defaultValue);
         } else if (paramType == boolean.class) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -301,6 +301,14 @@ public final class RuntimeEnvironment {
     public void setInteractiveCommandTimeout(int timeout) {
         setConfigurationValue("interactiveCommandTimeout", timeout);
     }
+
+    public int getCtagsTimeout() {
+        return (int) getConfigurationValue("ctagsTimeout");
+    }
+
+    public void setCtagsTimeout(int timeout) {
+        setConfigurationValue("ctagsTimeout", timeout);
+    }
     
     public Statistics getStatistics() {
         return statistics;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -302,11 +302,11 @@ public final class RuntimeEnvironment {
         setConfigurationValue("interactiveCommandTimeout", timeout);
     }
 
-    public int getCtagsTimeout() {
-        return (int) getConfigurationValue("ctagsTimeout");
+    public long getCtagsTimeout() {
+        return (long) getConfigurationValue("ctagsTimeout");
     }
 
-    public void setCtagsTimeout(int timeout) {
+    public void setCtagsTimeout(long timeout) {
         setConfigurationValue("ctagsTimeout", timeout);
     }
     

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -733,6 +733,8 @@ public class IndexDatabase {
      */
     private void addFile(File file, String path, Ctags ctags)
             throws IOException, InterruptedException {
+
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         AbstractAnalyzer fa = getAnalyzerFor(file, path);
 
         for (IndexChangedListener listener : listeners) {
@@ -740,12 +742,15 @@ public class IndexDatabase {
         }
 
         ctags.setTabSize(project != null ? project.getTabSize() : 0);
+        if (env.getCtagsTimeout() != 0) {
+            ctags.setTimeout(env.getCtagsTimeout());
+        }
         if (ctags.getBinary() != null) {
             fa.setCtags(ctags);
         }
         fa.setProject(Project.getProject(path));
-        fa.setScopesEnabled(RuntimeEnvironment.getInstance().isScopesEnabled());
-        fa.setFoldingEnabled(RuntimeEnvironment.getInstance().isFoldingEnabled());
+        fa.setScopesEnabled(env.isScopesEnabled());
+        fa.setFoldingEnabled(env.isFoldingEnabled());
 
         Document doc = new Document();
         try (Writer xrefOut = newXrefWriter(fa, path)) {


### PR DESCRIPTION
Tested with hacked Universal ctags:
```diff
diff --git a/main/main.c b/main/main.c
index 2384cea7..f0b608b8 100644
--- a/main/main.c
+++ b/main/main.c
@@ -278,7 +278,11 @@ static bool createTagsFromFileInput (FILE *const fp, const bool filter)
                parseCmdlineOptions (args);
                while (! cArgOff (args))
                {
-                       resize |= createTagsForEntry (cArgItem (args));
+                       const char *carg = cArgItem (args);
+                       if (strstr(carg, "toxic") != NULL)
+                               sleep(3600);
+
+                       resize |= createTagsForEntry (carg);
                        if (filter)
                        {
                                if (Option.filterTerminator != NULL)
```
and a repository that contained `toxic.txt` file. The logs from indexer run then looked like so:
```
WARNING: Terminating ctags process for file '/var/opengrok/src.ctags/foo/toxic.txt' due to timeout 30 seconds
Aug 19, 2019 4:14:59 PM org.opengrok.indexer.analysis.Ctags readTags
WARNING: ctags: Unexpected end of file!
Aug 19, 2019 4:14:59 PM org.opengrok.indexer.analysis.Ctags readTags
WARNING: ctags exited with code: 137
Aug 19, 2019 4:14:59 PM org.opengrok.indexer.index.IndexDatabase addFile
WARNING: File '/foo/toxic.txt' interrupted--tagLine == null
Aug 19, 2019 4:15:29 PM org.opengrok.indexer.analysis.Ctags$1 run
WARNING: Terminating ctags process for file '/var/opengrok/src.ctags/foo/toxic.txt' due to timeout 30 seconds
Aug 19, 2019 4:15:29 PM org.opengrok.indexer.analysis.Ctags readTags
WARNING: ctags: Unexpected end of file!
Aug 19, 2019 4:15:29 PM org.opengrok.indexer.analysis.Ctags readTags
WARNING: ctags exited with code: 137
Aug 19, 2019 4:15:29 PM org.opengrok.indexer.index.IndexDatabase addFile
WARNING: File '/foo/toxic.txt' interrupted--tagLine == null
Aug 19, 2019 4:15:29 PM org.opengrok.indexer.index.IndexDatabase lambda$null$1
WARNING: No retry: /var/opengrok/src.ctags/foo/toxic.txt
Aug 19, 2019 4:15:29 PM org.opengrok.indexer.index.IndexDatabase indexParallel
WARNING: 1 failures (33.3%) while parallel-indexing
```
Checked that index for the affected project was generated. The xref file for the `toxic.txt` file was empty.