### PR TITLE
Bump versions of SQLAnalyzer and PLSQLAnalyzer

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/PLSQLAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/PLSQLAnalyzer.java
@@ -50,11 +50,11 @@ public class PLSQLAnalyzer extends PlainAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20180208_00
+     * @return 20191216_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20180208_00; // Edit comment above too!
+        return 20191216_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/SQLAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/SQLAnalyzer.java
@@ -50,11 +50,11 @@ public class SQLAnalyzer extends PlainAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20180208_00
+     * @return 20191216_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20180208_00; // Edit comment above too!
+        return 20191216_00; // Edit comment above too!
     }
 
     /**


### PR DESCRIPTION
Hello,

Please consider for integration this patch to bump the versions of `SQLAnalyzer` and `PLSQLAnalyzer` after their recent refactoring.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
