### PR TITLE
Catch ExceptionInInitializerError produced by chronicle-map on JDK12

### DIFF
--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
@@ -298,13 +298,13 @@ class SuggesterProjectData implements Closeable {
             ChronicleMapAdapter m;
             try {
                 m = new ChronicleMapAdapter(field, conf.getAverageKeySize(), conf.getEntries(), f);
-            } catch (Exception e) {
+            } catch (Throwable t) {
                 logger.log(Level.SEVERE,
                         "Could not create ChronicleMap, most popular completion disabled, if you are using "
                                 + "JDK9+ make sure to specify: "
                                 + "--add-exports java.base/jdk.internal.ref=ALL-UNNAMED "
                                 + "--add-exports java.base/jdk.internal.misc=ALL-UNNAMED "
-                                + "--add-exports java.base/sun.nio.ch=ALL-UNNAMED", e);
+                                + "--add-exports java.base/sun.nio.ch=ALL-UNNAMED", t);
                 return;
             }
 


### PR DESCRIPTION
Hi,

I was trying OpenGrok on JDK12 and noticed that suggester was not working. The reason was `ExceptionInInitializerError` thrown when creating chronicle map. Suggester works as expected when the error is caught. Adding `--add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED` params solves the issue and chronicle map works properly.

Thanks :)