### PR TITLE
add disabled project handling to mirror.py

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -71,7 +71,11 @@ Besides `/suggester` and `/search` endpoints, everything is accessible from `loc
 
 ### adds message to a system [POST]
 
-Usable values for `cssClass` are: `info`, `warning`, `error`
+Usable values for `cssClass` are: `info`, `warning`, `error`.
+This will affect CSS class of the displayed message, leading to different coloring.
+
+The values in the `tags` list can be: `main` (special value for top level message in the whole web application),
+project name and project group name.
 
 The format of `duration` is the same as Java's java.time.Duration class,
 see https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-

--- a/opengrok-tools/setup.py
+++ b/opengrok-tools/setup.py
@@ -47,6 +47,8 @@ setup(
         'pytest',
         'GitPython',
         'pytest-xdist',
+        'mockito',
+        'pytest-mockito',
     ],
     entry_points={
         'console_scripts': [

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/__init__.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/__init__.py
@@ -7,6 +7,7 @@ from . import readconfig
 from . import utils
 from . import webutil
 from . import exitvals
+from . import restful
 
 __all__ = [
     'opengrok',
@@ -18,4 +19,5 @@ __all__ = [
     'readconfig',
     'parsers',
     'exitvals',
+    'restful',
 ]

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/commandsequence.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/commandsequence.py
@@ -29,6 +29,7 @@ from .exitvals import (
     SUCCESS_EXITVAL
 )
 from .restful import call_rest_api
+from .patterns import PROJECT_SUBST, COMMAND_PROPERTY
 import re
 
 
@@ -72,7 +73,6 @@ class CommandSequenceBase:
 
 
 class CommandSequence(CommandSequenceBase):
-    PROJECT_SUBST = '%PROJECT%'
 
     re_program = re.compile('ERROR[:]*\\s+')
 
@@ -87,11 +87,11 @@ class CommandSequence(CommandSequenceBase):
         """
         Execute a command and return its return code.
         """
-        command_args = command.get("command")
+        command_args = command.get(COMMAND_PROPERTY)
         cmd = Command(command_args,
                       env_vars=command.get("env"),
                       resource_limits=command.get("limits"),
-                      args_subst={self.PROJECT_SUBST: self.name},
+                      args_subst={PROJECT_SUBST: self.name},
                       args_append=[self.name], excl_subst=True)
         cmd.execute()
         self.retcodes[str(cmd)] = cmd.getretcode()
@@ -116,8 +116,8 @@ class CommandSequence(CommandSequenceBase):
         """
 
         for command in self.commands:
-            if is_web_uri(command.get("command")[0]):
-                call_rest_api(command, self.PROJECT_SUBST, self.name)
+            if is_web_uri(command.get(COMMAND_PROPERTY)[0]):
+                call_rest_api(command, PROJECT_SUBST, self.name)
             else:
                 retcode = self.run_command(command)
 
@@ -155,14 +155,14 @@ class CommandSequence(CommandSequenceBase):
             return
 
         for cleanup_cmd in self.cleanup:
-            if is_web_uri(cleanup_cmd.get("command")[0]):
-                call_rest_api(cleanup_cmd, self.PROJECT_SUBST, self.name)
+            if is_web_uri(cleanup_cmd.get(COMMAND_PROPERTY)[0]):
+                call_rest_api(cleanup_cmd, PROJECT_SUBST, self.name)
             else:
-                command_args = cleanup_cmd.get("command")
+                command_args = cleanup_cmd.get(COMMAND_PROPERTY)
                 self.logger.debug("Running cleanup command '{}'".
                                   format(command_args))
                 cmd = Command(command_args,
-                              args_subst={self.PROJECT_SUBST: self.name},
+                              args_subst={PROJECT_SUBST: self.name},
                               args_append=[self.name], excl_subst=True)
                 cmd.execute()
                 if cmd.getretcode() != SUCCESS_EXITVAL:

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/patterns.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/patterns.py
@@ -1,0 +1,25 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+#
+
+PROJECT_SUBST = '%PROJECT%'
+COMMAND_PROPERTY = "command"

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/restful.py
@@ -22,11 +22,13 @@
 #
 
 import logging
-from .webutil import put, post, delete
 import json
 
+from .webutil import put, post, delete
+from .patterns import COMMAND_PROPERTY
 
-def do_api_call(command, uri, headers, json_data):
+
+def do_api_call(command, uri, verb, headers, json_data):
     logger = logging.getLogger(__name__)
 
     if verb == 'PUT':
@@ -50,7 +52,7 @@ def call_rest_api(command, pattern, name):
     :param name: command name
     :return return value from given requests method
     """
-    command = command.get("command")
+    command = command.get(COMMAND_PROPERTY)
     uri = command[0].replace(pattern, name)
     verb = command[1]
     data = command[2]
@@ -64,4 +66,4 @@ def call_rest_api(command, pattern, name):
         json_data = json.dumps(data).replace(pattern, name)
         logger.debug("JSON data: {}".format(json_data))
 
-    return do_api_call(command, uri, headers, json_data)
+    return do_api_call(command, uri, verb, headers, json_data)

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/restful.py
@@ -1,0 +1,67 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+#
+
+import logging
+from .webutil import put, post, delete
+import json
+
+
+def do_api_call(command, uri, headers, json_data):
+    logger = logging.getLogger(__name__)
+
+    if verb == 'PUT':
+        return put(logger, uri, headers=headers, data=json_data)
+    elif verb == 'POST':
+        return post(logger, uri, headers=headers, data=json_data)
+    elif verb == 'DELETE':
+        return delete(logger, uri, headers=headers)
+    else:
+        raise Exception('Unknown HTTP verb in command {}'.
+                        format(command))
+
+
+def call_rest_api(command, pattern, name):
+    """
+    Make RESTful API call. Occurrence of the pattern in the URI
+    (first part of the command) or data payload will be replaced by the name.
+
+    :param command: command (list of URI, HTTP verb, data payload)
+    :param pattern: pattern for command name and/or data substitution
+    :param name: command name
+    :return return value from given requests method
+    """
+    command = command.get("command")
+    uri = command[0].replace(pattern, name)
+    verb = command[1]
+    data = command[2]
+
+    logger = logging.getLogger(__name__)
+
+    headers = None
+    json_data = None
+    if data:
+        headers = {'Content-Type': 'application/json'}
+        json_data = json.dumps(data).replace(pattern, name)
+        logger.debug("JSON data: {}".format(json_data))
+
+    return do_api_call(command, uri, headers, json_data)

--- a/opengrok-tools/src/test/python/test_command_sequence.py
+++ b/opengrok-tools/src/test/python/test_command_sequence.py
@@ -31,6 +31,7 @@ import tempfile
 
 from opengrok_tools.utils.commandsequence import CommandSequence, \
     CommandSequenceBase
+from opengrok_tools.utils.patterns import PROJECT_SUBST
 
 
 def test_str():
@@ -46,9 +47,9 @@ def test_str():
 def test_run_retcodes():
     cmd_list = [{"command": ["/bin/echo"]},
                 {"command": ["/bin/sh", "-c",
-                 "echo " + CommandSequence.PROJECT_SUBST + "; exit 0"]},
+                 "echo " + PROJECT_SUBST + "; exit 0"]},
                 {"command": ["/bin/sh", "-c",
-                 "echo " + CommandSequence.PROJECT_SUBST + "; exit 1"]}]
+                 "echo " + PROJECT_SUBST + "; exit 1"]}]
     cmds = CommandSequence(CommandSequenceBase("opengrok-master", cmd_list))
     cmds.run()
     assert cmds.retcodes == {
@@ -63,7 +64,7 @@ def test_run_retcodes():
                     reason="requires Unix")
 def test_terminate_after_non_zero_code():
     cmd_list = [{"command": ["/bin/sh", "-c",
-                 "echo " + CommandSequence.PROJECT_SUBST + "; exit 255"]},
+                 "echo " + PROJECT_SUBST + "; exit 255"]},
                 {"command": ["/bin/echo"]}]
     cmds = CommandSequence(CommandSequenceBase("opengrok-master", cmd_list))
     cmds.run()
@@ -77,7 +78,7 @@ def test_terminate_after_non_zero_code():
                     reason="requires Unix")
 def test_exit_2_handling():
     cmd_list = [{"command": ["/bin/sh", "-c",
-                 "echo " + CommandSequence.PROJECT_SUBST + "; exit 2"]},
+                 "echo " + PROJECT_SUBST + "; exit 2"]},
                 {"command": ["/bin/echo"]}]
     cmds = CommandSequence(CommandSequenceBase("opengrok-master", cmd_list))
     cmds.run()
@@ -92,13 +93,13 @@ def test_exit_2_handling():
                     reason="requires Unix")
 def test_driveon_flag():
     cmd_list = [{"command": ["/bin/sh", "-c",
-                 "echo " + CommandSequence.PROJECT_SUBST + "; exit 2"]},
+                 "echo " + PROJECT_SUBST + "; exit 2"]},
                 {"command": ["/bin/echo"]},
                 {"command": ["/bin/sh", "-c",
-                             "echo " + CommandSequence.PROJECT_SUBST +
+                             "echo " + PROJECT_SUBST +
                              "; exit 1"]},
                 {"command": ["/bin/sh", "-c",
-                             "echo " + CommandSequence.PROJECT_SUBST]}]
+                             "echo " + PROJECT_SUBST]}]
     cmds = CommandSequence(CommandSequenceBase("opengrok-master",
                                                cmd_list, driveon=True))
     cmds.run()
@@ -113,7 +114,7 @@ def test_driveon_flag():
 @pytest.mark.skipif(not os.path.exists('/bin/echo'),
                     reason="requires Unix")
 def test_project_subst():
-    cmd_list = [{"command": ["/bin/echo", CommandSequence.PROJECT_SUBST]}]
+    cmd_list = [{"command": ["/bin/echo", PROJECT_SUBST]}]
     cmds = CommandSequence(CommandSequenceBase("test-subst", cmd_list))
     cmds.run()
 
@@ -125,7 +126,7 @@ def test_cleanup_exception():
     If cleanup is not a list, Exception should be thrown when initializing
     the CommandSequence object.
     """
-    cleanup = {"cleanup": ["foo", CommandSequence.PROJECT_SUBST]}
+    cleanup = {"cleanup": ["foo", PROJECT_SUBST]}
     with pytest.raises(Exception):
         CommandSequence(CommandSequenceBase("test-cleanup-list", None,
                                             cleanup=cleanup))

--- a/opengrok-tools/src/test/python/test_restful.py
+++ b/opengrok-tools/src/test/python/test_restful.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+#
+
+import pytest
+from opengrok_tools.utils.restful import call_rest_api
+
+
+def test_restful_verbs(monkeypatch):
+    okay_status = 200
+
+    class MockResponse:
+        def __init__(self):
+            self.status_code = okay_status
+
+    def mock_response(command, uri, headers, json_data):
+        # Spying on mocked function is maybe too much so verify
+        # the arguments here.
+        assert uri == "http://localhost:8080/source/api/v1/BAR"
+        assert json_data == '"fooBARbar"'
+
+        return MockResponse()
+
+    for verb in ["PUT", "POST", "DELETE"]:
+        command = {"command": ["http://localhost:8080/source/api/v1/%FOO%",
+                               verb, "foo%FOO%bar"]}
+        pattern = "%FOO%"
+        value = "BAR"
+        with monkeypatch.context() as m:
+            m.setattr("opengrok_tools.utils.restful.do_api_call",
+                      mock_response)
+            assert call_rest_api(command, pattern, value). \
+                status_code == okay_status
+
+
+def test_unknown_verb():
+    command = {"command": ["http://localhost:8080/source/api/v1/foo",
+                           "FOOBAR", "data"]}
+    pattern = "%FOO%"
+    value = "BAR"
+    with pytest.raises(Exception):
+        call_rest_api(command, pattern, value)

--- a/opengrok-tools/src/test/python/test_restful.py
+++ b/opengrok-tools/src/test/python/test_restful.py
@@ -34,7 +34,7 @@ def test_restful_verbs(monkeypatch):
         def __init__(self):
             self.status_code = okay_status
 
-    def mock_response(command, uri, headers, json_data):
+    def mock_response(command, uri, verb, headers, json_data):
         # Spying on mocked function is maybe too much so verify
         # the arguments here.
         assert uri == "http://localhost:8080/source/api/v1/BAR"


### PR DESCRIPTION
This change adds optional command to be called/executed for disabled projects. Like with sync.py this supports both RESTful API calls as well as command execution. This allows for instance to tag the disabled projects with Messages so they are annotated in the UI.

The disabled command is configured globally and will vary based on project thanks to pattern substitution/append. If this is found not to be flexible enough, it can be modified to allow per-project disabled commands however for the time being I find this good enough.

Examples:
### API call:
```yml
disabled_command:                                                               
  command:                                                                     
    - http://localhost:8080/source/api/v1/messages                             
    - POST                                                                     
    - cssClass: info                                                           
      duration: PT1M                                                           
      tags: ['%PROJECT%']                                                      
      text: disabled project                                                   
projects:
  foo:
    disabled: true
```
### command exec:
```yml
disabled_command:                                                               
  command: [cat] 
projects:
  foo:
    disabled: true
```

Any failures in disabled command processing are logged and do not change the overall result of the mirroring command.

https://github.com/oracle/opengrok/wiki/Repository-synchronization will be updated once this is in.