### PR TITLE
Rewrite Dockerfile to build the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,6 @@ jobs:
     services:
     - docker
     before_install: dev/before_install
-    before_script: ./mvnw -DskipTests=true -Dmaven.javadoc.skip=true -B -V package
     script: dev/docker.sh
   - stage: javadoc
     name: Upload javadocs to Github pages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,59 @@
-FROM debian:stable-slim as fetcher
+# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
-# TODO copy just the 'distribution' directory, not all source code
+FROM ubuntu:bionic as build
+
+RUN apt-get update && apt-get install -y openjdk-8-jdk python3 maven python3-venv
+
+# Create a first layer to cache the "Maven World" in the local repository.
+# Incremental docker builds will always resume after that, unless you update the pom
+WORKDIR /mvn
+COPY pom.xml /mvn/
+COPY opengrok-indexer/pom.xml /mvn/opengrok-indexer/
+COPY opengrok-web/pom.xml /mvn/opengrok-web/
+COPY plugins/pom.xml /mvn/plugins/
+COPY suggester/pom.xml /mvn/suggester/
+
+# distribution and opengrok-tools do not have dependencies to cache
+RUN sed -i 's:<module>distribution</module>::g' /mvn/pom.xml
+RUN sed -i 's:<module>opengrok-tools</module>::g' /mvn/pom.xml
+
+RUN mkdir -p /mvn/opengrok-indexer/target/jflex-sources
+RUN mkdir -p /mvn/opengrok-web/src/main/webapp
+COPY opengrok-indexer/jflex-tt.txt /mvn/opengrok-indexer/jflex-tt.txt
+COPY opengrok-indexer/jflex-tt-end.txt /mvn/opengrok-indexer/jflex-tt-end.txt
+COPY opengrok-indexer/jflex-code.txt /mvn/opengrok-indexer/jflex-code.txt
+COPY opengrok-indexer/jflex-code-end.txt /mvn/opengrok-indexer/jflex-code-end.txt
+RUN mkdir -p /mvn/opengrok-web/src/main/webapp/WEB-INF/ && touch /mvn/opengrok-web/src/main/webapp/WEB-INF/web.xml
+
+# dummy build to cache the dependencies
+RUN mvn package -DskipTests -Dcheckstyle.skip -Dmaven.antrun.skip
+
+# build the project
 COPY ./ /opengrok-source
 WORKDIR /opengrok-source
 
-# update the system
-RUN apt-get update
-
-# find most recent package file
-RUN cp `ls -t distribution/target/*.tar.gz | head -n1 |awk '{printf("%s",$0)}'` /opengrok.tar.gz
+RUN mvn -DskipTests=true -Dmaven.javadoc.skip=true -B -V package
+RUN cp distribution/target/*.tar.gz /opengrok.tar.gz
 
 FROM tomcat:9-jre8
-LABEL maintainer "opengrok-dev@yahoogroups.com"
-
-# prepare OpenGrok binaries and directories
-COPY --from=fetcher opengrok.tar.gz /opengrok.tar.gz
-RUN mkdir -p /opengrok /opengrok/etc /opengrok/data /opengrok/src && \
-    tar -zxvf /opengrok.tar.gz -C /opengrok --strip-components 1 && \
-    rm -f /opengrok.tar.gz
+LABEL maintainer="opengrok-dev@yahoogroups.com"
 
 # install dependencies and Python tools
-RUN apt-get update && apt-get install -y git subversion mercurial unzip inotify-tools python3 python3-pip python3-venv && \
-    python3 -m pip install /opengrok/tools/opengrok-tools*
+RUN apt-get update && apt-get install -y git subversion mercurial unzip inotify-tools python3 python3-pip python3-venv
 
 # compile and install universal-ctags
 RUN apt-get install -y pkg-config autoconf build-essential && git clone https://github.com/universal-ctags/ctags /root/ctags && \
     cd /root/ctags && ./autogen.sh && ./configure && make && make install && \
     apt-get remove -y autoconf build-essential && apt-get -y autoremove && apt-get -y autoclean && \
     cd /root && rm -rf /root/ctags
+
+# prepare OpenGrok binaries and directories
+COPY --from=build opengrok.tar.gz /opengrok.tar.gz
+RUN mkdir -p /opengrok /opengrok/etc /opengrok/data /opengrok/src && \
+    tar -zxvf /opengrok.tar.gz -C /opengrok --strip-components 1 && \
+    rm -f /opengrok.tar.gz
+
+RUN python3 -m pip install /opengrok/tools/opengrok-tools*
 
 # environment variables
 ENV SRC_ROOT /opengrok/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM ubuntu:bionic as build
 
-RUN apt-get update && apt-get install -y openjdk-8-jdk python3 maven python3-venv
+RUN apt-get update && apt-get install -y openjdk-8-jdk maven python3 python3-venv
 
 # Create a first layer to cache the "Maven World" in the local repository.
 # Incremental docker builds will always resume after that, unless you update the pom

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY opengrok-indexer/jflex-code-end.txt /mvn/opengrok-indexer/jflex-code-end.tx
 RUN mkdir -p /mvn/opengrok-web/src/main/webapp/WEB-INF/ && touch /mvn/opengrok-web/src/main/webapp/WEB-INF/web.xml
 
 # dummy build to cache the dependencies
-RUN mvn package -DskipTests -Dcheckstyle.skip -Dmaven.antrun.skip
+RUN mvn -DskipTests -Dcheckstyle.skip -Dmaven.antrun.skip package
 
 # build the project
 COPY ./ /opengrok-source


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

I've seen that it is quite common to build projects directly in `Dockerfile` so I thought I will give it a try. It is then very useful in `docker-compose` since you can build many things by a single command.

If the maven repositories are cached, then it takes about 6 minutes to build the whole docker image. But if travis does not use cache and builds it all from scratch, then it may significantly prolong the travis execution time which might not be that wise.

What do you guys think?

If you do not like it, then feel free to close it :)