### PR TITLE
check_project_configuration() should be more robust

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -376,7 +376,17 @@ def check_project_configuration(multiple_project_config, hookdir=False,
     if not multiple_project_config:
         return True
 
+    logger.debug("Checking project configuration")
+
     for project_name, project_config in multiple_project_config.items():
+        logger.debug("Checking configuration of project {}".
+                     format(project_name))
+
+        if project_config is None:
+            logger.debug("Project {} has empty configuration".
+                         format(project_name))
+            continue
+
         diff = set(project_config.keys()).difference(known_project_tunables)
         if diff:
             logger.error("unknown project configuration option(s) '{}' "

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -169,3 +169,7 @@ def test_incoming_retval(monkeypatch):
             m.setattr("opengrok_tools.utils.mirror.get", mock_get)
 
             assert opengrok_tools.mirror.main() == CONTINUE_EXITVAL
+
+
+def test_empty_project_config():
+    assert check_project_configuration({'foo': None})


### PR DESCRIPTION
Production instance had this in `mirror.yml`:
```yml
projects:
  foo:
    # ha
```
which produced:
```
Traceback (most recent call last):
  File "/opengrok/dist/bin/venv/bin/opengrok-mirror", line 11, in <module>
    load_entry_point('opengrok-tools==1.3.1', 'console_scripts', 'opengrok-mirror')()
  File "/opengrok/dist/bin/venv/lib/python3.7/site-packages/opengrok_tools/mirror.py", line 175, in main
    with lock.acquire(timeout=0):
  File "/opengrok/dist/bin/venv/lib/python3.7/site-packages/filelock.py", line 271, in acquire
    self._acquire()
  File "/opengrok/dist/bin/venv/lib/python3.7/site-packages/filelock.py", line 384, in _acquire
    fd = os.open(self._lock_file, open_mode)
```
This change fixes that.
