### PR TITLE
report projects in Suggester log message

### DIFF
--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -432,7 +432,9 @@ public final class Suggester implements Closeable {
                 }
             }
         } catch (Exception e) {
-            logger.log(Level.FINE, "Could not update search count map", e);
+            logger.log(Level.FINE,
+                    String.format("Could not update search count map%s",
+                            projectsEnabled ? " for projects: " + projects: ""), e);
         }
     }
 

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -434,7 +434,7 @@ public final class Suggester implements Closeable {
         } catch (Exception e) {
             logger.log(Level.FINE,
                     String.format("Could not update search count map%s",
-                            projectsEnabled ? " for projects: " + projects: ""), e);
+                            projectsEnabled ? " for projects: " + projects : ""), e);
         }
     }
 


### PR DESCRIPTION
While reindexing from scratch, I noticed a log message:
```
02-Sep-2019 13:24:44.172 FINE [http-nio-8080-exec-5] org.opengrok.suggest.Suggester.onSearch Could not update search count map
        java.lang.NullPointerException
                at org.opengrok.suggest.SuggesterProjectData.incrementSearchCount(SuggesterProjectData.java:416)
                at org.opengrok.suggest.SuggesterProjectData.incrementSearchCount(SuggesterProjectData.java:397)
                at org.opengrok.suggest.Suggester.onSearch(Suggester.java:424)
                at org.opengrok.web.api.v1.suggester.provider.service.impl.SuggesterServiceImpl.onSearch(SuggesterServiceImpl.java:244)
                at org.apache.jsp.search_jsp._jspService(search_jsp.java:245)
```
It would be useful for which projects the update failed.