### PR TITLE
Bugfix/perforce

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
@@ -165,7 +165,7 @@ class PerforceHistoryParser {
             while ((line = reader.readLine()) != null) {
                 Matcher matcher = CHANGE_PATTERN.matcher(line);
                 if (matcher.find()) {
-                    entry = parseLedeLine(entries, entry, messageBuilder, matcher);
+                    entry = parseEntryLine(entries, entry, messageBuilder, matcher);
                 } else if (line.startsWith("\t")) {
                     messageBuilder.append(line.substring(1));
                     messageBuilder.append("\n");
@@ -207,7 +207,7 @@ class PerforceHistoryParser {
 
                 matcher = REVISION_PATTERN.matcher(line);
                 if (matcher.find()) {
-                    entry = parseLedeLine(entries, entry, messageBuilder, matcher);
+                    entry = parseEntryLine(entries, entry, messageBuilder, matcher);
                     if (fileName != null) {
                         entry.addFile(fileName);
                         /*
@@ -305,7 +305,7 @@ class PerforceHistoryParser {
         return cal.getTime();
     }
 
-    private static HistoryEntry parseLedeLine(List<HistoryEntry> entries, HistoryEntry entry,
+    private static HistoryEntry parseEntryLine(List<HistoryEntry> entries, HistoryEntry entry,
             StringBuilder messageBuilder, Matcher matcher) {
         if (entry != null) {
             /* An entry finishes when a new entry starts ... */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
@@ -70,7 +70,7 @@ public class PerforceRepository extends Repository {
         t = t.replace("#", "%23");
         t = t.replace("*", "%2A");
         t = t.replace("@", "%40");
-        if (!name.equals(t)) {
+        if (LOGGER.isLoggable(Level.FINEST) && !name.equals(t)) {
             LOGGER.log(Level.FINEST,
                        "protectPerforceFilename: replaced ''{0}'' with ''{1}''",
                        new Object[]{name, t});
@@ -83,7 +83,7 @@ public class PerforceRepository extends Repository {
         t = t.replace("%23", "#");
         t = t.replace("%2A", "*");
         t = t.replace("%25", "%");
-        if (!name.equals(t)) {
+        if (LOGGER.isLoggable(Level.FINEST) && !name.equals(t)) {
             LOGGER.log(Level.FINEST,
                     "unprotectPerforceFilename: replaced ''{0}'' with ''{1}''",
                     new Object[]{name, t});

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -51,21 +51,30 @@ public final class RepositoryFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryFactory.class);
 
     private static final Repository[] repositories = {
-        new BitKeeperRepository(),
-        new MercurialRepository(),
-        new AccuRevRepository(),
-        new BazaarRepository(),
-        new GitRepository(),
-        new MonotoneRepository(),
-        new SubversionRepository(),
-        new SCCSRepository(),
-        new RazorRepository(),
-        new ClearCaseRepository(),
-        new PerforceRepository(),
-        new RCSRepository(),
-        new CVSRepository(),
-        new RepoRepository(),
-        new SSCMRepository()
+            /*
+             * The following do cheap checks to determine isRepositoryFor(),
+             * but still put the most popular at the head of the repositories
+             * array.
+             */
+            new GitRepository(),
+            new MercurialRepository(),
+            new RepoRepository(),
+            new BitKeeperRepository(),
+            new BazaarRepository(),
+            new MonotoneRepository(),
+            new SubversionRepository(),
+            new SCCSRepository(),
+            new RazorRepository(),
+            new RCSRepository(),
+            new CVSRepository(),
+            new SSCMRepository(),
+            /*
+             * The following do expensive checks to determine isRepositoryFor(),
+             * so put them at the end of the repositories array.
+             */
+            new AccuRevRepository(),
+            new ClearCaseRepository(),
+            new PerforceRepository()
     };
 
     private static final Map<String, Class<? extends Repository>> byName = new HashMap<>();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
@@ -108,6 +108,10 @@ public class HistoryContext {
             return false;
         }
         History hist = HistoryGuru.getInstance().getHistory(src);
+        if (hist == null) {
+            LOGGER.log(Level.INFO, "Null history got for {0}", src);
+            return false;
+        }
         return getHistoryContext(hist, path, out, null, context);
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceHistoryParserTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceHistoryParserTest.java
@@ -19,54 +19,39 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.history;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.StringReader;
 import java.util.Calendar;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
- *
  * @author austvik
  */
 public class PerforceHistoryParserTest {
-
-    public PerforceHistoryParserTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
-    }
 
     /**
      * Test of parseChanges method, of class PerforceHistoryParser.
      */
     @Test
     public void parseChanges() throws Exception {
-        String output = "Change 1234 on 2008/10/13 11:30:00 by ADMIN@UserWorkspaceName 'Comment given to changelist within single qoutes, this is change one'\n" +
-                "Change 6543 on 2008/10/08 18:25:38 by USER@USER_WS 'Comment given to changelist within single qoutes'\n" +
-                "Change 7654 on 2008/09/30 01:00:01 by USER@USER_WS 'Comment given to changelist within single qoutes'\n" +
-                "Change 2345 on 2008/09/30 17:45:33 by ADMIN@Workspace2 'Comment given to changelist within single qoutes'\n";
-        History result = PerforceHistoryParser.parseChanges(new StringReader(output));
+        String output = "Change 1234 on 2008/10/13 11:30:00 by ADMIN@UserWorkspaceName\n" +
+                "\tComment given to changelist within single qoutes, this is change one\n" +
+                "Change 6543 on 2008/10/08 18:25:38 by USER@USER_WS\n" +
+                "\t'Comment given to changelist within single qoutes'\n" +
+                "Change 7654 on 2008/09/30 01:00:01 by USER@USER_WS\n" +
+                "\t'Comment given to changelist within single qoutes'\n" +
+                "Change 2345 on 2008/09/30 17:45:33 by ADMIN@Workspace2\n" +
+                "\t'Comment given to changelist within single qoutes'\n";
+        PerforceHistoryParser parser = new PerforceHistoryParser(new PerforceRepository());
+        History result = parser.parseChanges(new StringReader(output));
 
         assertNotNull(result);
         assertEquals(4, result.getHistoryEntries().size());
@@ -103,21 +88,22 @@ public class PerforceHistoryParserTest {
                 "\n" +
                 "... #4 change 1234 edit on 2008/08/19 11:30:00 by User@UserWorkspaceName (text)\n" +
                 "\n" +
-                "        Comment for the change number 4\n" +
+                "\tComment for the change number 4\n" +
                 "\n" +
                 "... #3 change 5678 edit on 2008/08/19 18:25:38 by ADMIN@UserWorkspaceName (text)\n" +
                 "\n" +
-                "        Comment for the change\n" +
+                "\tComment for the change\n" +
                 "\n" +
                 "... #2 change 8765 edit on 2008/08/01 01:00:01 by ADMIN@UserWorkspaceName (text)\n" +
                 "\n" +
-                "        Comment for the change\n" +
+                "\tComment for the change\n" +
                 "\n" +
                 "... #1 change 1 add on 2008/07/30 17:45:33 by ADMIN@UserWorkspaceName (text)\n" +
                 "\n" +
-                "        Comment for the change";
+                "\tComment for the change";
 
-        History result = PerforceHistoryParser.parseFileLog(new StringReader(output));
+        PerforceHistoryParser parser = new PerforceHistoryParser(new PerforceRepository());
+        History result = parser.parseFileLog(new StringReader(output));
 
         assertNotNull(result);
         assertEquals(4, result.getHistoryEntries().size());
@@ -125,7 +111,7 @@ public class PerforceHistoryParserTest {
         HistoryEntry e1 = result.getHistoryEntries().get(0);
         assertEquals("1234", e1.getRevision());
         assertEquals("User", e1.getAuthor());
-        assertEquals(0, e1.getFiles().size());
+        assertEquals(1, e1.getFiles().size());
         assertTrue(e1.getMessage().contains("number 4"));
 
         HistoryEntry e2 = result.getHistoryEntries().get(1);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
@@ -71,6 +71,45 @@ public class PerforceRepositoryTest {
         }
     }
 
+    /**
+     * Following are steps to set up for testing:
+     * <p><ul>
+     * <li>Install a Perforce server instance. I elected to install the
+     * helix-p4d package on Ubuntu by following the instructions at
+     * <a href="https://www.perforce.com/manuals/p4sag/Content/P4SAG/install.linux.packages.install.html">
+     * Helix Core Server Administrator Guide > Installing the server > Linux
+     * package-based installation > Installation</a>.
+     * <li>Configure the Perforce server. Follow the instructions at
+     * <a href="https://www.perforce.com/manuals/p4sag/Content/P4SAG/install.linux.packages.configure.html">
+     * Helix Core Server Administrator Guide > Installing the server > Linux
+     * package-based installation > Post-installation configuration</a>.
+     * <li>Secure the Perforce server transport layer. I deployed a private key
+     * and certificate following the instructions at
+     * <a href="https://www.perforce.com/manuals/p4sag/Content/P4SAG/DB5-16618.html">
+     * Helix Core Server Administrator Guide > Securing the server > Using SSL
+     * to encrypt connections to a Helix server > Key and certificate
+     * management</a>.
+     * <li>Define an authentication method for the Perforce server. I elected to
+     * authenticate against my home Active Directory following the instructions
+     * at <a href="https://www.perforce.com/manuals/p4sag/Content/P4SAG/security.ldap.auth.html">
+     * Helix Core Server Administrator Guide > Securing the server > LDAP
+     * authentication > Authenticating against Active Directory and LDAP
+     * servers</a> and then testing the LDAP configuration per
+     * <a href="https://www.perforce.com/manuals/p4sag/Content/P4SAG/security.ldap.testing.html">
+     * Helix Core Server Administrator Guide > Securing the server > LDAP
+     * authentication > Testing and enabling LDAP configurations</a>.
+     * <li>Install Perforce on the development workstation. I used Homebrew to
+     * install: {@code admin$ brew cask install perforce}
+     * <li>Set environment to connect to the Perforce server. My server is named
+     * p4: {@code export P4PORT=ssl:p4.localdomain:1666}
+     * <li>Define a Perforce client view on the workstation. For a workstation
+     * named workstation1: {@code cd /var/opengrok/src && p4 client workstation1}
+     * <li>Add sample code and submit: {@code p4 add *.h && p4 submit}
+     * <li>Add more sample code and submit: {@code p4 add *.c && p4 submit}
+     * <li>Add more sample code and submit: {@code p4 add *.txt && p4 submit}
+     * <li>Code, Index, Test, and Debug.
+     * </ul><p>
+     */
     @Test
     @ConditionalRun(RepositoryInstalled.PerforceInstalled.class)
     public void testHistoryAndAnnotations() throws Exception {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
@@ -77,27 +77,27 @@ public class PerforceRepositoryTest {
      * <li>Install a Perforce server instance. I elected to install the
      * helix-p4d package on Ubuntu by following the instructions at
      * <a href="https://www.perforce.com/manuals/p4sag/Content/P4SAG/install.linux.packages.install.html">
-     * Helix Core Server Administrator Guide > Installing the server > Linux
-     * package-based installation > Installation</a>.
+     * Helix Core Server Administrator Guide &gt; Installing the server &gt; Linux
+     * package-based installation &gt; Installation</a>.
      * <li>Configure the Perforce server. Follow the instructions at
      * <a href="https://www.perforce.com/manuals/p4sag/Content/P4SAG/install.linux.packages.configure.html">
-     * Helix Core Server Administrator Guide > Installing the server > Linux
-     * package-based installation > Post-installation configuration</a>.
+     * Helix Core Server Administrator Guide &gt; Installing the server &gt; Linux
+     * package-based installation &gt; Post-installation configuration</a>.
      * <li>Secure the Perforce server transport layer. I deployed a private key
      * and certificate following the instructions at
      * <a href="https://www.perforce.com/manuals/p4sag/Content/P4SAG/DB5-16618.html">
-     * Helix Core Server Administrator Guide > Securing the server > Using SSL
-     * to encrypt connections to a Helix server > Key and certificate
+     * Helix Core Server Administrator Guide &gt; Securing the server &gt; Using SSL
+     * to encrypt connections to a Helix server &gt; Key and certificate
      * management</a>.
      * <li>Define an authentication method for the Perforce server. I elected to
      * authenticate against my home Active Directory following the instructions
      * at <a href="https://www.perforce.com/manuals/p4sag/Content/P4SAG/security.ldap.auth.html">
-     * Helix Core Server Administrator Guide > Securing the server > LDAP
-     * authentication > Authenticating against Active Directory and LDAP
+     * Helix Core Server Administrator Guide &gt; Securing the server &gt; LDAP
+     * authentication &gt; Authenticating against Active Directory and LDAP
      * servers</a> and then testing the LDAP configuration per
      * <a href="https://www.perforce.com/manuals/p4sag/Content/P4SAG/security.ldap.testing.html">
-     * Helix Core Server Administrator Guide > Securing the server > LDAP
-     * authentication > Testing and enabling LDAP configurations</a>.
+     * Helix Core Server Administrator Guide &gt; Securing the server &gt; LDAP
+     * authentication &gt; Testing and enabling LDAP configurations</a>.
      * <li>Install Perforce on the development workstation. I used Homebrew to
      * install: {@code admin$ brew cask install perforce}
      * <li>Set environment to connect to the Perforce server. My server is named


### PR DESCRIPTION
Hello,

Please consider for integration this patch to optimize Perforce executions to get history data.

* Run a `p4 changes` and `p4 filelog`, and integrate the results, so only two p4 commands are needed for `History` of a directory tree.
* Parse file names from p4 commands so that `HistoryEntry` instances have defined files.
* Recognize binary file log for annotations.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
