### PR TITLE
fix subdirectory links on the index page

### DIFF
--- a/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
+++ b/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
@@ -57,7 +57,7 @@ Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
 
 <tr>
     <td class="name ${isSubrepository ? "subrepository" : "repository"}">
-        <a href="${pageContext.request.getContextPath()}${Prefix.XREF_P.toString()}/${project.name}"
+        <a href="${pageContext.request.getContextPath()}${Prefix.XREF_P.toString()}/${name}"
            title="Xref for project ${Util.htmlize(name)}">
             ${Util.htmlize(name)}
         </a>


### PR DESCRIPTION
Fixes sub-directory links on the index page. Reported in #2925 however I am not going to list that as a fix since that issue tracks multiple problems at once.