### PR TITLE
Format argv logging to aid copy/paste execution

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -47,7 +47,9 @@ import java.util.logging.Logger;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.index.IndexerParallelizer;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.IOUtils;
+import org.opengrok.indexer.util.PlatformUtils;
 import org.opengrok.indexer.util.SourceSplitter;
 
 /**
@@ -214,11 +216,7 @@ public class Ctags implements Resettable {
     }
 
     private void run() throws IOException {
-        StringBuilder sb = new StringBuilder();
-        for (String s : command) {
-            sb.append(s).append(" ");
-        }
-        String commandStr = sb.toString();
+        String commandStr = Executor.escapeForShell(command, false, PlatformUtils.isWindows());
         LOGGER.log(Level.FINE, "Executing ctags command [{0}]", commandStr);
 
         ProcessBuilder processBuilder = new ProcessBuilder(command);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -69,6 +69,7 @@ import org.opengrok.indexer.logger.LoggerUtil;
 import org.opengrok.indexer.util.CtagsUtil;
 import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.OptionParser;
+import org.opengrok.indexer.util.PlatformUtils;
 import org.opengrok.indexer.util.Statistics;
 
 /**
@@ -1121,29 +1122,8 @@ public final class Indexer {
     }
 
     private static String getCtagsCommand() {
-        StringBuilder result = new StringBuilder();
         Ctags ctags = CtagsUtil.newInstance(env);
-        List<String> argv = ctags.getArgv();
-        for (int i = 0; i < argv.size(); ++i) {
-            if (i > 0) {
-                result.append("\t");
-            }
-            String arg = argv.get(i);
-            result.append(maybeEscapeForSh(arg));
-            if (i + 1 < argv.size()) {
-                result.append(" \\");
-            }
-            result.append("\n");
-        }
-        return result.toString();
-    }
-
-    private static String maybeEscapeForSh(String value) {
-        if (!value.matches(".*[^-:.+=a-zA-Z0-9_].*")) {
-            return value;
-        }
-        return "$'" + value.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").
-                replace("\r", "\\r").replace("\t", "\\t") + "'";
+        return Executor.escapeForShell(ctags.getArgv(), true, PlatformUtils.isWindows());
     }
 
     private Indexer() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.util;
@@ -39,6 +40,9 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 
@@ -50,6 +54,10 @@ import org.opengrok.indexer.logger.LoggerFactory;
 public class Executor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Executor.class);
+
+    private static final Pattern ARG_WIN_QUOTING = Pattern.compile("[^-:.+=%a-zA-Z0-9_/\\\\]");
+    private static final Pattern ARG_UNIX_QUOTING = Pattern.compile("[^-:.+=%a-zA-Z0-9_/]");
+    private static final Pattern ARG_GNU_STYLE_EQ = Pattern.compile("^--[-.a-zA-Z0-9_]+=");
 
     private List<String> cmdList;
     private File workingDirectory;
@@ -147,7 +155,8 @@ public class Executor {
     public int exec(final boolean reportExceptions, StreamHandler handler) {
         int ret = -1;
         ProcessBuilder processBuilder = new ProcessBuilder(cmdList);
-        final String cmd_str = processBuilder.command().toString();
+        final String cmd_str = escapeForShell(processBuilder.command(), false,
+                PlatformUtils.isWindows());
         final String dir_str;
         Timer timer = null; // timer for timing out the process
 
@@ -172,7 +181,7 @@ public class Executor {
             env_str = " with environment: " + env_map.toString();
         }
         LOGGER.log(Level.FINE,
-                "Executing command {0} in directory {1}{2}",
+                "Executing command [{0}] in directory {1}{2}",
                 new Object[] {cmd_str, dir_str, env_str});
 
         Process process = null;
@@ -191,7 +200,7 @@ public class Executor {
                     } catch (IOException ex) {
                         if (reportExceptions) {
                             LOGGER.log(Level.SEVERE,
-                                    "Error while executing command {0} in directory {1}",
+                                    "Error while executing command [{0}] in directory {1}",
                                     new Object[] {cmd_str, dir_str});
                             LOGGER.log(Level.SEVERE, "Error during process pipe listening", ex);
                         }
@@ -211,7 +220,7 @@ public class Executor {
                 timer.schedule(new TimerTask() {
                     @Override public void run() {
                         LOGGER.log(Level.WARNING,
-                            String.format("Terminating process of command %s in directory %s " +
+                            String.format("Terminating process of command [%s] in directory %s " +
                             "due to timeout %d seconds", cmd_str, dir_str, timeout / 1000));
                         proc.destroy();
                     }
@@ -223,7 +232,7 @@ public class Executor {
             ret = process.waitFor();
             
             LOGGER.log(Level.FINE,
-                "Finished command {0} in directory {1} with exit code {2}",
+                "Finished command [{0}] in directory {1} with exit code {2}",
                 new Object[] {cmd_str, dir_str, ret});
 
             // Wait for the stderr read-out thread to finish the processing and
@@ -260,9 +269,9 @@ public class Executor {
         if (ret != 0 && reportExceptions) {
             int MAX_MSG_SZ = 512; /* limit to avoid flooding the logs */
             StringBuilder msg = new StringBuilder("Non-zero exit status ")
