### PR TITLE
bail deploy if CONFIGURATION is not present

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -68,7 +68,7 @@ public final class WebappListener
         
         String config = context.getInitParameter("CONFIGURATION");
         if (config == null) {
-            LOGGER.severe("CONFIGURATION section missing in web.xml");
+            throw new Error("CONFIGURATION parameter missing in the web.xml file");
         } else {
             try {
                 env.readConfiguration(new File(config), true);

--- a/opengrok-web/src/main/webapp/error.jsp
+++ b/opengrok-web/src/main/webapp/error.jsp
@@ -60,8 +60,8 @@ include file="pageheader.jspf"
     PageConfig cfg = PageConfig.get(request);
     String configError = "";
     if (cfg.getSourceRootPath() == null || cfg.getSourceRootPath().isEmpty()) {
-        configError = "The source root path has not been configured ! "
-            + " Please configure your webapp.";
+        configError = "The source root path has not been configured! "
+            + "Please configure your webapp.";
     } else if (!cfg.getEnv().getSourceRootFile().isDirectory()) {
         configError = "The source root " +  cfg.getEnv().getSourceRootPath()
             + " specified in your configuration does "

--- a/opengrok-web/src/main/webapp/error.jsp
+++ b/opengrok-web/src/main/webapp/error.jsp
@@ -60,10 +60,11 @@ include file="pageheader.jspf"
     PageConfig cfg = PageConfig.get(request);
     String configError = "";
     if (cfg.getSourceRootPath() == null || cfg.getSourceRootPath().isEmpty()) {
-        configError = "CONFIGURATION parameter has not been configured in "
-            + "web.xml! Please configure your webapp.";
+        configError = "The source root path has not been configured ! "
+            + " Please configure your webapp.";
     } else if (!cfg.getEnv().getSourceRootFile().isDirectory()) {
-        configError = "The source root specified in your configuration does "
+        configError = "The source root " +  cfg.getEnv().getSourceRootPath()
+            + " specified in your configuration does "
             + "not point to a valid directory! Please configure your webapp.";
     }
 %><h3 class="error">There was an error!</h3>


### PR DESCRIPTION
As mentioned in https://github.com/oracle/opengrok/issues/3054#issuecomment-591386503 the error messaging of the web application in the condition of missing configuration needs to improve.

This is crude but effective way how to stop the deployment. If the `CONFIGURATION` parameter is missing in `web.xml` then it is likely that we cannot trust the contents of the file anyway so tear down of the webapp is in order. I did not find any other way than to throw unchecked exception.