### PR TITLE
Python test long output

### DIFF
--- a/opengrok-tools/src/test/python/test_command.py
+++ b/opengrok-tools/src/test/python/test_command.py
@@ -192,7 +192,8 @@ def test_long_output():
         assert cmd.getstate() == Command.FINISHED
         assert cmd.getretcode() == 0
         assert cmd.geterroutput() is None
-        assert len(cmd.getoutputstr()) == num_lines * (line_length + 1)
+        # -1 because getoutputstr() strips the string
+        assert len(cmd.getoutputstr()) == num_lines * (line_length + 1) - 1
 
 
 @pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")

--- a/opengrok-tools/src/test/python/test_command_sequence.py
+++ b/opengrok-tools/src/test/python/test_command_sequence.py
@@ -24,6 +24,7 @@
 #
 
 import os
+import sys
 
 import pytest
 import tempfile
@@ -130,8 +131,10 @@ def test_cleanup_exception():
                                             cleanup=cleanup))
 
 
+# /bin/cat returns 2 on Solaris
 @pytest.mark.skipif(not os.path.exists('/usr/bin/touch') or
-                    not os.path.exists('/bin/cat'),
+                    not os.path.exists('/bin/cat') or
+                    not sys.platform != "sunos5",
                     reason="requires Unix")
 def test_cleanup():
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/opengrok-tools/src/test/python/test_command_sequence.py
+++ b/opengrok-tools/src/test/python/test_command_sequence.py
@@ -134,7 +134,7 @@ def test_cleanup_exception():
 # /bin/cat returns 2 on Solaris
 @pytest.mark.skipif(not os.path.exists('/usr/bin/touch') or
                     not os.path.exists('/bin/cat') or
-                    not sys.platform != "sunos5",
+                    sys.platform == "sunos5",
                     reason="requires Unix")
 def test_cleanup():
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Lately I found that `opengrok-indexer` hangs the java process underneath because it failed to consume what was written into the pipe. So far this is only happening on one system so the chances are this is isolated failure however to be sure, I added a test to cover the very basic case.