### PR TITLE
specify which Messages to delete with text

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -93,6 +93,10 @@ see https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java
 
 ### deletes messages with specified tag [DELETE]
 
++ Request (application/text)
+
+        string value of the message text - only messages with the text (and specified tag) will be deleted
+
 + Parameters
   + tag (string) - tag
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1935,11 +1935,11 @@ public final class RuntimeEnvironment {
 
     /**
      * Remove all messages containing at least one of the tags.
-     *
      * @param tags set of tags
+     * @param text message text (can be null, empty)
      */
-    public void removeAnyMessage(final Set<String> tags) {
-        messagesContainer.removeAnyMessage(tags);
+    public void removeAnyMessage(final Set<String> tags, final String text) {
+        messagesContainer.removeAnyMessage(tags, text);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/Message.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/Message.java
@@ -112,6 +112,19 @@ public class Message implements Comparable<Message>, JSONable {
         return !tmp.isEmpty();
     }
 
+    /**
+     * @param tags set of tags to check
+     * @param text message text
+     * @return true if a mesage has at least one of the tags and text
+     */
+    public boolean hasTagsAndText(Set<String> tags, String text) {
+        if (text == null || text.isEmpty()) {
+            return hasAny(tags);
+        }
+
+        return hasAny(tags) && getText().equals(text);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/MessagesContainer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/messages/MessagesContainer.java
@@ -167,6 +167,13 @@ public class MessagesContainer {
         removeAnyMessage(t -> t.getMessage().hasAny(tags));
     }
 
+    public void removeAnyMessage(Set<String> tags, String text) {
+        if (tags == null) {
+            return;
+        }
+        removeAnyMessage(t -> t.getMessage().hasTagsAndText(tags, text));
+    }
+
     /**
      * Remove messages which have expired.
      */

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/restful.py
@@ -29,17 +29,16 @@ from .patterns import COMMAND_PROPERTY
 
 
 def do_api_call(command, uri, verb, headers, data):
-    logger = logging.getLogger(__name__)
-
-    if verb == 'PUT':
-        return put(logger, uri, headers=headers, data=data)
-    elif verb == 'POST':
-        return post(logger, uri, headers=headers, data=data)
-    elif verb == 'DELETE':
-        return delete(logger, uri, headers=headers, data=data)
-    else:
-        raise Exception('Unknown HTTP verb in command {}'.
-                        format(command))
+    verbs = {
+        'PUT': put,
+        'POST': post,
+        'DELETE': delete
+    }
+    handler = verbs.get(verb)
+    if handler is not None:
+        logger = logging.getLogger(__name__)
+        return handler(logger, uri, headers=headers, data=data)
+    raise Exception('Unknown HTTP verb in command {}'.format(command))
 
 
 def call_rest_api(command, pattern, name):

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/restful.py
@@ -28,6 +28,10 @@ from .webutil import put, post, delete
 from .patterns import COMMAND_PROPERTY
 
 
+CONTENT_TYPE = 'Content-Type'
+APPLICATION_JSON = 'application/json'   # default
+
+
 def do_api_call(command, uri, verb, headers, data):
     verbs = {
         'PUT': put,
@@ -53,19 +57,25 @@ def call_rest_api(command, pattern, name):
     :param name: command name
     :return return value from given requests method
     """
+
+    logger = logging.getLogger(__name__)
+
     command = command.get(COMMAND_PROPERTY)
-    uri = command[0].replace(pattern, name)
+    if pattern and name:
+        uri = command[0].replace(pattern, name)
+    else:
+        uri = command[0]
+
     verb = command[1]
     data = command[2]
+
     try:
         headers = command[3]
     except IndexError:
         headers = {}
 
-    logger = logging.getLogger(__name__)
-
-    CONTENT_TYPE = 'Content-Type'
-    APPLICATION_JSON = 'application/json'   # default
+    if not headers:
+        headers = {}
 
     header_names = [x.lower() for x in headers.keys()]
 
@@ -82,7 +92,8 @@ def call_rest_api(command, pattern, name):
                     data = json.dumps(data)
                 break
 
-        data = data.replace(pattern, name)
+        if pattern and name:
+            data = data.replace(pattern, name)
         logger.debug("entity data: {}".format(data))
 
     logger.debug("{} API call: {} with data '{}' and headers: {}".

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/restful.py
@@ -60,22 +60,26 @@ def call_rest_api(command, pattern, name):
 
     logger = logging.getLogger(__name__)
 
-    command = command.get(COMMAND_PROPERTY)
-    if pattern and name:
-        uri = command[0].replace(pattern, name)
-    else:
-        uri = command[0]
+    if not isinstance(command, dict) or command.get(COMMAND_PROPERTY) is None:
+        raise Exception("invalid command")
 
-    verb = command[1]
-    data = command[2]
+    command = command[COMMAND_PROPERTY]
 
+    uri, verb, data, *_ = command
+    if verb not in ['PUT', 'POST', 'DELETE']:
+        raise Exception("invalid verb: {}".format(verb))
     try:
         headers = command[3]
+        if headers and not isinstance(headers, dict):
+            raise Exception("headers must be a dictionary")
     except IndexError:
         headers = {}
 
-    if not headers:
+    if headers is None:
         headers = {}
+
+    if pattern and name:
+        uri = uri.replace(pattern, name)
 
     header_names = [x.lower() for x in headers.keys()]
 

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/webutil.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/webutil.py
@@ -35,10 +35,10 @@ def get(logger, uri, params=None, headers=None):
         return None
 
 
-def delete(logger, uri, params=None, headers=None):
+def delete(logger, uri, params=None, headers=None, data=None):
     try:
         proxies = get_proxies(uri)
-        return requests.delete(uri, params=params, proxies=proxies)
+        return requests.delete(uri, data=data, params=params, proxies=proxies)
     except Exception:
         logger.debug(traceback.format_exc())
         return None

--- a/opengrok-tools/src/test/python/test_restful.py
+++ b/opengrok-tools/src/test/python/test_restful.py
@@ -27,7 +27,10 @@ import pytest
 from opengrok_tools.utils.restful import call_rest_api
 
 
-def test_restful_verbs(monkeypatch):
+def test_replacement(monkeypatch):
+    """
+    Test replacement performed both in the URL and data.
+    """
     okay_status = 200
 
     class MockResponse:

--- a/opengrok-tools/src/test/python/test_restful.py
+++ b/opengrok-tools/src/test/python/test_restful.py
@@ -26,6 +26,7 @@
 import pytest
 from opengrok_tools.utils.restful import call_rest_api,\
     CONTENT_TYPE, APPLICATION_JSON
+from opengrok_tools.utils.patterns import COMMAND_PROPERTY
 
 
 def test_replacement(monkeypatch):
@@ -88,3 +89,18 @@ def test_headers(monkeypatch):
                 m.setattr("opengrok_tools.utils.restful.do_api_call",
                           mock_response)
                 call_rest_api(command, None, None)
+
+
+def test_invalid_command_negative():
+    with pytest.raises(Exception):
+        call_rest_api(None, None, None)
+
+    with pytest.raises(Exception):
+        call_rest_api({"foo": "bar"}, None, None)
+
+    with pytest.raises(Exception):
+        call_rest_api(["foo", "bar"], None, None)
+
+    with pytest.raises(Exception):
+        call_rest_api({COMMAND_PROPERTY: ["foo", "PUT", "data", "headers"]},
+                      None, None)

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/MessagesController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/MessagesController.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.controller;
 
@@ -54,11 +54,12 @@ public class MessagesController {
     }
 
     @DELETE
-    public void removeMessagesWithTag(@QueryParam("tag") final String tag) {
+    @Consumes(MediaType.TEXT_PLAIN)
+    public void removeMessagesWithTag(@QueryParam("tag") final String tag, final String text) {
         if (tag == null) {
             throw new WebApplicationException("Message tag has to be specified", Response.Status.BAD_REQUEST);
         }
-        env.removeAnyMessage(Collections.singleton(tag));
+        env.removeAnyMessage(Collections.singleton(tag), text);
     }
 
     @GET

--- a/plugins/src/main/java/opengrok/auth/plugin/util/RestfulClient.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/util/RestfulClient.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Simple RESTful client code for PUT requests.
+ * Simple RESTful client.
  */
 public class RestfulClient {
     private static final Logger LOGGER = Logger.getLogger(RestfulClient.class.getName());


### PR DESCRIPTION
Trying to use the `opengrok-mirror` handling of disabled projects (#2973) I discovered this gets blocked by cleanup handling in `opengrok-sync` configuration:
```yml
commands:
- command:
  - http://localhost:8080/source/api/v1/messages
  - POST
  - cssClass: info
    duration: PT1H
    tags: ['%PROJECT%']
    text: resync + reindex in progress

... opengrok-mirror with disabled project handling emits the message

cleanup:
  - command: ['http://localhost:8080/source/api/v1/messages?tag=%PROJECT%', DELETE, '']
```
To make this possible, I extended the `DELETE` handling in `MessagesController` to accept entity body (this is possible due to HTTP 1.1 spec RFC 7231 as explained on https://stackoverflow.com/questions/299628/is-an-entity-body-allowed-for-an-http-delete-request?rq=1) and match also on that.

Tested with Tomcat 8.5 and curl (both allow DELETE requests with body out of the box).