### PR TITLE
Extract symbol-tokenizer test code

### DIFF
--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ada/AdaSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ada/AdaSymbolTokenizerTest.java
@@ -19,18 +19,17 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.ada;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+
+import org.junit.Test;
+import org.opengrok.indexer.util.StreamUtils;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link AdaSymbolTokenizer} class.
@@ -50,17 +49,8 @@ public class AdaSymbolTokenizerTest {
             "analysis/ada/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", wdsres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            wdsres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }            
-        }
-
+        List<String> expectedSymbols = StreamUtils.readSampleSymbols(wdsres);
         assertSymbolStream(AdaSymbolTokenizer.class, adbres, expectedSymbols);
     }
+
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.c;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link CSymbolTokenizer} class.
@@ -51,17 +50,7 @@ public class CSymbolTokenizerTest {
             "analysis/c/samplesymbols_c.txt");
         assertNotNull("despite samplesymbols_c.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symres);
         assertSymbolStream(CSymbolTokenizer.class, cres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CxxSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CxxSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.c;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link CxxSymbolTokenizer} class.
@@ -51,17 +50,7 @@ public class CxxSymbolTokenizerTest {
             "analysis/c/samplesymbols_cc.txt");
         assertNotNull("despite samplesymbols_cc.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symres);
         assertSymbolStream(CxxSymbolTokenizer.class, ccres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/clojure/ClojureSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/clojure/ClojureSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.clojure;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link ClojureSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class ClojureSymbolTokenizerTest {
             "analysis/clojure/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", wdsres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            wdsres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(ClojureSymbolTokenizer.class, cljres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(wdsres);
+        assertSymbolStream(ClojureSymbolTokenizer.class, cljres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/csharp/CSharpSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/csharp/CSharpSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.csharp;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link CSharpSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class CSharpSymbolTokenizerTest {
             "analysis/csharp/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(CSharpSymbolTokenizer.class, csres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(CSharpSymbolTokenizer.class, csres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/eiffel/EiffelSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/eiffel/EiffelSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.eiffel;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link EiffelSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class EiffelSymbolTokenizerTest {
             "analysis/eiffel/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(EiffelSymbolTokenizer.class, eres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(EiffelSymbolTokenizer.class, eres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/erlang/ErlangSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/erlang/ErlangSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.erlang;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link ErlangSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class ErlangSymbolTokenizerTest {
             "analysis/erlang/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }            
-        }
-
-        assertSymbolStream(ErlangSymbolTokenizer.class, erlres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(ErlangSymbolTokenizer.class, erlres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/fortran/FortranSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/fortran/FortranSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.fortran;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link FortranSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class FortranSymbolTokenizerTest {
             "analysis/fortran/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", wdsres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            wdsres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(FortranSymbolTokenizer.class, fres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(wdsres);
+        assertSymbolStream(FortranSymbolTokenizer.class, fres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/golang/GolangSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/golang/GolangSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.golang;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link GolangSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class GolangSymbolTokenizerTest {
             "analysis/golang/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(GolangSymbolTokenizer.class, gores,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(GolangSymbolTokenizer.class, gores, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/haskell/HaskellSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/haskell/HaskellSymbolTokenizerTest.java
@@ -19,27 +19,26 @@
 
 /*
  * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.haskell;
 
-import java.io.BufferedReader;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
 
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.Test;
+import org.opengrok.indexer.analysis.AbstractAnalyzer;
+import org.opengrok.indexer.analysis.JFlexTokenizer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
-import org.opengrok.indexer.analysis.AbstractAnalyzer;
-import org.opengrok.indexer.analysis.JFlexTokenizer;
-import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
 
 /**
  * Tests the {@link HaskellSymbolTokenizer} class.
@@ -99,18 +98,7 @@ public class HaskellSymbolTokenizerTest {
             "analysis/haskell/sample2symbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(HaskellSymbolTokenizer.class, pyres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(HaskellSymbolTokenizer.class, pyres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/javascript/JavaScriptSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/javascript/JavaScriptSymbolTokenizerTest.java
@@ -19,20 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.javascript;
 
 import static org.junit.Assert.assertNotNull;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link JavaScriptSymbolTokenizer} class.
@@ -67,18 +65,7 @@ public class JavaScriptSymbolTokenizerTest {
                 symbolsResource);
         assertNotNull(String.format("Unable to find %s as a resource", symbolsResource), symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) {
-                    line = line.substring(0, hasho);
-                }
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symres);
         assertSymbolStream(JavaScriptSymbolTokenizer.class, jsres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/json/JsonSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/json/JsonSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.json;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link JsonSymbolTokenizer} class.
@@ -51,17 +50,7 @@ public class JsonSymbolTokenizerTest {
             "analysis/json/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symres);
         assertSymbolStream(JsonSymbolTokenizer.class, jres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/kotlin/KotlinSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/kotlin/KotlinSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.kotlin;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link KotlinSymbolTokenizer} class.
@@ -50,18 +49,7 @@ public class KotlinSymbolTokenizerTest {
                 "analysis/kotlin/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(KotlinSymbolTokenizer.class, ktres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(KotlinSymbolTokenizer.class, ktres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/lua/LuaSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/lua/LuaSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.lua;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import java.io.InputStream;
+import java.util.List;
+import org.junit.Test;
 
 /**
  * Tests the {@link LuaSymbolTokenizer} class.
@@ -51,17 +50,7 @@ public class LuaSymbolTokenizerTest {
             "analysis/lua/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symres);
         assertSymbolStream(LuaSymbolTokenizer.class, luares, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/pascal/PascalSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/pascal/PascalSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.pascal;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import java.io.InputStream;
+import java.util.List;
+import org.junit.Test;
 
 /**
  * Tests the {@link PascalSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class PascalSymbolTokenizerTest {
             "analysis/pascal/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(PascalSymbolTokenizer.class, pasres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(PascalSymbolTokenizer.class, pasres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/perl/PerlSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/perl/PerlSymbolTokenizerTest.java
@@ -19,25 +19,24 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.perl;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.List;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.junit.Test;
 import org.opengrok.indexer.analysis.JFlexSymbolMatcher;
 import org.opengrok.indexer.analysis.JFlexTokenizer;
-import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.List;
 
 /**
  * Unit tests for {@link PerlSymbolTokenizer}.
@@ -104,17 +103,7 @@ public class PerlSymbolTokenizerTest {
         InputStream wdsres = getClass().getClassLoader().getResourceAsStream(
             "analysis/perl/samplesymbols.txt");
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            wdsres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }            
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(wdsres);
         assertSymbolStream(PerlSymbolTokenizer.class, plres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/powershell/PoshSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/powershell/PoshSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.powershell;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link PoshSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class PoshSymbolTokenizerTest {
             "analysis/powershell/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(PoshSymbolTokenizer.class, psres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(PoshSymbolTokenizer.class, psres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/python/PythonSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/python/PythonSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.python;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link PythonSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class PythonSymbolTokenizerTest {
             "analysis/python/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(PythonSymbolTokenizer.class, pyres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(PythonSymbolTokenizer.class, pyres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ruby/RubySymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ruby/RubySymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.ruby;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link RubySymbolTokenizer} class.
@@ -51,17 +50,7 @@ public class RubySymbolTokenizerTest {
             "analysis/ruby/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", wdsres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            wdsres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }            
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(wdsres);
         assertSymbolStream(RubySymbolTokenizer.class, rbres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/rust/RustSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/rust/RustSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.rust;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link RustSymbolTokenizer} class.
@@ -51,17 +50,7 @@ public class RustSymbolTokenizerTest {
             "analysis/rust/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symres);
         assertSymbolStream(RustSymbolTokenizer.class, rsres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/scala/ScalaSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/scala/ScalaSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.scala;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link ScalaSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class ScalaSymbolTokenizerTest {
             "analysis/scala/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(ScalaSymbolTokenizer.class, scalares,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(ScalaSymbolTokenizer.class, scalares, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sh/ShSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sh/ShSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.sh;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link ShSymbolTokenizer} class.
@@ -51,17 +50,7 @@ public class ShSymbolTokenizerTest {
             "analysis/sh/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symres);
         assertSymbolStream(ShSymbolTokenizer.class, shres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sql/PLSQLSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sql/PLSQLSymbolTokenizerTest.java
@@ -25,15 +25,12 @@ package org.opengrok.indexer.analysis.sql;
 
 import org.junit.Test;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
 
 /**
  * Tests the {@link PLSQLSymbolTokenizer} class.
@@ -52,19 +49,7 @@ public class PLSQLSymbolTokenizerTest {
                 "analysis/sql/sampleplssymbols.txt");
         assertNotNull("sampleplssymbols.txt should be an available resource", symRes);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
-                symRes, StandardCharsets.UTF_8))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                int hashOffset = line.indexOf('#');
-                if (hashOffset != -1) {
-                    line = line.substring(0, hashOffset);
-                }
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symRes);
         assertSymbolStream(PLSQLSymbolTokenizer.class, sqlRes, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sql/SQLSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/sql/SQLSymbolTokenizerTest.java
@@ -25,15 +25,12 @@ package org.opengrok.indexer.analysis.sql;
 
 import org.junit.Test;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
 
 /**
  * Tests the {@link SQLSymbolTokenizer} class.
@@ -52,19 +49,7 @@ public class SQLSymbolTokenizerTest {
                 "analysis/sql/samplesqlsymbols.txt");
         assertNotNull("samplesqlsymbols.txt should be an available resource", symRes);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
-                symRes, StandardCharsets.UTF_8))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                int hashOffset = line.indexOf('#');
-                if (hashOffset != -1) {
-                    line = line.substring(0, hashOffset);
-                }
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symRes);
         assertSymbolStream(SQLSymbolTokenizer.class, sqlRes, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/swift/SwiftSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/swift/SwiftSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.swift;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link SwiftSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class SwiftSymbolTokenizerTest {
             "analysis/swift/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(SwiftSymbolTokenizer.class, swiftres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(SwiftSymbolTokenizer.class, swiftres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/tcl/TclSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/tcl/TclSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.tcl;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link TclSymbolTokenizer} class.
@@ -51,18 +50,7 @@ public class TclSymbolTokenizerTest {
             "analysis/tcl/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
-        assertSymbolStream(TclSymbolTokenizer.class, tclres,
-            expectedSymbols);
+        List<String> expectedSymbols = readSampleSymbols(symres);
+        assertSymbolStream(TclSymbolTokenizer.class, tclres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/typescript/TypeScriptSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/typescript/TypeScriptSymbolTokenizerTest.java
@@ -26,13 +26,10 @@ package org.opengrok.indexer.analysis.typescript;
 
 import static org.junit.Assert.assertNotNull;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
 
 import org.junit.Test;
-import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -54,19 +51,7 @@ public class TypeScriptSymbolTokenizerTest {
         InputStream symRes = getClass().getClassLoader().getResourceAsStream(symbolsResource);
         assertNotNull(String.format("Unable to find %s as a resource", symbolsResource), symRes);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wordsReader = new BufferedReader(
-                new InputStreamReader(symRes, StandardCharsets.UTF_8))) {
-            String line;
-            while ((line = wordsReader.readLine()) != null) {
-                int hashOffset = line.indexOf('#');
-                if (hashOffset != -1) {
-                    line = line.substring(0, hashOffset);
-                }
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symRes);
         assertSymbolStream(TypeScriptSymbolTokenizer.class, tsRes, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/vb/VBSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/vb/VBSymbolTokenizerTest.java
@@ -19,19 +19,18 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.vb;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link VBSymbolTokenizer} class.
@@ -51,17 +50,7 @@ public class VBSymbolTokenizerTest {
             "analysis/vb/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symres);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader wdsr = new BufferedReader(new InputStreamReader(
-            symres, "UTF-8"))) {
-            String line;
-            while ((line = wdsr.readLine()) != null) {
-                int hasho = line.indexOf('#');
-                if (hasho != -1) line = line.substring(0, hasho);
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symres);
         assertSymbolStream(VBSymbolTokenizer.class, clsres, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/verilog/VerilogSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/verilog/VerilogSymbolTokenizerTest.java
@@ -24,16 +24,13 @@
 
 package org.opengrok.indexer.analysis.verilog;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.Test;
 import static org.junit.Assert.assertNotNull;
 import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+import org.junit.Test;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Tests the {@link VerilogSymbolTokenizer} class.
@@ -53,19 +50,7 @@ public class VerilogSymbolTokenizerTest {
                 "analysis/verilog/samplesymbols.txt");
         assertNotNull("despite samplesymbols.txt as resource,", symRes);
 
-        List<String> expectedSymbols = new ArrayList<>();
-        try (BufferedReader symRead = new BufferedReader(new InputStreamReader(
-                symRes, StandardCharsets.UTF_8))) {
-            String line;
-            while ((line = symRead.readLine()) != null) {
-                int hashOffset = line.indexOf('#');
-                if (hashOffset != -1) {
-                    line = line.substring(0, hashOffset);
-                }
-                expectedSymbols.add(line.trim());
-            }
-        }
-
+        List<String> expectedSymbols = readSampleSymbols(symRes);
         assertSymbolStream(VerilogSymbolTokenizer.class, vRes, expectedSymbols);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/StreamUtils.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/StreamUtils.java
@@ -35,6 +35,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -161,6 +163,28 @@ public class StreamUtils {
                 return new BufferedInputStream(res);
             }
         };
+    }
+
+    /**
+     * Parses symbols, one per line (trimmed), from a resource stream, but
+     * recognizing a hash character {@code '#'} as starting a line comment that
+     * is not included in a symbol.
+     * @return a defined instance
+     */
+    public static List<String> readSampleSymbols(InputStream symbolsResource) throws IOException {
+        List<String> result = new ArrayList<>();
+        try (BufferedReader rdr = new BufferedReader(new InputStreamReader(symbolsResource,
+                StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = rdr.readLine()) != null) {
+                int hashOffset = line.indexOf('#');
+                if (hashOffset != -1) {
+                    line = line.substring(0, hashOffset);
+                }
+                result.add(line.trim());
+            }
+        }
+        return result;
     }
 
     /** private to enforce static */


### PR DESCRIPTION
Hello,

Please consider for integration this patch to extract a method from code duplicated in symbol tokenizer tests.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
