### PR TITLE
better -J help for python java wrappers

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/utils/parsers.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/parsers.py
@@ -43,7 +43,9 @@ def get_java_parser():
     parser.add_argument('-j', '--java',
                         help='path to java binary')
     parser.add_argument('-J', '--java_opts',
-                        help='java options', action='append')
+                        help='java options. Use one for every java option, '
+                             'e.g. -J=-server -J=-Xmx16g',
+                        action='append')
     parser.add_argument('-e', '--environment', action='append',
                         help='Environment variables in the form of name=value')
     parser.add_argument('--doprint', type=str2bool, nargs=1, default=None,


### PR DESCRIPTION
expands on how to use -J with multiple `java` options.
