### PR TITLE
Fix volume paths in docker readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -106,7 +106,7 @@ services:
     volumes:
        - '~/opengrok-src/:/opengrok/src/'  # source code
        - '~/opengrok-etc/:/opengrok/etc/'  # folder contains configuration.xml
-       - '~/opengrok-data/:opengrok/data'  # index and other things for source code
+       - '~/opengrok-data/:/opengrok/data/'  # index and other things for source code
 ```
 
 Save the file into `docker-compose.yml` and then simply run
@@ -120,9 +120,9 @@ docker run -d \
     --name opengrok \
     -p 8080:8080/tcp \
     -e REINDEX="60" \
-    -v "~/opengrok-src/:/opengrok/src/" \
-    -v "~/opengrok-etc/:/opengrok/etc/" \
-    -v "~/opengrok-data/:opengrok/data" \
+    -v ~/opengrok-src/:/opengrok/src/ \
+    -v ~/opengrok-etc/:/opengrok/etc/ \
+    -v ~/opengrok-data/:/opengrok/data/ \
     opengrok/docker:latest
 ```
 


### PR DESCRIPTION
While trying the examples in the readme I've noticed the following errors:
```
docker: Error response from daemon: create ~/opengrok-src/: "~/opengrok-src/" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
```
and
```
docker: Error response from daemon: invalid volume specification: '/Users/ahornace/opengrok-data/:opengrok/data': invalid mount config for type "bind": invalid mount path: 'opengrok/data' mount path must be absolute.
```
Thanks.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
