### PR TITLE
use kwargs in get_repository(), get_repos_for_project()

### DIFF
--- a/opengrok-tools/README.md
+++ b/opengrok-tools/README.md
@@ -6,6 +6,8 @@ Set of scripts to facilitate project synchronization and mirroring
 The scripts require Python 3 and they rely on a binary/symlink `python3` to be
 present that points to the latest Python 3.x version present on the system.
 
+Currently it is assumed that Python 3.6 and greater is used.
+
 See https://github.com/oracle/opengrok/wiki/Repository-synchronization
 for more details.
 

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repofactory.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repofactory.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
 #
 
 import logging
@@ -33,14 +33,14 @@ from .teamware import TeamwareRepository
 logger = logging.getLogger(__name__)
 
 
-def get_repository(path, repo_type, project, commands, env, hooks,
-                   timeout):
+def get_repository(path, repo_type, project,
+                   commands=None, env=None, hooks=None, timeout=None):
     """
     :param path: full path
     :param repo_type: repository type
     :param project: project name
-    :param commands: commands list
-    :param env: environment varibables dictionary
+    :param commands: commands dictionary with paths to SCM utilities
+    :param env: environment variables dictionary
     :param hooks: hook dictionary
     :param timeout: timeout in seconds
     :return: a Repository derived object according to the type specified
@@ -62,7 +62,7 @@ def get_repository(path, repo_type, project, commands, env, hooks,
         return TeamwareRepository(logger, path, project,
                                   commands.get("teamware"),
                                   env, hooks, timeout)
-    elif repo_lower.lower() == "cvs":
+    elif repo_lower == "cvs":
         return CVSRepository(logger, path, project,
                              commands.get("cvs"),
                              env, hooks, timeout)

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -84,7 +84,8 @@ def get_repos_for_project(project_name, uri, source_root,
 
         if ignored_repos:
             r_path = os.path.relpath(repo_path, '/' + project_name)
-            if any(map(lambda repo: fnmatch.fnmatch(r_path, repo), ignored_repos)):
+            if any(map(lambda repo: fnmatch.fnmatch(r_path, repo),
+                       ignored_repos)):
                 logger.info("repository {} ignored".format(repo_path))
                 continue
 

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -99,7 +99,7 @@ def get_repos_for_project(project_name, uri, source_root,
         repo = None
         try:
             # The OpenGrok convention is that the form of repo_path is absolute
-            # so joining would the paths would actually spoil things. Hence, be
+            # so joining the paths would actually spoil things. Hence, be
             # careful.
             if repo_path.startswith(os.path.sep):
                 path = source_root + repo_path

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/opengrok.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/opengrok.py
@@ -30,7 +30,8 @@ def get_repos(logger, project, uri):
     :param logger: logger instance
     :param project: project name
     :param uri: web application URI
-    :return: list of repository paths (can be empty if no match) or None on failure
+    :return: list of repository paths (can be empty if no match)
+             or None on failure
     """
 
     r = get(logger, get_uri(uri, 'api', 'v1', 'projects',

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/opengrok.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/opengrok.py
@@ -27,9 +27,10 @@ from .webutil import put, get, post, delete, get_uri
 
 def get_repos(logger, project, uri):
     """
-    Get list of repositories for given project name.
-
-    Return  string with the result on success, None on failure.
+    :param logger: logger instance
+    :param project: project name
+    :param uri: web application URI
+    :return: list of repository paths (can be empty if no match) or None on failure
     """
 
     r = get(logger, get_uri(uri, 'api', 'v1', 'projects',

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -34,6 +34,7 @@ from mockito import verify, patch, spy2, mock, ANY
 import requests
 
 from opengrok_tools.scm.repofactory import get_repository
+from opengrok_tools.scm.git import GitRepository
 from opengrok_tools.utils.mirror import check_project_configuration, \
     check_configuration, mirror_project, run_command, get_repos_for_project, \
     HOOKS_PROPERTY, PROXY_PROPERTY, IGNORED_REPOS_PROPERTY, \
@@ -287,7 +288,8 @@ def test_get_repos_for_project(monkeypatch):
     """
     project_name = 'foo'
     proxy_dict = {}
-    commands = {}
+    git_cmd_path = "/foo/git"
+    commands = {"git": git_cmd_path}
     timeout = 314159
     test_repo = "/" + project_name
 
@@ -311,11 +313,14 @@ def test_get_repos_for_project(monkeypatch):
                                           commands=commands,
                                           proxy=proxy_dict,
                                           command_timeout=timeout)
-            print(repos)
             assert len(repos) == 1
+            assert isinstance(repos[0], GitRepository)
+            git_repo = repos[0]
+            assert git_repo.timeout == timeout
+            assert git_repo.command == git_cmd_path
+            assert git_repo.env == proxy_dict  # XXX contains
 
             # Now ignore the repository
             repos = get_repos_for_project(project_name, None, source_root,
                                           ignored_repos=['.'])
-            print(repos)
             assert len(repos) == 0

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -287,7 +287,8 @@ def test_get_repos_for_project(monkeypatch):
     Test argument passing between get_repos_for_project() and get_repository()
     """
     project_name = 'foo'
-    proxy_dict = {}
+    proxy_dict = {"http_proxy": "http://foo.bar:80",
+                  "https_proxy": "http://foo.bar:80"}
     git_cmd_path = "/foo/git"
     commands = {"git": git_cmd_path}
     timeout = 314159
@@ -318,7 +319,7 @@ def test_get_repos_for_project(monkeypatch):
             git_repo = repos[0]
             assert git_repo.timeout == timeout
             assert git_repo.command == git_cmd_path
-            assert git_repo.env == proxy_dict  # XXX contains
+            assert git_repo.env.items() >= proxy_dict.items()
 
             # Now ignore the repository
             repos = get_repos_for_project(project_name, None, source_root,

--- a/opengrok-tools/src/test/python/test_repofactory.py
+++ b/opengrok-tools/src/test/python/test_repofactory.py
@@ -41,7 +41,7 @@ def test_repofactory_timeout():
         project_name = "foo"    # does not matter for this test
         repo = get_repository(repo_path,
                               "git", project_name,
-                              None, None, None, timeout)
+                              timeout=timeout)
         assert repo is not None
         assert isinstance(repo, GitRepository)
         assert repo.timeout == timeout


### PR DESCRIPTION
This is a follow-up to #3025, making the changes suggested by @ericsaintetienne and adding better tests.