### PR TITLE
make getDiffData() parallel

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -265,9 +265,15 @@ public final class Configuration {
 
     /**
      * Upper bound for number of threads used for performing multi-project
-     * searches. This is total for the whole webapp/CLI utility.
+     * searches. This is total for the whole webapp.
      */
     private int MaxSearchThreadCount;
+
+    /**
+     * Upper bound for number of threads used for getting revision contents.
+     * This is total for the whole webapp.
+     */
+    private int MaxRevisionThreadCount;
 
     /**
      * If false, do not display listing or projects/repositories on the index page.
@@ -467,6 +473,7 @@ public final class Configuration {
         //luceneLocking default is OFF
         //mandoc is default(String)
         setMaxSearchThreadCount(2 * Runtime.getRuntime().availableProcessors());
+        setMaxRevisionThreadCount(Runtime.getRuntime().availableProcessors());
         setMessageLimit(500);
         setNavigateWindowEnabled(false);
         setOptimizeDatabase(true);
@@ -1211,7 +1218,15 @@ public final class Configuration {
     public void setMaxSearchThreadCount(int count) {
         this.MaxSearchThreadCount = count;
     }
-    
+
+    public int getMaxRevisionThreadCount() {
+        return MaxRevisionThreadCount;
+    }
+
+    public void setMaxRevisionThreadCount(int count) {
+        this.MaxRevisionThreadCount = count;
+    }
+
     public boolean isProjectsEnabled() {
         return projectsEnabled;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
@@ -163,6 +164,11 @@ public final class RuntimeEnvironment {
     private ExecutorService newRevisionExecutor() {
         return Executors.newFixedThreadPool(this.getMaxRevisionThreadCount(),
                 new NamedThreadFactory("get-revision"));
+    }
+
+    public void shutdownRevisionExecutor() throws InterruptedException {
+        getRevisionExecutor().shutdownNow();
+        getRevisionExecutor().awaitTermination(0, TimeUnit.SECONDS);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -168,7 +168,7 @@ public final class RuntimeEnvironment {
 
     public void shutdownRevisionExecutor() throws InterruptedException {
         getRevisionExecutor().shutdownNow();
-        getRevisionExecutor().awaitTermination(0, TimeUnit.SECONDS);
+        getRevisionExecutor().awaitTermination(getCommandTimeout(), TimeUnit.SECONDS);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -49,7 +49,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -306,7 +306,7 @@ public final class PageConfig {
                 ArrayList<String> lines = new ArrayList<>();
                 Project p = getProject();
                 for (int i = 0; i < 2; i++) {
-                    // SRCROOT is read with UTF-8 as a default.
+                    // All files under source root are read with UTF-8 as a default.
                     try (BufferedReader br = new BufferedReader(
                         ExpandTabsReader.wrap(IOUtils.createBOMStrippedReader(
                         in[i], StandardCharsets.UTF_8.name()), p))) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -51,7 +51,6 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -53,6 +53,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -281,7 +282,8 @@ public final class PageConfig {
                         return data;
                     }
                 }
-                executor.shutdown();
+                // The Executor used by given repository will enforce the timeout.
+                executor.awaitTermination(0, TimeUnit.SECONDS);
 
                 /*
                  * If the genre of the older revision cannot be determined,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -271,17 +271,15 @@ public final class PageConfig {
                 }
 
                 for (int i = 0; i < 2; i++) {
+                    // The Executor used by given repository will enforce the timeout.
                     in[i] = (InputStream) future[i].get();
                     if (in[i] == null) {
                         data.errorMsg = "Unable to get revision "
                                 + Util.htmlize(data.rev[i]) + " for file: "
                                 + Util.htmlize(getPath());
-                        executor.shutdownNow();
                         return data;
                     }
                 }
-                // The Executor used by given repository will enforce the timeout.
-                executor.awaitTermination(0, TimeUnit.SECONDS);
 
                 /*
                  * If the genre of the older revision cannot be determined,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -50,7 +50,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -63,7 +62,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.HttpHeaders;
 
-import org.apache.lucene.util.NamedThreadFactory;
 import org.opengrok.indexer.Info;
 import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
@@ -153,6 +151,8 @@ public final class PageConfig {
 
     private static final String ATTR_NAME = PageConfig.class.getCanonicalName();
     private HttpServletRequest req;
+
+    private ExecutorService executor;
 
     /**
      * Sets current request's attribute.
@@ -261,8 +261,7 @@ public final class PageConfig {
             InputStream[] in = new InputStream[2];
             try {
                 // Get input stream for both older and newer file.
-                ExecutorService executor = Executors.newFixedThreadPool(2,
-                        new NamedThreadFactory("get-revision"));
+                ExecutorService executor = this.executor;
                 Future<?>[] future = new Future<?>[2];
                 for (int i = 0; i < 2; i++) {
                     File f = new File(srcRoot + filepath[i]);
@@ -1548,6 +1547,7 @@ public final class PageConfig {
     private PageConfig(HttpServletRequest req) {
         this.req = req;
         this.authFramework = RuntimeEnvironment.getInstance().getAuthorizationFramework();
+        this.executor = RuntimeEnvironment.getInstance().getRevisionExecutor();
     }
 
     /**

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -115,6 +115,11 @@ public final class WebappListener
         env.watchDog.stop();
         env.stopExpirationTimer();
         try {
+            env.shutdownRevisionExecutor();
+        } catch (InterruptedException e) {
+            LOGGER.log(Level.WARNING, "Could not shutdown revision executor", e);
+        }
+        try {
             saveStatistics();
         } catch (IOException ex) {
             LOGGER.log(Level.SEVERE, "Could not save statistics into a file.", ex);


### PR DESCRIPTION
This change should speed up diff view for large (in terms of history) repositories.

For renamed files the approach taken (parallelize `getRevision()` in `getDiffData()`) is sub-optimal as the most expensive work (retrieve the history of the file across renames) is done twice (but in parallel as opposed to the previous state). @DaliborSkrobak told me he has maybe an idea how to fix this better.