### PR TITLE
To Jersey 2.30.1 and Jackson 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 CDDL HEADER END
 
 Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
-Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -65,9 +65,12 @@ Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
         <compileSource>1.8</compileSource>
         <compileTarget>1.8</compileTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jersey.version>2.29</jersey.version>
-        <!-- Jackson version needs to match the version of Jackson Jersey depends on otherwise weird things will happen. -->
-        <jackson.version>2.9.9</jackson.version>
+        <jersey.version>2.30.1</jersey.version>
+        <!-- Jackson version needs to match the version of Jackson which Jersey
+        depends on or otherwise weird things will happen.
+        https://eclipse-ee4j.github.io/jersey.github.io/release-notes/2.30.1.html
+        reads that Jersey 2.30.1 did "adopt Jackson 2.10.1." -->
+        <jackson.version>2.10.1</jackson.version>
         <junit.version>5.4.2</junit.version>
         <maven-surefire.version>2.22.2</maven-surefire.version>
         <apache-commons-lang3.version>3.9</apache-commons-lang3.version>


### PR DESCRIPTION
Let's see if Jersey 2.30.1 has any affect on the Windows build reliability.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
