### PR TITLE
Fix log suffix to read "linkages"

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.index;
@@ -319,7 +319,7 @@ class PendingFileCompleter {
                         f.getTargetRelPath())).collect(Collectors.toList());
 
         Map<Boolean, List<PendingSymlinkageExec>> bySuccess;
-        try (Progress progress = new Progress(LOGGER, "pending renames", numPending)) {
+        try (Progress progress = new Progress(LOGGER, "pending linkages", numPending)) {
             bySuccess = pendingExecs.parallelStream().collect(
                             Collectors.groupingByConcurrent((x) -> {
                                 progress.increment();


### PR DESCRIPTION
Hello,

Please consider for integration this patch to fix the log message for pending linkages from the recent PR #2947.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
