### PR TITLE
fix timeout inheritance in mirror.py

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
@@ -105,6 +105,7 @@ class Command:
                 """
                 Make sure the process goes away.
                 """
+                self.logger.info("Terminating PID {}".format(p.pid))
                 p.terminate()
 
                 # The following code tries more methods to terminate

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
 #
 
 import logging

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -19,7 +19,7 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
 #
 
 import re
@@ -99,7 +99,7 @@ def get_repos_for_project(project_name, ignored_repos, uri, source_root,
                                   kwargs[COMMANDS_PROPERTY],
                                   kwargs[PROXY_PROPERTY],
                                   None,
-                                  kwargs['command_timeout'])
+                                  kwargs[CMD_TIMEOUT_PROPERTY])
         except (RepositoryException, OSError) as e:
             logger.error("Cannot get repository for {}: {}".
                          format(repo_path, e))
@@ -338,6 +338,11 @@ def mirror_project(config, project_name, check_changes, uri,
         ignored_repos = get_project_properties(project_config,
                                                project_name,
                                                config.get(HOOKDIR_PROPERTY))
+
+    if not command_timeout:
+        command_timeout = config.get(CMD_TIMEOUT_PROPERTY)
+    if not hook_timeout:
+        hook_timeout = config.get(HOOK_TIMEOUT_PROPERTY)
 
     proxy = None
     if use_proxy:

--- a/opengrok-tools/src/test/python/test_repofactory.py
+++ b/opengrok-tools/src/test/python/test_repofactory.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+#
+
+import os
+import tempfile
+from git import Repo
+
+from opengrok_tools.scm import GitRepository
+from opengrok_tools.scm.repofactory import get_repository
+
+
+def test_repofactory_timeout():
+    with tempfile.TemporaryDirectory() as source_root:
+        repo_name = "foo"
+        repo_path = os.path.join(source_root, repo_name)
+        Repo.init(repo_path)
+        timeout = 3
+
+        project_name = "foo"    # does not matter for this test
+        repo = get_repository(repo_path,
+                              "git", project_name,
+                              None, None, None, timeout)
+        assert repo is not None
+        assert isinstance(repo, GitRepository)
+        assert repo.timeout == timeout


### PR DESCRIPTION
This change fixes bug in timeout properties not being used in mirror.py at all unless configured on project level.

The added tests merely check parameter passing between functions. More robust test would be e.g. to use GitPython in `git.py` (as suggested in #2852), mock it to timeout the pull operation and verify the timeout in tests.