### PR TITLE
Slightly parallelize opengrok-indexer tests

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -449,8 +449,8 @@ Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkCount>2</forkCount>
-                    <parallel>classes</parallel>
-                    <threadCount>3</threadCount>
+                    <parallel>all</parallel>
+                    <useUnlimitedThreads>true</useUnlimitedThreads>
                     <excludes>
                         <!-- Test helper class with name that confuses surefire -->
                         <exclude>**/TestRepository.java</exclude>

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -131,6 +131,11 @@ Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
+        </dependency>
         <dependency> <!-- TODO: remove! (moving Messages to web module) -->
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
@@ -443,6 +448,9 @@ Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <forkCount>2</forkCount>
+                    <parallel>classes</parallel>
+                    <threadCount>3</threadCount>
                     <excludes>
                         <!-- Test helper class with name that confuses surefire -->
                         <exclude>**/TestRepository.java</exclude>

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -473,10 +473,6 @@ Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <excludes>
-                                <!-- Test helper class with name that confuses surefire -->
-                                <exclude>**/TestRepository.java</exclude>
-                            </excludes>
                             <argLine>
                                 @{surefireArgLine}
                                 --illegal-access=permit

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -125,7 +125,7 @@ public final class RuntimeEnvironment {
     private transient volatile Boolean ctagsFound;
     private final transient Set<String> ctagsLanguages = new HashSet<>();
 
-    public WatchDogService watchDog;
+    private WatchDogService watchDog;
 
     /**
      * Creates a new instance of RuntimeEnvironment. Private to ensure a
@@ -2004,5 +2004,9 @@ public final class RuntimeEnvironment {
 
     public int getMessageLimit() {
         return (int) getConfigurationValue("messageLimit");
+    }
+
+    public WatchDogService getWatchDog() {
+        return watchDog;
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CAnalyzerFactoryTest.java
@@ -46,7 +46,6 @@ import org.opengrok.indexer.analysis.Ctags;
 import org.opengrok.indexer.analysis.Scopes;
 import org.opengrok.indexer.analysis.Scopes.Scope;
 import org.opengrok.indexer.analysis.StreamSource;
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.TestRepository;
 
@@ -79,10 +78,7 @@ public class CAnalyzerFactoryTest {
 
         CAnalyzerFactory analFact = new CAnalyzerFactory();
         analyzer = analFact.getAnalyzer();
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (env.validateUniversalCtags()) {
-            analyzer.setCtags(new Ctags());
-        }
+        analyzer.setCtags(new Ctags());
     }
 
     @AfterClass

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CxxAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/c/CxxAnalyzerFactoryTest.java
@@ -46,7 +46,6 @@ import org.opengrok.indexer.analysis.Ctags;
 import org.opengrok.indexer.analysis.Scopes;
 import org.opengrok.indexer.analysis.Scopes.Scope;
 import org.opengrok.indexer.analysis.StreamSource;
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.TestRepository;
 
@@ -79,10 +78,7 @@ public class CxxAnalyzerFactoryTest {
 
         CxxAnalyzerFactory analFact = new CxxAnalyzerFactory();
         analyzer = analFact.getAnalyzer();
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (env.validateUniversalCtags()) {
-            analyzer.setCtags(new Ctags());
-        }
+        analyzer.setCtags(new Ctags());
     }
 
     @AfterClass

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzerFactoryTest.java
@@ -32,7 +32,6 @@ import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.opengrok.indexer.analysis.Ctags;
 import org.opengrok.indexer.analysis.Definitions;
 import org.opengrok.indexer.analysis.StreamSource;
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.TestRepository;
 
@@ -76,10 +75,7 @@ public class ClojureAnalyzerFactoryTest {
 
         ClojureAnalyzerFactory analFact = new ClojureAnalyzerFactory();
         analyzer = analFact.getAnalyzer();
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (env.validateUniversalCtags()) {
-            analyzer.setCtags(new Ctags());
-        }
+        analyzer.setCtags(new Ctags());
     }
 
     @AfterClass

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzerFactoryTest.java
@@ -42,7 +42,6 @@ import org.opengrok.indexer.analysis.Ctags;
 import org.opengrok.indexer.analysis.Scopes;
 import org.opengrok.indexer.analysis.Scopes.Scope;
 import org.opengrok.indexer.analysis.StreamSource;
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.TestRepository;
 
@@ -75,10 +74,7 @@ public class CSharpAnalyzerFactoryTest {
 
         CSharpAnalyzerFactory analFact = new CSharpAnalyzerFactory();
         analyzer = analFact.getAnalyzer();
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (env.validateUniversalCtags()) {
-            analyzer.setCtags(new Ctags());
-        }
+        analyzer.setCtags(new Ctags());
     }
 
     @AfterClass

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
@@ -46,6 +46,7 @@ import org.opengrok.indexer.search.SearchEngine;
  * <p>
  * Derived from Trond Norbye's {@code SearchEngineTest}
  */
+@net.jcip.annotations.NotThreadSafe
 public class JarAnalyzerTest {
 
     private static final String TESTPLUGINS_JAR = "testplugins.jar";

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/java/JavaAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/java/JavaAnalyzerFactoryTest.java
@@ -46,7 +46,6 @@ import org.opengrok.indexer.analysis.Ctags;
 import org.opengrok.indexer.analysis.Scopes;
 import org.opengrok.indexer.analysis.Scopes.Scope;
 import org.opengrok.indexer.analysis.StreamSource;
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.TestRepository;
 
@@ -79,10 +78,7 @@ public class JavaAnalyzerFactoryTest {
 
         JavaAnalyzerFactory analFact = new JavaAnalyzerFactory();
         analyzer = analFact.getAnalyzer();
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (env.validateUniversalCtags()) {
-            analyzer.setCtags(new Ctags());
-        }
+        analyzer.setCtags(new Ctags());
     }
 
     @AfterClass

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzerFactoryTest.java
@@ -44,7 +44,6 @@ import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.opengrok.indexer.analysis.Ctags;
 import org.opengrok.indexer.analysis.Definitions;
 import org.opengrok.indexer.analysis.StreamSource;
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.TestRepository;
 
@@ -77,10 +76,7 @@ public class PascalAnalyzerFactoryTest {
 
         PascalAnalyzerFactory analyzerFactory = new PascalAnalyzerFactory();
         analyzer = analyzerFactory.getAnalyzer();
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (env.validateUniversalCtags()) {
-            analyzer.setCtags(new Ctags());
-        }
+        analyzer.setCtags(new Ctags());
     }
 
     @AfterClass

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationEntityTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationEntityTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.authorization;
 
@@ -33,6 +34,7 @@ import java.util.TreeSet;
 import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -47,8 +49,10 @@ import static org.junit.Assert.assertEquals;
  * @author Krystof Tulinger
  */
 @RunWith(Parameterized.class)
+@net.jcip.annotations.NotThreadSafe
 public class AuthorizationEntityTest {
 
+    private static RuntimeEnvironment env;
     private Set<Group> envGroups;
     private Map<String, Project> envProjects;
 
@@ -80,9 +84,13 @@ public class AuthorizationEntityTest {
         this.authEntityFactory = authEntityFactory;
     }
 
+    @BeforeClass
+    public static void setUpClass() {
+        env = RuntimeEnvironment.getInstance();
+    }
+
     @Before
     public void setUp() {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         envGroups = env.getGroups();
         envProjects = env.getProjects();
         env.setGroups(new TreeSet<>());
@@ -91,8 +99,8 @@ public class AuthorizationEntityTest {
 
     @After
     public void tearDown() {
-        RuntimeEnvironment.getInstance().setGroups(envGroups);
-        RuntimeEnvironment.getInstance().setProjects(envProjects);
+        env.setGroups(envGroups);
+        env.setProjects(envProjects);
     }
 
     @Test
@@ -100,7 +108,6 @@ public class AuthorizationEntityTest {
         Group g1, g2, g3;
         AuthorizationEntity authEntity;
 
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setProjectsEnabled(true);
 
         env.getProjects().put("project 1", new Project("project 1"));
@@ -216,7 +223,6 @@ public class AuthorizationEntityTest {
         AuthorizationEntity authEntity = authEntityFactory.apply(null);
 
         authEntity.setForGroups(new TreeSet<>(Arrays.asList(new String[]{"group 1", "group 2"})));
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
         Group g1 = new Group();
         g1.setName("group 1");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkReloadTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkReloadTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.authorization;
 
@@ -43,6 +44,7 @@ import org.opengrok.indexer.web.Statistics;
  *
  * @author Vladimir Kotal
  */
+@net.jcip.annotations.NotThreadSafe
 public class AuthorizationFrameworkReloadTest {
 
     private final File pluginDirectory;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/PluginClassLoaderTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/PluginClassLoaderTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.authorization;
 
@@ -32,6 +33,7 @@ import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.framework.PluginClassLoader;
 import org.opengrok.indexer.web.DummyHttpServletRequest;
 
+@net.jcip.annotations.NotThreadSafe
 public class PluginClassLoaderTest {
 
     private final File pluginDirectory;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/IncludeFilesTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/IncludeFilesTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;
 
@@ -38,15 +39,17 @@ import static org.junit.Assert.assertEquals;
  * 
  * @author Vladimir Kotal
  */
+@net.jcip.annotations.NotThreadSafe
 public class IncludeFilesTest {
-    static Path includeRoot;
-    static final String CONTENT_1 = "foo";
-    static final String CONTENT_2 = "bar";
-    static RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-    static final String LINE_SEP = System.lineSeparator();
+    private static RuntimeEnvironment env;
+    private static Path includeRoot;
+    private static final String CONTENT_1 = "foo";
+    private static final String CONTENT_2 = "bar";
+    private static final String LINE_SEP = System.lineSeparator();
     
     @BeforeClass
     public static void setUpClass() throws IOException {
+        env = RuntimeEnvironment.getInstance();
         includeRoot = Files.createTempDirectory("include_root");
         env.setIncludeRoot(includeRoot.toString());
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ProjectTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ProjectTest.java
@@ -19,8 +19,15 @@
 
  /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.beans.ExceptionListener;
 import java.beans.XMLDecoder;
@@ -31,11 +38,18 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import junit.framework.AssertionFailedError;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
+@net.jcip.annotations.NotThreadSafe
 public class ProjectTest {
+
+    private static RuntimeEnvironment env;
+
+    @BeforeClass
+    public static void setUpClass() {
+        env = RuntimeEnvironment.getInstance();
+    }
 
     /**
      * Test that a {@code Project} instance can be encoded and decoded without
@@ -97,7 +111,6 @@ public class ProjectTest {
         HashMap<String, Project> projects = new HashMap<>();
         projects.put("foo", foo);
         projects.put("bar", bar);
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setProjectsEnabled(true);
         env.setProjects(projects);
 
@@ -123,7 +136,6 @@ public class ProjectTest {
         HashMap<String, Project> projects = new HashMap<>();
         projects.put("foo", foo);
         projects.put("bar", bar);
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setProjects(projects);
 
         List<String> descs = env.getProjectNames();
@@ -138,7 +150,6 @@ public class ProjectTest {
      */
     @Test
     public void testMergeProjects1() {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setTabSize(new Configuration().getTabSize() + 3731);
         env.setNavigateWindowEnabled(!new Configuration().isNavigateWindowEnabled());
 
@@ -156,7 +167,6 @@ public class ProjectTest {
      */
     @Test
     public void testMergeProjects2() {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setTabSize(new Configuration().getTabSize() + 3731);
 
         Project p1 = new Project();
@@ -177,7 +187,6 @@ public class ProjectTest {
      */
     @Test
     public void testCreateProjectWithConfiguration() {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setTabSize(4);
 
         Project p1 = new Project("a", "/a");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BazaarHistoryParserTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BazaarHistoryParserTest.java
@@ -24,44 +24,39 @@
 
 package org.opengrok.indexer.history;
 
-import java.nio.file.Paths;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.HashSet;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.PlatformUtils;
-import org.opengrok.indexer.web.Util;
-
-import static org.junit.Assert.*;
 
 /**
  *
  * @author austvik
  */
+@net.jcip.annotations.NotThreadSafe
 public class BazaarHistoryParserTest {
 
+    private static RuntimeEnvironment env;
     private BazaarHistoryParser instance;
-    
-    public BazaarHistoryParserTest() {
-    }
 
     @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
+    public static void setUpClass() {
+        env = RuntimeEnvironment.getInstance();
     }
 
     @Before
     public void setUp() {
-        if (RuntimeEnvironment.getInstance().getSourceRootPath() == null) {
-            RuntimeEnvironment.getInstance().setSourceRoot("");
+        if (env.getSourceRootPath() == null) {
+            env.setSourceRoot("");
         }
         BazaarRepository bzrRepo = new BazaarRepository();
         // BazaarHistoryParser needs to have a valid directory name.
@@ -158,7 +153,6 @@ public class BazaarHistoryParserTest {
     }
     
     @Test
-    @SuppressWarnings("unchecked")
     public void parseLogDirectory() throws Exception {
         String revId1 = "1234";
         String author1 = "username@example.com";

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -52,6 +52,7 @@ import static org.opengrok.indexer.history.MercurialRepositoryTest.runHgCommand;
  *
  * @author Vladimir Kotal
  */
+@net.jcip.annotations.NotThreadSafe
 public class FileHistoryCacheTest {
 
     private TestRepository repositories;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
  */
 package org.opengrok.indexer.history;
@@ -57,6 +57,7 @@ import org.opengrok.indexer.util.TestRepository;
  * @author austvik
  */
 @ConditionalRun(RepositoryInstalled.GitInstalled.class)
+@net.jcip.annotations.NotThreadSafe
 public class GitRepositoryTest {
 
     @Rule

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -54,6 +54,7 @@ import org.opengrok.indexer.util.TestRepository;
  * @author Trond Norbye
  * @author Vladimir Kotal
  */
+@net.jcip.annotations.NotThreadSafe
 public class HistoryGuruTest {
 
     private static TestRepository repository = new TestRepository();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2019, Chris Ross <cross@distal.com>.
  */
 package org.opengrok.indexer.history;
@@ -49,6 +49,7 @@ import static org.opengrok.indexer.history.PerforceRepository.protectPerforceFil
  * @author Trond Norbye
  */
 @ConditionalRun(RepositoryInstalled.PerforceInstalled.class)
+@net.jcip.annotations.NotThreadSafe
 public class PerforceRepositoryTest {
 
     @Rule

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
@@ -53,9 +53,10 @@ import org.opengrok.indexer.util.TestRepository;
  *
  * @author Vladimir Kotal
  */
+@net.jcip.annotations.NotThreadSafe
 public class RepositoryFactoryTest {
     private static RuntimeEnvironment env;
-    private static TestRepository repository = new TestRepository();
+    private static TestRepository repository;
     private static Set<String> savedDisabledRepositories;
     private static boolean savedIsProjectsEnabled;
 
@@ -65,6 +66,7 @@ public class RepositoryFactoryTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         env = RuntimeEnvironment.getInstance();
+        repository = new TestRepository();
         repository.create(RepositoryFactoryTest.class.getResourceAsStream("repositories.zip"));
         savedDisabledRepositories = env.getDisabledRepositories();
         savedIsProjectsEnabled = env.isProjectsEnabled();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryInfoTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryInfoTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -34,6 +34,7 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
  *
  * @author Vladimir Kotal
  */
+@net.jcip.annotations.NotThreadSafe
 public class RepositoryInfoTest {
     @Before
     public void setUp() {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IgnoredNamesTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IgnoredNamesTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
 
@@ -53,19 +54,22 @@ import org.opengrok.indexer.util.TestRepository;
  *
  * @author Trond Norbye
  */
+@net.jcip.annotations.NotThreadSafe
 public class IgnoredNamesTest {
 
-    private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+    private static RuntimeEnvironment env;
     private static TestRepository repository;
 
     @BeforeClass
     public static void setUpClass() throws Exception {
+        env = RuntimeEnvironment.getInstance();
+
         repository = new TestRepository();
         repository.create(CAnalyzerFactoryTest.class.getResourceAsStream(
                 "/org/opengrok/indexer/index/source.zip"));
 
         // Populate ignored lists with repository specific entries.
-        RepositoryFactory.initializeIgnoredNames(RuntimeEnvironment.getInstance());
+        RepositoryFactory.initializeIgnoredNames(env);
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
@@ -60,6 +60,7 @@ import java.util.TreeSet;
 @ConditionalRun(UnixPresent.class)
 @ConditionalRun(RepositoryInstalled.GitInstalled.class)
 @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
+@net.jcip.annotations.NotThreadSafe
 public class IndexDatabaseSymlinksTest {
 
     private static RuntimeEnvironment env;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -51,6 +51,7 @@ import org.opengrok.indexer.util.TestRepository;
 /**
  * Unit tests for the {@code IndexDatabase} class.
  */
+@net.jcip.annotations.NotThreadSafe
 public class IndexDatabaseTest {
 
     private static TestRepository repository;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexVersionTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexVersionTest.java
@@ -48,15 +48,16 @@ import org.opengrok.indexer.util.TestRepository;
  * 
  * @author Vladimir Kotal
  */
+@net.jcip.annotations.NotThreadSafe
 public class IndexVersionTest {
 
+    private static RuntimeEnvironment env;
     private TestRepository repository;
-    private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
     private Path oldIndexDataDir;
     
     @BeforeClass
     public static void setUpClass() {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env = RuntimeEnvironment.getInstance();
         RepositoryFactory.initializeIgnoredNames(env);
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerRepoTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerRepoTest.java
@@ -60,6 +60,7 @@ import org.opengrok.indexer.util.IOUtils;
  *
  * @author Vladimir Kotal
  */
+@net.jcip.annotations.NotThreadSafe
 public class IndexerRepoTest {
 
     @Rule

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -70,6 +70,7 @@ import org.opengrok.indexer.util.TestRepository;
  *
  * @author Trond Norbye
  */
+@net.jcip.annotations.NotThreadSafe
 public class IndexerTest {
 
     TestRepository repository;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -45,6 +45,7 @@ import org.opengrok.indexer.history.RepositoryFactory;
  *
  * @author Trond Norbye
  */
+@net.jcip.annotations.NotThreadSafe
 public class SearchEngineTest {
 
     static TestRepository repository;
@@ -71,7 +72,7 @@ public class SearchEngineTest {
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);
-        RuntimeEnvironment.getInstance().readConfiguration(new File(configFile.getAbsolutePath()));
+        env.readConfiguration(new File(configFile.getAbsolutePath()));
     }
 
     @AfterClass

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/ContextTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/ContextTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;
 
@@ -49,6 +49,7 @@ import org.opengrok.indexer.search.Hit;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.w3c.dom.Document;
 
+@net.jcip.annotations.NotThreadSafe
 public class ContextTest {
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.search.context;
@@ -52,6 +52,7 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 /**
  * Unit tests for the {@code HistoryContext} class.
  */
+@net.jcip.annotations.NotThreadSafe
 public class HistoryContextTest {
 
     private static TestRepository repositories;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
@@ -56,6 +56,7 @@ import static org.opengrok.indexer.util.CustomAssertions.assertLinesEqual;
  * <p>
  * Derived from Trond Norbye's {@code SearchEngineTest}
  */
+@net.jcip.annotations.NotThreadSafe
 public class SearchAndContextFormatterTest {
 
     private static RuntimeEnvironment env;
@@ -85,8 +86,7 @@ public class SearchAndContextFormatterTest {
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);
-        RuntimeEnvironment.getInstance().readConfiguration(new File(
-            configFile.getAbsolutePath()));
+        env.readConfiguration(new File(configFile.getAbsolutePath()));
     }
 
     @AfterClass

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
@@ -61,6 +61,7 @@ import org.opengrok.indexer.util.IOUtils;
  * <p>
  * Derived from Trond Norbye's {@code SearchEngineTest}
  */
+@net.jcip.annotations.NotThreadSafe
 public class SearchAndContextFormatterTest2 {
 
     private static final int TABSIZE = 8;
@@ -130,8 +131,7 @@ public class SearchAndContextFormatterTest2 {
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);
-        RuntimeEnvironment.getInstance().readConfiguration(new File(
-            configFile.getAbsolutePath()));
+        env.readConfiguration(new File(configFile.getAbsolutePath()));
     }
 
     @AfterClass

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/CtagsUtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/CtagsUtilTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 /**
  * Represents a container for tests of {@link CtagsUtil}.
  */
+@net.jcip.annotations.NotThreadSafe
 public class CtagsUtilTest {
 
     @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
@@ -1,3 +1,27 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
 package org.opengrok.indexer.util;
 
 import org.junit.Assert;
@@ -8,7 +32,6 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -20,6 +43,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.times;
 
+@net.jcip.annotations.NotThreadSafe
 public class ProgressTest {
     @BeforeClass
     public static void setup() {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/StatisticsUtilsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/StatisticsUtilsTest.java
@@ -1,7 +1,32 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
 package org.opengrok.indexer.util;
 
 import org.apache.tools.ant.filters.StringInputStream;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.web.Statistics;
@@ -16,7 +41,16 @@ import java.util.TreeMap;
 import static org.opengrok.indexer.util.StatisticsUtils.loadStatistics;
 import static org.opengrok.indexer.util.StatisticsUtils.saveStatistics;
 
+@net.jcip.annotations.NotThreadSafe
 public class StatisticsUtilsTest {
+
+    private static RuntimeEnvironment env;
+
+    @BeforeClass
+    public static void setUpClass() {
+        env = RuntimeEnvironment.getInstance();
+    }
+
     /**
      * Creates a map of String key and Long values.
      *
@@ -33,7 +67,6 @@ public class StatisticsUtilsTest {
 
     @Test
     public void testLoadEmptyStatistics() throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         String json = "{}";
         try (InputStream in = new StringInputStream(json)) {
             loadStatistics(in);
@@ -43,7 +76,6 @@ public class StatisticsUtilsTest {
 
     @Test
     public void testLoadStatistics() throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         String json = "{"
                 + "\"requests_per_minute_max\":3,"
                 + "\"timing\":{"
@@ -108,7 +140,6 @@ public class StatisticsUtilsTest {
 
     @Test(expected = IOException.class)
     public void testLoadInvalidStatistics() throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         String json = "{ malformed json with missing bracket";
         try (InputStream in = new StringInputStream(json)) {
             loadStatistics(in);
@@ -117,7 +148,6 @@ public class StatisticsUtilsTest {
 
     @Test
     public void testSaveStatistics() throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setStatistics(new Statistics());
         env.getStatistics().addRequest();
         env.getStatistics().addRequest("root");
@@ -132,7 +162,7 @@ public class StatisticsUtilsTest {
 
     @Test(expected = IOException.class)
     public void testSaveNullStatistics() throws IOException {
-        RuntimeEnvironment.getInstance().setStatisticsFilePath(null);
+        env.setStatisticsFilePath(null);
         saveStatistics();
     }
 
@@ -143,7 +173,7 @@ public class StatisticsUtilsTest {
 
     @Test(expected = IOException.class)
     public void testLoadNullStatistics() throws IOException {
-        RuntimeEnvironment.getInstance().setStatisticsFilePath(null);
+        env.setStatisticsFilePath(null);
         loadStatistics();
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigRequestedProjectsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigRequestedProjectsTest.java
@@ -1,3 +1,27 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
 package org.opengrok.indexer.web;
 
 import java.util.Arrays;
@@ -10,6 +34,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opengrok.indexer.authorization.AuthorizationStack;
@@ -17,13 +42,19 @@ import org.opengrok.indexer.configuration.Group;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
+@net.jcip.annotations.NotThreadSafe
 public class PageConfigRequestedProjectsTest {
 
-    final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+    private static RuntimeEnvironment env;
 
     private Map<String, Project> oldProjects;
     private Set<Group> oldGroups;
     private AuthorizationStack oldPluginStack;
+
+    @BeforeClass
+    public static void setUpClass() {
+        env = RuntimeEnvironment.getInstance();
+    }
 
     @Before
     public void setUp() {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/ProjectHelperExtendedTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/ProjectHelperExtendedTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -36,6 +37,7 @@ import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.RepositoryInfo;
 
+@net.jcip.annotations.NotThreadSafe
 public class ProjectHelperExtendedTest extends ProjectHelperTestBase {
 
     @BeforeClass

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/ProjectHelperTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/ProjectHelperTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -39,6 +39,7 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.RepoRepository;
 import org.opengrok.indexer.history.RepositoryInfo;
 
+@net.jcip.annotations.NotThreadSafe
 public class ProjectHelperTest extends ProjectHelperTestBase {
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
@@ -31,6 +31,7 @@ import java.util.TreeSet;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -42,17 +43,22 @@ import org.opengrok.indexer.util.TestRepository;
 /**
  * Unit tests for the {@code SearchHelper} class.
  */
+@net.jcip.annotations.NotThreadSafe
 public class SearchHelperTest {
 
-    TestRepository repository;
-    RuntimeEnvironment env;
+    private static RuntimeEnvironment env;
+    private TestRepository repository;
+
+    @BeforeClass
+    public static void setUpClass() {
+        env = RuntimeEnvironment.getInstance();
+    }
 
     @Before
     public void setUp() throws IOException {
         repository = new TestRepository();
         repository.create(IndexerTest.class.getResourceAsStream("source.zip"));
 
-        env = RuntimeEnvironment.getInstance();
         env.setSourceRoot(repository.getSourceRoot());
         env.setDataRoot(repository.getDataRoot());
         env.setHistoryEnabled(false);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/messages/MessagesUtilsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/messages/MessagesUtilsTest.java
@@ -19,11 +19,12 @@
 
 /*
  * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.web.messages;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -33,11 +34,12 @@ import java.util.HashMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+@net.jcip.annotations.NotThreadSafe
 public class MessagesUtilsTest {
-    RuntimeEnvironment env;
+    private static RuntimeEnvironment env;
 
-    @Before
-    public void setUp() {
+    @BeforeClass
+    public static void setUpClass() {
         env = RuntimeEnvironment.getInstance();
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -97,7 +97,7 @@ public final class WebappListener
 
         String pluginDirectory = env.getPluginDirectory();
         if (pluginDirectory != null && env.isAuthorizationWatchdog()) {
-            env.watchDog.start(new File(pluginDirectory));
+            env.getWatchDog().start(new File(pluginDirectory));
         }
 
         env.startExpirationTimer();
@@ -116,7 +116,7 @@ public final class WebappListener
     public void contextDestroyed(final ServletContextEvent servletContextEvent) {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.getIndexerParallelizer().bounce();
-        env.watchDog.stop();
+        env.getWatchDog().stop();
         env.stopExpirationTimer();
         try {
             env.shutdownRevisionExecutor();


### PR DESCRIPTION
Hello,

I'm raising this PR to see if a slight parallelization of opengrok-indexer tests succeeds on Jenkins.

I'm using 2 forks * 3 threads. Anything more, including a number of forks equal to cores, did not run reliably on my machine.

I removed `RuntimeEnvironment` dependency from a few tests. For remaining (many) tests dependent on `RuntimeEnvironment`, I decorated with `@net.jcip.annotations.NotThreadSafe` so they would not be parallelized.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
