### PR TITLE
Fixes #2900 : Add Repository isNestable() property

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -536,6 +536,15 @@ public class GitRepository extends Repository {
         return true;
     }
 
+    /**
+     * Gets a value indicating the instance is nestable.
+     * @return {@code true}
+     */
+    @Override
+    boolean isNestable() {
+        return true;
+    }
+
     @Override
     public boolean isWorking() {
         if (working == null) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -491,6 +491,15 @@ public class MercurialRepository extends Repository {
         return !(val == null
                 ? Boolean.getBoolean(NOFOREST_PROPERTY_KEY)
                 : Boolean.parseBoolean(val));
+    }
+
+    /**
+     * Gets a value indicating the instance is nestable.
+     * @return {@code true}
+     */
+    @Override
+    boolean isNestable() {
+        return true;
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -503,6 +503,14 @@ public abstract class Repository extends RepositoryInfo {
      */
     @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
     boolean supportsSubRepositories() {
+        return false;
+    }
+
+    /**
+     * Subclasses can override to get a value indicating that a repository implementation is nestable.
+     * @return {@code false}
+     */
+    boolean isNestable() {
         return false;
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSRepositoryTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -102,7 +102,7 @@ public class CVSRepositoryTest {
      * @param reposRoot directory of the repository root
      * @param args arguments to use for the command
      */
-    private static void runCvsCommand(File reposRoot, String ... args) {
+    public static void runCvsCommand(File reposRoot, String ... args) {
         List<String> cmdargs = new ArrayList<>();
         CVSRepository repo = new CVSRepository();
         cmdargs.add(repo.getRepoCommand());

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -19,8 +19,13 @@
 
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,8 +47,6 @@ import org.opengrok.indexer.condition.RepositoryInstalled;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.FileUtilities;
 import org.opengrok.indexer.util.TestRepository;
-
-import static org.junit.Assert.*;
 
 /**
  * Test the functionality provided by the HistoryGuru (with friends)
@@ -174,21 +177,21 @@ public class HistoryGuruTest {
     }
 
     @Test
-    @ConditionalRun(RepositoryInstalled.GitInstalled.class)
+    @ConditionalRun(RepositoryInstalled.CvsInstalled.class)
     @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
-    public void testAddSubRepositoryNoTypeMatch() {
+    public void testAddSubRepositoryNotNestable() {
         HistoryGuru instance = HistoryGuru.getInstance();
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
-        // Clone a Mercurial repository underneath a Git repository.
-        File hgRoot = new File(repository.getSourceRoot(), "mercurial");
-        assertTrue(hgRoot.exists());
-        assertTrue(hgRoot.isDirectory());
+        // Check out CVS underneath a Git repository.
+        File cvsRoot = new File(repository.getSourceRoot(), "cvs_test");
+        assertTrue(cvsRoot.exists());
+        assertTrue(cvsRoot.isDirectory());
         File gitRoot = new File(repository.getSourceRoot(), "git");
         assertTrue(gitRoot.exists());
         assertTrue(gitRoot.isDirectory());
-        MercurialRepositoryTest.runHgCommand(gitRoot,
-                "clone", hgRoot.getAbsolutePath(), "subrepo");
+        CVSRepositoryTest.runCvsCommand(gitRoot, "-d",
+                cvsRoot.toPath().resolve("cvsroot").toFile().getAbsolutePath(), "checkout", "cvsrepo");
 
         Collection<RepositoryInfo> addedRepos = instance.
                 addRepositories(Collections.singleton(Paths.get(repository.getSourceRoot(), "git").toString()),


### PR DESCRIPTION
@vladak, this PR is a different approach from your #2901 to fixing #2900 where instead of modifying a repository to know of others' type, a property, `isNestable()` (default `false`), indicates if a `Repository` subclass can be contained within other repositories. I think this is simpler to achieve your goal in #2817 of "efficiency (esp. those repository types which do not just look for special files/directories but execute a command to detect a repository)."

Only Git and Mercurial are marked as `isNestable() == true`. (N.b. only Git, Mercurial, and Repo are marked as `supportsSubRepositories() == true`.)

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->