### PR TITLE
report duration of PendingFileCompleter

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -47,6 +47,11 @@ Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
             <artifactId>bcel</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${apache-commons-lang3.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
         </dependency>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -99,11 +99,10 @@ import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
 import org.opengrok.indexer.util.IOUtils;
 import org.opengrok.indexer.util.ObjectPool;
+import org.opengrok.indexer.util.Progress;
 import org.opengrok.indexer.util.Statistics;
 import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.Util;
-
-import static org.opengrok.indexer.util.Progress.printProgress;
 
 /**
  * This class is used to create / update the index databases. Currently we use
@@ -1159,6 +1158,7 @@ public class IndexDatabase {
         IndexerParallelizer parallelizer = RuntimeEnvironment.getInstance().
                 getIndexerParallelizer();
         ObjectPool<Ctags> ctagsPool = parallelizer.getCtagsPool();
+        Progress progress = new Progress(LOGGER, dir, worksCount);
 
         Map<Boolean, List<IndexFileWork>> bySuccess = null;
         try {
@@ -1206,8 +1206,7 @@ public class IndexDatabase {
                             }
                         }
 
-                        int ncount = currentCounter.incrementAndGet();
-                        printProgress(LOGGER, dir, ncount, worksCount);
+                        progress.incrementAndLog();
                         return ret;
                     }
                 }))).get();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -103,6 +103,8 @@ import org.opengrok.indexer.util.Statistics;
 import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.Util;
 
+import static org.opengrok.indexer.util.Progress.printProgress;
+
 /**
  * This class is used to create / update the index databases. Currently we use
  * one index database per project.
@@ -1026,27 +1028,6 @@ public class IndexDatabase {
         return local;
     }
 
-    private void printProgress(String dir, int currentCount, int totalCount) {
-        if (totalCount > 0 && RuntimeEnvironment.getInstance().isPrintProgress()) {
-            Level currentLevel;
-            if (currentCount <= 1 || currentCount >= totalCount ||
-                    currentCount % 100 == 0) {
-                currentLevel = Level.INFO;
-            } else if (currentCount % 50 == 0) {
-                currentLevel = Level.FINE;
-            } else if (currentCount % 10 == 0) {
-                currentLevel = Level.FINER;
-            } else {
-                currentLevel = Level.FINEST;
-            }
-            if (LOGGER.isLoggable(currentLevel)) {
-                LOGGER.log(currentLevel, "Progress: {0} ({1}%) for {2}",
-                        new Object[]{currentCount, currentCount * 100.0f /
-                                totalCount, dir});
-            }
-        }
-    }
-
     /**
      * Executes the first, serial stage of indexing, recursively.
      * <p>Files at least are counted, and any deleted or updated files (based on
@@ -1226,7 +1207,7 @@ public class IndexDatabase {
                         }
 
                         int ncount = currentCounter.incrementAndGet();
-                        printProgress(dir, ncount, worksCount);
+                        printProgress(LOGGER, dir, ncount, worksCount);
                         return ret;
                     }
                 }))).get();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1158,10 +1158,9 @@ public class IndexDatabase {
         IndexerParallelizer parallelizer = RuntimeEnvironment.getInstance().
                 getIndexerParallelizer();
         ObjectPool<Ctags> ctagsPool = parallelizer.getCtagsPool();
-        Progress progress = new Progress(LOGGER, dir, worksCount);
 
         Map<Boolean, List<IndexFileWork>> bySuccess = null;
-        try {
+        try (Progress progress = new Progress(LOGGER, dir, worksCount)) {
             bySuccess = parallelizer.getForkJoinPool().submit(() ->
                 args.works.parallelStream().collect(
                 Collectors.groupingByConcurrent((x) -> {
@@ -1206,7 +1205,7 @@ public class IndexDatabase {
                             }
                         }
 
-                        progress.incrementAndLog();
+                        progress.increment();
                         return ret;
                     }
                 }))).get();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
@@ -46,6 +46,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.TandemPath;
 
@@ -174,17 +176,23 @@ class PendingFileCompleter {
         Instant start = Instant.now();
         int numDeletions = completeDeletions();
         LOGGER.log(Level.FINE, "deleted {0} file(s) (took {1})",
-                new Object[]{numDeletions, Duration.between(start, Instant.now())});
+                new Object[]{numDeletions, DurationFormatUtils.
+                        formatDurationWords(Duration.between(start, Instant.now()).toMillis(),
+                        true, true)});
 
         start = Instant.now();
         int numRenamings = completeRenamings();
         LOGGER.log(Level.FINE, "renamed {0} file(s) (took {1})",
-                new Object[]{numRenamings, Duration.between(start, Instant.now())});
+                new Object[]{numRenamings, DurationFormatUtils.
+                        formatDurationWords(Duration.between(start, Instant.now()).toMillis(),
+                true, true)});
 
         start = Instant.now();
         int numLinkages = completeLinkages();
         LOGGER.log(Level.FINE, "affirmed links for {0} path(s) (took {1})",
-                new Object[]{numLinkages, Duration.between(start, Instant.now())});
+                new Object[]{numLinkages, DurationFormatUtils.
+                        formatDurationWords(Duration.between(start, Instant.now()).toMillis(),
+                        true, true)});
 
         return numDeletions + numRenamings + numLinkages;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
@@ -34,6 +34,8 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -166,12 +168,21 @@ class PendingFileCompleter {
      * @throws java.io.IOException if an I/O error occurs
      */
     public int complete() throws IOException {
+        Instant start = Instant.now();
         int numDeletions = completeDeletions();
-        LOGGER.log(Level.FINE, "deleted {0} file(s)", numDeletions);
+        LOGGER.log(Level.FINE, "deleted {0} file(s) (took {1})",
+                new Object[]{numDeletions, Duration.between(start, Instant.now())});
+
+        start = Instant.now();
         int numRenamings = completeRenamings();
-        LOGGER.log(Level.FINE, "renamed {0} file(s)", numRenamings);
+        LOGGER.log(Level.FINE, "renamed {0} file(s) (took {1})",
+                new Object[]{numRenamings, Duration.between(start, Instant.now())});
+
+        start = Instant.now();
         int numLinkages = completeLinkages();
-        LOGGER.log(Level.FINE, "affirmed links for {0} path(s)", numLinkages);
+        LOGGER.log(Level.FINE, "affirmed links for {0} path(s) (took {1})",
+                new Object[]{numLinkages, Duration.between(start, Instant.now())});
+
         return numDeletions + numRenamings + numLinkages;
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
@@ -49,9 +49,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.Progress;
 import org.opengrok.indexer.util.TandemPath;
-
-import static org.opengrok.indexer.util.Progress.printProgress;
 
 /**
  * Represents a tracker of pending file deletions and renamings that can later
@@ -216,13 +215,12 @@ class PendingFileCompleter {
             new PendingFileRenamingExec(f.getTransientPath(),
                 f.getAbsolutePath())).collect(
             Collectors.toList());
+        Progress progress = new Progress(LOGGER, "pending renames", numPending);
 
-        AtomicInteger currentCount = new AtomicInteger();
         Map<Boolean, List<PendingFileRenamingExec>> bySuccess =
             pendingExecs.parallelStream().collect(
             Collectors.groupingByConcurrent((x) -> {
-                printProgress(LOGGER, "pending renames",
-                        currentCount.incrementAndGet(), numPending);
+                progress.incrementAndLog();
                 try {
                     doRename(x);
                     return true;
@@ -265,13 +263,12 @@ class PendingFileCompleter {
             parallelStream().map(f ->
             new PendingFileDeletionExec(f.getAbsolutePath())).collect(
             Collectors.toList());
+        Progress progress = new Progress(LOGGER, "pending deletions", numPending);
 
-        AtomicInteger currentCount = new AtomicInteger();
         Map<Boolean, List<PendingFileDeletionExec>> bySuccess =
             pendingExecs.parallelStream().collect(
             Collectors.groupingByConcurrent((x) -> {
-                printProgress(LOGGER, "pending deletions",
-                        currentCount.incrementAndGet(), numPending);
+                progress.incrementAndLog();
                 try {
                     doDelete(x);
                     return true;
@@ -319,13 +316,12 @@ class PendingFileCompleter {
             linkages.parallelStream().map(f ->
                 new PendingSymlinkageExec(f.getSourcePath(),
                         f.getTargetRelPath())).collect(Collectors.toList());
+        Progress progress = new Progress(LOGGER, "pending renames", numPending);
 
-        AtomicInteger currentCount = new AtomicInteger();
         Map<Boolean, List<PendingSymlinkageExec>> bySuccess =
             pendingExecs.parallelStream().collect(
                 Collectors.groupingByConcurrent((x) -> {
-                    printProgress(LOGGER, "pending renames",
-                            currentCount.incrementAndGet(), numPending);
+                    progress.incrementAndLog();
                     try {
                         doLink(x);
                         return true;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
@@ -42,11 +42,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.TandemPath;
+
+import static org.opengrok.indexer.util.Progress.printProgress;
 
 /**
  * Represents a tracker of pending file deletions and renamings that can later
@@ -206,9 +209,12 @@ class PendingFileCompleter {
                 f.getAbsolutePath())).collect(
             Collectors.toList());
 
+        AtomicInteger currentCount = new AtomicInteger();
         Map<Boolean, List<PendingFileRenamingExec>> bySuccess =
             pendingExecs.parallelStream().collect(
             Collectors.groupingByConcurrent((x) -> {
+                printProgress(LOGGER, "pending renames",
+                        currentCount.incrementAndGet(), numPending);
                 try {
                     doRename(x);
                     return true;
@@ -252,9 +258,12 @@ class PendingFileCompleter {
             new PendingFileDeletionExec(f.getAbsolutePath())).collect(
             Collectors.toList());
 
+        AtomicInteger currentCount = new AtomicInteger();
         Map<Boolean, List<PendingFileDeletionExec>> bySuccess =
             pendingExecs.parallelStream().collect(
             Collectors.groupingByConcurrent((x) -> {
+                printProgress(LOGGER, "pending deletions",
+                        currentCount.incrementAndGet(), numPending);
                 try {
                     doDelete(x);
                     return true;
@@ -303,9 +312,12 @@ class PendingFileCompleter {
                 new PendingSymlinkageExec(f.getSourcePath(),
                         f.getTargetRelPath())).collect(Collectors.toList());
 
+        AtomicInteger currentCount = new AtomicInteger();
         Map<Boolean, List<PendingSymlinkageExec>> bySuccess =
             pendingExecs.parallelStream().collect(
                 Collectors.groupingByConcurrent((x) -> {
+                    printProgress(LOGGER, "pending renames",
+                            currentCount.incrementAndGet(), numPending);
                     try {
                         doLink(x);
                         return true;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
@@ -214,20 +214,21 @@ class PendingFileCompleter {
             new PendingFileRenamingExec(f.getTransientPath(),
                 f.getAbsolutePath())).collect(
             Collectors.toList());
-        Progress progress = new Progress(LOGGER, "pending renames", numPending);
+        Map<Boolean, List<PendingFileRenamingExec>> bySuccess;
 
-        Map<Boolean, List<PendingFileRenamingExec>> bySuccess =
-            pendingExecs.parallelStream().collect(
-            Collectors.groupingByConcurrent((x) -> {
-                progress.incrementAndLog();
-                try {
-                    doRename(x);
-                    return true;
-                } catch (IOException e) {
-                    x.exception = e;
-                    return false;
-                }
-            }));
+        try (Progress progress = new Progress(LOGGER, "pending renames", numPending)) {
+            bySuccess = pendingExecs.parallelStream().collect(
+                            Collectors.groupingByConcurrent((x) -> {
+                                progress.increment();
+                                try {
+                                    doRename(x);
+                                    return true;
+                                } catch (IOException e) {
+                                    x.exception = e;
+                                    return false;
+                                }
+                            }));
+        }
         renames.clear();
 
         List<PendingFileRenamingExec> failures = bySuccess.getOrDefault(
@@ -262,20 +263,21 @@ class PendingFileCompleter {
             parallelStream().map(f ->
             new PendingFileDeletionExec(f.getAbsolutePath())).collect(
             Collectors.toList());
-        Progress progress = new Progress(LOGGER, "pending deletions", numPending);
+        Map<Boolean, List<PendingFileDeletionExec>> bySuccess;
 
-        Map<Boolean, List<PendingFileDeletionExec>> bySuccess =
-            pendingExecs.parallelStream().collect(
-            Collectors.groupingByConcurrent((x) -> {
-                progress.incrementAndLog();
-                try {
-                    doDelete(x);
-                    return true;
-                } catch (IOException e) {
-                    x.exception = e;
-                    return false;
-                }
-            }));
+        try (Progress progress = new Progress(LOGGER, "pending deletions", numPending)) {
+            bySuccess = pendingExecs.parallelStream().collect(
+                            Collectors.groupingByConcurrent((x) -> {
+                                progress.increment();
+                                try {
+                                    doDelete(x);
+                                    return true;
+                                } catch (IOException e) {
+                                    x.exception = e;
+                                    return false;
+                                }
+                            }));
+        }
         deletions.clear();
 
         List<PendingFileDeletionExec> successes = bySuccess.getOrDefault(
@@ -315,20 +317,21 @@ class PendingFileCompleter {
             linkages.parallelStream().map(f ->
                 new PendingSymlinkageExec(f.getSourcePath(),
                         f.getTargetRelPath())).collect(Collectors.toList());
-        Progress progress = new Progress(LOGGER, "pending renames", numPending);
 
-        Map<Boolean, List<PendingSymlinkageExec>> bySuccess =
-            pendingExecs.parallelStream().collect(
-                Collectors.groupingByConcurrent((x) -> {
-                    progress.incrementAndLog();
-                    try {
-                        doLink(x);
-                        return true;
-                    } catch (IOException e) {
-                        x.exception = e;
-                        return false;
-                    }
-                }));
+        Map<Boolean, List<PendingSymlinkageExec>> bySuccess;
+        try (Progress progress = new Progress(LOGGER, "pending renames", numPending)) {
+            bySuccess = pendingExecs.parallelStream().collect(
+                            Collectors.groupingByConcurrent((x) -> {
+                                progress.increment();
+                                try {
+                                    doLink(x);
+                                    return true;
+                                } catch (IOException e) {
+                                    x.exception = e;
+                                    return false;
+                                }
+                            }));
+        }
         linkages.clear();
 
         List<PendingSymlinkageExec> failures = bySuccess.getOrDefault(

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -136,7 +136,7 @@ public class Progress implements AutoCloseable {
             synchronized (sync) {
                 sync.notify();
             }
-            loggerThread.join(0);
+            loggerThread.join();
         } catch (InterruptedException e) {
             logger.log(Level.WARNING, "logger thread interrupted");
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -87,21 +87,23 @@ public class Progress implements AutoCloseable {
             long currentCount = this.currentCount.get();
             Level currentLevel;
 
-            if (currentCount <= 1 || currentCount % 100 == 0) {
-                currentLevel = Level.INFO;
-            } else if (currentCount % 50 == 0) {
-                currentLevel = Level.FINE;
-            } else if (currentCount % 10 == 0) {
-                currentLevel = Level.FINER;
-            } else {
-                currentLevel = Level.FINEST;
-            }
+            if (cachedCount < currentCount) {
+                if (currentCount <= 1 || currentCount % 100 == 0) {
+                    currentLevel = Level.INFO;
+                } else if (currentCount % 50 == 0) {
+                    currentLevel = Level.FINE;
+                } else if (currentCount % 10 == 0) {
+                    currentLevel = Level.FINER;
+                } else {
+                    currentLevel = Level.FINEST;
+                }
 
-            // Do not log if there was no progress.
-            if (logger.isLoggable(currentLevel) && (cachedCount < currentCount)) {
-                logger.log(currentLevel, "Progress: {0} ({1}%) for {2}",
-                        new Object[]{currentCount, currentCount * 100.0f /
-                                totalCount, suffix});
+                // Do not log if there was no progress.
+                if (logger.isLoggable(currentLevel)) {
+                    logger.log(currentLevel, "Progress: {0} ({1}%) for {2}",
+                            new Object[]{currentCount, currentCount * 100.0f /
+                                    totalCount, suffix});
+                }
             }
 
             if (!run) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -105,8 +105,9 @@ public class Progress implements AutoCloseable {
             // wait for event
             try {
                 synchronized (sync) {
-                    if (!run.get())
+                    if (!run.get()) {
                         return;
+                    }
                     sync.wait();
                 }
             } catch (InterruptedException e) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -76,6 +76,8 @@ public class Progress implements AutoCloseable {
     }
 
     private void logLoop() {
+        long cachedCount = 0;
+
         while (true) {
             if (!run) {
                 return;
@@ -84,8 +86,12 @@ public class Progress implements AutoCloseable {
             long currentCount = this.currentCount.get();
             Level currentLevel;
 
-            if (currentCount <= 1 || currentCount >= totalCount ||
-                    currentCount % 100 == 0) {
+            // Do not log if there was no progress.
+            if (cachedCount >= currentCount) {
+                continue;
+            }
+
+            if (currentCount <= 1 || currentCount % 100 == 0) {
                 currentLevel = Level.INFO;
             } else if (currentCount % 50 == 0) {
                 currentLevel = Level.FINE;
@@ -101,9 +107,7 @@ public class Progress implements AutoCloseable {
                                 totalCount, suffix});
             }
 
-            if (currentCount >= totalCount) {
-                return;
-            }
+            cachedCount = currentCount;
 
             // wait for event
             try {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -35,7 +35,7 @@ public class Progress {
     }
 
     /**
-     * report progress of an operation with known count to log
+     * report progress of an operation with known count to log.
      * @param logger Logger instance
      * @param prefix string prefix to identify the operation
      * @param currentCount current count

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -1,0 +1,64 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.util;
+
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class Progress {
+    private Progress() {
+        // utility class
+    }
+
+    /**
+     * report progress of an operation with known count to log
+     * @param logger Logger instance
+     * @param prefix string prefix to identify the operation
+     * @param currentCount current count
+     * @param totalCount total count
+     */
+    public static void printProgress(Logger logger, String prefix, int currentCount, int totalCount) {
+        if (totalCount > 0 && RuntimeEnvironment.getInstance().isPrintProgress()) {
+            Level currentLevel;
+            if (currentCount <= 1 || currentCount >= totalCount ||
+                    currentCount % 100 == 0) {
+                currentLevel = Level.INFO;
+            } else if (currentCount % 50 == 0) {
+                currentLevel = Level.FINE;
+            } else if (currentCount % 10 == 0) {
+                currentLevel = Level.FINER;
+            } else {
+                currentLevel = Level.FINEST;
+            }
+            if (logger.isLoggable(currentLevel)) {
+                logger.log(currentLevel, "Progress: {0} ({1}%) for {2}",
+                        new Object[]{currentCount, currentCount * 100.0f /
+                                totalCount, prefix});
+            }
+        }
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -26,23 +26,34 @@ package org.opengrok.indexer.util;
 
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class Progress {
-    private Progress() {
-        // utility class
+    private Logger logger;
+    private int totalCount;
+    private String prefix;
+
+    private AtomicInteger currentCount = new AtomicInteger();
+
+    /**
+     * @param logger logger instance
+     * @param prefix string prefix to identify the operation
+     * @param totalCount total count
+     */
+    public Progress(Logger logger, String prefix, int totalCount) {
+        this.logger = logger;
+        this.prefix = prefix;
+        this.totalCount = totalCount;
     }
 
     /**
-     * report progress of an operation with known count to log.
-     * @param logger Logger instance
-     * @param prefix string prefix to identify the operation
-     * @param currentCount current count
-     * @param totalCount total count
+     * increment counter and log progress.
      */
-    public static void printProgress(Logger logger, String prefix, int currentCount, int totalCount) {
-        if (totalCount > 0 && RuntimeEnvironment.getInstance().isPrintProgress()) {
+    public void incrementAndLog() {
+        if (RuntimeEnvironment.getInstance().isPrintProgress()) {
+            int currentCount = this.currentCount.incrementAndGet();
             Level currentLevel;
             if (currentCount <= 1 || currentCount >= totalCount ||
                     currentCount % 100 == 0) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class Progress implements AutoCloseable {
     private Logger logger;
     private long totalCount;
-    private String prefix;
+    private String suffix;
 
     private AtomicLong currentCount = new AtomicLong();
     private Thread loggerThread = null;
@@ -44,12 +44,12 @@ public class Progress implements AutoCloseable {
 
     /**
      * @param logger logger instance
-     * @param prefix string prefix to identify the operation
+     * @param suffix string suffix to identify the operation
      * @param totalCount total count
      */
-    public Progress(Logger logger, String prefix, long totalCount) {
+    public Progress(Logger logger, String suffix, long totalCount) {
         this.logger = logger;
-        this.prefix = prefix;
+        this.suffix = suffix;
         this.totalCount = totalCount;
 
         // Assuming printProgress configuration setting cannot be changed on the fly.
@@ -57,7 +57,7 @@ public class Progress implements AutoCloseable {
             // spawn a logger thread.
             run.set(true);
             loggerThread = new Thread(this::logLoop,
-                    "progress-thread-" + prefix.replaceAll(" ", "_"));
+                    "progress-thread-" + suffix.replaceAll(" ", "_"));
             loggerThread.start();
         }
     }
@@ -95,7 +95,7 @@ public class Progress implements AutoCloseable {
             if (logger.isLoggable(currentLevel)) {
                 logger.log(currentLevel, "Progress: {0} ({1}%) for {2}",
                         new Object[]{currentCount, currentCount * 100.0f /
-                                totalCount, prefix});
+                                totalCount, suffix});
             }
 
             if (currentCount >= totalCount) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -52,7 +52,7 @@ public class Progress implements AutoCloseable {
         this.totalCount = totalCount;
 
         // Assuming printProgress configuration setting cannot be changed on the fly.
-        if (RuntimeEnvironment.getInstance().isPrintProgress()) {
+        if (totalCount > 0 && RuntimeEnvironment.getInstance().isPrintProgress()) {
             // spawn a logger thread.
             run = true;
             loggerThread = new Thread(this::logLoop,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -32,9 +32,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class Progress implements AutoCloseable {
-    private Logger logger;
-    private long totalCount;
-    private String suffix;
+    private final Logger logger;
+    private final long totalCount;
+    private final String suffix;
 
     private AtomicLong currentCount = new AtomicLong();
     private Thread loggerThread = null;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -76,7 +76,11 @@ public class Progress implements AutoCloseable {
     }
 
     private void logLoop() {
-        while (run) {
+        while (true) {
+            if (!run) {
+                return;
+            }
+
             long currentCount = this.currentCount.get();
             Level currentLevel;
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
@@ -1,0 +1,47 @@
+package org.opengrok.indexer.util;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
+
+public class ProgressTest {
+    @Test
+    public void testProgress() throws InterruptedException {
+        final Logger logger = Mockito.mock(Logger.class);
+        final int totalCount = 100; // use int because of Mockito.calls()/times() only accepts int
+
+        // needed to spawn logger thread in Progress
+        RuntimeEnvironment.getInstance().setPrintProgress(true);
+
+        Mockito.when(logger.isLoggable(any())).thenReturn(true);
+        boolean first = true;
+        try (final Progress progress = new Progress(logger, "foo", totalCount)) {
+            assertNotNull(progress.getLoggerThread());
+
+            // Progress does not give any indication that the logger thread reached the point when
+            // it can accept notifications from increment() so check the Thread state.
+            if (first) {
+                while (progress.getLoggerThread().getState() != Thread.State.WAITING) {
+                    System.out.println("Waiting for the logger thread to reach the initial wait()");
+                    TimeUnit.SECONDS.sleep(1);
+                }
+                first = false;
+            }
+
+            for (int i = 0; i < totalCount; i++) {
+                progress.increment();
+                // Give the logger thread some time to log.
+                TimeUnit.MILLISECONDS.sleep(10);
+            }
+        }
+
+        Mockito.verify(logger, times(totalCount)).log(any(), anyString(), any(Object[].class));
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
@@ -31,14 +31,16 @@ public class ProgressTest {
     public void testProgress() throws InterruptedException {
         final Logger logger = Mockito.mock(Logger.class);
         final int totalCount = 100; // use int because of Mockito.calls()/times() only accepts int
+        Thread loggerThread = null;
 
         Mockito.when(logger.isLoggable(any())).thenReturn(true);
         try (final Progress progress = new Progress(logger, "foo", totalCount)) {
             assertNotNull(progress.getLoggerThread());
+            loggerThread = progress.getLoggerThread();
 
             // Progress does not give any indication that the logger thread reached the point when
             // it can accept notifications from increment() so check the Thread state.
-            while (progress.getLoggerThread().getState() != Thread.State.WAITING) {
+            while (loggerThread.getState() != Thread.State.WAITING) {
                 System.out.println("Waiting for the logger thread to reach the initial wait()");
                 TimeUnit.MILLISECONDS.sleep(10);
             }
@@ -46,12 +48,13 @@ public class ProgressTest {
             for (int i = 0; i < totalCount; i++) {
                 progress.increment();
                 // Give the logger thread some time to log.
-                while (progress.getLoggerThread().getState() != Thread.State.WAITING) {
+                while (loggerThread.getState() != Thread.State.WAITING) {
                     TimeUnit.MILLISECONDS.sleep(10);
                 }
             }
         }
 
+        Assert.assertSame(loggerThread.getState(), Thread.State.TERMINATED);
         Mockito.verify(logger, times(totalCount)).log(any(), anyString(), any(Object[].class));
     }
 
@@ -73,16 +76,17 @@ public class ProgressTest {
             for (int i = 0; i < totalCount; i++) {
                 futures.add(executor.submit(progress::increment));
             }
+
+            System.out.println("Waiting for threads to finish");
+            futures.forEach(future -> {
+                try {
+                    future.get();
+                } catch (Exception e) {
+                    Assert.fail();
+                }
+            });
         }
 
-        System.out.println("Waiting for threads to finish");
-        futures.forEach(future -> {
-            try {
-                future.get();
-            } catch (Exception e) {
-                Assert.fail();
-            }
-        });
         executor.shutdown();
         System.out.println("Verifying");
         Mockito.verify(logger, atLeast(1)).log(any(), anyString(), any(Object[].class));

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
@@ -54,7 +54,14 @@ public class ProgressTest {
             }
         }
 
+        System.out.println("Waiting for the logger thread to terminate");
+        int i = 0;
+        while (i < 3 && loggerThread.getState() != Thread.State.TERMINATED) {
+            TimeUnit.MILLISECONDS.sleep(10);
+            i++;
+        }
         Assert.assertSame(loggerThread.getState(), Thread.State.TERMINATED);
+
         Mockito.verify(logger, times(totalCount)).log(any(), anyString(), any(Object[].class));
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
@@ -1,38 +1,41 @@
 package org.opengrok.indexer.util;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.times;
 
 public class ProgressTest {
+    @BeforeClass
+    public static void setup() {
+        // needed to spawn logger thread in Progress
+        RuntimeEnvironment.getInstance().setPrintProgress(true);
+    }
+
     @Test
     public void testProgress() throws InterruptedException {
         final Logger logger = Mockito.mock(Logger.class);
         final int totalCount = 100; // use int because of Mockito.calls()/times() only accepts int
 
-        // needed to spawn logger thread in Progress
-        RuntimeEnvironment.getInstance().setPrintProgress(true);
-
         Mockito.when(logger.isLoggable(any())).thenReturn(true);
-        boolean first = true;
         try (final Progress progress = new Progress(logger, "foo", totalCount)) {
             assertNotNull(progress.getLoggerThread());
 
             // Progress does not give any indication that the logger thread reached the point when
             // it can accept notifications from increment() so check the Thread state.
-            if (first) {
-                while (progress.getLoggerThread().getState() != Thread.State.WAITING) {
-                    System.out.println("Waiting for the logger thread to reach the initial wait()");
-                    TimeUnit.MILLISECONDS.sleep(10);
-                }
-                first = false;
+            while (progress.getLoggerThread().getState() != Thread.State.WAITING) {
+                System.out.println("Waiting for the logger thread to reach the initial wait()");
+                TimeUnit.MILLISECONDS.sleep(10);
             }
 
             for (int i = 0; i < totalCount; i++) {
@@ -45,5 +48,22 @@ public class ProgressTest {
         }
 
         Mockito.verify(logger, times(totalCount)).log(any(), anyString(), any(Object[].class));
+    }
+
+    @Test
+    public void testThreads() throws InterruptedException {
+        final Logger logger = Mockito.mock(Logger.class);
+        final int totalCount = Runtime.getRuntime().availableProcessors();
+
+        Mockito.when(logger.isLoggable(any())).thenReturn(true);
+        ExecutorService executor = Executors.newFixedThreadPool(totalCount);
+        try (final Progress progress = new Progress(logger, "foo", totalCount)) {
+            for (int i = 0; i < totalCount; i++) {
+                executor.submit(progress::increment);
+            }
+        }
+
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+        Mockito.verify(logger, atLeast(1)).log(any(), anyString(), any(Object[].class));
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
@@ -30,7 +30,7 @@ public class ProgressTest {
             if (first) {
                 while (progress.getLoggerThread().getState() != Thread.State.WAITING) {
                     System.out.println("Waiting for the logger thread to reach the initial wait()");
-                    TimeUnit.SECONDS.sleep(1);
+                    TimeUnit.MILLISECONDS.sleep(10);
                 }
                 first = false;
             }
@@ -38,7 +38,9 @@ public class ProgressTest {
             for (int i = 0; i < totalCount; i++) {
                 progress.increment();
                 // Give the logger thread some time to log.
-                TimeUnit.MILLISECONDS.sleep(10);
+                while (progress.getLoggerThread().getState() != Thread.State.WAITING) {
+                    TimeUnit.MILLISECONDS.sleep(10);
+                }
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
         <jackson.version>2.9.9</jackson.version>
         <junit.version>5.4.2</junit.version>
         <maven-surefire.version>2.22.2</maven-surefire.version>
+        <apache-commons-lang3.version>3.9</apache-commons-lang3.version>
     </properties>
 
     <dependencyManagement>

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
+            <version>${apache-commons-lang3.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Lately I found that indexer spends inordinate amount of time in `PendingFileCompleter#complete()` (also there were lots of files under the `xref` directory with the `org_opengrok` suffix) which made me wonder how much time is actually spend there. This change adds simple reporting.