### PR TITLE
Improve configuration help

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
@@ -18,10 +18,12 @@
  */
 
 /*
- * Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis;
+
+import org.opengrok.indexer.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -141,7 +143,7 @@ public class AnalyzerGuruHelp {
         int llen = 0;
         int i = 0;
         while (i < str.length()) {
-            int wlen = nextTestWhitespaceLength(false, str, i);
+            int wlen = StringUtils.whitespaceOrControlLength(str, i, false);
             if (wlen > 0) {
                 String word = str.substring(i, i + wlen);
                 if (llen < 1) {
@@ -160,7 +162,7 @@ public class AnalyzerGuruHelp {
                 i += wlen;
             }
 
-            int slen = nextTestWhitespaceLength(true, str, i);
+            int slen = StringUtils.whitespaceOrControlLength(str, i, true);
             i += slen;
         }
         if (b.length() > 0) {
@@ -169,20 +171,6 @@ public class AnalyzerGuruHelp {
         }
 
         return res.stream().toArray(String[]::new);
-    }
-
-    private static int nextTestWhitespaceLength(boolean match, String str,
-        int off) {
-        int i = 0;
-        while (off + i < str.length()) {
-            int cp = Character.codePointAt(str, off + i);
-            if ((Character.isWhitespace(cp) || Character.isISOControl(cp)) !=
-                match) {
-                return i;
-            }
-            i += Character.charCount(cp);
-        }
-        return str.length() - off;
     }
 
     private static List<MappedFactory> byKey(

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuggesterConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuggesterConfig.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;
 
@@ -41,7 +42,7 @@ public class SuggesterConfig {
     public static final boolean ENABLED_DEFAULT = true;
     public static final int MAX_RESULTS_DEFAULT = 10;
     public static final int MIN_CHARS_DEFAULT = 0;
-    public static final int MAX_PROJECTS_DEFAULT = Integer.MAX_VALUE;
+    public static final int MAX_PROJECTS_DEFAULT = Short.MAX_VALUE;
     public static final boolean ALLOW_COMPLEX_QUERIES_DEFAULT = true;
     public static final boolean ALLOW_MOST_POPULAR_DEFAULT = true;
     public static final boolean SHOW_SCORES_DEFAULT = false;
@@ -335,4 +336,33 @@ public class SuggesterConfig {
                 buildTerminationTime, rebuildThreadPoolSizeInNcpuPercent);
     }
 
+    /**
+     * Gets an instance version suitable for helper documentation by shifting
+     * most default properties slightly.
+     */
+    static SuggesterConfig getForHelp() {
+        SuggesterConfig res = new SuggesterConfig();
+        res.setEnabled(!res.isEnabled());
+        res.setMaxResults(1 + res.getMaxResults());
+        res.setMinChars(1 + res.getMinChars());
+        res.setAllowedProjects(new HashSet<>(Arrays.asList("project-1", "project-2")));
+        res.setMaxProjects(1 + res.getMaxProjects());
+        res.setAllowedFields(getAllowedFieldsForHelp(res.getAllowedFields()));
+        res.setAllowComplexQueries(!res.isAllowComplexQueries());
+        res.setAllowMostPopular(!res.isAllowMostPopular());
+        res.setShowScores(!res.isShowScores());
+        res.setShowProjects(!res.isShowProjects());
+        res.setShowTime(!res.isShowTime());
+        res.setTimeThreshold(1 + res.getTimeThreshold());
+        res.setRebuildCronConfig("1 0 * * *");
+        res.setBuildTerminationTime(1 + res.getBuildTerminationTime());
+        res.setRebuildThreadPoolSizeInNcpuPercent(1 + res.getRebuildThreadPoolSizeInNcpuPercent());
+        return res;
+    }
+
+    private static HashSet<String> getAllowedFieldsForHelp(Set<String> allowedFields) {
+        HashSet<String> res = new HashSet<>(allowedFields);
+        res.remove(QueryBuilder.FULL);
+        return res;
+    }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IgnoredNames.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IgnoredNames.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
 
