### PR TITLE
fix Python install issues

### DIFF
--- a/dev/before_install
+++ b/dev/before_install
@@ -30,7 +30,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 	# Bitkeeper install failure is not critical, so exit code is not checked.
 	sudo ./dev/install-bitkeeper.sh
 
-	sudo ./dev/install-python-packages.sh
+	sudo -H ./dev/install-python-packages.sh
 	if [[ $? != 0 ]]; then
 		echo "cannot install Python packages"
 		exit 1

--- a/dev/install-python-packages.sh
+++ b/dev/install-python-packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Installing/upgrading pip.."
-python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade pip setuptools
 
 echo "Installing Python packages.."
 python3 -m pip install pep8 virtualenv

--- a/dev/install-python-packages.sh
+++ b/dev/install-python-packages.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+echo "Installing/upgrading pip.."
 python3 -m pip install --upgrade pip
 
+echo "Installing Python packages.."
 python3 -m pip install pep8 virtualenv
 if [[ $? != 0 ]]; then
 	echo "cannot install Python packages"


### PR DESCRIPTION
currently all Linux builds fail due to (from `pep8` install):
```
Collecting distlib<1,>=0.3.0
  Downloading distlib-0.3.0.zip (571 kB)
     |████████████████████████████████| 571 kB 43.4 MB/s 
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-n_2nuwn0/distlib/setup.py'"'"'; __file__='"'"'/tmp/pip-install-n_2nuwn0/distlib/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-n_2nuwn0/distlib/pip-egg-info
         cwd: /tmp/pip-install-n_2nuwn0/distlib/
    Complete output (3 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ImportError: No module named 'setuptools'
```
so evidently we need to install `setuptools` beforehand.

Further, `pip install` complains:
```
WARNING: The directory '/home/travis/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
```
so we need to let `sudo` to set `HOME` env var.