### PR TITLE
handle exceptions when printing in OutputThread

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
@@ -177,7 +177,12 @@ class Command:
                     self.out.append(line)
 
                     if self.doprint:
-                        print(line.rstrip())
+                        # Even if print() fails the thread has to keep
+                        # running to avoid hangups of the executed command.
+                        try:
+                            print(line.rstrip())
+                        except Exception as print_exc:
+                            self.logger.error(print_exc)
 
             def getoutput(self):
                 return self.out


### PR DESCRIPTION
Tested with this program running with C locale:
```
#!/usr/bin/env python3.4

from opengrok_tools.utils.command import Command

cmd = Command(["python", "-c", "print(u'\\ua000\\nfoo\\n')"],
              env_vars={"LANG": "en_US.UTF-8", "LC_ALL": "en_US.UTF-8"},
              doprint=True)
cmd.execute()

print(cmd.getretcode())
print(len(cmd.getoutput()))
```
It reported:
```
'ascii' codec can't encode character '\ua000' in position 0: ordinal not in range(128)
foo

0
3
```
without the fix the program just gets stuck.