### PR TITLE
Use ctags --pattern-length-limit=180 to reduce likelihood of re-read

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -176,6 +176,7 @@ public class Ctags implements Resettable {
         command.add("--filter-terminator=" + CTAGS_FILTER_TERMINATOR + "\n");
         command.add("--fields=-af+iKnS");
         command.add("--excmd=pattern");
+        command.add("--pattern-length-limit=180"); // Increase from default 96
 
         //Ideally all below should be in ctags, or in outside config file,
         //we might run out of command line SOON


### PR DESCRIPTION
Hello,

Please consider for integration this patch to increase the ctags `--pattern-length-limit` to 180 from the default of 96 to reduce the likelihood of a file re-read by OpenGrok's `Ctags.trySplitSource()`.

180 seems to me large enough for any sensible coding style's maximum line length while still being short enough to avoid pathologically large tags files as used to affect Exuberant Ctags with its unbounded patterns (e.g. as when tagging minified JavaScript).

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