@@ -34,6 +35,8 @@ import java.util.List;
  */
 public class IgnoredNames implements Serializable {
     private static final long serialVersionUID = 1L;
+    private static final String FILE_PREFIX = "f:";
+    private static final String DIR_PREFIX = "d:";
 
     private IgnoredFiles ignoredFiles;
     private IgnoredDirs ignoredDirs;
@@ -58,10 +61,10 @@ public class IgnoredNames implements Serializable {
     }
 
     public void add(String pattern) {
-        if (pattern.startsWith("f:")) {
-            ignoredFiles.add(pattern.substring(2));
-        } else if (pattern.startsWith("d:")) {
-            ignoredDirs.add(pattern.substring(2));
+        if (pattern.startsWith(FILE_PREFIX)) {
+            ignoredFiles.add(pattern.substring(FILE_PREFIX.length()));
+        } else if (pattern.startsWith(DIR_PREFIX)) {
+            ignoredDirs.add(pattern.substring(DIR_PREFIX.length()));
         } else {
             // backward compatibility
             ignoredFiles.add(pattern);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StringUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StringUtils.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.util;
@@ -298,5 +298,28 @@ public final class StringUtils {
             }
         }
         return 0;
+    }
+
+    /**
+     * Determine the length of the next whitespace- or ISO control
+     * character-related sequence within a string.
+     * @param str a defined instance
+     * @param off the starting offset within {@code str}
+     * @param shouldMatch a value indicating whether to match all contiguous
+     *                    whitespace or ISO control characters ({@code true}) or
+     *                    all contiguous non-whitespace and non-control
+     *                    characters ({@code false}) starting at {@code off}
+     * @return a length greater than or equal to zero
+     */
+    public static int whitespaceOrControlLength(String str, int off, boolean shouldMatch) {
+        int i = 0;
+        while (off + i < str.length()) {
+            int cp = Character.codePointAt(str, off + i);
+            if ((Character.isWhitespace(cp) || Character.isISOControl(cp)) != shouldMatch) {
+                return i;
+            }
+            i += Character.charCount(cp);
+        }
+        return str.length() - off;
     }
 }


### PR DESCRIPTION
Hello,

Please consider for integration this patch to improve `--help --detailed` as shown below:

Thank you.

**ignoredNames**
Former:
```
  <!-- Sample for setIgnoredNames. Default is: org.opengrok.indexer.index.IgnoredNames@638ef7ed -->
```
New:
```
  <!-- Sample for setIgnoredNames. Default is OpenGrok's standard set of ignored
       files and directories -->
```

**includedNames**
Former:
```
  <!-- Sample for setIncludedNames. Default is: org.opengrok.indexer.index.Filter@14f232c4 -->
```
New:
```
  <!-- Sample for setIncludedNames. Default is an empty filter -->
```

**pluginStack**
Former:
```
  <!-- Sample for setPluginStack. Default is: org.opengrok.indexer.authorization.AuthorizationStack@2072acb2 -->
```
New:
```
  <!-- Sample for setPluginStack. Default is an empty stack -->
```

**suggesterConfig**
Former:
```
  <!-- Sample for setSuggesterConfig. Default is: org.opengrok.indexer.configuration.SuggesterConfig@6eea4a46 -->
<?xml version="1.0" encoding="UTF-8"?>
<java version="1.8.0_222-internal" class="java.beans.XMLDecoder">
 <object class="org.opengrok.indexer.configuration.Configuration"/>
</java>
```
New:
```
  <!-- Sample for setSuggesterConfig. Default is as below but with Boolean
       opposites, non-zeroes decremented by 1, null for allowed-projects, and
       also including "full" in allowed-fields -->
  <void property="suggesterConfig">
   <void property="allowComplexQueries">
    <boolean>false</boolean>
   </void>
   <void property="allowMostPopular">
    <boolean>false</boolean>
   </void>
   <void property="allowedFields">
    <object class="java.util.HashSet">
     <void method="add">
      <string>defs</string>
     </void>
     <void method="add">
      <string>path</string>
     </void>
     <void method="add">
      <string>hist</string>
     </void>
     <void method="add">
      <string>refs</string>
     </void>
     <void method="add">
      <string>type</string>
     </void>
    </object>
   </void>
   <void property="allowedProjects">
    <object class="java.util.HashSet">
     <void method="add">
      <string>project-1</string>
     </void>
     <void method="add">
      <string>project-2</string>
     </void>
    </object>
   </void>
   <void property="buildTerminationTime">
    <int>1801</int>
   </void>
   <void property="enabled">
    <boolean>false</boolean>
   </void>
   <void property="maxProjects">
    <int>32768</int>
   </void>
   <void property="maxResults">
    <int>11</int>
   </void>
   <void property="minChars">
    <int>1</int>
   </void>
   <void property="rebuildCronConfig">
    <string>1 0 * * *</string>
   </void>
   <void property="rebuildThreadPoolSizeInNcpuPercent">
    <int>81</int>
   </void>
   <void property="showProjects">
    <boolean>false</boolean>
   </void>
   <void property="showScores">
    <boolean>true</boolean>
   </void>
   <void property="showTime">
    <boolean>true</boolean>
   </void>
   <void property="timeThreshold">
    <int>2001</int>
   </void>
  </void>
```

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
