### PR TITLE
revise auth framework locking in RuntimeEnvironment

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -44,7 +44,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1595,7 +1595,7 @@ public final class RuntimeEnvironment {
      *
      * @return the framework
      */
-    public synchronized AuthorizationFramework getAuthorizationFramework() {
+    public AuthorizationFramework getAuthorizationFramework() {
         try {
             authFrameworkLock.readLock().lock();
             if (authFramework == null) {
@@ -1613,7 +1613,7 @@ public final class RuntimeEnvironment {
      *
      * @param fw the new framework
      */
-    public synchronized void setAuthorizationFramework(AuthorizationFramework fw) {
+    public void setAuthorizationFramework(AuthorizationFramework fw) {
         try {
             authFrameworkLock.writeLock().lock();
             if (this.authFramework != null) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -132,7 +132,7 @@ public final class RuntimeEnvironment {
         lzSearchExecutor = LazilyInstantiate.using(() -> newSearchExecutor());
     }
 
-    /** Instance of authorization framework and its lock.*/
+    // Instance of authorization framework and its lock.
     private AuthorizationFramework authFramework;
     private final ReentrantReadWriteLock authFrameworkLock;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -125,7 +126,7 @@ public final class RuntimeEnvironment {
     private RuntimeEnvironment() {
         configuration = new Configuration();
         configLock = new ReentrantReadWriteLock();
-        authFrameworkLock = new ReentrantReadWriteLock();
+        authFrameworkLock = new ReentrantLock();
         watchDog = new WatchDogService();
         lzIndexerParallelizer = LazilyInstantiate.using(() ->
                 new IndexerParallelizer(this));
@@ -134,7 +135,7 @@ public final class RuntimeEnvironment {
 
     // Instance of authorization framework and its lock.
     private AuthorizationFramework authFramework;
-    private final ReadWriteLock authFrameworkLock;
+    private final Lock authFrameworkLock;
 
     /** Gets the thread pool used for multi-project searches. */
     public ExecutorService getSearchExecutor() {
@@ -1597,13 +1598,13 @@ public final class RuntimeEnvironment {
      */
     public AuthorizationFramework getAuthorizationFramework() {
         try {
-            authFrameworkLock.readLock().lock();
+            authFrameworkLock.lock();
             if (authFramework == null) {
                 authFramework = new AuthorizationFramework(getPluginDirectory(), getPluginStack());
             }
             return authFramework;
         } finally {
-            authFrameworkLock.readLock().unlock();
+            authFrameworkLock.unlock();
         }
     }
 
@@ -1615,13 +1616,13 @@ public final class RuntimeEnvironment {
      */
     public void setAuthorizationFramework(AuthorizationFramework fw) {
         try {
-            authFrameworkLock.writeLock().lock();
+            authFrameworkLock.lock();
             if (this.authFramework != null) {
                 this.authFramework.removeAll();
             }
             this.authFramework = fw;
         } finally {
-            authFrameworkLock.writeLock().unlock();
+            authFrameworkLock.unlock();
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -125,7 +125,6 @@ public final class RuntimeEnvironment {
     private RuntimeEnvironment() {
         configuration = new Configuration();
         configLock = new ReentrantReadWriteLock();
-        authFrameworkLock = new Object();
         watchDog = new WatchDogService();
         lzIndexerParallelizer = LazilyInstantiate.using(() ->
                 new IndexerParallelizer(this));
@@ -134,7 +133,7 @@ public final class RuntimeEnvironment {
 
     // Instance of authorization framework and its lock.
     private AuthorizationFramework authFramework;
-    private final Object authFrameworkLock;
+    private final Object authFrameworkLock = new Object();
 
     /** Gets the thread pool used for multi-project searches. */
     public ExecutorService getSearchExecutor() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -134,7 +134,7 @@ public final class RuntimeEnvironment {
 
     // Instance of authorization framework and its lock.
     private AuthorizationFramework authFramework;
-    private final ReentrantReadWriteLock authFrameworkLock;
+    private final ReadWriteLock authFrameworkLock;
 
     /** Gets the thread pool used for multi-project searches. */
     public ExecutorService getSearchExecutor() {


### PR DESCRIPTION
Tested with `RuntimeEnvironment:setConfiguration()` modified to sleep for 5 minutes. First, the method was triggered:
```
curl -X PUT -H 'Content-Type: application/xml' -d @/var/opengrok/etc/configuration.xml 'http://localhost:8080/source/api/v1/configuration?reindex=true'
```
and then I did bunch of requests (`curl  http://localhost:8080/source/`) to make sure they are not blocked anymore.