### PR TITLE
Feature/ctags opts

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AbstractAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AbstractAnalyzer.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * Use is subject to license terms.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
 
@@ -34,7 +34,6 @@ import org.apache.lucene.document.Document;
 import org.opengrok.indexer.configuration.Project;
 
 /**
- *
  * @author Chandan
  */
 public abstract class AbstractAnalyzer extends Analyzer {
@@ -52,16 +51,25 @@ public abstract class AbstractAnalyzer extends Analyzer {
         super(reuseStrategy);
     }
 
+    /**
+     * Subclasses should override to return the case-insensitive name aligning
+     * with either a built-in Universal Ctags language name or an OpenGrok
+     * custom language name.
+     * @return a defined instance or {@code null} if the analyzer has no aligned
+     * Universal Ctags language
+     */
+    public abstract String getCtagsLang();
+
     public abstract long getVersionNo();
 
     /**
      * Subclasses should override to produce a value relevant for the evolution
      * of their analysis in each release.
      *
-     * @return 0
+     * @return 0 since {@link AbstractAnalyzer} is not specialized
      */
     protected int getSpecializedVersionNo() {
-        return 0; // FileAnalyzer is not specialized.
+        return 0;
     }
 
     public void setCtags(Ctags ctags) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -242,20 +242,20 @@ public class Ctags implements Resettable {
     }
 
     private void addPowerShellSupport(List<String> command) {
-        command.add("--langdef=Posh");
-        command.add("--langmap=Posh:+.ps1,Posh:+.psm1");
-        command.add("--regex-Posh=/\\$(\\{[^}]+\\})/\\1/v,variable/");
-        command.add("--regex-Posh=/\\$([[:alnum:]_]+([:.][[:alnum:]_]+)*)/\\1/v,variable/");
-        command.add("--regex-Posh=/^[[:space:]]*(:[^[:space:]]+)/\\1/l,label/");
+        command.add("--langdef=powershell");
+        command.add("--langmap=powershell:+.ps1,powershell:+.psm1");
+        command.add("--regex-powershell=/\\$(\\{[^}]+\\})/\\1/v,variable/");
+        command.add("--regex-powershell=/\\$([[:alnum:]_]+([:.][[:alnum:]_]+)*)/\\1/v,variable/");
+        command.add("--regex-powershell=/^[[:space:]]*(:[^[:space:]]+)/\\1/l,label/");
 
-        command.add("--_fielddef-Posh=signature,signatures");
-        command.add("--fields-Posh=+{signature}");
+        command.add("--_fielddef-powershell=signature,signatures");
+        command.add("--fields-powershell=+{signature}");
         // escaped variable markers
-        command.add("--regex-Posh=/`\\$([[:alnum:]_]+([:.][[:alnum:]_]+)*)/\\1//{exclusive}");
-        command.add("--regex-Posh=/`\\$(\\{[^}]+\\})/\\1//{exclusive}");
-        command.add("--regex-Posh=/#.*\\$([[:alnum:]_]+([:.][[:alnum:]_]+)*)/\\1//{exclusive}");
-        command.add("--regex-Posh=/#.*\\$(\\{[^}]+\\})/\\1//{exclusive}");
-        command.add("--regex-Posh=/^[[:space:]]*(function|filter)[[:space:]]+([^({[:space:]]+)[[:space:]]*" +
+        command.add("--regex-powershell=/`\\$([[:alnum:]_]+([:.][[:alnum:]_]+)*)/\\1//{exclusive}");
+        command.add("--regex-powershell=/`\\$(\\{[^}]+\\})/\\1//{exclusive}");
+        command.add("--regex-powershell=/#.*\\$([[:alnum:]_]+([:.][[:alnum:]_]+)*)/\\1//{exclusive}");
+        command.add("--regex-powershell=/#.*\\$(\\{[^}]+\\})/\\1//{exclusive}");
+        command.add("--regex-powershell=/^[[:space:]]*(function|filter)[[:space:]]+([^({[:space:]]+)[[:space:]]*" +
                 "(\\(([^)]+)\\))?/\\2/f,function,functions/{icase}{exclusive}{_field=signature:(\\4)}");
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzer.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * Use is subject to license terms.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
 
@@ -58,6 +58,14 @@ import org.opengrok.indexer.search.QueryBuilder;
 public class FileAnalyzer extends AbstractAnalyzer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FileAnalyzer.class);
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/LangMap.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/LangMap.java
@@ -1,0 +1,89 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.analysis;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents an API for mapping file specifications versus languages and
+ * getting the ctags options representation (--langmap-&lt;LANG&gt; or
+ * --map-&lt;LANG&gt;) thereof.
+ */
+public interface LangMap {
+
+    /**
+     * Removes all settings from this map.
+     */
+    void clear();
+
+    /**
+     * Adds the specified mapping of a file specification to a language. Any
+     * matching exclusion via {@link #exclude(String)} is undone.
+     * @param fileSpec a value starting with a period ({@code '.'}) to specify
+     *                 a file extension; otherwise specifying a prefix.
+     * @throws IllegalArgumentException if {@code fileSpec} is {@code null} or
+     * is an extension (i.e. starting with a period) but contains any other
+     * periods, as that is not ctags-compatible
+     */
+    void add(String fileSpec, String ctagsLang);
+
+    /**
+     * Exclude the specified mapping of a file specification to any language.
+     * Any matching addition via {@link #add(String, String)} is undone.
+     * @throws IllegalArgumentException if {@code fileSpec} is {@code null}
+     */
+    void exclude(String fileSpec);
+
+    /**
+     * Gets the transformation of the instance's mappings to ctags arguments.
+     */
+    List<String> getCtagsArgs();
+
+    /**
+     * Creates a new instance, merging the settings from the current instance
+     * overlaying a specified {@code other}. Additions from the current instance
+     * take precedence, and exclusions from the {@code other} only take effect
+     * if the current instance has no matching addition.
+     * @param other a defined instance
+     * @return a defined instance
+     */
+    LangMap mergeSecondary(LangMap other);
+
+    /**
+     * Gets an unmodifiable view of the current instance.
+     */
+    LangMap unmodifiable();
+
+    /**
+     * Gets an unmodifiable view of the current additions.
+     */
+    Map<String, String> getAdditions();
+
+    /**
+     * Gets an unmodifiable view of the current exclusions.
+     */
+    Set<String> getExclusions();
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/LangTreeMap.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/LangTreeMap.java
@@ -1,0 +1,323 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.analysis;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Represents an implementation of {@link LangMap} using structures with natural
+ * ordering of file specifications.
+ */
+public class LangTreeMap implements LangMap {
+
+    private final TreeMap<String, String> langMap = new TreeMap<>();
+    private final TreeSet<String> exclusions = new TreeSet<>();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clear() {
+        langMap.clear();
+        exclusions.clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void add(String fileSpec, String ctagsLang) {
+        if (fileSpec == null) {
+            throw new IllegalArgumentException("fileSpec is required");
+        }
+        if (ctagsLang == null) {
+            // Some analyzers may not have a defined, associated ctags lang.
+            return;
+        }
+        validateFileSpec(fileSpec);
+        langMap.put(fileSpec, ctagsLang);
+        exclusions.remove(fileSpec);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void exclude(String fileSpec) {
+        if (fileSpec == null) {
+            throw new IllegalArgumentException("fileSpec is required");
+        }
+        validateFileSpec(fileSpec);
+        exclusions.add(fileSpec);
+        langMap.remove(fileSpec);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> getCtagsArgs() {
+        List<String> result = new ArrayList<>();
+
+        for (Map.Entry<String, String> entry : langMap.entrySet()) {
+            if (entry.getKey().startsWith(".")) {
+                result.add(asExtensionMap(entry.getKey(), entry.getValue()));
+            } else {
+                result.add(asPrefixMap(entry.getKey(), entry.getValue()));
+            }
+        }
+        for (String entry : exclusions) {
+            if (entry.startsWith(".")) {
+                result.addAll(asExtensionExclusion(entry));
+            } else {
+                result.add(asPrefixExclusion(entry));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LangMap mergeSecondary(LangMap other) {
+        if (other == null) {
+            throw new IllegalArgumentException("other is null");
+        }
+
+        LangTreeMap unified = new LangTreeMap();
+        unified.langMap.putAll(langMap);
+        unified.exclusions.addAll(exclusions);
+
+        for (Map.Entry<String, String> entry : other.getAdditions().entrySet()) {
+            if (!langMap.containsKey(entry.getKey()) && !exclusions.contains(entry.getKey())) {
+                unified.langMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        for (String entry : other.getExclusions()) {
+            if (!langMap.containsKey(entry)) {
+                unified.exclusions.add(entry);
+            }
+        }
+
+        return unified;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LangMap unmodifiable() {
+        return new LangMap() {
+            final LangMap source = LangTreeMap.this;
+
+            @Override
+            public void clear() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void add(String fileSpec, String ctagsLang) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void exclude(String fileSpec) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public List<String> getCtagsArgs() {
+                return source.getCtagsArgs();
+            }
+
+            @Override
+            public LangMap mergeSecondary(LangMap other) {
+                return source.mergeSecondary(other);
+            }
+
+            @Override
+            public Map<String, String> getAdditions() {
+                return source.getAdditions();
+            }
+
+            @Override
+            public Set<String> getExclusions() {
+                return source.getExclusions();
+            }
+
+            @Override
+            public LangMap unmodifiable() {
+                return this;
+            }
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, String> getAdditions() {
+        return Collections.unmodifiableMap(langMap);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<String> getExclusions() {
+        return Collections.unmodifiableSet(exclusions);
+    }
+
+    private void validateFileSpec(String fileSpec) {
+        if (fileSpec.startsWith(".")) {
+            if (fileSpec.indexOf(".", 1) > 0) {
+                throw new IllegalArgumentException("Invalid extension " + fileSpec);
+            }
+        }
+    }
+
+    private String asLangmapOption(String spec, String ctagsLang) {
+        return "--langmap=" + ctagsLang + ":+" + spec;
+    }
+
+    private String asMapAllExclusion(String spec) {
+        return "--map-all=-" + spec;
+    }
+
+    private String asExtensionMap(String fileSpec, String ctagsLang) {
+        return asLangmapOption(asAllCasesExtension(fileSpec), ctagsLang);
+    }
+
+    private String asPrefixMap(String fileSpec, String ctagsLang) {
+        return asLangmapOption(asAllCasesPrefix(fileSpec), ctagsLang);
+    }
+
+    private Collection<? extends String> asExtensionExclusion(String fileSpec) {
+        List<String> extensionList = asAllCasesExtensionList(fileSpec);
+        ArrayList<String> result = new ArrayList<>();
+        for (String ext : extensionList) {
+            result.add(asMapAllExclusion(ext));
+        }
+        return result;
+    }
+
+    private String asPrefixExclusion(String fileSpec) {
+        return asMapAllExclusion(asAllCasesPrefix(fileSpec));
+    }
+
+    private String asAllCasesPrefix(String fileSpec) {
+        String lower = checkNaiveCaseFolding(fileSpec);
+        if (lower == null) {
+            /*
+             * If naive case-folding doesn't transform the string, then return
+             * just the original fileSpec enclosed in parentheses to indicate
+             * a file name pattern with a trailing wildcard.
+             */
+            return "(" + fileSpec + "*)";
+        }
+
+        StringBuilder result = new StringBuilder("(");
+        for (int i = 0; i < lower.length(); ++i) {
+            char c = lower.charAt(i);
+            char C = Character.toUpperCase(c);
+            if (c == C) {
+                result.append(c);
+            } else {
+                result.append("[");
+                result.append(c);
+                result.append(C);
+                result.append("]");
+            }
+        }
+        result.append("*)");
+        return result.toString();
+    }
+
+    private String asAllCasesExtension(String extension) {
+        List<String> extensionList = asAllCasesExtensionList(extension);
+        return String.join("", extensionList); // no delimiter
+    }
+
+    private List<String> asAllCasesExtensionList(String extension) {
+        String lower = checkNaiveCaseFolding(extension);
+        if (lower == null) {
+            /*
+             * If naive case-folding doesn't transform the string, then return
+             * just the original extension.
+             */
+            return Collections.singletonList(extension);
+        }
+
+        /*
+         * On case-sensitive filesystems, ctags is also case-sensitive.
+         * OpenGrok, however, matches filename extensions and prefixes after
+         * first upper-casing the values. To fully accord the two match
+         * techniques on a technical basis would mean specifying to ctags e.g.
+         * .pas.Pas.pAs.paS.PAs.PaS.PAS but for pragmatism we'll just specify
+         * the lower-, upper-, and initial-case forms.
+         */
+        ArrayList<String> result = new ArrayList<>();
+        result.add(lower);
+        // If e.g. .PAS but not .C ...
+        if (lower.length() > 2) {
+            StringBuilder initial = new StringBuilder(lower);
+            initial.setCharAt(1, Character.toUpperCase(lower.charAt(1)));
+            result.add(initial.toString());
+        }
+        result.add(lower.toUpperCase(Locale.ROOT));
+        return result;
+    }
+
+    /**
+     * @return the lower-case transformation of {@code value}
+     */
+    private static String checkNaiveCaseFolding(String value) {
+        String lower = value.toLowerCase(Locale.ROOT);
+        String upper = value.toUpperCase(Locale.ROOT);
+        String upper2 = lower.toUpperCase(Locale.ROOT);
+        // Build upper3 character-by-character toUpperCase().
+        StringBuilder upper3 = new StringBuilder(value.length());
+        for (int i = 0; i < lower.length(); ++i) {
+            upper3.append(Character.toUpperCase(lower.charAt(i)));
+        }
+        if (lower.length() != upper.length() || lower.length() != value.length() ||
+                !upper.equals(upper2) || !upper.equals(upper3.toString())) {
+            /*
+             * If naive case-folding doesn't transform the string, then return
+             * null to indicate to use the original value by itself.
+             */
+            return null;
+        }
+        return lower;
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ada/AdaAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ada/AdaAnalyzer.java
@@ -48,6 +48,14 @@ public class AdaAnalyzer extends AbstractSourceCodeAnalyzer {
     }
 
     /**
+     * @return {@code "Ada"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Ada";
+    }
+
+    /**
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/BZip2Analyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/BZip2Analyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.archive;
 
@@ -56,6 +56,14 @@ public class BZip2Analyzer extends FileAnalyzer {
 
     protected BZip2Analyzer(AnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/GZIPAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/GZIPAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.archive;
 
@@ -62,6 +62,14 @@ public class GZIPAnalyzer extends FileAnalyzer {
 
     protected GZIPAnalyzer(AnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/TarAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/TarAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.archive;
 
@@ -47,6 +47,14 @@ public class TarAnalyzer extends FileAnalyzer {
 
     protected TarAnalyzer(AnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/ZipAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/ZipAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.archive;
 
@@ -47,6 +47,14 @@ public class ZipAnalyzer extends FileAnalyzer {
 
     protected ZipAnalyzer(AnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.c;
 
@@ -46,6 +46,14 @@ public class CAnalyzer extends AbstractSourceCodeAnalyzer {
     protected CAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new CSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "C"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "C";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CxxAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CxxAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.c;
 
@@ -44,7 +44,15 @@ public class CxxAnalyzer extends AbstractSourceCodeAnalyzer {
     protected CxxAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new CxxSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }      
+    }
+
+    /**
+     * @return {@code "C++"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "C++";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.clojure;
 
@@ -35,6 +35,15 @@ public class ClojureAnalyzer extends AbstractSourceCodeAnalyzer {
     protected ClojureAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new ClojureSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "clojure"} to match the OpenGrok-customized definitions,
+     * despite there being a built-in Clojure definition
+     */
+    @Override
+    public String getCtagsLang() {
+        return "clojure";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.csharp;
 
@@ -39,6 +39,14 @@ public class CSharpAnalyzer extends AbstractSourceCodeAnalyzer {
     protected CSharpAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new CSharpSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "C#"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "C#";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.document;
 
@@ -49,6 +49,15 @@ public class MandocAnalyzer extends TextAnalyzer {
     protected MandocAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new TroffFullTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language (nevermind ctags
+     * supporting "Man" which is not useful for OpenGrok)
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/TroffAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/TroffAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.document;
 
@@ -52,7 +52,15 @@ public class TroffAnalyzer extends TextAnalyzer {
     protected TroffAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new TroffFullTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }    
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/eiffel/EiffelAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/eiffel/EiffelAnalyzer.java
@@ -45,6 +45,14 @@ public class EiffelAnalyzer extends AbstractSourceCodeAnalyzer {
     }
 
     /**
+     * @return {@code "Eiffel"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Eiffel";
+    }
+
+    /**
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/erlang/ErlangAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/erlang/ErlangAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.erlang;
@@ -40,6 +40,14 @@ public class ErlangAnalyzer extends AbstractSourceCodeAnalyzer {
     protected ErlangAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new ErlangSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "Erlang"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Erlang";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/ELFAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/ELFAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.executables;
 
@@ -71,6 +71,14 @@ public class ELFAnalyzer extends FileAnalyzer {
      */
     protected ELFAnalyzer(AnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JarAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JarAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.executables;
 
@@ -51,6 +51,14 @@ public class JarAnalyzer extends FileAnalyzer {
 
     protected JarAnalyzer(AnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JavaClassAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JavaClassAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.executables;
 
@@ -85,6 +85,14 @@ public class JavaClassAnalyzer extends FileAnalyzer {
      */
     protected JavaClassAnalyzer(AnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/fortran/FortranAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/fortran/FortranAnalyzer.java
@@ -42,6 +42,14 @@ public class FortranAnalyzer extends AbstractSourceCodeAnalyzer {
     }
 
     /**
+     * @return {@code "Fortran"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Fortran";
+    }
+
+    /**
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/golang/GolangAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/golang/GolangAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.golang;
@@ -44,7 +44,15 @@ public class GolangAnalyzer extends AbstractSourceCodeAnalyzer {
     protected GolangAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new GolangSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }   
+    }
+
+    /**
+     * @return {@code "Go"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Go";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/haskell/HaskellAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/haskell/HaskellAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.haskell;
@@ -43,7 +43,15 @@ public class HaskellAnalyzer extends AbstractSourceCodeAnalyzer {
     protected HaskellAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new HaskellSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }    
+    }
+
+    /**
+     * @return {@code "haskell"} to match the OpenGrok-customized definitions
+     */
+    @Override
+    public String getCtagsLang() {
+        return "haskell";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/JavaAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/JavaAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.java;
 
@@ -43,6 +43,14 @@ public class JavaAnalyzer extends AbstractSourceCodeAnalyzer {
     protected JavaAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new JavaSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "Java"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Java";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/javascript/JavaScriptAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/javascript/JavaScriptAnalyzer.java
@@ -44,7 +44,15 @@ public class JavaScriptAnalyzer extends AbstractSourceCodeAnalyzer {
     protected JavaScriptAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new JavaScriptSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }    
+    }
+
+    /**
+     * @return {@code "JavaScript"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "JavaScript";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/json/JsonAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/json/JsonAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.json;
 
@@ -44,7 +44,15 @@ public class JsonAnalyzer extends AbstractSourceCodeAnalyzer {
     protected JsonAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new JsonSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }    
+    }
+
+    /**
+     * @return {@code "JSON"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "JSON";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/kotlin/KotlinAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/kotlin/KotlinAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.kotlin;
 
@@ -43,6 +43,14 @@ public class KotlinAnalyzer extends AbstractSourceCodeAnalyzer {
     protected KotlinAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new KotlinSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "kotlin"} to match the OpenGrok-customized definitions
+     */
+    @Override
+    public String getCtagsLang() {
+        return "kotlin";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lisp/LispAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lisp/LispAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.lisp;
 
@@ -39,6 +39,14 @@ public class LispAnalyzer extends AbstractSourceCodeAnalyzer {
     protected LispAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new LispSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "Lisp"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Lisp";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lua/LuaAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lua/LuaAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.lua;
@@ -43,7 +43,15 @@ public class LuaAnalyzer extends AbstractSourceCodeAnalyzer {
     protected LuaAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new LuaSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }    
+    }
+
+    /**
+     * @return {@code "Lua"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Lua";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.pascal;
 
@@ -43,7 +43,16 @@ public class PascalAnalyzer extends AbstractSourceCodeAnalyzer {
     protected PascalAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new PascalSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }       
+    }
+
+    /**
+     * @return {@code "pascal"} to match the OpenGrok-customized definitions,
+     * despite there being a built-in Pascal definition.
+     */
+    @Override
+    public String getCtagsLang() {
+        return "pascal";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/perl/PerlAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/perl/PerlAnalyzer.java
@@ -46,6 +46,14 @@ public class PerlAnalyzer extends AbstractSourceCodeAnalyzer {
     }
 
     /**
+     * @return {@code "Perl"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Perl";
+    }
+
+    /**
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/php/PhpAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/php/PhpAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.php;
 
@@ -43,7 +43,15 @@ public class PhpAnalyzer extends AbstractSourceCodeAnalyzer {
     protected PhpAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new PhpSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }    
+    }
+
+    /**
+     * @return {@code "PHP"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "PHP";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.plain;
 
@@ -68,6 +68,14 @@ public class PlainAnalyzer extends TextAnalyzer {
     protected PlainAnalyzer(AnalyzerFactory factory,
         JFlexTokenizer symbolTokenizer) {
         super(factory, symbolTokenizer);
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/XMLAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/XMLAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.plain;
 
@@ -50,6 +50,14 @@ public class XMLAnalyzer extends TextAnalyzer {
      */
     protected XMLAnalyzer(AnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * @return {@code "XML"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "XML";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/powershell/PowershellAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/powershell/PowershellAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.powershell;
 
@@ -45,7 +45,16 @@ public class PowershellAnalyzer extends AbstractSourceCodeAnalyzer {
     protected PowershellAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new PoshSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }    
+    }
+
+    /**
+     * @return {@code "powershell"} to match the OpenGrok-customized definitions,
+     * despite there being a built-in PowerShell definition.
+     */
+    @Override
+    public String getCtagsLang() {
+        return "powershell";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/python/PythonAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/python/PythonAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.python;
 
@@ -43,6 +43,14 @@ public class PythonAnalyzer extends AbstractSourceCodeAnalyzer {
     protected PythonAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new PythonSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "Python"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Python";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/RubyAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/RubyAnalyzer.java
@@ -47,6 +47,14 @@ public class RubyAnalyzer extends AbstractSourceCodeAnalyzer {
     }
 
     /**
+     * @return {@code "Ruby"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Ruby";
+    }
+
+    /**
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/rust/RustAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/rust/RustAnalyzer.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2016 Nikolay Denev.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.rust;
@@ -46,7 +46,16 @@ public class RustAnalyzer extends AbstractSourceCodeAnalyzer {
     protected RustAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new RustSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }    
+    }
+
+    /**
+     * @return {@code "rust"} to match the OpenGrok-customized definitions,
+     * despite there being a built-in Rust definition.
+     */
+    @Override
+    public String getCtagsLang() {
+        return "rust";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/scala/ScalaAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/scala/ScalaAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.scala;
 
@@ -43,6 +43,14 @@ public class ScalaAnalyzer extends AbstractSourceCodeAnalyzer {
     protected ScalaAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new ScalaSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "scala"} to match the OpenGrok-customized definitions
+     */
+    @Override
+    public String getCtagsLang() {
+        return "scala";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sh/ShAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sh/ShAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.sh;
 
@@ -45,7 +45,15 @@ public class ShAnalyzer extends AbstractSourceCodeAnalyzer {
     protected ShAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new ShSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }    
+    }
+
+    /**
+     * @return {@code "Sh"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Sh";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/PLSQLAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/PLSQLAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.sql;
 
@@ -32,6 +32,14 @@ public class PLSQLAnalyzer extends PlainAnalyzer {
 
     public PLSQLAnalyzer(AnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * @return {@code "SQL"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "SQL";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/SQLAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/SQLAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.sql;
 
@@ -32,6 +32,14 @@ public class SQLAnalyzer extends PlainAnalyzer {
 
     public SQLAnalyzer(AnalyzerFactory factory) {
         super(factory);
+    }
+
+    /**
+     * @return {@code "SQL"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "SQL";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/SwiftAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/SwiftAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.swift;
 
@@ -43,6 +43,14 @@ public class SwiftAnalyzer extends AbstractSourceCodeAnalyzer {
     protected SwiftAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new SwiftSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "Swift"} to match the OpenGrok-customized definitions
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Swift";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/tcl/TclAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/tcl/TclAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.tcl;
 
@@ -39,7 +39,15 @@ public class TclAnalyzer extends AbstractSourceCodeAnalyzer {
     protected TclAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new TclSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }    
+    }
+
+    /**
+     * @return {@code "Tcl"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Tcl";
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/uue/UuencodeAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/uue/UuencodeAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.uue;
 
@@ -52,6 +52,14 @@ public class UuencodeAnalyzer extends TextAnalyzer {
     protected UuencodeAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new UuencodeFullTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/vb/VBAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/vb/VBAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.vb;
 
@@ -43,7 +43,15 @@ public class VBAnalyzer extends AbstractSourceCodeAnalyzer {
     protected VBAnalyzer(AnalyzerFactory factory) {
         super(factory, new JFlexTokenizer(new VBSymbolTokenizer(
                 AbstractAnalyzer.DUMMY_READER)));
-    }    
+    }
+
+    /**
+     * @return {@code null} as there is no aligned language
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
+    }
 
     /**
      * Gets a version number to be used to tag processed documents so that

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/verilog/VerilogAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/verilog/VerilogAnalyzer.java
@@ -46,6 +46,14 @@ public class VerilogAnalyzer extends AbstractSourceCodeAnalyzer {
     }
 
     /**
+     * @return {@code "SystemVerilog"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "SystemVerilog";
+    }
+
+    /**
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.index;
@@ -28,6 +28,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.logging.Logger;
+
+import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.analysis.Ctags;
 import org.opengrok.indexer.analysis.CtagsValidator;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -268,6 +270,7 @@ public class IndexerParallelizer implements AutoCloseable {
                 " searching definitions will not work!");
         } else {
             ctags.setBinary(ctagsBinary);
+            ctags.setLangMap(AnalyzerGuru.getLangMap());
 
             String filename = env.getCTagsExtraOptionsFile();
             if (filename != null) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/LangMapTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/LangMapTest.java
@@ -1,0 +1,211 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.analysis;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents a container for tests of {@link LangMap}.
+ */
+public class LangMapTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testEmptyMap() {
+        LangMap map = new LangTreeMap();
+        List<String> args = map.getCtagsArgs();
+        assertTrue("args should be empty", args.isEmpty());
+    }
+
+    @Test
+    public void testMakefile() {
+        LangMap map = new LangTreeMap();
+        map.add("Makefile", "Sh");
+        List<String> args = map.getCtagsArgs();
+        assertArrayEquals("args should have one all-case Makefile entry",
+                new Object[]{"--langmap=Sh:+([mM][aA][kK][eE][fF][iI][lL][eE]*)"}, args.toArray());
+    }
+
+    @Test
+    public void test1Prefix2Extension() {
+        LangMap map = new LangTreeMap();
+        map.add("Makefile", "Sh");
+        map.add(".FOO", "XML");
+        map.add(".B", "Basic");
+        List<String> args = map.getCtagsArgs();
+        assertArrayEquals("args should have specific, multiple entries",
+                new Object[]{
+                        "--langmap=Basic:+.b.B",
+                        "--langmap=XML:+.foo.Foo.FOO",
+                        "--langmap=Sh:+([mM][aA][kK][eE][fF][iI][lL][eE]*)"
+                }, args.toArray());
+    }
+
+    @Test
+    public void testNonTrivialCaseFolding() {
+        LangMap map = new LangTreeMap();
+        map.add("groß", "Sh");
+        List<String> args = map.getCtagsArgs();
+        assertArrayEquals("args should have one original-case groß entry",
+                new Object[]{"--langmap=Sh:+(groß*)"}, args.toArray());
+    }
+
+    @Test
+    public void testMerge1() {
+        LangMap map1 = new LangTreeMap();
+        map1.add("Makefile", "Sh");
+        map1.add(".B", "Basic");
+
+        LangMap map2 = new LangTreeMap();
+        map2.add(".B", "C");
+        map2.add(".ZZZ", "C++");
+
+        LangMap map3 = map1.mergeSecondary(map2);
+        List<String> args = map3.getCtagsArgs();
+        assertArrayEquals("args should have specific, multiple entries",
+                new Object[]{
+                        "--langmap=Basic:+.b.B",
+                        "--langmap=C++:+.zzz.Zzz.ZZZ",
+                        "--langmap=Sh:+([mM][aA][kK][eE][fF][iI][lL][eE]*)"
+                }, args.toArray());
+    }
+
+    @Test
+    public void testMerge2() {
+        LangMap map1 = new LangTreeMap();
+        map1.exclude(".B");
+
+        LangMap map2 = new LangTreeMap();
+        map2.add(".B", "C");
+        map2.add(".ZZZ", "C++");
+
+        LangMap map3 = map1.mergeSecondary(map2);
+        List<String> args = map3.getCtagsArgs();
+        assertArrayEquals("args should have specific, multiple entries",
+                new Object[]{
+                        "--langmap=C++:+.zzz.Zzz.ZZZ",
+                        "--map-all=-.b",
+                        "--map-all=-.B"
+                }, args.toArray());
+    }
+
+    @Test
+    public void testExcludeMakefile() {
+        LangMap map = new LangTreeMap();
+        map.exclude("Makefile");
+        List<String> args = map.getCtagsArgs();
+        assertArrayEquals("args should have one all-case Makefile entry",
+                new Object[]{"--map-all=-([mM][aA][kK][eE][fF][iI][lL][eE]*)"}, args.toArray());
+    }
+
+    @Test
+    public void testExcludeExtension() {
+        LangMap map = new LangTreeMap();
+        map.exclude(".d");
+        List<String> args = map.getCtagsArgs();
+        assertArrayEquals("args should have specific, multiple entries",
+                new Object[]{
+                        "--map-all=-.d",
+                        "--map-all=-.D"
+                }, args.toArray());
+    }
+
+    @Test
+    public void testExcludeExtensionThenAdd() {
+        LangMap map = new LangTreeMap();
+        map.exclude(".d");
+        map.add(".d", "D");
+        List<String> args = map.getCtagsArgs();
+        assertArrayEquals("args should have a specified entry",
+                new Object[]{"--langmap=D:+.d.D"}, args.toArray());
+    }
+
+    @Test
+    public void testAddExtensionThenExclude() {
+        LangMap map = new LangTreeMap();
+        map.add(".d", "D");
+        map.exclude(".d");
+        List<String> args = map.getCtagsArgs();
+        assertArrayEquals("args should have specific, multiple entries",
+                new Object[]{
+                        "--map-all=-.d",
+                        "--map-all=-.D"
+                }, args.toArray());
+    }
+
+    @Test
+    public void testBadExtensionFileSpec() {
+        LangMap map = new LangTreeMap();
+
+        thrown.expect(IllegalArgumentException.class);
+        map.add(".c.in", "foo");
+    }
+
+    @Test
+    public void testImmutabilityOfUnmodifiable1() {
+        LangMap map = new LangTreeMap();
+        LangMap map2 = map.unmodifiable();
+
+        thrown.expect(UnsupportedOperationException.class);
+        map2.add(".FOO", "foo");
+    }
+
+    @Test
+    public void testImmutabilityOfUnmodifiable2() {
+        LangMap map = new LangTreeMap();
+        LangMap map2 = map.unmodifiable();
+
+        thrown.expect(UnsupportedOperationException.class);
+        map2.exclude(".FOO");
+    }
+
+    @Test
+    public void testImmutabilityOfAdditionsView() {
+        LangMap map = new LangTreeMap();
+        Map<String, String> additions = map.getAdditions();
+
+        thrown.expect(UnsupportedOperationException.class);
+        additions.clear();
+    }
+
+    @Test
+    public void testImmutabilityOfExclusionsView() {
+        LangMap map = new LangTreeMap();
+        Set<String> exclusions = map.getExclusions();
+
+        thrown.expect(UnsupportedOperationException.class);
+        exclusions.clear();
+    }
+}


### PR DESCRIPTION
Hello,

Please consider for integration this patch to support customizing `Ctags` language mapping (inclusion or exclusion) per `-A,--indexer` so that Universal Ctags operation is changed too when users specify additional extensions or prefixes to map to analyzers (or unmap from them).

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
