### PR TITLE
allow to set doprint

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/config_merge.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/config_merge.py
@@ -55,7 +55,7 @@ def main():
     cmd = Java(args.options, classpath=args.jar, java=args.java,
                java_opts=args.java_opts, redirect_stderr=False,
                main_class='org.opengrok.indexer.configuration.ConfigMerge',
-               logger=logger)
+               logger=logger, doprint=args.doprint)
     cmd.execute()
     ret = cmd.getretcode()
     if ret is None or ret != SUCCESS_EXITVAL:

--- a/opengrok-tools/src/main/python/opengrok_tools/groups.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/groups.py
@@ -51,7 +51,7 @@ def main():
     cmd = Java(args.options, classpath=args.jar, java=args.java,
                java_opts=args.java_opts, redirect_stderr=False,
                main_class='org.opengrok.indexer.configuration.Groups',
-               logger=logger)
+               logger=logger, doprint=args.doprint)
     cmd.execute()
     ret = cmd.getretcode()
     if ret is None or ret != SUCCESS_EXITVAL:

--- a/opengrok-tools/src/main/python/opengrok_tools/indexer.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/indexer.py
@@ -63,7 +63,7 @@ def main():
 
     indexer = Indexer(args.options, logger=logger, java=args.java,
                       jar=args.jar, java_opts=args.java_opts,
-                      env_vars=args.environment, doprint=True)
+                      env_vars=args.environment, doprint=args.doprint)
     indexer.execute()
     ret = indexer.getretcode()
     if ret is None or ret != SUCCESS_EXITVAL:

--- a/opengrok-tools/src/main/python/opengrok_tools/java.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/java.py
@@ -50,7 +50,7 @@ def main():
     java = Java(args.options, logger=logger, java=args.java,
                 jar=args.jar, java_opts=args.java_opts,
                 classpath=args.classpath, main_class=args.mainclass,
-                env_vars=args.environment)
+                env_vars=args.environment, doprint=args.doprint)
     java.execute()
     ret = java.getretcode()
     if ret is None or ret != SUCCESS_EXITVAL:

--- a/opengrok-tools/src/main/python/opengrok_tools/reindex_project.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/reindex_project.py
@@ -105,9 +105,7 @@ def main():
                                     args.project)
 
     # Reindex with the modified logging.properties file and read-only config.
-    command = []
-    command.append('-R')
-    command.append(conf_file)
+    command = ['-R', conf_file]
     command.extend(args.options)
     java_opts = []
     if args.java_opts:
@@ -116,7 +114,7 @@ def main():
                      format(logprop_file))
     indexer = Indexer(command, logger=logger, jar=args.jar,
                       java=args.java, java_opts=java_opts,
-                      env_vars=args.environment)
+                      env_vars=args.environment, doprint=args.doprint)
     indexer.execute()
     ret = indexer.getretcode()
     os.remove(conf_file)

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/parsers.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/parsers.py
@@ -31,6 +31,9 @@ def get_javaparser():
                         help='java options', action='append')
     parser.add_argument('-e', '--environment', action='append',
                         help='Environment variables in the form of name=value')
+    parser.add_argument('--doprint', action='store_true', default=False,
+                        help='Print messages from the application as they '
+                        'are produced.')
 
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-a', '--jar',


### PR DESCRIPTION
Introduce --doprint option to allow better flexibility - possible to run all Java apps with output being continuously written to the console.