### PR TITLE
Lookup LOC and #Lines for project-less setup too

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryExtraReader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryExtraReader.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.search;
@@ -43,7 +43,7 @@ import org.opengrok.indexer.logger.LoggerFactory;
 public class DirectoryExtraReader {
 
     // N.b.: update #search() comment when changing
-    private final int DIR_LIMIT_NUM = 2000;
+    private static final int DIR_LIMIT_NUM = 2000;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(
         DirectoryExtraReader.class);


### PR DESCRIPTION
Hello,

Please consider for integration this patch to retrieve LOC and #Lines for project-less setups too.

I noticed those values were blank in testing the example for #3058 .

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
