### PR TITLE
--doprint fixes

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/config_merge.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/config_merge.py
@@ -27,7 +27,7 @@ import sys
 
 from .utils.java import Java
 from .utils.log import fatal
-from .utils.parsers import get_javaparser
+from .utils.parsers import get_java_parser
 from .utils.exitvals import (
     FAILURE_EXITVAL,
     SUCCESS_EXITVAL
@@ -40,7 +40,7 @@ from .utils.exitvals import (
 def main():
     parser = argparse.ArgumentParser(description='Java wrapper for project '
                                                  'configuration merging',
-                                     parents=[get_javaparser()])
+                                     parents=[get_java_parser()])
 
     try:
         args = parser.parse_args()

--- a/opengrok-tools/src/main/python/opengrok_tools/deploy.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/deploy.py
@@ -30,7 +30,7 @@ from zipfile import ZipFile
 
 from .utils.log import get_console_logger, get_class_basename, \
     fatal
-from .utils.parsers import get_baseparser
+from .utils.parsers import get_base_parser
 from .utils.xml import insert_file, XMLProcessingException
 
 WEB_XML = 'WEB-INF/web.xml'
@@ -124,7 +124,7 @@ def deploy_war(logger, source_war, target_war, config_file=None,
 
 def main():
     parser = argparse.ArgumentParser(description='Deploy WAR file',
-                                     parents=[get_baseparser()])
+                                     parents=[get_base_parser()])
 
     parser.add_argument('-c', '--config',
                         help='Path to OpenGrok configuration file')

--- a/opengrok-tools/src/main/python/opengrok_tools/groups.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/groups.py
@@ -26,7 +26,7 @@ import sys
 
 from .utils.java import Java
 from .utils.log import get_console_logger, get_class_basename, fatal
-from .utils.parsers import get_javaparser
+from .utils.parsers import get_java_parser
 from .utils.exitvals import (
     FAILURE_EXITVAL,
     SUCCESS_EXITVAL
@@ -39,7 +39,7 @@ from .utils.exitvals import (
 def main():
     parser = argparse.ArgumentParser(description='Java wrapper for project '
                                                  'group manipulation',
-                                     parents=[get_javaparser()])
+                                     parents=[get_java_parser()])
 
     try:
         args = parser.parse_args()

--- a/opengrok-tools/src/main/python/opengrok_tools/indexer.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/indexer.py
@@ -61,9 +61,16 @@ def main():
     if not args.no_ctags_check and not FindCtags(logger):
         logger.warning("Unable to determine Universal CTags command")
 
+    if args.doprint is None:
+        logger.debug("Console logging is enabled by default")
+        doprint = True
+    else:
+        doprint = args.doprint[0]
+        logger.debug("Console logging: {}".format(doprint))
+
     indexer = Indexer(args.options, logger=logger, java=args.java,
                       jar=args.jar, java_opts=args.java_opts,
-                      env_vars=args.environment, doprint=args.doprint)
+                      env_vars=args.environment, doprint=doprint)
     indexer.execute()
     ret = indexer.getretcode()
     if ret is None or ret != SUCCESS_EXITVAL:

--- a/opengrok-tools/src/main/python/opengrok_tools/indexer.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/indexer.py
@@ -28,7 +28,7 @@ import sys
 
 from .utils.indexer import FindCtags, Indexer
 from .utils.log import get_console_logger, get_class_basename, fatal
-from .utils.parsers import get_javaparser
+from .utils.parsers import get_java_parser
 from .utils.exitvals import (
     FAILURE_EXITVAL,
     SUCCESS_EXITVAL
@@ -43,7 +43,7 @@ from .utils.exitvals import (
 
 def main():
     parser = argparse.ArgumentParser(description='OpenGrok indexer wrapper',
-                                     parents=[get_javaparser()])
+                                     parents=[get_java_parser()])
     parser.add_argument('-C', '--no_ctags_check', action='store_true',
                         default=False, help='Suppress checking for ctags')
 

--- a/opengrok-tools/src/main/python/opengrok_tools/java.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/java.py
@@ -27,7 +27,7 @@ import sys
 
 from .utils.java import Java
 from .utils.log import get_console_logger, get_class_basename, fatal
-from .utils.parsers import get_javaparser
+from .utils.parsers import get_java_parser
 from .utils.exitvals import (
     FAILURE_EXITVAL,
     SUCCESS_EXITVAL
@@ -36,7 +36,7 @@ from .utils.exitvals import (
 
 def main():
     parser = argparse.ArgumentParser(description='java wrapper',
-                                     parents=[get_javaparser()])
+                                     parents=[get_java_parser()])
     parser.add_argument('-m', '--mainclass', required=True,
                         help='Main class')
 

--- a/opengrok-tools/src/main/python/opengrok_tools/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/mirror.py
@@ -47,7 +47,7 @@ from .utils.exitvals import (
 from .utils.log import get_console_logger, get_class_basename, \
     fatal, get_batch_logger
 from .utils.opengrok import get_config_value, list_indexed_projects
-from .utils.parsers import get_baseparser
+from .utils.parsers import get_base_parser
 from .utils.readconfig import read_config
 from .utils.utils import get_int, is_web_uri
 from .utils.mirror import check_configuration, LOGDIR_PROPERTY, \
@@ -80,7 +80,7 @@ def main():
     ret = SUCCESS_EXITVAL
 
     parser = argparse.ArgumentParser(description='project mirroring',
-                                     parents=[get_baseparser(
+                                     parents=[get_base_parser(
                                          tool_version=__version__)
                                      ])
 

--- a/opengrok-tools/src/main/python/opengrok_tools/projadm.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/projadm.py
@@ -41,7 +41,7 @@ from .utils.log import get_console_logger, get_class_basename, \
     fatal
 from .utils.opengrok import get_configuration, set_configuration, \
     add_project, delete_project, get_config_value
-from .utils.parsers import get_baseparser
+from .utils.parsers import get_base_parser
 from .utils.utils import get_command, is_web_uri
 from .utils.exitvals import (
     FAILURE_EXITVAL,
@@ -212,7 +212,7 @@ def main():
     parser = argparse.ArgumentParser(description='project management.',
                                      formatter_class=argparse.
                                      ArgumentDefaultsHelpFormatter,
-                                     parents=[get_baseparser(
+                                     parents=[get_base_parser(
                                          tool_version=__version__)
                                      ])
 

--- a/opengrok-tools/src/main/python/opengrok_tools/reindex_project.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/reindex_project.py
@@ -30,7 +30,7 @@ import tempfile
 from .utils.indexer import Indexer
 from .utils.log import get_console_logger, get_class_basename, fatal
 from .utils.opengrok import get_configuration
-from .utils.parsers import get_javaparser
+from .utils.parsers import get_java_parser
 from .utils.exitvals import (
     FAILURE_EXITVAL,
     SUCCESS_EXITVAL
@@ -75,7 +75,7 @@ def get_config_file(logger, uri):
 def main():
     parser = argparse.ArgumentParser(description='OpenGrok indexer wrapper '
                                                  'for indexing single project',
-                                     parents=[get_javaparser()])
+                                     parents=[get_java_parser()])
     parser.add_argument('-t', '--template', required=True,
                         help='Logging template file')
     parser.add_argument('-p', '--pattern', required=True,

--- a/opengrok-tools/src/main/python/opengrok_tools/sync.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/sync.py
@@ -39,7 +39,7 @@ from filelock import Timeout, FileLock
 from .utils.commandsequence import CommandSequence, CommandSequenceBase
 from .utils.log import get_console_logger, get_class_basename, fatal
 from .utils.opengrok import list_indexed_projects, get_config_value
-from .utils.parsers import get_baseparser
+from .utils.parsers import get_base_parser
 from .utils.readconfig import read_config
 from .utils.utils import is_web_uri
 from .utils.exitvals import (
@@ -71,7 +71,7 @@ def main():
 
     parser = argparse.ArgumentParser(description='Manage parallel workers.',
                                      parents=[
-                                         get_baseparser(
+                                         get_base_parser(
                                              tool_version=__version__)
                                      ])
     parser.add_argument('-w', '--workers', default=multiprocessing.cpu_count(),

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 
 import logging
@@ -184,10 +184,10 @@ class Command:
                     self.out.append(line)
 
                     if self.doprint:
-                        # Even if print() fails the thread has to keep
+                        # Even if logging below fails, the thread has to keep
                         # running to avoid hangups of the executed command.
                         try:
-                            print(line.rstrip())
+                            self.logger.info(line.rstrip())
                         except Exception as print_exc:
                             self.logger.error(print_exc)
 

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
@@ -52,6 +52,13 @@ class Command:
     def __init__(self, cmd, args_subst=None, args_append=None, logger=None,
                  excl_subst=False, work_dir=None, env_vars=None, timeout=None,
                  redirect_stderr=True, resource_limits=None, doprint=False):
+
+        if doprint is None:
+            doprint = False
+
+        if isinstance(doprint, list):
+            doprint = doprint[0]
+
         self.cmd = cmd
         self.state = "notrun"
         self.excl_subst = excl_subst

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/hook.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/hook.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 
 from .command import Command
@@ -40,12 +40,10 @@ def run_hook(logger, script, path, env, timeout):
     logger.debug("Running hook '{}' in directory {}".
                  format(script, path))
     cmd = Command([script], logger=logger, work_dir=path, env_vars=env,
-                  timeout=timeout)
+                  timeout=timeout, doprint=True)
     cmd.execute()
     if cmd.state != "finished" or cmd.getretcode() != SUCCESS_EXITVAL:
         logger.error("command failed: {} -> {}".format(cmd, cmd.getretcode()))
         ret = FAILURE_EXITVAL
-
-    logger.info("command output:\n{}".format(cmd.getoutputstr()))
 
     return ret

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/parsers.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/parsers.py
@@ -4,6 +4,21 @@ from .log import add_log_level_argument
 from ..version import __version__ as tools_version
 
 
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+
+    if isinstance(v, str):
+        v_lower = v.lower()
+        if v_lower in ('yes', 'true', 'y', '1'):
+            return True
+        elif v_lower in ('no', 'false', 'n', '0'):
+            return False
+
+    raise argparse.ArgumentTypeError('Boolean value or its string '
+                                     'representation expected.')
+
+
 def get_baseparser(tool_version=None):
     """
     Get the base parser which supports --version option reporting
@@ -31,9 +46,10 @@ def get_javaparser():
                         help='java options', action='append')
     parser.add_argument('-e', '--environment', action='append',
                         help='Environment variables in the form of name=value')
-    parser.add_argument('--doprint', action='store_true', default=False,
-                        help='Print messages from the application as they '
-                        'are produced.')
+    parser.add_argument('--doprint', type=str2bool, nargs=1, default=None,
+                        metavar='boolean',
+                        help='Enable/disable printing of messages '
+                             'from the application as they are produced.')
 
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('-a', '--jar',

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/parsers.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/parsers.py
@@ -19,7 +19,7 @@ def str2bool(v):
                                      'representation expected.')
 
 
-def get_baseparser(tool_version=None):
+def get_base_parser(tool_version=None):
     """
     Get the base parser which supports --version option reporting
     the overall version of the tools and the specific version of the
@@ -37,9 +37,9 @@ def get_baseparser(tool_version=None):
     return parser
 
 
-def get_javaparser():
+def get_java_parser():
     parser = argparse.ArgumentParser(add_help=False,
-                                     parents=[get_baseparser()])
+                                     parents=[get_base_parser()])
     parser.add_argument('-j', '--java',
                         help='path to java binary')
     parser.add_argument('-J', '--java_opts',

--- a/opengrok-tools/src/test/python/test_parsers.py
+++ b/opengrok-tools/src/test/python/test_parsers.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+#
+
+import argparse
+import pytest
+from opengrok_tools.utils.parsers import str2bool
+
+
+def test_str2bool_exception():
+    with pytest.raises(argparse.ArgumentTypeError):
+        str2bool('foo')
+
+
+def test_str2bool_exception_empty_str():
+    with pytest.raises(argparse.ArgumentTypeError):
+        str2bool('')
+
+
+def test_str2bool_bool():
+    assert str2bool(True)
+    assert not str2bool(False)
+
+
+def test_str2bool():
+    for val in ['true', 'y', 'yes']:
+        assert str2bool(val)
+        assert str2bool(val.upper())
+
+    for val in ['false', 'n', 'no']:
+        assert not str2bool(val)
+        assert not str2bool(val.upper())


### PR DESCRIPTION
This contains bunch of changes:
- chage `--doprint` to be a toggle
- restore logging to the console by default in `opengrok-indexer`
- change the `doprint` logging to use a logger rather than writing to standard output