### PR TITLE
Feature/redirect 1 result

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/DefinitionsTokenStream.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/DefinitionsTokenStream.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.plain;
@@ -118,7 +118,7 @@ public class DefinitionsTokenStream extends TokenStream {
 
             if (lineno >= 0 && lineno < brk.count() && tag.symbol != null &&
                     tag.text != null) {
-                int lineoff = brk.getPosition(lineno);
+                int lineoff = brk.getOffset(lineno);
                 if (tag.lineStart >= 0) {
                     PendingToken tok = new PendingToken(tag.symbol, lineoff +
                         tag.lineStart, lineoff + tag.lineEnd);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
@@ -151,8 +151,7 @@ public final class Results {
      * <li>{@link SearchHelper#historyContext} (ignored if {@code null})</li>
      * <li>{@link SearchHelper#sourceContext} (ignored if {@code null})</li>
      * <li>{@link SearchHelper#summarizer} (if sourceContext is not
-     * {@code null})</li> <li>{@link SearchHelper#compressed} (if sourceContext
-     * is not {@code null})</li> <li>{@link SearchHelper#sourceRoot} (if
+     * {@code null})</li> <li>{@link SearchHelper#sourceRoot} (if
      * sourceContext or historyContext is not {@code null})</li> </ul>
      *
      * @param out write destination

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
@@ -232,7 +232,7 @@ public final class Results {
                     AbstractAnalyzer.Genre genre = AbstractAnalyzer.Genre.get(
                             doc.get(QueryBuilder.T));
                     if (AbstractAnalyzer.Genre.XREFABLE == genre && sh.summarizer != null) {
-                        String xtags = getTags(xrefDataDir, rpath, sh.compressed);
+                        String xtags = getTags(xrefDataDir, rpath, env.isCompressXref());
                         // FIXME use Highlighter from lucene contrib here,
                         // instead of summarizer, we'd also get rid of
                         // apache lucene in whole source ...

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;
 
@@ -56,12 +56,13 @@ import org.opengrok.indexer.web.Util;
  */
 public class Context {
 
+    static final int MAXFILEREAD = 1024 * 1024;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(Context.class);
 
     private final Query query;
     private final QueryBuilder qbuilder;
     private final LineMatcher[] m;
-    static final int MAXFILEREAD = 1024 * 1024;
     private char[] buffer;
     PlainLineTokenizer tokens;
     String queryAsURI;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
@@ -63,7 +63,7 @@ public class Context {
     private final Query query;
     private final QueryBuilder qbuilder;
     private final LineMatcher[] m;
-    String queryAsURI;
+    private final String queryAsURI;
 
     /**
      * Map whose keys tell which fields to look for in the source file, and
@@ -95,7 +95,9 @@ public class Context {
         QueryMatchers qm = new QueryMatchers();
         m = qm.getMatchers(query, TOKEN_FIELDS);
         if (m != null) {
-            buildQueryAsURI(qbuilder.getQueries());
+            queryAsURI = buildQueryAsURI(qbuilder.getQueries());
+        } else {
+            queryAsURI = "";
         }
     }
 
@@ -232,10 +234,9 @@ public class Context {
      *
      * @param subqueries a map containing the query text for each field
      */
-    private void buildQueryAsURI(Map<String, String> subqueries) {
+    private String buildQueryAsURI(Map<String, String> subqueries) {
         if (subqueries.isEmpty()) {
-            queryAsURI = "";
-            return;
+            return "";
         }
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<String, String> entry : subqueries.entrySet()) {
@@ -245,7 +246,7 @@ public class Context {
                 .append('&');
         }
         sb.setLength(sb.length() - 1);
-        queryAsURI = sb.toString();
+        return sb.toString();
     }
 
     private boolean alt = true;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
@@ -63,7 +63,6 @@ public class Context {
     private final Query query;
     private final QueryBuilder qbuilder;
     private final LineMatcher[] m;
-    private char[] buffer;
     PlainLineTokenizer tokens;
     String queryAsURI;
 
@@ -99,7 +98,6 @@ public class Context {
         if (m != null) {
             buildQueryAsURI(qbuilder.getQueries());
             //System.err.println("Found Matchers = "+ m.length + " for " + query);
-            buffer = new char[MAXFILEREAD];
             tokens = new PlainLineTokenizer((Reader) null);
         }
     }
@@ -213,7 +211,7 @@ public class Context {
 
         try {
             List<String> fieldList = qbuilder.getContextFields();
-            String[] fields = fieldList.toArray(new String[fieldList.size()]);
+            String[] fields = fieldList.toArray(new String[0]);
 
             String res = uhi.highlightFieldsUnion(fields, query, docId,
                 linelimit);
@@ -299,7 +297,8 @@ public class Context {
                             if (scopes != null) {
                                 Scope scp = scopes.getScope(tag.line);
                                 scope = scp.getName() + "()";
-                                scopeUrl = "<a href=\"" + urlPrefixE + pathE + "#" + Integer.toString(scp.getLineFrom()) + "\">" + scope + "</a>";
+                                scopeUrl = "<a href=\"" + urlPrefixE + pathE + "#" +
+                                        scp.getLineFrom() + "\">" + scope + "</a>";
                             }
 
                             /* desc[0] is matched symbol
@@ -368,7 +367,7 @@ public class Context {
         if (in == null) {
             return anything;
         }
-        int charsRead = 0;
+        int charsRead;
         boolean truncated = false;
 
         boolean lim = limit;
@@ -378,6 +377,7 @@ public class Context {
         }
 
         if (lim) {
+            char[] buffer = new char[MAXFILEREAD];
             try {
                 charsRead = in.read(buffer);
                 if (charsRead == MAXFILEREAD) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/Context.java
@@ -63,7 +63,6 @@ public class Context {
     private final Query query;
     private final QueryBuilder qbuilder;
     private final LineMatcher[] m;
-    PlainLineTokenizer tokens;
     String queryAsURI;
 
     /**
@@ -97,8 +96,6 @@ public class Context {
         m = qm.getMatchers(query, TOKEN_FIELDS);
         if (m != null) {
             buildQueryAsURI(qbuilder.getQueries());
-            //System.err.println("Found Matchers = "+ m.length + " for " + query);
-            tokens = new PlainLineTokenizer((Reader) null);
         }
     }
 
@@ -367,9 +364,9 @@ public class Context {
         if (in == null) {
             return anything;
         }
-        int charsRead;
-        boolean truncated = false;
 
+        PlainLineTokenizer tokens = new PlainLineTokenizer(null);
+        boolean truncated = false;
         boolean lim = limit;
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         if (!env.isQuickContextScan()) {
@@ -378,6 +375,7 @@ public class Context {
 
         if (lim) {
             char[] buffer = new char[MAXFILEREAD];
+            int charsRead;
             try {
                 charsRead = in.read(buffer);
                 if (charsRead == MAXFILEREAD) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/ContextFormatter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/ContextFormatter.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.search.context;
@@ -323,7 +323,7 @@ public class ContextFormatter extends PassageFormatter {
             throws IOException {
         Scopes.Scope scope = null;
         if (scopes != null) {
-            // N.b. use ctags 1-offset vs 0-offset.
+            // N.b. use ctags 1-based indexing vs 0-based.
             scope = scopes.getScope(lineOffset + 1);
         }
         if (scope != null && scope != scopes.getScope(-1)) {
@@ -340,7 +340,7 @@ public class ContextFormatter extends PassageFormatter {
     private void writeTag(int lineOffset, Appendable dest, List<String> marks)
             throws IOException {
         if (defs != null) {
-            // N.b. use ctags 1-offset vs 0-offset.
+            // N.b. use ctags 1-based indexing vs 0-based.
             List<Tag> linetags =  defs.getTags(lineOffset + 1);
             if (linetags != null) {
                 Tag pickedTag = findTagForMark(linetags, marks);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/PassageConverter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/PassageConverter.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.search.context;
@@ -75,11 +75,11 @@ public class PassageConverter {
                 continue;
             }
 
-            int m = splitter.findLineOffset(start);
+            int m = splitter.findLineIndex(start);
             if (m < 0) {
                 continue;
             }
-            int n = splitter.findLineOffset(end - 1);
+            int n = splitter.findLineIndex(end - 1);
             if (n < 0) {
                 continue;
             }
@@ -97,23 +97,23 @@ public class PassageConverter {
             // Create LineHighlight entries for passage matches.
             for (int i = 0; i < passage.getNumMatches(); ++i) {
                 int mstart = passage.getMatchStarts()[i];
-                int mm = splitter.findLineOffset(mstart);
+                int mm = splitter.findLineIndex(mstart);
                 int mend = passage.getMatchEnds()[i];
-                int nn = splitter.findLineOffset(mend - 1);
+                int nn = splitter.findLineIndex(mend - 1);
                 if (mstart < mend && mm >= m && mm <= n && nn >= m && nn <= n) {
                     if (mm == nn) {
-                        int lbeg = splitter.getPosition(mm);
+                        int lbeg = splitter.getOffset(mm);
                         int lstart = mstart - lbeg;
                         int lend = mend - lbeg;
                         LineHighlight lhigh = res.get(mm);
                         lhigh.addMarkup(PhraseHighlight.create(lstart, lend));
                     } else {
-                        int lbeg = splitter.getPosition(mm);
+                        int lbeg = splitter.getOffset(mm);
                         int loff = mstart - lbeg;
                         LineHighlight lhigh = res.get(mm);
                         lhigh.addMarkup(PhraseHighlight.createStarter(loff));
 
-                        lbeg = splitter.getPosition(nn);
+                        lbeg = splitter.getOffset(nn);
                         loff = mend - lbeg;
                         lhigh = res.get(nn);
                         lhigh.addMarkup(PhraseHighlight.createEnder(loff));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/LineBreaker.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/LineBreaker.java
@@ -76,33 +76,30 @@ public class LineBreaker {
         int c;
         while ((c = reader.read()) != -1) {
             ++length;
-            switch (c) {
-                case '\r':
-                    c = reader.read();
-                    if (c == -1) {
-                        newOffsets.add(length);
-                        break;
-                    } else {
-                        ++length;
-                        switch (c) {
-                            case '\n':
-                                newOffsets.add(length);
-                                break;
-                            case '\r':
-                                newOffsets.add(length - 1);
-                                newOffsets.add(length);
-                                break;
-                            default:
-                                newOffsets.add(length - 1);
-                                break;
+
+            redo_c:
+            while (true) {
+                switch (c) {
+                    case '\r':
+                        c = reader.read();
+                        if (c == -1) {
+                            newOffsets.add(length);
+                            break redo_c;
                         }
-                    }
-                    break;
-                case '\n':
-                    newOffsets.add(length);
-                    break;
-                default:
-                    break;
+                        ++length;
+                        if (c == '\n') {
+                            newOffsets.add(length);
+                            break redo_c;
+                        }
+                        newOffsets.add(length - 1);
+                        continue redo_c;
+                    case '\n':
+                        newOffsets.add(length);
+                        break redo_c;
+                    default:
+                        // pass
+                }
+                break;
             }
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/LineBreaker.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/LineBreaker.java
@@ -18,16 +18,13 @@
  */
 
 /*
- * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.util;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.opengrok.indexer.analysis.StreamSource;
@@ -40,6 +37,7 @@ import org.opengrok.indexer.analysis.StreamSource;
 public class LineBreaker {
 
     private int length;
+    private int count;
     private int[] lineOffsets;
 
     /**
@@ -65,29 +63,13 @@ public class LineBreaker {
             throw new IllegalArgumentException("`src' is null");
         }
 
-        length = 0;
-        lineOffsets = null;
-
-        try (InputStream in = src.getStream();
-            Reader rdr = IOUtils.createBOMStrippedReader(in,
-                StandardCharsets.UTF_8.name())) {
-            Reader intermediate = null;
-            if (wrapper != null) {
-                intermediate = wrapper.get(rdr);
-            }
-
-            try (BufferedReader brdr = new BufferedReader(
-                    intermediate != null ? intermediate : rdr)) {
-                reset(brdr);
-            } finally {
-                if (intermediate != null) {
-                    intermediate.close();
-                }
-            }
-        }
+        SplitterUtil.reset(this::reset, src, wrapper);
     }
 
     private void reset(Reader reader) throws IOException {
+        length = 0;
+        lineOffsets = null;
+
         List<Integer> newOffsets = new ArrayList<>();
         newOffsets.add(0);
 
@@ -124,6 +106,12 @@ public class LineBreaker {
             }
         }
 
+        count = newOffsets.size();
+        if (newOffsets.get(newOffsets.size() - 1) < length) {
+            newOffsets.add(length);
+            // Do not increment count.
+        }
+
         lineOffsets = new int[newOffsets.size()];
         for (int i = 0; i < lineOffsets.length; ++i) {
             lineOffsets[i] = newOffsets.get(i);
@@ -139,28 +127,44 @@ public class LineBreaker {
     }
 
     /**
-     * Gets the number of broken lines.
-     * @return value
+     * Gets the number of split lines.
      */
     public int count() {
         if (lineOffsets == null) {
             throw new IllegalStateException("reset() did not succeed");
         }
-        return lineOffsets.length;
+        return count;
     }
 
     /**
-     * Gets the starting document character position of the line at the
-     * specified offset.
-     * @param offset greater than or equal to zero and less than or equal to
+     * Gets the starting document character offset of the line at the
+     * specified index in the lines list.
+     * @param index greater than or equal to zero and less than or equal to
      * {@link #count()}
-     * @return line length, including the end-of-line token
-     * @throws IllegalArgumentException if {@code offset} is out of bounds
+     * @return line starting offset
+     * @throws IllegalArgumentException if {@code index} is out of bounds
      */
-    public int getPosition(int offset) {
-        if (offset < 0 || lineOffsets == null || offset >= lineOffsets.length) {
-            throw new IllegalArgumentException("`offset' is out of bounds");
+    public int getOffset(int index) {
+        if (lineOffsets == null) {
+            throw new IllegalStateException("reset() did not succeed");
         }
-        return lineOffsets[offset];
+        if (index < 0 || index >= lineOffsets.length) {
+            throw new IllegalArgumentException("index is out of bounds");
+        }
+        return lineOffsets[index];
+    }
+
+    /**
+     * Find the line index for the specified document offset.
+     * @param offset greater than or equal to zero and less than
+     * {@link #originalLength()}.
+     * @return -1 if {@code offset} is beyond the document bounds; otherwise,
+     * a valid index
+     */
+    public int findLineIndex(int offset) {
+        if (lineOffsets == null) {
+            throw new IllegalStateException("reset() did not succeed");
+        }
+        return SplitterUtil.findLineIndex(length, lineOffsets, offset);
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/LineBreaker.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/LineBreaker.java
@@ -71,43 +71,11 @@ public class LineBreaker {
         lineOffsets = null;
 
         List<Integer> newOffsets = new ArrayList<>();
-        newOffsets.add(0);
-
-        int c;
-        while ((c = reader.read()) != -1) {
-            ++length;
-
-            redo_c:
-            while (true) {
-                switch (c) {
-                    case '\r':
-                        c = reader.read();
-                        if (c == -1) {
-                            newOffsets.add(length);
-                            break redo_c;
-                        }
-                        ++length;
-                        if (c == '\n') {
-                            newOffsets.add(length);
-                            break redo_c;
-                        }
-                        newOffsets.add(length - 1);
-                        continue redo_c;
-                    case '\n':
-                        newOffsets.add(length);
-                        break redo_c;
-                    default:
-                        // pass
-                }
-                break;
-            }
-        }
-
-        count = newOffsets.size();
-        if (newOffsets.get(newOffsets.size() - 1) < length) {
-            newOffsets.add(length);
-            // Do not increment count.
-        }
+        LineBreakerScanner scanner = new LineBreakerScanner(reader);
+        scanner.setTarget(newOffsets);
+        scanner.consume();
+        length = scanner.getLength();
+        count = newOffsets.size() - 1;
 
         lineOffsets = new int[newOffsets.size()];
         for (int i = 0; i < lineOffsets.length; ++i) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/SourceSplitter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/SourceSplitter.java
@@ -159,52 +159,10 @@ public class SourceSplitter {
         lineOffsets = null;
 
         List<String> slist = new ArrayList<>();
-        StringBuilder bld = new StringBuilder();
-        int c;
-        while ((c = reader.read()) != -1) {
-            ++length;
-
-            redo_c:
-            while (true) {
-                bld.append((char) c);
-                switch (c) {
-                    case '\r':
-                        c = reader.read();
-                        if (c == -1) {
-                            slist.add(bld.toString());
-                            bld.setLength(0);
-                            break redo_c;
-                        }
-                        ++length;
-                        if (c == '\n') {
-                            bld.append((char) c);
-                            slist.add(bld.toString());
-                            bld.setLength(0);
-                            break redo_c;
-                        }
-                        slist.add(bld.toString());
-                        bld.setLength(0);
-                        continue redo_c;
-                    case '\n':
-                        slist.add(bld.toString());
-                        bld.setLength(0);
-                        break redo_c;
-                    default:
-                        // pass
-                }
-                break;
-            }
-        }
-        if (bld.length() > 0) {
-            slist.add(bld.toString());
-            bld.setLength(0);
-        } else {
-            /*
-             * Following JFlexXref's custom, an empty file or a file ending
-             * with LF produces an additional line of length zero.
-             */
-            slist.add("");
-        }
+        SourceSplitterScanner scanner = new SourceSplitterScanner(reader);
+        scanner.setTarget(slist);
+        scanner.consume();
+        length = scanner.getLength();
 
         lines = slist.toArray(new String[0]);
         setLineOffsets();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/SourceSplitter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/SourceSplitter.java
@@ -18,25 +18,22 @@
  */
 
 /*
- * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.util;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
 import org.opengrok.indexer.analysis.StreamSource;
 
 /**
- * Represents a splitter of source text into lines where end-of-line tokens --
- * identified by {@link StringUtils#STANDARD_EOL} -- are maintained instead of
- * being stripped.
+ * Represents a splitter of source text into lines, where end-of-line tokens --
+ * in accordance with {@link StringUtils#STANDARD_EOL} -- are maintained instead
+ * of being stripped.
  */
 public class SourceSplitter {
 
@@ -46,7 +43,6 @@ public class SourceSplitter {
 
     /**
      * Gets the number of characters in the original source document.
-     * @return value
      */
     public int originalLength() {
         return length;
@@ -54,82 +50,61 @@ public class SourceSplitter {
 
     /**
      * Gets the number of split lines.
-     * @return value
      */
     public int count() {
         if (lines == null) {
-            throw new IllegalStateException("reset() has not succeeded");
+            throw new IllegalStateException("reset() did not succeed");
         }
         return lines.length;
     }
 
     /**
-     * Gets the lines at the specified offset.
-     * @param offset greater than or equal to zero and less than
+     * Gets the line at the specified index in the lines list.
+     * @param index greater than or equal to zero and less than
      * {@link #count()}
      * @return defined instance
-     * @throws IllegalArgumentException if {@code offset} is out of bounds
+     * @throws IllegalArgumentException if {@code index} is out of bounds
      */
-    public String getLine(int offset) {
+    public String getLine(int index) {
         if (lines == null) {
-            throw new IllegalStateException("reset() has not succeeded");
+            throw new IllegalStateException("reset() did not succeed");
         }
-        if (offset < 0 || offset >= lines.length) {
-            throw new IllegalArgumentException("`offset' is out of bounds");
+        if (index < 0 || index >= lines.length) {
+            throw new IllegalArgumentException("index is out of bounds");
         }
-        return lines[offset];
+        return lines[index];
     }
 
     /**
-     * Gets the starting document character position of the line at the
-     * specified offset.
-     * @param offset greater than or equal to zero and less than or equal to
+     * Gets the starting document character offset of the line at the
+     * specified index in the lines list.
+     * @param index greater than or equal to zero and less than or equal to
      * {@link #count()}
-     * @return line length, including the end-of-line token
-     * @throws IllegalArgumentException if {@code offset} is out of bounds
+     * @return line starting offset
+     * @throws IllegalArgumentException if {@code index} is out of bounds
      */
-    public int getPosition(int offset) {
+    public int getOffset(int index) {
         if (lineOffsets == null) {
-            throw new IllegalStateException("reset() has not succeeded");
+            throw new IllegalStateException("reset() did not succeed");
         }
-        if (offset < 0 || offset >= lineOffsets.length) {
-            throw new IllegalArgumentException("`offset' is out of bounds");
+        if (index < 0 || index >= lineOffsets.length) {
+            throw new IllegalArgumentException("index is out of bounds");
         }
-        return lineOffsets[offset];
+        return lineOffsets[index];
     }
 
     /**
-     * Find the line offset for the specified document position.
-     * @param position greater than or equal to zero and less than
+     * Find the line index for the specified document offset.
+     * @param offset greater than or equal to zero and less than
      * {@link #originalLength()}.
-     * @return -1 if {@code position} is beyond the document bounds; otherwise,
-     * a valid offset
+     * @return -1 if {@code offset} is beyond the document bounds; otherwise,
+     * a valid index
      */
-    public int findLineOffset(int position) {
+    public int findLineIndex(int offset) {
         if (lineOffsets == null) {
-            throw new IllegalStateException("reset() has not succeeded");
+            throw new IllegalStateException("reset() did not succeed");
         }
-        if (position < 0 || position > length) {
-            return -1;
-        }
-
-        int lo = 0;
-        int hi = lineOffsets.length - 1;
-        int mid;
-        while (lo <= hi) {
-            mid = lo + (hi - lo) / 2;
-            int linelen = mid < lines.length ? lines[mid].length() : 0;
-            if (position < lineOffsets[mid]) {
-                hi = mid - 1;
-            } else if (linelen == 0 && position == lineOffsets[mid]) {
-                return mid;
-            } else if (position >= lineOffsets[mid] + linelen) {
-                lo = mid + 1;
-            } else {
-                return mid;
-            }
-        }
-        return -1;
+        return SplitterUtil.findLineIndex(length, lineOffsets, offset);
     }
 
     /**
@@ -141,29 +116,15 @@ public class SourceSplitter {
             throw new IllegalArgumentException("`original' is null");
         }
 
-        length = original.length();
-        lines = null;
-        lineOffsets = null;
-
-        List<String> slist = new ArrayList<>();
-        int position = 0;
-        Matcher eolm = StringUtils.STANDARD_EOL.matcher(original);
-        while (eolm.find()) {
-            slist.add(original.substring(position, eolm.end()));
-            position = eolm.end();
-        }
-        if (position < original.length()) {
-            slist.add(original.substring(position));
-        } else {
+        try {
+            reset(new StringReader(original));
+        } catch (IOException ex) {
             /*
-             * Following JFlexXref's custom, an empty file or a file ending
-             * with LF produces an additional line of length zero.
+             * Should not get here, as String and StringReader operations cannot
+             * throw IOException.
              */
-            slist.add("");
+            throw new RuntimeException(ex);
         }
-
-        lines = slist.stream().toArray(String[]::new);
-        setLineOffsets();
     }
 
     /**
@@ -189,30 +150,14 @@ public class SourceSplitter {
             throw new IllegalArgumentException("`src' is null");
         }
 
+        SplitterUtil.reset(this::reset, src, wrapper);
+    }
+
+    private void reset(Reader reader) throws IOException {
         length = 0;
         lines = null;
         lineOffsets = null;
 
-        try (InputStream in = src.getStream();
-            Reader rdr = IOUtils.createBOMStrippedReader(in,
-                StandardCharsets.UTF_8.name())) {
-            Reader intermediate = null;
-            if (wrapper != null) {
-                intermediate = wrapper.get(rdr);
-            }
-
-            try (BufferedReader brdr = new BufferedReader(
-                    intermediate != null ? intermediate : rdr)) {
-                reset(brdr);
-            } finally {
-                if (intermediate != null) {
-                    intermediate.close();
-                }
-            }
-        }
-    }
-
-    private void reset(Reader reader) throws IOException {
         List<String> slist = new ArrayList<>();
         StringBuilder bld = new StringBuilder();
         int c;
@@ -270,21 +215,21 @@ public class SourceSplitter {
             slist.add("");
         }
 
-        lines = slist.stream().toArray(String[]::new);
+        lines = slist.toArray(new String[0]);
         setLineOffsets();
     }
 
     private void setLineOffsets() {
-        /**
-         * Add one more entry for lineOffsets so that findLineOffset() can
+        /*
+         * Add one more entry for lineOffsets so that findLineIndex() can
          * easily work on the last line.
          */
         lineOffsets = new int[lines.length + 1];
-        int position = 0;
+        int offset = 0;
         for (int i = 0; i < lineOffsets.length; ++i) {
-            lineOffsets[i] = position;
+            lineOffsets[i] = offset;
             if (i < lines.length) {
-                position += lines[i].length();
+                offset += lines[i].length();
             }
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/SourceSplitter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/SourceSplitter.java
@@ -163,45 +163,36 @@ public class SourceSplitter {
         int c;
         while ((c = reader.read()) != -1) {
             ++length;
-            bld.append((char) c);
-            switch (c) {
-                case '\r':
-                    c = reader.read();
-                    if (c == -1) {
+
+            redo_c:
+            while (true) {
+                bld.append((char) c);
+                switch (c) {
+                    case '\r':
+                        c = reader.read();
+                        if (c == -1) {
+                            slist.add(bld.toString());
+                            bld.setLength(0);
+                            break redo_c;
+                        }
+                        ++length;
+                        if (c == '\n') {
+                            bld.append((char) c);
+                            slist.add(bld.toString());
+                            bld.setLength(0);
+                            break redo_c;
+                        }
                         slist.add(bld.toString());
                         bld.setLength(0);
-                        break;
-                    } else {
-                        ++length;
-                        switch (c) {
-                            case '\n':
-                                bld.append((char) c);
-                                slist.add(bld.toString());
-                                bld.setLength(0);
-                                break;
-                            case '\r':
-                                slist.add(bld.toString());
-                                bld.setLength(0);
-
-                                bld.append((char) c);
-                                slist.add(bld.toString());
-                                bld.setLength(0);
-                                break;
-                            default:
-                                slist.add(bld.toString());
-                                bld.setLength(0);
-
-                                bld.append((char) c);
-                                break;
-                        }
-                    }
-                    break;
-                case '\n':
-                    slist.add(bld.toString());
-                    bld.setLength(0);
-                    break;
-                default:
-                    break;
+                        continue redo_c;
+                    case '\n':
+                        slist.add(bld.toString());
+                        bld.setLength(0);
+                        break redo_c;
+                    default:
+                        // pass
+                }
+                break;
             }
         }
         if (bld.length() > 0) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/SplitterUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/SplitterUtil.java
@@ -1,0 +1,113 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.util;
+
+import org.opengrok.indexer.analysis.StreamSource;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Represents a container for reusable splitter-oriented utility methods.
+ */
+class SplitterUtil {
+
+    @FunctionalInterface
+    interface Resetter {
+        void reset(Reader reader) throws IOException;
+    }
+
+    /**
+     * Find the line index for the specified document offset.
+     * @param offset greater than or equal to zero and less than
+     * {@code length}.
+     * @return -1 if {@code offset} is beyond the document bounds; otherwise,
+     * a valid index
+     */
+    static int findLineIndex(int length, int[] lineOffsets, int offset) {
+        if (lineOffsets == null) {
+            throw new IllegalArgumentException("lineOffsets");
+        }
+        if (offset < 0 || offset > length) {
+            return -1;
+        }
+
+        int lo = 0;
+        int hi = lineOffsets.length - 1;
+        int mid;
+        while (lo <= hi) {
+            mid = lo + (hi - lo) / 2;
+            int lineLength = (mid + 1 < lineOffsets.length ? lineOffsets[mid + 1] : length) -
+                    lineOffsets[mid];
+            if (offset < lineOffsets[mid]) {
+                hi = mid - 1;
+            } else if (lineLength == 0 && offset == lineOffsets[mid]) {
+                return mid;
+            } else if (offset >= lineOffsets[mid] + lineLength) {
+                lo = mid + 1;
+            } else {
+                return mid;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Resets the breaker using the specified inputs.
+     * @param resetter a defined instance
+     * @param src a defined instance
+     * @param wrapper an optional instance
+     * @throws java.io.IOException if an I/O error occurs
+     */
+    static void reset(Resetter resetter, StreamSource src, ReaderWrapper wrapper)
+            throws IOException {
+        if (src == null) {
+            throw new IllegalArgumentException("src is null");
+        }
+
+        try (InputStream in = src.getStream();
+             Reader rdr = IOUtils.createBOMStrippedReader(in, StandardCharsets.UTF_8.name())) {
+            Reader intermediate = null;
+            if (wrapper != null) {
+                intermediate = wrapper.get(rdr);
+            }
+
+            try (BufferedReader brdr = new BufferedReader(intermediate != null ?
+                    intermediate : rdr)) {
+                resetter.reset(brdr);
+            } finally {
+                if (intermediate != null) {
+                    intermediate.close();
+                }
+            }
+        }
+    }
+
+    /* private to enforce static. */
+    private SplitterUtil() {
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StringUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StringUtils.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.util;
@@ -37,7 +37,7 @@ public final class StringUtils {
     /**
      * Matches a standard end-of-line indicator, identical to Common.lexh's {EOL}.
      */
-    public static final Pattern STANDARD_EOL = Pattern.compile("\\r?\\n|\\r");
+    public static final Pattern STANDARD_EOL = Pattern.compile("\\r\\n?|\\n");
 
     /**
      * Matches an apostrophe not following a backslash escape or following an

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -361,7 +361,7 @@ public final class PageConfig {
      * @see DiffType#toString()
      */
     public DiffType getDiffType() {
-        DiffType d = DiffType.get(req.getParameter("format"));
+        DiffType d = DiffType.get(req.getParameter(QueryParameters.FORMAT_PARAM));
         return d == null ? DiffType.SIDEBYSIDE : d;
     }
 
@@ -723,7 +723,7 @@ public final class PageConfig {
     public boolean annotate() {
         if (annotate == null) {
             annotate = hasAnnotations()
-                    && Boolean.parseBoolean(req.getParameter("a"));
+                    && Boolean.parseBoolean(req.getParameter(QueryParameters.ANNOTATION_PARAM));
         }
         return annotate;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1334,15 +1334,11 @@ public final class PageConfig {
 
     /**
      * Get the location of cross reference for given file containing the given revision.
-     * @param revStr revision string
-     * @return location to redirect to or null if revision string is empty
+     * @param revStr defined revision string
+     * @return location to redirect to
      */
     public String getRevisionLocation(String revStr) {
         StringBuilder sb = new StringBuilder();
-
-        if (revStr == null) {
-            return null;
-        }
 
         sb.append(req.getContextPath());
         sb.append(Prefix.XREF_P);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1355,6 +1355,11 @@ public final class PageConfig {
             sb.append("&");
             sb.append(req.getQueryString());
         }
+        String frag = req.getParameter(QueryParameters.FRAGMENT_IDENTIFIER_PARAM);
+        if (frag != null) {
+            sb.append("#");
+            sb.append(Util.URIEncode(frag));
+        }
 
         return sb.toString();
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1527,6 +1527,8 @@ public final class PageConfig {
         sh.isGuiSearch = sh.isCrossRefSearch || getPrefix() == Prefix.SEARCH_P;
         sh.desc = getEftarReader();
         sh.sourceRoot = new File(getSourceRootPath());
+        String xrValue = req.getParameter(QueryParameters.NO_REDIRECT_PARAM);
+        sh.noRedirect = xrValue != null && !xrValue.isEmpty();
         return sh;
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -65,6 +65,7 @@ import org.opengrok.indexer.Info;
 import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.analysis.ExpandTabsReader;
+import org.opengrok.indexer.analysis.StreamSource;
 import org.opengrok.indexer.authorization.AuthorizationFramework;
 import org.opengrok.indexer.configuration.Group;
 import org.opengrok.indexer.configuration.Project;
@@ -78,6 +79,7 @@ import org.opengrok.indexer.index.IgnoredNames;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.IOUtils;
+import org.opengrok.indexer.util.LineBreaker;
 import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.messages.MessagesContainer.AcceptedMessage;
 import org.suigeneris.jrcs.diff.Diff;
@@ -131,6 +133,7 @@ public final class PageConfig {
     private String pageTitle;
     private String dtag;
     private String rev;
+    private String fragmentIdentifier; // Also settable via match offset translation
     private Boolean hasAnnotation;
     private Boolean annotate;
     private Annotation annotation;
@@ -309,7 +312,7 @@ public final class PageConfig {
                         while ((line = br.readLine()) != null) {
                             lines.add(line);
                         }
-                        data.file[i] = lines.toArray(new String[lines.size()]);
+                        data.file[i] = lines.toArray(new String[0]);
                         lines.clear();
                     }
                     in[i] = null;
@@ -536,7 +539,7 @@ public final class PageConfig {
                     ret = x;
                 }
             } catch (NumberFormatException e) {
-                LOGGER.log(Level.INFO, "Failed to parse integer " + s, e);
+                LOGGER.log(Level.INFO, "Failed to parse " + name + " integer " + s, e);
             }
         }
         return ret;
@@ -746,15 +749,6 @@ public final class PageConfig {
             /* ignore */
         }
         return annotation;
-    }
-
-    /**
-     * Get the name which should be show as "Crossfile".
-     *
-     * @return the name of the related file or directory.
-     */
-    public String getCrossFilename() {
-        return getResourceFile().getName();
     }
 
     /**
@@ -1351,10 +1345,22 @@ public final class PageConfig {
             sb.append("&");
             sb.append(req.getQueryString());
         }
-        String frag = req.getParameter(QueryParameters.FRAGMENT_IDENTIFIER_PARAM);
-        if (frag != null) {
+        if (fragmentIdentifier != null) {
+            String anchor = Util.URIEncode(fragmentIdentifier);
+
+            String reqFrag = req.getParameter(QueryParameters.FRAGMENT_IDENTIFIER_PARAM);
+            if (reqFrag == null || reqFrag.isEmpty()) {
+                /*
+                 * We've determined that the fragmentIdentifier field must have
+                 * been set to augment request parameters. Now include it
+                 * explicitly in the next request parameters.
+                 */
+                sb.append("&");
+                sb.append(QueryParameters.FRAGMENT_IDENTIFIER_PARAM_EQ);
+                sb.append(anchor);
+            }
             sb.append("#");
-            sb.append(Util.URIEncode(frag));
+            sb.append(anchor);
         }
 
         return sb.toString();
@@ -1518,6 +1524,7 @@ public final class PageConfig {
         // jel: this should be IMHO a config param since not only core dependend
         sh.parallel = Runtime.getRuntime().availableProcessors() > 1;
         sh.isCrossRefSearch = getPrefix() == Prefix.SEARCH_R;
+        sh.isGuiSearch = sh.isCrossRefSearch || getPrefix() == Prefix.SEARCH_P;
         sh.compressed = env.isCompressXref();
         sh.desc = getEftarReader();
         sh.sourceRoot = new File(getSourceRootPath());
@@ -1547,6 +1554,7 @@ public final class PageConfig {
         this.req = req;
         this.authFramework = RuntimeEnvironment.getInstance().getAuthorizationFramework();
         this.executor = RuntimeEnvironment.getInstance().getRevisionExecutor();
+        this.fragmentIdentifier = req.getParameter(QueryParameters.FRAGMENT_IDENTIFIER_PARAM);
     }
 
     /**
@@ -1781,5 +1789,31 @@ public final class PageConfig {
      */
     public static String getRelativePath(String root, String path) {
         return Paths.get(root).relativize(Paths.get(path)).toString();
+    }
+
+    public boolean evaluateMatchOffset() {
+        if (fragmentIdentifier == null) {
+            int matchOffset = getIntParam(QueryParameters.MATCH_OFFSET_PARAM, -1);
+            if (matchOffset >= 0) {
+                File resourceFile = getResourceFile();
+                if (resourceFile.isFile()) {
+                    LineBreaker breaker = new LineBreaker();
+                    StreamSource streamSource = StreamSource.fromFile(resourceFile);
+                    try {
+                        breaker.reset(streamSource);
+                        int matchLine = breaker.findLineIndex(matchOffset);
+                        if (matchLine >= 0) {
+                            // Convert to 1-based offset to accord with OpenGrok line number.
+                            fragmentIdentifier = String.valueOf(matchLine + 1);
+                            return true;
+                        }
+                    } catch (IOException e) {
+                        LOGGER.log(Level.WARNING, "Failed to evaluate match offset for " +
+                                resourceFile, e);
+                    }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1525,7 +1525,6 @@ public final class PageConfig {
         sh.parallel = Runtime.getRuntime().availableProcessors() > 1;
         sh.isCrossRefSearch = getPrefix() == Prefix.SEARCH_R;
         sh.isGuiSearch = sh.isCrossRefSearch || getPrefix() == Prefix.SEARCH_P;
-        sh.compressed = env.isCompressXref();
         sh.desc = getEftarReader();
         sh.sourceRoot = new File(getSourceRootPath());
         return sh;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
@@ -20,6 +20,7 @@
 /*
  * Copyright (c) 2011 Jens Elkner.
  * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -105,7 +106,7 @@ public enum Prefix {
      * @see #toString()
      */
     public static Prefix get(String servletPath) {
-        if (servletPath == null || servletPath.length() < 3 || servletPath.charAt(0) != '/') {
+        if (servletPath == null || servletPath.length() < 2 || servletPath.charAt(0) != '/') {
             return UNKNOWN;
         }
         int idx = servletPath.indexOf('/', 1);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/QueryParameters.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/QueryParameters.java
@@ -108,6 +108,16 @@ public class QueryParameters {
     public static final String HIST_SEARCH_PARAM_EQ = HIST_SEARCH_PARAM + "=";
 
     /**
+     * Parameter name to specify a match offset.
+     */
+    public static final String MATCH_OFFSET_PARAM = "mo";
+
+    /**
+     * {@link #MATCH_OFFSET_PARAM} concatenated with {@code "=" }.
+     */
+    public static final String MATCH_OFFSET_PARAM_EQ = MATCH_OFFSET_PARAM + "=";
+
+    /**
      * Parameter name to specify an OpenGrok search of paths.
      */
     public static final String PATH_SEARCH_PARAM = "path";

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/QueryParameters.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/QueryParameters.java
@@ -78,6 +78,16 @@ public class QueryParameters {
     public static final String FORMAT_PARAM_EQ = FORMAT_PARAM + "=";
 
     /**
+     * Parameter name to specify a mediated fragment identifier.
+     */
+    public static final String FRAGMENT_IDENTIFIER_PARAM = "fi";
+
+    /**
+     * {@link #FRAGMENT_IDENTIFIER_PARAM} concatenated with {@code "=" }.
+     */
+    public static final String FRAGMENT_IDENTIFIER_PARAM_EQ = FRAGMENT_IDENTIFIER_PARAM + "=";
+
+    /**
      * Parameter name to specify an OpenGrok full search.
      */
     public static final String FULL_SEARCH_PARAM = "full";

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/QueryParameters.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/QueryParameters.java
@@ -118,6 +118,13 @@ public class QueryParameters {
     public static final String MATCH_OFFSET_PARAM_EQ = MATCH_OFFSET_PARAM + "=";
 
     /**
+     * Parameter name to specify a value indicating if redirection should be
+     * short-circuited when state or query result would have an indicated
+     * otherwise.
+     */
+    public static final String NO_REDIRECT_PARAM = "xrd";
+
+    /**
      * Parameter name to specify an OpenGrok search of paths.
      */
     public static final String PATH_SEARCH_PARAM = "path";

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
@@ -110,7 +110,7 @@ public class Scripts implements Iterable<Scripts.Script> {
         putjs("jquery-ui", "js/jquery-ui-1.12.1-custom", 11);
         putjs("jquery-tablesorter", "js/jquery-tablesorter-2.26.6", 12);
         putjs("tablesorter-parsers", "js/tablesorter-parsers-0.0.2", 13, true);
-        putjs("searchable-option-list", "js/searchable-option-list-2.0.11", 14);
+        putjs("searchable-option-list", "js/searchable-option-list-2.0.12", 14);
         putjs("utils", "js/utils-0.0.34", 15, true);
         putjs("repos", "js/repos-0.0.2", 20, true);
         putjs("diff", "js/diff-0.0.4", 20, true);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -468,7 +468,7 @@ public class SearchHelper {
         Query rewritten = query.rewrite(reader);
         Weight weight = rewritten.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1);
         Matches matches = weight.matches(leaf, docID);
-        if (matches != MatchesUtils.MATCH_WITH_NO_TERMS) {
+        if (matches != null && matches != MatchesUtils.MATCH_WITH_NO_TERMS) {
             int matchCount = 0;
             int offset = -1;
             for (String field : contextFields) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -112,11 +112,6 @@ public class SearchHelper {
      */
     public String contextPath;
     /**
-     * piggyback: if {@code true}, files in opengrok's data directory are
-     * gzipped compressed.
-     */
-    public boolean compressed;
-    /**
      * piggyback: the source root directory.
      */
     public File sourceRoot;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -467,7 +467,7 @@ public class SearchHelper {
 
         Query rewritten = query.rewrite(reader);
         Weight weight = rewritten.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1);
-        Matches matches = weight.matches(leaf, docID);
+        Matches matches = weight.matches(leaf, docID - leaf.docBase); // Adjust docID
         if (matches != null && matches != MatchesUtils.MATCH_WITH_NO_TERMS) {
             int matchCount = 0;
             int offset = -1;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions copyright (c) 2011 Jens Elkner. 
- * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -401,7 +401,7 @@ public class SearchHelper {
             // one single definition term AND we have exactly one match AND there
             // is only one definition of that symbol in the document that matches.
             boolean uniqueDefinition = false;
-            if (isSingleDefinitionSearch && hits != null && hits.length == 1) {
+            if (isCrossRefSearch && isSingleDefinitionSearch && hits != null && hits.length == 1) {
                 Document doc = searcher.doc(hits[0].doc);
                 if (doc.getField(QueryBuilder.TAGS) != null) {
                     byte[] rawTags = doc.getField(QueryBuilder.TAGS).binaryValue().bytes;
@@ -412,9 +412,7 @@ public class SearchHelper {
                     }
                 }
             }
-            // @TODO fix me. I should try to figure out where the exact hit is
-            // instead of returning a page with just _one_ entry in....
-            if (uniqueDefinition && hits != null && hits.length > 0 && isCrossRefSearch) {
+            if (uniqueDefinition) {
                 redirect = contextPath + Prefix.XREF_P
                         + Util.URIEncodePath(searcher.doc(hits[0].doc).get(QueryBuilder.PATH))
                         + '#' + Util.URIEncode(((TermQuery) query).getTerm().text());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -157,6 +157,11 @@ public class SearchHelper {
      */
     public String redirect;
     /**
+     * A value indicating if redirection should be short-circuited when state or
+     * query result would have indicated otherwise.
+     */
+    public boolean noRedirect;
+    /**
      * if not {@code null}, the UI should show this error message and stop
      * processing the search. Automatically set via
      * {@link #prepareExec(SortedSet)} and {@link #executeQuery()}.
@@ -404,7 +409,7 @@ public class SearchHelper {
              * Determine if possibly a single-result redirect to xref is
              * eligible and applicable. If history query is active, then nope.
              */
-            if (hits != null && hits.length == 1 && builder.getHist() == null) {
+            if (!noRedirect && hits != null && hits.length == 1 && builder.getHist() == null) {
                 int docID = hits[0].doc;
                 if (isCrossRefSearch && query instanceof TermQuery && builder.getDefs() != null) {
                     maybeRedirectToDefinition(docID, (TermQuery) query);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -413,9 +413,11 @@ public class SearchHelper {
                 }
             }
             if (uniqueDefinition) {
+                String anchor = Util.URIEncode(((TermQuery) query).getTerm().text());
                 redirect = contextPath + Prefix.XREF_P
                         + Util.URIEncodePath(searcher.doc(hits[0].doc).get(QueryBuilder.PATH))
-                        + '#' + Util.URIEncode(((TermQuery) query).getTerm().text());
+                        + '?' + QueryParameters.FRAGMENT_IDENTIFIER_PARAM_EQ + anchor
+                        + '#' + anchor;
             }
         } catch (BooleanQuery.TooManyClauses e) {
             errorMsg = "Too many results for wildcard!";

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -48,7 +48,6 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
@@ -423,8 +422,6 @@ public class SearchHelper {
                         + '?' + QueryParameters.FRAGMENT_IDENTIFIER_PARAM_EQ + anchor
                         + '#' + anchor;
             }
-        } catch (BooleanQuery.TooManyClauses e) {
-            errorMsg = "Too many results for wildcard!";
         } catch (IOException | ClassNotFoundException e) {
             errorMsg = e.getMessage();
         }
@@ -495,19 +492,19 @@ public class SearchHelper {
                         && !builder.getFreetext().isEmpty()) {
                     t = new Term(QueryBuilder.FULL, builder.getFreetext());
                     getSuggestion(t, ir, dummy);
-                    s.freetext = dummy.toArray(new String[dummy.size()]);
+                    s.freetext = dummy.toArray(new String[0]);
                     dummy.clear();
                 }
                 if (builder.getRefs() != null && !builder.getRefs().isEmpty()) {
                     t = new Term(QueryBuilder.REFS, builder.getRefs());
                     getSuggestion(t, ir, dummy);
-                    s.refs = dummy.toArray(new String[dummy.size()]);
+                    s.refs = dummy.toArray(new String[0]);
                     dummy.clear();
                 }
                 if (builder.getDefs() != null && !builder.getDefs().isEmpty()) {
                     t = new Term(QueryBuilder.DEFS, builder.getDefs());
                     getSuggestion(t, ir, dummy);
-                    s.defs = dummy.toArray(new String[dummy.size()]);
+                    s.defs = dummy.toArray(new String[0]);
                     dummy.clear();
                 }
                 //TODO suggest also for path and history?

--- a/opengrok-indexer/src/main/resources/util/LineBreakerScanner.lex
+++ b/opengrok-indexer/src/main/resources/util/LineBreakerScanner.lex
@@ -35,21 +35,16 @@ import java.util.List;
     return false;
 %eofval}
 %eof{
-    length = yychar;
-
     /*
      * Following JFlexXref's custom, an empty file or a file ending with EOL
      * produces an additional line of length zero. We also ensure there are two
      * entries to describe the boundaries.
      */
-    if (lastHadEOL || offsets.size() <= 1) {
-        offsets.add(yychar);
-    }
+    offsets.add(yychar);
+    length = yychar;
 %eof}
 %{
     private int length;
-
-    private boolean lastHadEOL;
 
     private List<Integer> offsets;
 
@@ -58,12 +53,11 @@ import java.util.List;
     }
 
     /**
-     * Sets the required target to write.
+     * Sets the required target to write, and adds a first offset of 0.
      * @param offsets a required instance
      */
     public void setTarget(List<Integer> offsets) {
         this.length = 0;
-        this.lastHadEOL = false;
         this.offsets = offsets;
         offsets.add(0);
     }
@@ -84,12 +78,9 @@ import java.util.List;
 %include Common.lexh
 %%
 
-[^\n\r]* {EOL}    {
+{EOL}    {
     offsets.add(yychar + yylength());
-    lastHadEOL = true;
 }
 
-[^\n\r]+    {
-    offsets.add(yychar + yylength());
-    lastHadEOL = false;
+[^\n\r]    {
 }

--- a/opengrok-indexer/src/main/resources/util/LineBreakerScanner.lex
+++ b/opengrok-indexer/src/main/resources/util/LineBreakerScanner.lex
@@ -1,0 +1,95 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.util;
+
+import java.io.IOException;
+import java.util.List;
+%%
+%public
+%class LineBreakerScanner
+%char
+%unicode
+%type boolean
+%eofval{
+    return false;
+%eofval}
+%eof{
+    length = yychar;
+
+    /*
+     * Following JFlexXref's custom, an empty file or a file ending with EOL
+     * produces an additional line of length zero. We also ensure there are two
+     * entries to describe the boundaries.
+     */
+    if (lastHadEOL || offsets.size() <= 1) {
+        offsets.add(yychar);
+    }
+%eof}
+%{
+    private int length;
+
+    private boolean lastHadEOL;
+
+    private List<Integer> offsets;
+
+    public int getLength() {
+        return length;
+    }
+
+    /**
+     * Sets the required target to write.
+     * @param offsets a required instance
+     */
+    public void setTarget(List<Integer> offsets) {
+        this.length = 0;
+        this.lastHadEOL = false;
+        this.offsets = offsets;
+        offsets.add(0);
+    }
+
+    /**
+     * Call {@link #yylex()} until {@code false}, which consumes all input so
+     * that the argument to {@link #setTarget(List)} contains the entire
+     * transformation.
+     */
+    public void consume() throws IOException {
+        while (yylex()) {
+            //noinspection UnnecessaryContinue
+            continue;
+        }
+    }
+%}
+
+%include Common.lexh
+%%
+
+[^\n\r]* {EOL}    {
+    offsets.add(yychar + yylength());
+    lastHadEOL = true;
+}
+
+[^\n\r]+    {
+    offsets.add(yychar + yylength());
+    lastHadEOL = false;
+}

--- a/opengrok-indexer/src/main/resources/util/SourceSplitterScanner.lex
+++ b/opengrok-indexer/src/main/resources/util/SourceSplitterScanner.lex
@@ -1,0 +1,93 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.util;
+
+import java.io.IOException;
+import java.util.List;
+%%
+%public
+%class SourceSplitterScanner
+%char
+%unicode
+%type boolean
+%eofval{
+    return false;
+%eofval}
+%eof{
+    length = yychar;
+
+    /*
+     * Following JFlexXref's custom, an empty file or a file ending with EOL
+     * produces an additional line of length zero.
+     */
+    if (lastHadEOL || lines.size() < 1) {
+        lines.add("");
+    }
+%eof}
+%{
+    private int length;
+
+    private boolean lastHadEOL;
+
+    private List<String> lines;
+
+    public int getLength() {
+        return length;
+    }
+
+    /**
+     * Sets the required target to write.
+     * @param lines a required instance
+     */
+    public void setTarget(List<String> lines) {
+        this.length = 0;
+        this.lastHadEOL = false;
+        this.lines = lines;
+    }
+
+    /**
+     * Call {@link #yylex()} until {@code false}, which consumes all input so
+     * that the argument to {@link #setTarget(List)} contains the entire
+     * transformation.
+     */
+    public void consume() throws IOException {
+        while (yylex()) {
+            //noinspection UnnecessaryContinue
+            continue;
+        }
+    }
+%}
+
+%include Common.lexh
+%%
+
+[^\n\r]* {EOL}    {
+    lines.add(yytext());
+    lastHadEOL = true;
+}
+
+[^\n\r]+    {
+    lines.add(yytext());
+    lastHadEOL = false;
+}

--- a/opengrok-indexer/src/main/resources/util/SourceSplitterScanner.lex
+++ b/opengrok-indexer/src/main/resources/util/SourceSplitterScanner.lex
@@ -35,20 +35,19 @@ import java.util.List;
     return false;
 %eofval}
 %eof{
-    length = yychar;
-
     /*
      * Following JFlexXref's custom, an empty file or a file ending with EOL
      * produces an additional line of length zero.
      */
-    if (lastHadEOL || lines.size() < 1) {
-        lines.add("");
-    }
+    lines.add(builder.toString());
+    builder.setLength(0);
+
+    length = yychar;
 %eof}
 %{
-    private int length;
+    private final StringBuilder builder = new StringBuilder();
 
-    private boolean lastHadEOL;
+    private int length;
 
     private List<String> lines;
 
@@ -61,8 +60,8 @@ import java.util.List;
      * @param lines a required instance
      */
     public void setTarget(List<String> lines) {
+        this.builder.setLength(0);
         this.length = 0;
-        this.lastHadEOL = false;
         this.lines = lines;
     }
 
@@ -82,12 +81,16 @@ import java.util.List;
 %include Common.lexh
 %%
 
-[^\n\r]* {EOL}    {
-    lines.add(yytext());
-    lastHadEOL = true;
+{EOL}    {
+    for (int i = 0; i < yylength(); ++i) {
+        builder.append(yycharat(i)); // faster than yytext()
+    }
+    lines.add(builder.toString());
+    builder.setLength(0);
 }
 
-[^\n\r]+    {
-    lines.add(yytext());
-    lastHadEOL = false;
+[^\n\r]    {
+    for (int i = 0; i < yylength(); ++i) {
+        builder.append(yycharat(i)); // faster than yytext()
+    }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/LineBreakerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/LineBreakerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.util;
@@ -46,7 +46,10 @@ public class LineBreakerTest {
         StreamSource src = StreamSource.fromString("");
         brkr.reset(src);
         assertEquals("split count", 1, brkr.count());
-        assertEquals("split position", 0, brkr.getPosition(0));
+        assertEquals("split offset", 0, brkr.getOffset(0));
+
+        assertEquals("split find-index", 0, brkr.findLineIndex(0));
+        assertEquals("split find-index", -1, brkr.findLineIndex(1));
     }
 
     @Test
@@ -54,9 +57,9 @@ public class LineBreakerTest {
         StreamSource src = StreamSource.fromString("abc\ndef\n");
         brkr.reset(src);
         assertEquals("split count", 3, brkr.count());
-        assertEquals("split position", 0, brkr.getPosition(0));
-        assertEquals("split position", 4, brkr.getPosition(1));
-        assertEquals("split position", 8, brkr.getPosition(2));
+        assertEquals("split offset", 0, brkr.getOffset(0));
+        assertEquals("split offset", 4, brkr.getOffset(1));
+        assertEquals("split offset", 8, brkr.getOffset(2));
     }
 
     @Test
@@ -64,8 +67,9 @@ public class LineBreakerTest {
         StreamSource src = StreamSource.fromString("abc\r\ndef");
         brkr.reset(src);
         assertEquals("split count", 2, brkr.count());
-        assertEquals("split position", 0, brkr.getPosition(0));
-        assertEquals("split position", 5, brkr.getPosition(1));
+        assertEquals("split offset", 0, brkr.getOffset(0));
+        assertEquals("split offset", 5, brkr.getOffset(1));
+        assertEquals("split offset", 8, brkr.getOffset(2));
     }
 
     @Test
@@ -77,10 +81,14 @@ public class LineBreakerTest {
 
         brkr.reset(src);
         assertEquals("split count", 5, brkr.count());
-        assertEquals("split position", 0, brkr.getPosition(0));
-        assertEquals("split position", 4, brkr.getPosition(1));
-        assertEquals("split position", 9, brkr.getPosition(2));
-        assertEquals("split position", 15, brkr.getPosition(3));
-        assertEquals("split position", 20, brkr.getPosition(4));
+        assertEquals("split offset", 0, brkr.getOffset(0));
+        assertEquals("split offset", 4, brkr.getOffset(1));
+        assertEquals("split offset", 9, brkr.getOffset(2));
+        assertEquals("split offset", 15, brkr.getOffset(3));
+        assertEquals("split offset", 20, brkr.getOffset(4));
+
+        assertEquals("split find-index", 3, brkr.findLineIndex(19));
+        assertEquals("split find-index", 4, brkr.findLineIndex(20));
+        assertEquals("split find-index", 4, brkr.findLineIndex(21));
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/LineBreakerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/LineBreakerTest.java
@@ -23,8 +23,9 @@
 
 package org.opengrok.indexer.util;
 
-import java.io.IOException;
 import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengrok.indexer.analysis.StreamSource;
@@ -90,5 +91,30 @@ public class LineBreakerTest {
         assertEquals("split find-index", 3, brkr.findLineIndex(19));
         assertEquals("split find-index", 4, brkr.findLineIndex(20));
         assertEquals("split find-index", 4, brkr.findLineIndex(21));
+    }
+
+    @Test
+    public void shouldHandleInterspersedLineEndings() throws IOException {
+        //                                    0                0
+        //                    0- -- -5 - -- - 1 - - - -5 -- - -2--
+        //                    0  1  2    3  4 5   6 7  8 9    0
+        //                                                    1
+        final String INPUT = "a\rb\nc\r\nd\r\r\r\n\re\n\rf\r\nghij";
+        StreamSource src = StreamSource.fromString(INPUT);
+
+        brkr.reset(src);
+        assertEquals("split count", 11, brkr.count());
+        assertEquals("split offset", 0, brkr.getOffset(0));
+        assertEquals("split offset", 2, brkr.getOffset(1));
+        assertEquals("split offset", 4, brkr.getOffset(2));
+        assertEquals("split offset", 7, brkr.getOffset(3));
+        assertEquals("split offset", 9, brkr.getOffset(4));
+        assertEquals("split offset", 10, brkr.getOffset(5));
+        assertEquals("split offset", 12, brkr.getOffset(6));
+        assertEquals("split offset", 13, brkr.getOffset(7));
+        assertEquals("split offset", 15, brkr.getOffset(8));
+        assertEquals("split offset", 16, brkr.getOffset(9));
+        assertEquals("split offset", 19, brkr.getOffset(10));
+        assertEquals("split offset", 23, brkr.getOffset(11));
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/SourceSplitterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/SourceSplitterTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.util;
@@ -38,11 +38,11 @@ public class SourceSplitterTest {
         SourceSplitter splitter = new SourceSplitter();
         splitter.reset("");
         assertEquals("split count", 1, splitter.count());
-        assertEquals("split position", 0, splitter.getPosition(0));
-        assertEquals("split position", 0, splitter.getPosition(1));
+        assertEquals("split offset", 0, splitter.getOffset(0));
+        assertEquals("split offset", 0, splitter.getOffset(1));
 
-        assertEquals("split find-offset", 0, splitter.findLineOffset(0));
-        assertEquals("split find-offset", -1, splitter.findLineOffset(1));
+        assertEquals("split find-index", 0, splitter.findLineIndex(0));
+        assertEquals("split find-index", -1, splitter.findLineIndex(1));
     }
 
     @Test
@@ -50,10 +50,10 @@ public class SourceSplitterTest {
         SourceSplitter splitter = new SourceSplitter();
         splitter.reset("abc\ndef\n");
         assertEquals("split count", 3, splitter.count());
-        assertEquals("split position", 0, splitter.getPosition(0));
-        assertEquals("split position", 4, splitter.getPosition(1));
-        assertEquals("split position", 8, splitter.getPosition(2));
-        assertEquals("split position", 8, splitter.getPosition(3));
+        assertEquals("split offset", 0, splitter.getOffset(0));
+        assertEquals("split offset", 4, splitter.getOffset(1));
+        assertEquals("split offset", 8, splitter.getOffset(2));
+        assertEquals("split offset", 8, splitter.getOffset(3));
     }
 
     @Test
@@ -61,15 +61,15 @@ public class SourceSplitterTest {
         SourceSplitter splitter = new SourceSplitter();
         splitter.reset("abc\r\ndef");
         assertEquals("split count", 2, splitter.count());
-        assertEquals("split position", 0, splitter.getPosition(0));
-        assertEquals("split position", 5, splitter.getPosition(1));
-        assertEquals("split position", 8, splitter.getPosition(2));
+        assertEquals("split offset", 0, splitter.getOffset(0));
+        assertEquals("split offset", 5, splitter.getOffset(1));
+        assertEquals("split offset", 8, splitter.getOffset(2));
 
-        assertEquals("split find-offset", 0, splitter.findLineOffset(0));
-        assertEquals("split find-offset", 0, splitter.findLineOffset(1));
-        assertEquals("split find-offset", 0, splitter.findLineOffset(4));
-        assertEquals("split find-offset", 1, splitter.findLineOffset(5));
-        assertEquals("split find-offset", 1, splitter.findLineOffset(6));
+        assertEquals("split find-index", 0, splitter.findLineIndex(0));
+        assertEquals("split find-index", 0, splitter.findLineIndex(1));
+        assertEquals("split find-index", 0, splitter.findLineIndex(4));
+        assertEquals("split find-index", 1, splitter.findLineIndex(5));
+        assertEquals("split find-index", 1, splitter.findLineIndex(6));
     }
 
     @Test
@@ -81,24 +81,24 @@ public class SourceSplitterTest {
         SourceSplitter splitter = new SourceSplitter();
         splitter.reset(INPUT);
         assertEquals("split count", 5, splitter.count());
-        assertEquals("split position", 0, splitter.getPosition(0));
-        assertEquals("split position", 4, splitter.getPosition(1));
-        assertEquals("split position", 9, splitter.getPosition(2));
-        assertEquals("split position", 15, splitter.getPosition(3));
-        assertEquals("split position", 20, splitter.getPosition(4));
-        assertEquals("split position", 22, splitter.getPosition(5));
+        assertEquals("split offset", 0, splitter.getOffset(0));
+        assertEquals("split offset", 4, splitter.getOffset(1));
+        assertEquals("split offset", 9, splitter.getOffset(2));
+        assertEquals("split offset", 15, splitter.getOffset(3));
+        assertEquals("split offset", 20, splitter.getOffset(4));
+        assertEquals("split offset", 22, splitter.getOffset(5));
 
         /*
-         * Test findLineOffset() for every character with an alternate
-         * computation that counts every LFs.
+         * Test findLineIndex() for every character with an alternate
+         * computation that counts every LF.
          */
         for (int i = 0; i < splitter.originalLength(); ++i) {
             char c = INPUT.charAt(i);
-            int off = splitter.findLineOffset(i);
+            int li = splitter.findLineIndex(i);
             long numLF = INPUT.substring(0, i + 1).chars().filter(ch ->
                 ch == '\n').count();
             long exp = numLF - (c == '\n' ? 1 : 0);
-            assertEquals("split find-offset of " + i, exp, off);
+            assertEquals("split find-index of " + i, exp, li);
         }
     }
 
@@ -112,24 +112,24 @@ public class SourceSplitterTest {
         SourceSplitter splitter = new SourceSplitter();
         splitter.reset(src);
         assertEquals("split count", 5, splitter.count());
-        assertEquals("split position", 0, splitter.getPosition(0));
-        assertEquals("split position", 4, splitter.getPosition(1));
-        assertEquals("split position", 9, splitter.getPosition(2));
-        assertEquals("split position", 15, splitter.getPosition(3));
-        assertEquals("split position", 20, splitter.getPosition(4));
-        assertEquals("split position", 22, splitter.getPosition(5));
+        assertEquals("split offset", 0, splitter.getOffset(0));
+        assertEquals("split offset", 4, splitter.getOffset(1));
+        assertEquals("split offset", 9, splitter.getOffset(2));
+        assertEquals("split offset", 15, splitter.getOffset(3));
+        assertEquals("split offset", 20, splitter.getOffset(4));
+        assertEquals("split offset", 22, splitter.getOffset(5));
 
         /*
-         * Test findLineOffset() for every character with an alternate
-         * computation that counts every LFs.
+         * Test findLineIndex() for every character with an alternate
+         * computation that counts every LF.
          */
         for (int i = 0; i < splitter.originalLength(); ++i) {
             char c = INPUT.charAt(i);
-            int off = splitter.findLineOffset(i);
+            int li = splitter.findLineIndex(i);
             long numLF = INPUT.substring(0, i + 1).chars().filter(ch ->
                 ch == '\n').count();
             long exp = numLF - (c == '\n' ? 1 : 0);
-            assertEquals("split find-offset of " + i, exp, off);
+            assertEquals("split find-index of " + i, exp, li);
         }
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/SourceSplitterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/SourceSplitterTest.java
@@ -23,8 +23,9 @@
 
 package org.opengrok.indexer.util;
 
-import java.io.IOException;
 import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
 import org.junit.Test;
 import org.opengrok.indexer.analysis.StreamSource;
 
@@ -131,5 +132,31 @@ public class SourceSplitterTest {
             long exp = numLF - (c == '\n' ? 1 : 0);
             assertEquals("split find-index of " + i, exp, li);
         }
+    }
+
+    @Test
+    public void shouldHandleInterspersedLineEndings() throws IOException {
+        //                                    0                0
+        //                    0- -- -5 - -- - 1 - - - -5 -- - -2--
+        //                    0  1  2    3  4 5   6 7  8 9    0
+        //                                                    1
+        final String INPUT = "a\rb\nc\r\nd\r\r\r\n\re\n\rf\r\nghij";
+        StreamSource src = StreamSource.fromString(INPUT);
+
+        SourceSplitter splitter = new SourceSplitter();
+        splitter.reset(src);
+        assertEquals("split count", 11, splitter.count());
+        assertEquals("split offset", 0, splitter.getOffset(0));
+        assertEquals("split offset", 2, splitter.getOffset(1));
+        assertEquals("split offset", 4, splitter.getOffset(2));
+        assertEquals("split offset", 7, splitter.getOffset(3));
+        assertEquals("split offset", 9, splitter.getOffset(4));
+        assertEquals("split offset", 10, splitter.getOffset(5));
+        assertEquals("split offset", 12, splitter.getOffset(6));
+        assertEquals("split offset", 13, splitter.getOffset(7));
+        assertEquals("split offset", 15, splitter.getOffset(8));
+        assertEquals("split offset", 16, splitter.getOffset(9));
+        assertEquals("split offset", 19, splitter.getOffset(10));
+        assertEquals("split offset", 23, splitter.getOffset(11));
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/DummyHttpServletRequest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/DummyHttpServletRequest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -26,6 +27,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -66,7 +68,9 @@ import static org.opengrok.indexer.util.RandomString.generate;
 public class DummyHttpServletRequest implements HttpServletRequest {
 
     private final Map<String, Object> attrs = new HashMap<>();
-    
+
+    private Map<String, String[]> parameters = Collections.emptyMap();
+
     private class DummyHttpSession implements HttpSession {
         private Map<String, Object> attrs = new HashMap<>();
 
@@ -159,7 +163,7 @@ public class DummyHttpServletRequest implements HttpServletRequest {
     };
     
     private HttpSession session;
-    
+
     @Override
     public String getAuthType() {
         throw new UnsupportedOperationException("Not supported yet.");
@@ -368,23 +372,45 @@ public class DummyHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
-    public String getParameter(String string) {
-        throw new UnsupportedOperationException("Not supported yet.");
+    public String getParameter(String name) {
+        String[] values = parameters.get(name);
+        if (values != null && values.length > 0) {
+            return values[0];
+        } else {
+            return null;
+        }
     }
 
     @Override
     public Enumeration<String> getParameterNames() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return Collections.enumeration(parameters.keySet());
     }
 
     @Override
-    public String[] getParameterValues(String string) {
-        throw new UnsupportedOperationException("Not supported yet.");
+    public String[] getParameterValues(String name) {
+        return parameters.get(name);
     }
 
     @Override
     public Map<String, String[]> getParameterMap() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return Collections.unmodifiableMap(parameters);
+    }
+
+    public void setParameterMap(Map<String, String[]> parameters) {
+        if (parameters == null) {
+            this.parameters = Collections.emptyMap();
+        } else {
+            this.parameters = new HashMap<>(parameters);
+            for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
+                String[] values;
+                if (entry.getValue() == null) {
+                    values = new String[0];
+                } else {
+                    values = Arrays.copyOf(entry.getValue(), entry.getValue().length);
+                }
+                this.parameters.put(entry.getKey(), values);
+            }
+        }
     }
 
     @Override

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -332,9 +333,6 @@ public class PageConfigTest {
         PageConfig cfg = PageConfig.get(req2);
         String rev = cfg.getLatestRevision();
         assertNull(rev);
-
-        String location = cfg.getRevisionLocation(cfg.getLatestRevision());
-        assertNull(location);
     }
 
     @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.web;
@@ -84,7 +84,6 @@ public class SearchHelperTest {
         sh.contextPath = env.getUrlPrefix();
         sh.parallel = Runtime.getRuntime().availableProcessors() > 1;
         sh.isCrossRefSearch = false;
-        sh.compressed = env.isCompressXref();
         sh.desc = null;
         sh.sourceRoot = env.getSourceRootFile();
         return sh;
@@ -102,7 +101,6 @@ public class SearchHelperTest {
         sh.contextPath = env.getUrlPrefix();
         sh.parallel = Runtime.getRuntime().availableProcessors() > 1;
         sh.isCrossRefSearch = false;
-        sh.compressed = env.isCompressXref();
         sh.desc = null;
         sh.sourceRoot = env.getSourceRootFile();
         return sh;

--- a/opengrok-web/src/main/webapp/js/searchable-option-list-2.0.12.js
+++ b/opengrok-web/src/main/webapp/js/searchable-option-list-2.0.12.js
@@ -1094,6 +1094,7 @@
                          * Modified for OpenGrok in 2017.
                          */
                         if (isOnSearchPage()) {
+                            $('#xrd').val("1"); // no redirect
                             $('#sbox').submit();
                         }
                     })

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -78,11 +78,13 @@ final String DUMMY_REVISION = "unknown";
          */
         String latestRevision = cfg.getLatestRevision();
         if (latestRevision != null) {
+            cfg.evaluateMatchOffset();
             String location = cfg.getRevisionLocation(latestRevision);
             response.sendRedirect(location);
             return;
         }
         if (!cfg.getEnv().isGenerateHtml()) {
+            cfg.evaluateMatchOffset();
             /*
              * Economy mode is on and failed to get the last revision
              * (presumably running with history turned off).  Use dummy
@@ -90,6 +92,17 @@ final String DUMMY_REVISION = "unknown";
              * file directly.
              */
             String location = cfg.getRevisionLocation(DUMMY_REVISION);
+            response.sendRedirect(location);
+            return;
+        }
+
+        if (cfg.evaluateMatchOffset()) {
+            /*
+             * If after calling, a match offset has been translated to a
+             * fragment identifier (specifying a line#), then redirect to self.
+             * This block will not be activated again the second time.
+             */
+            String location = cfg.getRevisionLocation(""); // empty
             response.sendRedirect(location);
             return;
         }

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -267,12 +267,12 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
                     }
                 } finally {
                     if (r != null) {
-                        try { r.close(); bin = null; }
-                        catch (Exception e) { /* ignore */ }
+                        IOUtils.close(r);
+                        bin = null;
                     }
                     if (bin != null) {
-                        try { bin.close(); }
-                        catch (Exception e) { /* ignore */ }
+                        IOUtils.close(bin);
+                        bin = null;
                     }
                 }
 
@@ -396,12 +396,12 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
                         error = e.getMessage();
                     } finally {
                         if (r != null) {
-                            try { r.close(); in = null;}
-                            catch (Exception e) { /* ignore */ }
+                            IOUtils.close(r);
+                            in = null;
                         }
                         if (in != null) {
-                            try { in.close(); }
-                            catch (Exception e) { /* ignore */ }
+                            IOUtils.close(in);
+                            in = null;
                         }
                         if (tempf != null) {
                             tempf.delete();

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -394,7 +394,7 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
                             }
                         }
                     } catch (IOException e) {
-                        error = e.getMessage();
+                        LOGGER.log(Level.SEVERE, "Failed xref on-the-fly", e);
                     } finally {
                         if (r != null) {
                             IOUtils.close(r);

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -76,8 +76,9 @@ final String DUMMY_REVISION = "unknown";
          * Get the latest revision and redirect so that the revision number
          * appears in the URL.
          */
-        String location = cfg.getRevisionLocation(cfg.getLatestRevision());
-        if (location != null) {
+        String latestRevision = cfg.getLatestRevision();
+        if (latestRevision != null) {
+            String location = cfg.getRevisionLocation(latestRevision);
             response.sendRedirect(location);
             return;
         }
@@ -88,7 +89,7 @@ final String DUMMY_REVISION = "unknown";
              * revision string so that xref can be generated from the resource
              * file directly.
              */
-            location = cfg.getRevisionLocation(DUMMY_REVISION);
+            String location = cfg.getRevisionLocation(DUMMY_REVISION);
             response.sendRedirect(location);
             return;
         }

--- a/opengrok-web/src/main/webapp/menu.jspf
+++ b/opengrok-web/src/main/webapp/menu.jspf
@@ -230,7 +230,8 @@ document.domReady.push(function() { domReadyMenu(); });
     </tbody>
 </table>
 <div id="form-controls">
-    <input tabindex="9" class="submit btn" type="submit" value="Search"/>
+    <input tabindex="9" class="submit btn" onclick="$('#xrd').val(''); $('#sbox').submit()"
+           type="button" value="Search"/>
     <input tabindex="10" class="submit btn" onclick="javascript: clearSearchFrom();"
            type="button" value="Clear"/>
     <input tabindex="11" class="submit btn" onclick="window.open('help.jsp', '_blank');"
@@ -240,6 +241,8 @@ document.domReady.push(function() { domReadyMenu(); });
 <div id="ltbl">
     <!-- filled with javascript -->
 </div>
+<input type="hidden" id="<%= QueryParameters.NO_REDIRECT_PARAM %>"
+       name="<%= QueryParameters.NO_REDIRECT_PARAM %>" value=""/>
 </form>
 <div class="clearfix"></div>
 <%

--- a/opengrok-web/src/main/webapp/search.jsp
+++ b/opengrok-web/src/main/webapp/search.jsp
@@ -86,6 +86,7 @@ include file="projects.jspf"
     SuggesterServiceFactory.getDefault().onSearch(cfg.getRequestedProjects(), searchHelper.query);
     if (searchHelper.redirect != null) {
         response.sendRedirect(searchHelper.redirect);
+        return;
     }
     if (searchHelper.errorMsg != null) {
         cfg.setTitle("Search Error");


### PR DESCRIPTION
Hello,

Please consider for integration this patch to redirect directly to a file when a search produces a single hit.

* Fix existing but broken functionality to automatically link to a definition from an xref file (e.g. `#function1`) when the definition is the single search result. The previous functionality used only an HTML fragment identifier, which was broken when list.jsp was updated to redirect so as to include a revision ID in the URL (e.g. `?r=04f4d4a`). As a fragment identifier is client-side only, it is lost in a redirect without special handling (i.e. a mediating parameter, `?fi=function1`).
* Add general support for redirecting directly to a file when a search produces a single hit. A mediating parameter for a match offset (e.g. `?mo=5733`) is used so that an offset can be translated to a fragment identifier (e.g. `?fi=23`) while still allowing the revision ID production (e.g. `?r=04f4d4a`).
* ~Add `QueryParameters` class, and extract named literals for OpenGrok's web query parameters.~ Add several literals to support this patch, including `FRAGMENT_IDENTIFIER` and `MATCH_OFFSET`.
* Share some duplicated code between `SourceSplitter` and `LineBreaker`, and share logic to convert an offset to a line index. This is needed for translating e.g. `?mo=5733` to `?fi=23`.
* Optimize the `Context` class to avoid creating some large allocations when not usually needed.
* Revise some OpenGrok-internal APIs to rationalize some inconsistencies with the use of "offset" and "position". "Offset" should be used to accord with Lucene's definition as the number of characters from the beginning of a document. "Position" means an ordinal designation among lists of tokens where the token list matches the order in source code. "Index" can be used to mean ordinal designation in a general collection.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
