### PR TITLE
Feature/uctags

### DIFF
--- a/dev/checkstyle/suppressions.xml
+++ b/dev/checkstyle/suppressions.xml
@@ -39,6 +39,8 @@ Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
         |JFlexXrefUtils\.java|FileAnalyzerFactory\.java|SearchController\.java|
         |Context\.java|HistoryContext\.java|Suggester\.java" />
 
+    <suppress checks="FileLength" files="RuntimeEnvironment\.java" />
+
     <suppress checks="MethodLength" files="Indexer\.java" />
 
     <suppress checks="JavadocStyle" files="MellonHeaderDecoder\.java|CustomSloppyPhraseScorer\.java|

--- a/dev/install-universal_ctags.sh
+++ b/dev/install-universal_ctags.sh
@@ -2,8 +2,6 @@
 
 git clone https://github.com/universal-ctags/ctags.git
 cd ctags
-# need to use last working version until issue #2977 is resolved.
-git reset --hard 1295de210df49c979f27e185106a7ebc55146c57
 ./autogen.sh
 ./configure && make && make install
 /usr/local/bin/ctags --version

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -148,17 +148,17 @@ public class Ctags implements Resettable {
 
         command = new ArrayList<>();
         command.add(env.getCtags());
-        command.add("--c-kinds=+l");
+        command.add("--kinds-c=+l");
 
         // Workaround for bug #14924: Don't get local variables in Java
         // code since that creates many false positives.
         // CtagsTest : bug14924 "too many methods" guards for this
         // universal ctags are however safe, so enabling for them
-        command.add("--java-kinds=+l");
+        command.add("--kinds-java=+l");
 
-        command.add("--sql-kinds=+l");
-        command.add("--Fortran-kinds=+L");
-        command.add("--C++-kinds=+l");
+        command.add("--kinds-sql=+l");
+        command.add("--kinds-Fortran=+L");
+        command.add("--kinds-C++=+l");
         command.add("--file-scope=yes");
         command.add("-u");
         command.add("--filter=yes");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -144,8 +144,9 @@ public class Ctags implements Resettable {
     }
 
     private void initialize() {
-        command = new ArrayList<>();
+        env.validateUniversalCtags();
 
+        command = new ArrayList<>();
         command.add(env.getCtags());
         command.add("--c-kinds=+l");
 
@@ -250,7 +251,9 @@ public class Ctags implements Resettable {
     }
 
     private void addRustSupport(List<String> command) {
-        command.add("--langdef=rust");
+        if (!env.getCtagsLanguages().contains("Rust")) { // Built-in would be capitalized.
+            command.add("--langdef=rust"); // Lower-case if user-defined.
+        }
         defaultLangMap.add(".RS", "rust"); // Upper-case file spec
 
         // The following are not supported yet in Universal Ctags b13cb551
@@ -264,9 +267,12 @@ public class Ctags implements Resettable {
     }
 
     private void addPowerShellSupport(List<String> command) {
-        command.add("--langdef=powershell");
+        if (!env.getCtagsLanguages().contains("PowerShell")) { // Built-in would be capitalized.
+            command.add("--langdef=powershell"); // Lower-case if user-defined.
+        }
         defaultLangMap.add(".PS1", "powershell"); // Upper-case file spec
         defaultLangMap.add(".PSM1", "powershell"); // Upper-case file spec
+
         command.add("--regex-powershell=/\\$(\\{[^}]+\\})/\\1/v,variable/");
         command.add("--regex-powershell=/\\$([[:alnum:]_]+([:.][[:alnum:]_]+)*)/\\1/v,variable/");
         command.add("--regex-powershell=/^[[:space:]]*(:[^[:space:]]+)/\\1/l,label/");
@@ -283,8 +289,11 @@ public class Ctags implements Resettable {
     }
 
     private void addPascalSupport(List<String> command) {
-        command.add("--langdef=pascal");
+        if (!env.getCtagsLanguages().contains("Pascal")) { // Built-in would be capitalized.
+            command.add("--langdef=pascal"); // Lower-case if user-defined.
+        }
         defaultLangMap.add(".PAS", "pascal"); // Upper-case file spec
+
         command.add("--regex-pascal=/([[:alnum:]_]+)[[:space:]]*=[[:space:]]*\\([[:space:]]*[[:alnum:]_][[:space:]]*\\)/\\1/t,Type/");
         command.add("--regex-pascal=/([[:alnum:]_]+)[[:space:]]*=[[:space:]]*class[[:space:]]*[^;]*$/\\1/c,Class/");
         command.add("--regex-pascal=/([[:alnum:]_]+)[[:space:]]*=[[:space:]]*interface[[:space:]]*[^;]*$/\\1/i,interface/");
@@ -298,7 +307,9 @@ public class Ctags implements Resettable {
     }
 
     private void addSwiftSupport(List<String> command) {
-        command.add("--langdef=swift");
+        if (!env.getCtagsLanguages().contains("Swift")) { // Built-in would be capitalized.
+            command.add("--langdef=swift"); // Lower-case if user-defined.
+        }
         defaultLangMap.add(".SWIFT", "swift"); // Upper-case file spec
         command.add("--regex-swift=/enum[[:space:]]+([^\\{\\}]+).*$/\\1/n,enum,enums/");
         command.add("--regex-swift=/typealias[[:space:]]+([^:=]+).*$/\\1/t,typealias,typealiases/");
@@ -311,9 +322,12 @@ public class Ctags implements Resettable {
     }
 
     private void addKotlinSupport(List<String> command) {
-        command.add("--langdef=kotlin");
+        if (!env.getCtagsLanguages().contains("Kotlin")) { // Built-in would be capitalized.
+            command.add("--langdef=kotlin"); // Lower-case if user-defined.
+        }
         defaultLangMap.add(".KT", "kotlin"); // Upper-case file spec
         defaultLangMap.add(".KTS", "kotlin"); // Upper-case file spec
+
         command.add("--regex-kotlin=/^[[:space:]]*((abstract|final|sealed|implicit|lazy)[[:space:]]*)*" +
                 "(private[^ ]*|protected)?[[:space:]]*class[[:space:]]+([[:alnum:]_:]+)/\\4/c,classes/");
         command.add("--regex-kotlin=/^[[:space:]]*((abstract|final|sealed|implicit|lazy)[[:space:]]*)*" +
@@ -334,8 +348,13 @@ public class Ctags implements Resettable {
         command.add("--regex-kotlin=/^[[:space:]]*import[[:space:]]+([[:alnum:]_.:]+)/\\1/I,imports/");
     }
 
+    /**
+     * Override Clojure support with patterns from https://gist.github.com/kul/8704283.
+     */
     private void addClojureSupport(List<String> command) {
-        command.add("--langdef=clojure"); // clojure support (patterns are from https://gist.github.com/kul/8704283)
+        if (!env.getCtagsLanguages().contains("Clojure")) { // Built-in would be capitalized.
+            command.add("--langdef=clojure"); // Lower-case if user-defined.
+        }
         defaultLangMap.add(".CLJ", "clojure"); // Upper-case file spec
         defaultLangMap.add(".CLJS", "clojure"); // Upper-case file spec
         defaultLangMap.add(".CLJX", "clojure"); // Upper-case file spec
@@ -353,9 +372,12 @@ public class Ctags implements Resettable {
     }
 
     private void addHaskellSupport(List<String> command) {
-        command.add("--langdef=haskell"); // below was added with #912
+        if (!env.getCtagsLanguages().contains("Haskell")) { // Built-in would be capitalized.
+            command.add("--langdef=haskell"); // below added with #912. Lowercase if user-defined.
+        }
         defaultLangMap.add(".HS", "haskell"); // Upper-case file spec
         defaultLangMap.add(".HSC", "haskell"); // Upper-case file spec
+
         command.add("--regex-haskell=/^[[:space:]]*class[[:space:]]+([a-zA-Z0-9_]+)/\\1/c,classes/");
         command.add("--regex-haskell=/^[[:space:]]*data[[:space:]]+([a-zA-Z0-9_]+)/\\1/t,types/");
         command.add("--regex-haskell=/^[[:space:]]*newtype[[:space:]]+([a-zA-Z0-9_]+)/\\1/t,types/");
@@ -367,8 +389,11 @@ public class Ctags implements Resettable {
     }
 
     private void addScalaSupport(List<String> command) {
-        command.add("--langdef=scala"); // below is bug 61 to get full scala support
+        if (!env.getCtagsLanguages().contains("Scala")) { // Built-in would be capitalized.
+            command.add("--langdef=scala"); // below is bug 61 to get full scala support. Lower-case
+        }
         defaultLangMap.add(".SCALA", "scala"); // Upper-case file spec
+
         command.add("--regex-scala=/^[[:space:]]*((abstract|final|sealed|implicit|lazy)[[:space:]]*)*" +
                 "(private|protected)?[[:space:]]*class[[:space:]]+([a-zA-Z0-9_]+)/\\4/c,classes/");
         command.add("--regex-scala=/^[[:space:]]*((abstract|final|sealed|implicit|lazy)[[:space:]]*)*" +

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -59,6 +59,7 @@ public class Ctags implements Resettable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Ctags.class);
 
+    private final RuntimeEnvironment env;
     private volatile boolean closing;
     private final LangTreeMap defaultLangMap = new LangTreeMap();
     private LangMap langMap;
@@ -67,12 +68,15 @@ public class Ctags implements Resettable {
     private OutputStreamWriter ctagsIn;
     private BufferedReader ctagsOut;
     private static final String CTAGS_FILTER_TERMINATOR = "__ctags_done_with_file__";
-    private String binary;
     private String CTagsExtraOptionsFile = null;
     private int tabSize;
     private Duration timeout = Duration.ofSeconds(10);
 
     private boolean junit_testing = false;
+
+    public Ctags() {
+        env = RuntimeEnvironment.getInstance();
+    }
 
     /**
      * Gets a value indicating if a subprocess of ctags was started and it is
@@ -82,14 +86,6 @@ public class Ctags implements Resettable {
      */
     public boolean isClosed() {
         return ctags != null && !ctags.isAlive();
-    }
-
-    public String getBinary() {
-        return binary;
-    }
-
-    public void setBinary(String binary) {
-        this.binary = binary;
     }
 
     public void setLangMap(LangMap langMap) {
@@ -150,7 +146,7 @@ public class Ctags implements Resettable {
     private void initialize() {
         command = new ArrayList<>();
 
-        command.add(binary);
+        command.add(env.getCtags());
         command.add("--c-kinds=+l");
 
         // Workaround for bug #14924: Don't get local variables in Java
@@ -442,7 +438,7 @@ public class Ctags implements Resettable {
              * the ctags process completes so that the indexer can
              * make progress instead of hanging the whole operation.
              */
-            IndexerParallelizer parallelizer = RuntimeEnvironment.getInstance().getIndexerParallelizer();
+            IndexerParallelizer parallelizer = env.getIndexerParallelizer();
             ExecutorService executor = parallelizer.getCtagsWatcherExecutor();
             Future<Definitions> future = executor.submit(() -> {
                 readTags(rdr);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/SwiftAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/SwiftAnalyzer.java
@@ -46,11 +46,11 @@ public class SwiftAnalyzer extends AbstractSourceCodeAnalyzer {
     }
 
     /**
-     * @return {@code "Swift"} to match the OpenGrok-customized definitions
+     * @return {@code "swift"} to match the OpenGrok-customized definitions
      */
     @Override
     public String getCtagsLang() {
-        return "Swift";
+        return "swift";
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -121,6 +122,11 @@ public final class RuntimeEnvironment {
 
     private transient File dtagsEftar = null;
 
+    private transient volatile Boolean ctagsFound;
+    private final transient Set<String> ctagsLanguages = new HashSet<>();
+
+    public WatchDogService watchDog;
+
     /**
      * Creates a new instance of RuntimeEnvironment. Private to ensure a
      * singleton anti-pattern.
@@ -179,8 +185,6 @@ public final class RuntimeEnvironment {
     public static RuntimeEnvironment getInstance() {
         return instance;
     }
-
-    public WatchDogService watchDog;
 
     public IndexerParallelizer getIndexerParallelizer() {
         return lzIndexerParallelizer.get();
@@ -641,8 +645,6 @@ public final class RuntimeEnvironment {
         setConfigurationValue("hitsPerPage", hitsPerPage);
     }
 
-    private transient Boolean ctagsFound;
-
     /**
      * Validate that there is a Universal ctags program.
      *
@@ -650,13 +652,33 @@ public final class RuntimeEnvironment {
      */
     public boolean validateUniversalCtags() {
         if (ctagsFound == null) {
-            if (!CtagsUtil.validate(getCtags())) {
-                ctagsFound = false;
-            } else {
-                ctagsFound = true;
+            String ctagsBinary = getCtags();
+            configLock.writeLock().lock();
+            try {
+                if (ctagsFound == null) {
+                    ctagsFound = CtagsUtil.validate(ctagsBinary);
+                    if (ctagsFound) {
+                        List<String> languages = CtagsUtil.getLanguages(ctagsBinary);
+                        if (languages != null) {
+                            ctagsLanguages.addAll(languages);
+                        }
+                    }
+                }
+            } finally {
+                configLock.writeLock().unlock();
             }
         }
         return ctagsFound;
+    }
+
+    /**
+     * Gets the base set of supported Ctags languages.
+     * @return a defined set which may be empty if
+     * {@link #validateUniversalCtags()} has not yet been called or if the call
+     * fails
+     */
+    public Set<String> getCtagsLanguages() {
+        return Collections.unmodifiableSet(ctagsLanguages);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -742,9 +742,7 @@ public class IndexDatabase {
         if (env.getCtagsTimeout() != 0) {
             ctags.setTimeout(env.getCtagsTimeout());
         }
-        if (ctags.getBinary() != null) {
-            fa.setCtags(ctags);
-        }
+        fa.setCtags(ctags);
         fa.setProject(Project.getProject(path));
         fa.setScopesEnabled(env.isScopesEnabled());
         fa.setFoldingEnabled(env.isFoldingEnabled());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -447,12 +447,16 @@ public final class Indexer {
         // An example of how to add a data type for option parsing
         OptionParser.accept(WebAddress.class, Indexer::parseWebAddress);
 
+        // Limit usage lines to 72 characters for concise formatting.
+
         optParser = OptionParser.Do(parser -> {
             parser.setPrologue(
                 String.format("\nUsage: java -jar %s [options] [subDir1 [...]]\n", program));
 
             parser.on(HELP_OPT_3, Indexer.HELP_OPT_2, HELP_OPT_1,
-                    "Display this usage summary. Repeat for more detailed help.").Do(v -> {
+                    "Display this usage summary.",
+                    "    Repeat once for configuration.xml samples.",
+                    "    Repeat twice for ctags command-line.").Do(v -> {
                         ++help;
                         helpUsage = parser.getUsage();
             });

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 import org.opengrok.indexer.Info;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.analysis.AnalyzerGuruHelp;
+import org.opengrok.indexer.analysis.Ctags;
 import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.configuration.ConfigurationHelp;
 import org.opengrok.indexer.configuration.LuceneLockName;
@@ -64,6 +65,7 @@ import org.opengrok.indexer.history.RepositoryInfo;
 import org.opengrok.indexer.index.IndexVersion.IndexVersionException;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.logger.LoggerUtil;
+import org.opengrok.indexer.util.CtagsUtil;
 import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.OptionParser;
 import org.opengrok.indexer.util.Statistics;
@@ -107,9 +109,8 @@ public final class Indexer {
     private static boolean bareConfig = false;
     private static boolean awaitProfiler;
 
-    private static boolean help;
+    private static int help;
     private static String helpUsage;
-    private static boolean helpDetailed;
 
     private static String configFilename = null;
     private static int status = 0;
@@ -146,12 +147,15 @@ public final class Indexer {
 
         try {
             argv = parseOptions(argv);
-            if (help) {
+            if (help > 0) {
                 PrintStream helpStream = status != 0 ? System.err : System.out;
                 helpStream.println(helpUsage);
-                if (helpDetailed) {
+                if (help > 1) {
                     helpStream.println(AnalyzerGuruHelp.getUsage());
                     helpStream.println(ConfigurationHelp.getSamples());
+                }
+                if (help > 2) {
+                    helpStream.println(getCtagsCommand());
                 }
                 System.exit(status);
             }
@@ -425,13 +429,13 @@ public final class Indexer {
          * Pre-match any of the --help options so that some possible exception-
          * generating args handlers (e.g. -R) can be short-circuited.
          */
-        help = Arrays.stream(argv).anyMatch(s -> HELP_OPT_1.equals(s) ||
+        boolean preHelp = Arrays.stream(argv).anyMatch(s -> HELP_OPT_1.equals(s) ||
                 HELP_OPT_2.equals(s) || HELP_OPT_3.equals(s));
 
         OptionParser configure = OptionParser.scan(parser -> {
             parser.on("-R configPath").Do(cfgFile -> {
                 try {
-                    if (!help) {
+                    if (!preHelp) {
                         cfg = Configuration.read(new File((String) cfgFile));
                     }
                 } catch (IOException e) {
@@ -448,13 +452,10 @@ public final class Indexer {
                 String.format("\nUsage: java -jar %s [options] [subDir1 [...]]\n", program));
 
             parser.on(HELP_OPT_3, Indexer.HELP_OPT_2, HELP_OPT_1,
-                    "Display this usage summary.").Do(v -> {
-                help = true;
-                helpUsage = parser.getUsage();
+                    "Display this usage summary. Repeat for more detailed help.").Do(v -> {
+                        ++help;
+                        helpUsage = parser.getUsage();
             });
-
-            parser.on("--detailed",
-                "Display additional help with -h,--help.").Do(v -> helpDetailed = true);
 
             parser.on(
                 "-A (.ext|prefix.):(-|analyzer)", "--analyzer", "/(\\.\\w+|\\w+\\.):(-|[a-zA-Z_0-9.]+)/",
@@ -1114,6 +1115,36 @@ public final class Indexer {
         if (in.equals("n")) {
             System.exit(1);
         }
+    }
+
+    private static String getCtagsCommand() {
+        StringBuilder result = new StringBuilder();
+        Ctags ctags = CtagsUtil.newInstance(env);
+        List<String> argv = ctags.getArgv();
+        for (int i = 0; i < argv.size(); ++i) {
+            if (i > 0) {
+                result.append("\t");
+            }
+            String arg = argv.get(i);
+            if (arg == null) {
+                result.append("UNDEFINED");
+            } else {
+                result.append(maybeEscapeForSh(arg));
+            }
+            if (i + 1 < argv.size()) {
+                result.append(" \\");
+            }
+            result.append("\n");
+        }
+        return result.toString();
+    }
+
+    private static String maybeEscapeForSh(String value) {
+        if (!value.matches(".*[^-:.+=a-zA-Z0-9_].*")) {
+            return value;
+        }
+        return "$'" + value.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").
+                replace("\r", "\\r").replace("\t", "\\t") + "'";
     }
 
     private Indexer() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
@@ -250,10 +250,10 @@ public class IndexerParallelizer implements AutoCloseable {
                 Executors.newFixedThreadPool(env.getHistoryRenamedParallelism()));
     }
 
-    private static class CtagsObjectFactory implements ObjectFactory<Ctags> {
+    private class CtagsObjectFactory implements ObjectFactory<Ctags> {
 
         public Ctags createNew() {
-            return CtagsUtil.newInstance(RuntimeEnvironment.getInstance());
+            return CtagsUtil.newInstance(env);
         }
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
@@ -19,10 +19,14 @@
 
 /*
  * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.util;
 
+import org.opengrok.indexer.analysis.AnalyzerGuru;
+import org.opengrok.indexer.analysis.Ctags;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 
 import java.util.logging.Level;
@@ -54,6 +58,31 @@ public class CtagsUtil {
         return true;
     }
 
-    private CtagsUtil() {
+    /**
+     * Creates a new instance, and attempts to configure it from the
+     * environment.
+     * @return a defined instance, possibly with a {@code null} ctags binary
+     * setting if a value was not available from {@link RuntimeEnvironment}.
+     */
+    public static Ctags newInstance(RuntimeEnvironment env) {
+        Ctags ctags = new Ctags();
+
+        String ctagsBinary = env.getCtags();
+        if (ctagsBinary == null) {
+            LOGGER.severe("Unable to run ctags! Searching definitions will not work!");
+        } else {
+            ctags.setBinary(ctagsBinary);
+            ctags.setLangMap(AnalyzerGuru.getLangMap());
+
+            String filename = env.getCTagsExtraOptionsFile();
+            if (filename != null) {
+                ctags.setCTagsExtraOptionsFile(filename);
+            }
         }
+        return ctags;
+    }
+
+    /** Private to enforce static. */
+    private CtagsUtil() {
+    }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis;
@@ -34,7 +34,6 @@ import org.junit.Test;
 import org.opengrok.indexer.condition.ConditionalRun;
 import org.opengrok.indexer.condition.ConditionalRunRule;
 import org.opengrok.indexer.condition.CtagsInstalled;
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.TestRepository;
 
 /**
@@ -53,7 +52,6 @@ public class CtagsTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         ctags = new Ctags();
-        ctags.setBinary(RuntimeEnvironment.getInstance().getCtags());
 
         repository = new TestRepository();
         repository.create(CtagsTest.class.getResourceAsStream(
@@ -71,7 +69,7 @@ public class CtagsTest {
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {        
+    public static void tearDownClass() {
         ctags.close();
         ctags = null;
         repository.destroy();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/JFlexXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/JFlexXrefTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis;
@@ -61,7 +61,6 @@ import org.opengrok.indexer.analysis.uue.UuencodeXref;
 import org.opengrok.indexer.condition.ConditionalRun;
 import org.opengrok.indexer.condition.ConditionalRunRule;
 import org.opengrok.indexer.condition.CtagsInstalled;
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
 import org.opengrok.indexer.util.TestRepository;
 import org.xml.sax.InputSource;
@@ -87,14 +86,13 @@ public class JFlexXrefTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         ctags = new Ctags();
-        ctags.setBinary(RuntimeEnvironment.getInstance().getCtags());
         repository = new TestRepository();
         repository.create(JFlexXrefTest.class.getResourceAsStream(
                 "/org/opengrok/indexer/index/source.zip"));
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {
+    public static void tearDownClass() {
         ctags.close();
         ctags = null;
         repository.destroy();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CAnalyzerFactoryTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.c;
 
@@ -80,7 +80,6 @@ public class CAnalyzerFactoryTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         ctags = new Ctags();
-        ctags.setBinary(RuntimeEnvironment.getInstance().getCtags());
 
         repository = new TestRepository();
         repository.create(CAnalyzerFactoryTest.class.getResourceAsStream(
@@ -95,7 +94,7 @@ public class CAnalyzerFactoryTest {
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {
+    public static void tearDownClass() {
         ctags.close();
         ctags = null;
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CxxAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CxxAnalyzerFactoryTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.c;
 
@@ -80,7 +80,6 @@ public class CxxAnalyzerFactoryTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         ctags = new Ctags();
-        ctags.setBinary(RuntimeEnvironment.getInstance().getCtags());
 
         repository = new TestRepository();
         repository.create(CxxAnalyzerFactoryTest.class.getResourceAsStream(
@@ -95,7 +94,7 @@ public class CxxAnalyzerFactoryTest {
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {
+    public static void tearDownClass() {
         ctags.close();
         ctags = null;
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzerFactoryTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.clojure;
 
@@ -77,7 +77,6 @@ public class ClojureAnalyzerFactoryTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         ctags = new Ctags();
-        ctags.setBinary(RuntimeEnvironment.getInstance().getCtags());
 
         repository = new TestRepository();
         repository.create(ClojureAnalyzerFactoryTest.class.getResourceAsStream(

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzerFactoryTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.csharp;
 
@@ -76,7 +76,6 @@ public class CSharpAnalyzerFactoryTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         ctags = new Ctags();
-        ctags.setBinary(RuntimeEnvironment.getInstance().getCtags());
 
         repository = new TestRepository();
         repository.create(CSharpAnalyzerFactoryTest.class.getResourceAsStream(
@@ -91,7 +90,7 @@ public class CSharpAnalyzerFactoryTest {
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {
+    public static void tearDownClass() {
         ctags.close();
         ctags = null;
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/java/JavaAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/java/JavaAnalyzerFactoryTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2015, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.java;
 
@@ -80,7 +80,6 @@ public class JavaAnalyzerFactoryTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         ctags = new Ctags();
-        ctags.setBinary(RuntimeEnvironment.getInstance().getCtags());
 
         repository = new TestRepository();
         repository.create(JavaAnalyzerFactoryTest.class.getResourceAsStream(
@@ -95,15 +94,13 @@ public class JavaAnalyzerFactoryTest {
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {
+    public static void tearDownClass() {
         ctags.close();
         ctags = null;
     }
 
     /**
      * Test of writeXref method, of class CAnalyzerFactory.
-     *
-     * @throws java.lang.Exception
      */
     @Test
     public void testScopeAnalyzer() throws Exception {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzerFactoryTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.pascal;
 
@@ -78,7 +78,6 @@ public class PascalAnalyzerFactoryTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         ctags = new Ctags();
-        ctags.setBinary(RuntimeEnvironment.getInstance().getCtags());        
 
         repository = new TestRepository();
         repository.create(PascalAnalyzerFactoryTest.class.getResourceAsStream(
@@ -93,7 +92,7 @@ public class PascalAnalyzerFactoryTest {
     }
 
     @AfterClass
-    public static void tearDownClass() throws Exception {
+    public static void tearDownClass() {
         ctags.close();
         ctags = null;
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/CtagsUtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/CtagsUtilTest.java
@@ -33,6 +33,9 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
 import java.util.List;
 
+/**
+ * Represents a container for tests of {@link CtagsUtil}.
+ */
 @ConditionalRun(CtagsInstalled.class)
 public class CtagsUtilTest {
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/CtagsUtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/CtagsUtilTest.java
@@ -1,0 +1,48 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.util;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.opengrok.indexer.condition.ConditionalRun;
+import org.opengrok.indexer.condition.CtagsInstalled;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+
+import java.util.List;
+
+@ConditionalRun(CtagsInstalled.class)
+public class CtagsUtilTest {
+
+    @Test
+    public void getLanguages() {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        List<String> result = CtagsUtil.getLanguages(env.getCtags());
+        assertNotNull("should get Ctags languages", result);
+        assertTrue("Ctags languages should contains C++", result.contains("C++"));
+        // Test that the [disabled] tag is stripped for OldC.
+        assertTrue("Ctags languages should contains OldC", result.contains("OldC"));
+    }
+}


### PR DESCRIPTION
Hello,

Please consider for integration this patch to accommodate the recent Universal Ctags strictness of language definitions by running an additional `ctags --list-languages` during the verification stage and only declaring `--langdef` if required by the Ctags version.

I also switched away from the newly deprecated syntax `--LANG-kinds` to `--kinds-LANG`.

To aid initial debugging, I updated `Indexer --help` to show the Ctags command-line when an extra level of detail is requested. This changes `--help --detailed` to instead show more details when `-h,--help` is specified an increasing number of times. I'm open to suggestions if this seems clunky.

Thank you.
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