-                    .append(ret).append(" from command ")
+                    .append(ret).append(" from command [")
                     .append(cmd_str)
-                    .append(" in directory ")
+                    .append("] in directory ")
                     .append(dir_str);
             if (stderr != null && stderr.length > 0) {
                     msg.append(": ");
@@ -396,5 +405,80 @@ public class Executor {
                 }
             });
         }
+    }
+
+    /**
+     * Build a string from the specified argv list with optional tab-indenting
+     * and line-continuations if {@code multiline} is {@code true}.
+     * @param isWindows a value indicating if the platform is Windows so that
+     *                  PowerShell escaping is done; else Bourne shell escaping
+     *                  is done.
+     * @return a defined instance
+     */
+    public static String escapeForShell(List<String> argv, boolean multiline, boolean isWindows) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < argv.size(); ++i) {
+            if (multiline && i > 0) {
+                result.append("\t");
+            }
+            String arg = argv.get(i);
+            result.append(isWindows ? maybeEscapeForPowerShell(arg) : maybeEscapeForSh(arg));
+            if (i + 1 < argv.size()) {
+                if (!multiline) {
+                    result.append(" ");
+                } else {
+                    result.append(isWindows ? " `" : " \\");
+                    result.append(System.lineSeparator());
+                }
+            }
+        }
+        return result.toString();
+    }
+
+    private static String maybeEscapeForSh(String value) {
+        Matcher m = ARG_UNIX_QUOTING.matcher(value);
+        if (!m.find()) {
+            return value;
+        }
+        m = ARG_GNU_STYLE_EQ.matcher(value);
+        if (!m.find()) {
+            return "$'" + escapeForSh(value) + "'";
+        }
+        String following = value.substring(m.end());
+        return m.group() + "$'" + escapeForSh(following) + "'";
+    }
+
+    private static String escapeForSh(String value) {
+        return value.replace("\\", "\\\\").
+                replace("'", "\\'").
+                replace("\n", "\\n").
+                replace("\r", "\\r").
+                replace("\f", "\\f").
+                replace("\u0011", "\\v").
+                replace("\t", "\\t");
+    }
+
+    private static String maybeEscapeForPowerShell(String value) {
+        Matcher m = ARG_WIN_QUOTING.matcher(value);
+        if (!m.find()) {
+            return value;
+        }
+        m = ARG_GNU_STYLE_EQ.matcher(value);
+        if (!m.find()) {
+            return "\"" + escapeForPowerShell(value) + "\"";
+        }
+        String following = value.substring(m.end());
+        return m.group() + "\"" + escapeForPowerShell(following) + "\"";
+    }
+
+    private static String escapeForPowerShell(String value) {
+        return value.replace("`", "``").
+                replace("\"", "`\"").
+                replace("$", "`$").
+                replace("\n", "`n").
+                replace("\r", "`r").
+                replace("\f", "`f").
+                replace("\u0011", "`v").
+                replace("\t", "`t");
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/PlatformUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/PlatformUtils.java
@@ -1,0 +1,78 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright 2011 Jens Elkner.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
+ */
+
+package org.opengrok.indexer.util;
+
+import java.util.Locale;
+
+public class PlatformUtils {
+
+    private static String OS;
+    private static Boolean IS_UNIX;
+    private static Boolean IS_WINDOWS;
+
+    /** Private to enforce static. */
+    private PlatformUtils() {
+    }
+
+    /**
+     * Gets a value indicating the operating system name.
+     * @return the name in lowercase
+     */
+    public static String getOsName() {
+        if (OS == null) {
+            OS = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+        }
+        return OS;
+    }
+
+    /**
+     * Gets a value indicating if the operating system name indicates Windows.
+     * @return {@code true} if Windows
+     */
+    public static boolean isWindows() {
+        if (IS_WINDOWS == null) {
+            String osName = getOsName();
+            IS_WINDOWS = osName.startsWith("windows");
+        }
+        return IS_WINDOWS;
+    }
+
+    /**
+     * Gets a value indicating if the operating system name is Unix-like
+     * (Solaris, SunOS, Linux, Mac, BSD).
+     * @return {@code true} if Unix-like
+     */
+    public static boolean isUnix() {
+        if (IS_UNIX == null) {
+            String osName = getOsName();
+            IS_UNIX = osName.startsWith("linux") || osName.startsWith("solaris") ||
+                    osName.contains("bsd") || osName.startsWith("mac") ||
+                    osName.startsWith("sunos");
+        }
+        return IS_UNIX;
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
  */
 
@@ -66,6 +66,7 @@ import org.opengrok.indexer.history.Annotation;
 import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.PlatformUtils;
 
 /**
  * Class for useful functions.
@@ -80,8 +81,6 @@ public final class Util {
      * Matches a character that is not ASCII alpha-numeric or underscore.
      */
     private static final Pattern NON_ASCII_ALPHA_NUM = Pattern.compile("[^A-Za-z0-9_]");
-
-    private static String OS = null;
 
     private static final String anchorLinkStart = "<a href=\"";
     private static final String anchorClassStart = "<a class=\"";
@@ -832,45 +831,12 @@ public final class Util {
     }
 
     public static String fixPathIfWindows(String path) {
-        if (Util.isWindows()) {
+        if (PlatformUtils.isWindows()) {
             // Sanitize Windows path delimiters in order not to conflict with Lucene escape character
             // and also so the path appears as correctly formed URI in the search results.
             return path.replace(File.separatorChar, PATH_SEPARATOR);
         }
         return path;
-    }
-
-    /**
-     * Determine the operation system name.
-     *
-     * @return the name in lowercase, {@code null} if unknown
-     */
-    public static String getOsName() {
-        if (OS == null) {
-            OS = System.getProperty("os.name").toLowerCase(Locale.ROOT);
-        }
-        return OS;
-    }
-
-    /**
-     * Determine if the current platform is Windows.
-     *
-     * @return true if windows, false when not windows or we can not determine
-     */
-    public static boolean isWindows() {
-        String osname = getOsName();
-        return osname != null ? osname.startsWith("windows") : false;
-    }
-
-    /**
-     * Determine if the current platform is Unix.
-     *
-     * @return true if unix, false when not unix or we can not determine
-     */
-    public static boolean isUnix() {
-        String osname = getOsName();
-        return osname != null ? (osname.startsWith("linux") || osname.startsWith("solaris") ||
-                osname.contains("bsd") || osname.startsWith("mac")) : false;
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/condition/UnixPresent.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/condition/UnixPresent.java
@@ -1,6 +1,30 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
 package org.opengrok.indexer.condition;
 
-import org.opengrok.indexer.web.Util;
+import org.opengrok.indexer.util.PlatformUtils;
 
 public class UnixPresent implements RunCondition {
     @Override
@@ -8,10 +32,10 @@ public class UnixPresent implements RunCondition {
         if (Boolean.getBoolean(forceSystemProperty())) {
             return true;
         }
-        return Util.isUnix();
+        return PlatformUtils.isUnix();
     }
 
     private String forceSystemProperty() {
-        return String.format("junit-force-unix");
+        return "junit-force-unix";
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BazaarHistoryParserTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BazaarHistoryParserTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.history;
@@ -33,6 +34,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.util.PlatformUtils;
 import org.opengrok.indexer.web.Util;
 
 import static org.junit.Assert.*;
@@ -168,7 +170,7 @@ public class BazaarHistoryParserTest {
             "/directory/filename2.ext2",
             "/otherdir/file.extension"
         };
-        if (Util.isWindows()) {
+        if (PlatformUtils.isWindows()) {
             files = new String[] {
                     "\\\\filename.ext",
                     "\\\\directory",

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -19,7 +19,7 @@
 
  /*
  * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.web;
@@ -40,6 +40,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.opengrok.indexer.util.PlatformUtils;
 
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.*;
@@ -157,7 +158,7 @@ public class UtilTest {
 
     @Test
     public void fixPathIfWindows() {
-        if (Util.isWindows()) {
+        if (PlatformUtils.isWindows()) {
             assertEquals("/var/opengrok",
                     Util.fixPathIfWindows("\\var\\opengrok"));
         }


### PR DESCRIPTION
Hello,

Please consider for integration this patch to adjust the format of `Executor` logging not to use the default `List` serialization that uses commas but to use a specialized serialization that formats commands as would be required to execute on the platform. I.e. the commands are logged more clearly and also could be copy/pasted to a shell for execution (as when debugging).

E.g. formerly the following would appear in a log:

```
Executing command [git, log, -1, --pretty=%cd#%h %an %s, --date=iso8601-strict]
```

and would now be formatted as:

```
Executing command [git log -1 --pretty=$'%cd#%h %an %s' --date=iso8601-strict]
```

I also included `os.name`-dependent formatting for Windows:

```
Executing command [git log -1 --pretty="%cd#%h %an %s" --date=iso8601-strict]
```

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
