### PR TITLE
Filter subclasses override Match() instead of creating Ignore()

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Filter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Filter.java
@@ -46,7 +46,7 @@ public class Filter implements Serializable {
      * The full list of all patterns. This list will be saved in the
      * configuration file (if used).
      */
-    private final List<String> items;
+    private final PatternList items;
 
     public Filter() {
         filenames = new HashSet<>();
@@ -154,7 +154,7 @@ public class Filter implements Serializable {
      * @return true if this pathname matches, false otherwise
      */
     public boolean match(String name) {
-        /**
+        /*
          * Creating File object out of relative path would mean the path would be
          * checked against current working directory which is usually undesired.
          */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IgnoredDirs.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IgnoredDirs.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
 
@@ -45,21 +46,14 @@ public final class IgnoredDirs extends Filter {
     }
 
     /**
-     * Should the file be ignored or not?
-     * @param file the file to check
-     * @return true if this file should be ignored, false otherwise
+     * Should the file (that must be a directory) be ignored or not?
+     * @return {@code true} if {@code file} has
+     * {@link File#isDirectory()} () == true} and should be ignored per
+     * filtering
      */
-    public boolean ignore(File file) {
-        return file.isDirectory() && match(file);
-    }
-
-    /**
-     * Should the file be ignored or not?
-     * @param name the name of the file to check
-     * @return true if this pathname should be ignored, false otherwise
-     */
-    public boolean ignore(String name) {
-        return match(name);
+    @Override
+    public boolean match(File file) {
+        return file.isDirectory() && super.match(file);
     }
 
     private void addDefaultPatterns() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IgnoredFiles.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IgnoredFiles.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
 
@@ -67,20 +68,12 @@ public final class IgnoredFiles extends Filter {
 
     /**
      * Should the file be ignored or not?
-     * @param file the file to check
-     * @return true if this file should be ignored, false otherwise
+     * @return {@code true} if {@code file} has {@link File#isFile() == true}
+     * and should be ignored per filtering
      */
-    public boolean ignore(File file) {
-        return file.isFile() && match(file);
-    }
-
-    /**
-     * Should the file be ignored or not?
-     * @param name the name of the file to check
-     * @return true if this pathname should be ignored, false otherwise
-     */
-    public boolean ignore(String name) {
-        return match(name);
+    @Override
+    public boolean match(File file) {
+        return file.isFile() && super.match(file);
     }
 
     private void addDefaultPatterns() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IgnoredNames.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IgnoredNames.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
 
@@ -76,9 +77,9 @@ public class IgnoredNames implements Serializable {
      */
     public boolean ignore(File file) {
         if (file.isFile()) {
-            return ignoredFiles.ignore(file);
+            return ignoredFiles.match(file);
         } else {
-            return ignoredDirs.ignore(file);
+            return ignoredDirs.match(file);
         }
     }
 
@@ -89,7 +90,7 @@ public class IgnoredNames implements Serializable {
      * @return true if this pathname should be ignored, false otherwise
      */
     public boolean ignore(String name) {
-        return ignoredFiles.ignore(name) || ignoredDirs.ignore(name);
+        return ignoredFiles.match(name) || ignoredDirs.match(name);
     }
 
     public void clear() {


### PR DESCRIPTION
Hello,

Please consider for integration this minor revision to `@Override match()` instead of creating `Ignore()` methods for `Filter` subclasses, which improves clarity.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
