### PR TITLE
Add --disableRepository handling

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -66,8 +66,10 @@ import org.opengrok.indexer.logger.LoggerFactory;
  * nature of the web application, each thread will use the same instance of the
  * configuration object for each page request. Class and methods should have
  * package scope, but that didn't work with the XMLDecoder/XMLEncoder.
- *
- * This should be as close to POJO (https://en.wikipedia.org/wiki/Plain_old_Java_object) as possible.
+ * <p>
+ * This should be as close to a
+ * <a href="https://en.wikipedia.org/wiki/Plain_old_Java_object">POJO</a> as
+ * possible.
  */
 public final class Configuration {
 
@@ -185,6 +187,7 @@ public final class Configuration {
     private String webappLAF;
     private RemoteSCM remoteScmSupported;
     private boolean optimizeDatabase;
+    private boolean quickContextScan;
 
     private LuceneLockName luceneLocking = LuceneLockName.OFF;
     private boolean compressXref;
@@ -287,6 +290,8 @@ public final class Configuration {
     private boolean navigateWindowEnabled;
 
     private SuggesterConfig suggesterConfig = new SuggesterConfig();
+
+    private Set<String> disabledRepositories;
 
     /*
      * types of handling history for remote SCM repositories:
@@ -476,6 +481,7 @@ public final class Configuration {
         setPluginDirectory(null);
         setPluginStack(new AuthorizationStack(AuthControlFlag.REQUIRED, "default stack"));
         setPrintProgress(false);
+        setDisabledRepositories(new HashSet<>());
         setProjects(new ConcurrentHashMap<>());
         setQuickContextScan(true);
         //below can cause an outofmemory error, since it is defaulting to NO LIMIT
@@ -901,8 +907,6 @@ public final class Configuration {
         return allowLeadingWildcard;
     }
 
-    private boolean quickContextScan;
-
     public boolean isQuickContextScan() {
         return quickContextScan;
     }
@@ -1240,6 +1244,14 @@ public final class Configuration {
             throw new IllegalArgumentException("Cannot set Suggester configuration to null");
         }
         this.suggesterConfig = config;
+    }
+
+    public Set<String> getDisabledRepositories() {
+        return disabledRepositories;
+    }
+
+    public void setDisabledRepositories(Set<String> disabledRepositories) {
+        this.disabledRepositories = disabledRepositories;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -977,6 +977,16 @@ public final class RuntimeEnvironment {
         return cmd;
     }
 
+    public void setRepoCmds(Map<String, String> cmds) {
+        Lock writeLock = configLock.writeLock();
+        writeLock.lock();
+        try {
+            configuration.setCmds(cmds);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
     /**
      * Sets the user page for the history listing.
      *
@@ -1367,6 +1377,15 @@ public final class RuntimeEnvironment {
      */
     public short getContextSurround() {
         return (short) getConfigurationValue("contextSurround");
+    }
+
+    @SuppressWarnings("unchecked")
+    public Set<String> getDisabledRepositories() {
+        return (Set<String>) getConfigurationValue("disabledRepositories");
+    }
+
+    public void setDisabledRepositories(Set<String> disabledRepositories) {
+        setConfigurationValue("disabledRepositories", disabledRepositories);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -118,6 +118,7 @@ public final class Indexer {
     private static final HashSet<String> allowedSymlinks = new HashSet<>();
     private static final HashSet<String> canonicalRoots = new HashSet<>();
     private static final Set<String> defaultProjects = new TreeSet<>();
+    private static final HashSet<String> disabledRepositories = new HashSet<>();
     private static RuntimeEnvironment env = null;
     private static String webappURI = null;
 
@@ -161,6 +162,9 @@ public final class Indexer {
             if (awaitProfiler) {
                 pauseToAwaitProfiler();
             }
+
+            disabledRepositories.addAll(cfg.getDisabledRepositories());
+            cfg.setDisabledRepositories(disabledRepositories);
 
             env = RuntimeEnvironment.getInstance();
 
@@ -410,8 +414,8 @@ public final class Indexer {
      * @throws ParseException if parsing failed
      */
     public static String[] parseOptions(String[] argv) throws ParseException {
-        String[] usage = {HELP_OPT_1};
-        String program = "opengrok.jar";
+        final String[] usage = {HELP_OPT_1};
+        final String program = "opengrok.jar";
         final String[] ON_OFF = {ON, OFF};
         final String[] REMOTE_REPO_CHOICES = {ON, OFF, DIRBASED, UIONLY};
         final String[] LUCENE_LOCKS = {ON, OFF, "simple", "native"};
@@ -458,10 +462,10 @@ public final class Indexer {
 
             parser.on(
                 "-A (.ext|prefix.):(-|analyzer)", "--analyzer", "/(\\.\\w+|\\w+\\.):(-|[a-zA-Z_0-9.]+)/",
-                    "Files with the named prefix/extension should be analyzed",
-                    "with the given analyzer, where 'analyzer' may be specified",
-                    "using a simple class name (RubyAnalyzer) or language name (C)",
-                    "(Note, analyzer specification is case-sensitive)",
+                    "Files with the named prefix/extension should be analyzed with the given",
+                    "analyzer, where 'analyzer' may be specified using a simple class name",
+                    "(e.g. RubyAnalyzer) or language name (e.g. C) and is case-sensitive.",
+                    "Option may be repeated.",
                     "  Ex: -A .foo:CAnalyzer",
                     "      will use the C analyzer for all files ending with .FOO",
                     "  Ex: -A bar.:Perl",
@@ -525,6 +529,22 @@ public final class Indexer {
                 "Scanning depth for repositories in directory structure relative to",
                 "source root. Default is " + Configuration.defaultScanningDepth + ".").Do(depth -> {
                 cfg.setScanningDepth((Integer) depth);
+            });
+
+            parser.on("--disableRepository", "=type_name",
+                    "Disables operation of an OpenGrok-supported repository. Option may be",
+                    "repeated.",
+                    "  Ex: --disableRepository git",
+                    "      will disable the GitRepository",
+                    "  Ex: --disableRepository MercurialRepository").Do(v -> {
+                String repoType = (String) v;
+                String repoSimpleType = RepositoryFactory.matchRepositoryByName(repoType);
+                if (repoSimpleType == null) {
+                    System.err.println(String.format(
+                            "'--disableRepository %s' does not match a type and is ignored", v));
+                } else {
+                    disabledRepositories.add(repoSimpleType);
+                }
             });
 
             parser.on("-e", "--economical",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -165,6 +165,9 @@ public final class Indexer {
 
             disabledRepositories.addAll(cfg.getDisabledRepositories());
             cfg.setDisabledRepositories(disabledRepositories);
+            for (String repoName : disabledRepositories) {
+                LOGGER.log(Level.FINEST, "Disabled {0}", repoName);
+            }
 
             env = RuntimeEnvironment.getInstance();
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -163,5 +164,15 @@ public class RepositoryFactoryTest {
             throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException,
             IOException, ForbiddenSymlinkException {
         testNotWorkingRepository("bitkeeper", BitKeeperRepository.CMD_PROPERTY_KEY);
+    }
+
+    @Test
+    public void testRepositoryFactoryEveryImplIsNamedAsRepository() {
+        List<Class<? extends Repository>> repositoryClasses =
+                RepositoryFactory.getRepositoryClasses();
+        for (Class<? extends Repository> clazz : repositoryClasses) {
+            assertTrue("should end with \"Repository\"",
+                    clazz.getSimpleName().endsWith("Repository"));
+        }
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
@@ -105,8 +105,12 @@ public class RepositoryFactoryTest {
 
         File root = new File(repository.getSourceRoot(), "mercurial");
         env.setSourceRoot(root.getAbsolutePath());
-        assertNotNull("should get MercurialRepository",
+        assertNotNull("should get repository for mercurial/",
                 RepositoryFactory.getRepository(root));
+
+        List<Class<? extends Repository>> clazzes = RepositoryFactory.getRepositoryClasses();
+        assertTrue("should contain MercurialRepository",
+                clazzes.contains(MercurialRepository.class));
     }
 
     @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
@@ -120,7 +124,7 @@ public class RepositoryFactoryTest {
 
         File root = new File(repository.getSourceRoot(), "mercurial");
         env.setSourceRoot(root.getAbsolutePath());
-        assertNull("should not get MercurialRepository if disabled",
+        assertNull("should not get repository for mercurial/ if disabled",
                 RepositoryFactory.getRepository(root));
 
         List<Class<? extends Repository>> clazzes = RepositoryFactory.getRepositoryClasses();


### PR DESCRIPTION
Hello,

Please consider for integration this patch to add `--disableRepository <type_name>` handling, which is an easier workaround for #2589 (via `--disableRepository cvs`) versus enhancing ignored-directory handling to support qualifying only a `CVS` directory containing e.g. `cvswrappers`. (A `Configuration` serialization DSL to support this nuanced ignoring did not seem prudent compared to a user-specified disabling of `CVSRepository`.)

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
