### PR TITLE
Bugfix/redirect 1 def

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/BZip2Analyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/BZip2Analyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.archive;
 
@@ -35,6 +35,7 @@ import org.opengrok.indexer.analysis.AnalyzerFactory;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.analysis.FileAnalyzer;
 import org.opengrok.indexer.analysis.StreamSource;
+import org.opengrok.indexer.search.QueryBuilder;
 
 /**
  * Analyzes a BZip2 file.
@@ -98,10 +99,11 @@ public class BZip2Analyzer extends FileAnalyzer {
                     this.g = Genre.DATA;
                 }
                 fa.analyze(doc, bzSrc, xrefOut);
-                if (doc.get("t") != null) {
-                    doc.removeField("t");
+                if (doc.get(QueryBuilder.T) != null) {
+                    doc.removeField(QueryBuilder.T);
                     if (g == Genre.XREFABLE) {
-                        doc.add(new Field("t", g.typeName(), AnalyzerGuru.string_ft_stored_nanalyzed_norms));
+                        doc.add(new Field(QueryBuilder.T, g.typeName(),
+                                AnalyzerGuru.string_ft_stored_nanalyzed_norms));
                     }
                 }
             }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/GZIPAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/GZIPAnalyzer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.archive;
 
@@ -39,6 +39,7 @@ import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.analysis.FileAnalyzer;
 import org.opengrok.indexer.analysis.StreamSource;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.search.QueryBuilder;
 
 /**
  * Analyzes GZip files.
@@ -108,10 +109,11 @@ public class GZIPAnalyzer extends FileAnalyzer {
                     this.g = Genre.DATA;
                 }
                 fa.analyze(doc, gzSrc, xrefOut);
-                if (doc.get("t") != null) {
-                    doc.removeField("t");
+                if (doc.get(QueryBuilder.T) != null) {
+                    doc.removeField(QueryBuilder.T);
                     if (g == Genre.XREFABLE) {
-                        doc.add(new Field("t", g.typeName(), AnalyzerGuru.string_ft_stored_nanalyzed_norms));
+                        doc.add(new Field(QueryBuilder.T, g.typeName(),
+                                AnalyzerGuru.string_ft_stored_nanalyzed_norms));
                     }
                 }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
- * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.search;
@@ -229,7 +229,8 @@ public final class Results {
                 out.write("</a>");
                 out.write("</td><td><code class=\"con\">");
                 if (sh.sourceContext != null) {
-                    AbstractAnalyzer.Genre genre = AbstractAnalyzer.Genre.get(doc.get("t"));
+                    AbstractAnalyzer.Genre genre = AbstractAnalyzer.Genre.get(
+                            doc.get(QueryBuilder.T));
                     if (AbstractAnalyzer.Genre.XREFABLE == genre && sh.summarizer != null) {
                         String xtags = getTags(xrefDataDir, rpath, sh.compressed);
                         // FIXME use Highlighter from lucene contrib here,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;
 
@@ -56,12 +56,13 @@ import org.opengrok.indexer.web.Util;
  */
 public class Context {
 
+    static final int MAXFILEREAD = 1024 * 1024;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(Context.class);
 
     private final Query query;
     private final QueryBuilder qbuilder;
     private final LineMatcher[] m;
-    static final int MAXFILEREAD = 1024 * 1024;
     private char[] buffer;
     PlainLineTokenizer tokens;
     String queryAsURI;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
@@ -63,7 +63,7 @@ public class Context {
     private final Query query;
     private final QueryBuilder qbuilder;
     private final LineMatcher[] m;
-    String queryAsURI;
+    private final String queryAsURI;
 
     /**
      * Map whose keys tell which fields to look for in the source file, and
@@ -95,7 +95,9 @@ public class Context {
         QueryMatchers qm = new QueryMatchers();
         m = qm.getMatchers(query, TOKEN_FIELDS);
         if (m != null) {
-            buildQueryAsURI(qbuilder.getQueries());
+            queryAsURI = buildQueryAsURI(qbuilder.getQueries());
+        } else {
+            queryAsURI = "";
         }
     }
 
@@ -232,10 +234,9 @@ public class Context {
      *
      * @param subqueries a map containing the query text for each field
      */
-    private void buildQueryAsURI(Map<String, String> subqueries) {
+    private String buildQueryAsURI(Map<String, String> subqueries) {
         if (subqueries.isEmpty()) {
-            queryAsURI = "";
-            return;
+            return "";
         }
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<String, String> entry : subqueries.entrySet()) {
@@ -245,7 +246,7 @@ public class Context {
                 .append('&');
         }
         sb.setLength(sb.length() - 1);
-        queryAsURI = sb.toString();
+        return sb.toString();
     }
 
     private boolean alt = true;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
@@ -63,7 +63,6 @@ public class Context {
     private final Query query;
     private final QueryBuilder qbuilder;
     private final LineMatcher[] m;
-    private char[] buffer;
     PlainLineTokenizer tokens;
     String queryAsURI;
 
@@ -99,7 +98,6 @@ public class Context {
         if (m != null) {
             buildQueryAsURI(qbuilder.getQueries());
             //System.err.println("Found Matchers = "+ m.length + " for " + query);
-            buffer = new char[MAXFILEREAD];
             tokens = new PlainLineTokenizer((Reader) null);
         }
     }
@@ -213,7 +211,7 @@ public class Context {
 
         try {
             List<String> fieldList = qbuilder.getContextFields();
-            String[] fields = fieldList.toArray(new String[fieldList.size()]);
+            String[] fields = fieldList.toArray(new String[0]);
 
             String res = uhi.highlightFieldsUnion(fields, query, docId,
                 linelimit);
@@ -299,7 +297,8 @@ public class Context {
                             if (scopes != null) {
                                 Scope scp = scopes.getScope(tag.line);
                                 scope = scp.getName() + "()";
-                                scopeUrl = "<a href=\"" + urlPrefixE + pathE + "#" + Integer.toString(scp.getLineFrom()) + "\">" + scope + "</a>";
+                                scopeUrl = "<a href=\"" + urlPrefixE + pathE + "#" +
+                                        scp.getLineFrom() + "\">" + scope + "</a>";
                             }
 
                             /* desc[0] is matched symbol
@@ -368,7 +367,7 @@ public class Context {
         if (in == null) {
             return anything;
         }
-        int charsRead = 0;
+        int charsRead;
         boolean truncated = false;
 
         boolean lim = limit;
@@ -378,6 +377,7 @@ public class Context {
         }
 
         if (lim) {
+            char[] buffer = new char[MAXFILEREAD];
             try {
                 charsRead = in.read(buffer);
                 if (charsRead == MAXFILEREAD) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
@@ -63,7 +63,6 @@ public class Context {
     private final Query query;
     private final QueryBuilder qbuilder;
     private final LineMatcher[] m;
-    PlainLineTokenizer tokens;
     String queryAsURI;
 
     /**
@@ -97,8 +96,6 @@ public class Context {
         m = qm.getMatchers(query, TOKEN_FIELDS);
         if (m != null) {
             buildQueryAsURI(qbuilder.getQueries());
-            //System.err.println("Found Matchers = "+ m.length + " for " + query);
-            tokens = new PlainLineTokenizer((Reader) null);
         }
     }
 
@@ -367,9 +364,9 @@ public class Context {
         if (in == null) {
             return anything;
         }
-        int charsRead;
-        boolean truncated = false;
 
+        PlainLineTokenizer tokens = new PlainLineTokenizer(null);
+        boolean truncated = false;
         boolean lim = limit;
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         if (!env.isQuickContextScan()) {
@@ -378,6 +375,7 @@ public class Context {
 
         if (lim) {
             char[] buffer = new char[MAXFILEREAD];
+            int charsRead;
             try {
                 charsRead = in.read(buffer);
                 if (charsRead == MAXFILEREAD) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions copyright (c) 2011 Jens Elkner.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -1353,6 +1353,11 @@ public final class PageConfig {
         if (req.getQueryString() != null) {
             sb.append("&");
             sb.append(req.getQueryString());
+        }
+        String frag = req.getParameter(UriConsts.FRAGMENT_IDENTIFIER);
+        if (frag != null) {
+            sb.append("#");
+            sb.append(Util.URIEncode(frag));
         }
 
         return sb.toString();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2011 Jens Elkner.
  * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -105,7 +106,7 @@ public enum Prefix {
      * @see #toString()
      */
     public static Prefix get(String servletPath) {
-        if (servletPath == null || servletPath.length() < 3 || servletPath.charAt(0) != '/') {
+        if (servletPath == null || servletPath.length() < 2 || servletPath.charAt(0) != '/') {
             return UNKNOWN;
         }
         int idx = servletPath.indexOf('/', 1);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -413,9 +413,13 @@ public class SearchHelper {
                 }
             }
             if (uniqueDefinition) {
+                String anchor = Util.URIEncode(((TermQuery) query).getTerm().text());
                 redirect = contextPath + Prefix.XREF_P
                         + Util.URIEncodePath(searcher.doc(hits[0].doc).get(QueryBuilder.PATH))
-                        + '#' + Util.URIEncode(((TermQuery) query).getTerm().text());
+                        + '?'
+                        + UriConsts.FRAGMENT_IDENTIFIER
+                        + '=' + anchor
+                        + '#' + anchor;
             }
         } catch (BooleanQuery.TooManyClauses e) {
             errorMsg = "Too many results for wildcard!";

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions copyright (c) 2011 Jens Elkner. 
- * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -401,7 +401,7 @@ public class SearchHelper {
             // one single definition term AND we have exactly one match AND there
             // is only one definition of that symbol in the document that matches.
             boolean uniqueDefinition = false;
-            if (isSingleDefinitionSearch && hits != null && hits.length == 1) {
+            if (isCrossRefSearch && isSingleDefinitionSearch && hits != null && hits.length == 1) {
                 Document doc = searcher.doc(hits[0].doc);
                 if (doc.getField(QueryBuilder.TAGS) != null) {
                     byte[] rawTags = doc.getField(QueryBuilder.TAGS).binaryValue().bytes;
@@ -412,9 +412,7 @@ public class SearchHelper {
                     }
                 }
             }
-            // @TODO fix me. I should try to figure out where the exact hit is
-            // instead of returning a page with just _one_ entry in....
-            if (uniqueDefinition && hits != null && hits.length > 0 && isCrossRefSearch) {
+            if (uniqueDefinition) {
                 redirect = contextPath + Prefix.XREF_P
                         + Util.URIEncodePath(searcher.doc(hits[0].doc).get(QueryBuilder.PATH))
                         + '#' + Util.URIEncode(((TermQuery) query).getTerm().text());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.BooleanQuery;
@@ -401,24 +402,25 @@ public class SearchHelper {
             // one single definition term AND we have exactly one match AND there
             // is only one definition of that symbol in the document that matches.
             boolean uniqueDefinition = false;
+            Document doc = null;
+            String symbol = null;
             if (isCrossRefSearch && isSingleDefinitionSearch && hits != null && hits.length == 1) {
-                Document doc = searcher.doc(hits[0].doc);
-                if (doc.getField(QueryBuilder.TAGS) != null) {
-                    byte[] rawTags = doc.getField(QueryBuilder.TAGS).binaryValue().bytes;
+                doc = searcher.doc(hits[0].doc);
+                IndexableField tagsField = doc.getField(QueryBuilder.TAGS);
+                if (tagsField != null) {
+                    byte[] rawTags = tagsField.binaryValue().bytes;
                     Definitions tags = Definitions.deserialize(rawTags);
-                    String symbol = ((TermQuery) query).getTerm().text();
+                    symbol = ((TermQuery) query).getTerm().text();
                     if (tags.occurrences(symbol) == 1) {
                         uniqueDefinition = true;
                     }
                 }
             }
             if (uniqueDefinition) {
-                String anchor = Util.URIEncode(((TermQuery) query).getTerm().text());
+                String anchor = Util.URIEncode(symbol);
                 redirect = contextPath + Prefix.XREF_P
-                        + Util.URIEncodePath(searcher.doc(hits[0].doc).get(QueryBuilder.PATH))
-                        + '?'
-                        + UriConsts.FRAGMENT_IDENTIFIER
-                        + '=' + anchor
+                        + Util.URIEncodePath(doc.get(QueryBuilder.PATH))
+                        + '?' + UriConsts.FRAGMENT_IDENTIFIER + '=' + anchor
                         + '#' + anchor;
             }
         } catch (BooleanQuery.TooManyClauses e) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/UriConsts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/UriConsts.java
@@ -1,0 +1,32 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.web;
+
+public class UriConsts {
+    public static final String FRAGMENT_IDENTIFIER = "fragment_identifier";
+
+    /* private to enforce static */
+    private UriConsts() {
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/DummyHttpServletRequest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/DummyHttpServletRequest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -26,6 +27,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -66,7 +68,9 @@ import static org.opengrok.indexer.util.RandomString.generate;
 public class DummyHttpServletRequest implements HttpServletRequest {
 
     private final Map<String, Object> attrs = new HashMap<>();
-    
+
+    private Map<String, String[]> parameters = Collections.emptyMap();
+
     private class DummyHttpSession implements HttpSession {
         private Map<String, Object> attrs = new HashMap<>();
 
@@ -159,7 +163,7 @@ public class DummyHttpServletRequest implements HttpServletRequest {
     };
     
     private HttpSession session;
-    
+
     @Override
     public String getAuthType() {
         throw new UnsupportedOperationException("Not supported yet.");
@@ -368,23 +372,45 @@ public class DummyHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
-    public String getParameter(String string) {
-        throw new UnsupportedOperationException("Not supported yet.");
+    public String getParameter(String name) {
+        String[] values = parameters.get(name);
+        if (values != null && values.length > 0) {
+            return values[0];
+        } else {
+            return null;
+        }
     }
 
     @Override
     public Enumeration<String> getParameterNames() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return Collections.enumeration(parameters.keySet());
     }
 
     @Override
-    public String[] getParameterValues(String string) {
-        throw new UnsupportedOperationException("Not supported yet.");
+    public String[] getParameterValues(String name) {
+        return parameters.get(name);
     }
 
     @Override
     public Map<String, String[]> getParameterMap() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return Collections.unmodifiableMap(parameters);
+    }
+
+    public void setParameterMap(Map<String, String[]> parameters) {
+        if (parameters == null) {
+            this.parameters = Collections.emptyMap();
+        } else {
+            this.parameters = new HashMap<>(parameters);
+            for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
+                String[] values;
+                if (entry.getValue() == null) {
+                    values = new String[0];
+                } else {
+                    values = Arrays.copyOf(entry.getValue(), entry.getValue().length);
+                }
+                this.parameters.put(entry.getKey(), values);
+            }
+        }
     }
 
     @Override

--- a/opengrok-web/src/main/webapp/search.jsp
+++ b/opengrok-web/src/main/webapp/search.jsp
@@ -20,7 +20,7 @@ CDDL HEADER END
 
 Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
-Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
 
 --%>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
@@ -83,6 +83,7 @@ include file="projects.jspf"
     SuggesterServiceFactory.getDefault().onSearch(cfg.getRequestedProjects(), searchHelper.query);
     if (searchHelper.redirect != null) {
         response.sendRedirect(searchHelper.redirect);
+        return;
     }
     if (searchHelper.errorMsg != null) {
         cfg.setTitle("Search Error");


### PR DESCRIPTION
Hello,

Please consider for integration this patch to remedy the broken functionality to automatically link to a definition from an xref file when the definition is the single search result.

While researching an approach for #1984 I found there was a former single-definition redirect that was no longer working but could be fixed with a bit of special handling.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
