### PR TITLE
Marshal random port through CONTAINER_PORT forced property

### DIFF
--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/AnnotationControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/AnnotationControllerTest.java
@@ -19,12 +19,12 @@
 
 /*
  * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.web.api.v1.controller;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,7 +56,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ConditionalRun(RepositoryInstalled.GitInstalled.class)
-public class AnnotationControllerTest extends JerseyTest {
+public class AnnotationControllerTest extends OGKJerseyTest {
 
     @Rule
     public ConditionalRunRule rule = new ConditionalRunRule();
@@ -71,6 +71,7 @@ public class AnnotationControllerTest extends JerseyTest {
     }
 
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         repository = new TestRepository();
@@ -92,6 +93,7 @@ public class AnnotationControllerTest extends JerseyTest {
     }
 
     @After
+    @Override
     public void tearDown() throws Exception {
         super.tearDown();
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ConcurrentConfigurationControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ConcurrentConfigurationControllerTest.java
@@ -1,3 +1,26 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
 package org.opengrok.web.api.v1.controller;
 
 import java.nio.file.Paths;
@@ -17,7 +40,6 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.io.FileUtils;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,7 +58,7 @@ import org.opengrok.indexer.util.TestRepository;
 import org.opengrok.web.api.v1.suggester.provider.service.SuggesterService;
 
 @ConditionalRun(RepositoryInstalled.GitInstalled.class)
-public class ConcurrentConfigurationControllerTest extends JerseyTest {
+public class ConcurrentConfigurationControllerTest extends OGKJerseyTest {
 
     private static final int PROJECTS_COUNT = 20;
     private static final int THREAD_COUNT = Math.max(30, Runtime.getRuntime().availableProcessors() * 2);
@@ -69,6 +91,7 @@ public class ConcurrentConfigurationControllerTest extends JerseyTest {
     }
 
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         origSourceRootPath = env.getSourceRootPath();
@@ -112,6 +135,7 @@ public class ConcurrentConfigurationControllerTest extends JerseyTest {
     }
 
     @After
+    @Override
     public void tearDown() throws Exception {
         super.tearDown();
         repository.destroy();

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ConfigurationControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ConfigurationControllerTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
 
@@ -26,40 +27,24 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
-import org.apache.commons.io.FileUtils;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.opengrok.indexer.condition.ConditionalRun;
-import org.opengrok.indexer.condition.ConditionalRunRule;
-import org.opengrok.indexer.condition.RepositoryInstalled;
 import org.opengrok.indexer.configuration.Configuration;
-import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
-import org.opengrok.indexer.history.HistoryGuru;
-import org.opengrok.indexer.history.RepositoryInfo;
-import org.opengrok.indexer.util.TestRepository;
 import org.opengrok.indexer.web.DummyHttpServletRequest;
 import org.opengrok.indexer.web.PageConfig;
 import org.opengrok.web.api.v1.suggester.provider.service.SuggesterService;
 
-public class ConfigurationControllerTest extends JerseyTest {
+public class ConfigurationControllerTest extends OGKJerseyTest {
 
     private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
@@ -1,7 +1,29 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
 package org.opengrok.web.api.v1.controller;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.Assert.assertEquals;
 
-public class FileControllerTest extends JerseyTest {
+public class FileControllerTest extends OGKJerseyTest {
 
     private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
@@ -33,6 +55,7 @@ public class FileControllerTest extends JerseyTest {
     }
 
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         repository = new TestRepository();
@@ -55,6 +78,7 @@ public class FileControllerTest extends JerseyTest {
     }
 
     @After
+    @Override
     public void tearDown() throws Exception {
         super.tearDown();
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -1,7 +1,29 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
 package org.opengrok.web.api.v1.controller;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -33,7 +55,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.opengrok.web.api.v1.controller.HistoryController.getHistoryDTO;
 
 @ConditionalRun(RepositoryInstalled.GitInstalled.class)
-public class HistoryControllerTest extends JerseyTest {
+public class HistoryControllerTest extends OGKJerseyTest {
 
     private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
@@ -48,6 +70,7 @@ public class HistoryControllerTest extends JerseyTest {
     }
 
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         repository = new TestRepository();
@@ -69,6 +92,7 @@ public class HistoryControllerTest extends JerseyTest {
     }
 
     @After
+    @Override
     public void tearDown() throws Exception {
         super.tearDown();
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/MessagesControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/MessagesControllerTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
 
@@ -30,7 +31,6 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.spi.TestContainer;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
@@ -57,7 +57,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -66,7 +65,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class MessagesControllerTest extends JerseyTest {
+public class MessagesControllerTest extends OGKJerseyTest {
 
     private static final GenericType<List<AcceptedMessageModel>> messagesType =
             new GenericType<List<AcceptedMessageModel>>() {};

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/OGKJerseyTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/OGKJerseyTest.java
@@ -1,0 +1,56 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.web.api.v1.controller;
+
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.Before;
+
+import java.util.Random;
+
+/**
+ * Represents a subclass of {@link JerseyTest} customized for OpenGrok.
+ */
+public abstract class OGKJerseyTest extends JerseyTest {
+
+    private static final int BASE_DYNAMIC_OR_PRIVATE_PORT = 49152;
+
+    /** Random.nextInt() will be at most one less than this -- but OK */
+    private static final int DYNAMIC_OR_PRIVATE_PORT_RANGE = 16383;
+
+    private final Random rand = new Random();
+
+    /**
+     * Marshal a random high port through {@link TestProperties#CONTAINER_PORT}
+     * for use by {@link #getPort()}.
+     */
+    @Before
+    public void setUp() throws Exception {
+        int jerseyPort = BASE_DYNAMIC_OR_PRIVATE_PORT +
+                rand.nextInt(DYNAMIC_OR_PRIVATE_PORT_RANGE);
+        forceSet(TestProperties.CONTAINER_PORT, String.valueOf(jerseyPort));
+
+        super.setUp();
+    }
+}

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
@@ -19,13 +19,12 @@
 
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2019-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -76,7 +75,7 @@ import static org.opengrok.indexer.util.IOUtils.removeRecursive;
 @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
 @ConditionalRun(RepositoryInstalled.GitInstalled.class)
 @ConditionalRun(RepositoryInstalled.SubversionInstalled.class)
-public class ProjectsControllerTest extends JerseyTest {
+public class ProjectsControllerTest extends OGKJerseyTest {
 
     private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
@@ -101,6 +100,7 @@ public class ProjectsControllerTest extends JerseyTest {
     }
 
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         repository = new TestRepository();
@@ -115,6 +115,7 @@ public class ProjectsControllerTest extends JerseyTest {
     }
 
     @After
+    @Override
     public void tearDown() throws Exception {
         super.tearDown();
         // This should match Configuration constructor.

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/RepositoriesControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/RepositoriesControllerTest.java
@@ -19,12 +19,11 @@
 
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2019-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,7 +48,7 @@ import static org.junit.Assert.assertEquals;
 
 @ConditionalRun(RepositoryInstalled.MercurialInstalled.class)
 @ConditionalRun(RepositoryInstalled.GitInstalled.class)
-public class RepositoriesControllerTest extends JerseyTest {
+public class RepositoriesControllerTest extends OGKJerseyTest {
 
     private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
@@ -64,6 +63,7 @@ public class RepositoriesControllerTest extends JerseyTest {
     }
 
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         repository = new TestRepository();
@@ -76,6 +76,7 @@ public class RepositoriesControllerTest extends JerseyTest {
     }
 
     @After
+    @Override
     public void tearDown() throws Exception {
         super.tearDown();
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
@@ -1,10 +1,34 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
 package org.opengrok.web.api.v1.controller;
 
-import org.glassfish.jersey.test.JerseyTest;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.opengrok.indexer.condition.ConditionalRunRule;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
-import org.opengrok.indexer.index.Indexer;
 import org.opengrok.indexer.util.TestRepository;
 import org.opengrok.web.api.v1.RestApp;
 
@@ -16,12 +40,11 @@ import static org.junit.Assert.assertEquals;
 import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
 
-public class SearchControllerTest extends JerseyTest {
+public class SearchControllerTest extends OGKJerseyTest {
     @ClassRule
     public static ConditionalRunRule rule = new ConditionalRunRule();
 
     private static final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-
 
     private static TestRepository repository;
 
@@ -49,11 +72,6 @@ public class SearchControllerTest extends JerseyTest {
         repository.destroy();
     }
 
-    @Before
-    public void before() {
-
-    }
-
     @Test
     public void testSearchCors() {
         Response response = target(SearchController.PATH)
@@ -62,5 +80,4 @@ public class SearchControllerTest extends JerseyTest {
                 .get();
         assertEquals("*", response.getHeaderString(ALLOW_CORS_HEADER));
     }
-
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatsControllerTest.java
@@ -19,11 +19,11 @@
 
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -36,7 +36,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
-public class StatsControllerTest extends JerseyTest {
+public class StatsControllerTest extends OGKJerseyTest {
 
     private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
@@ -19,11 +19,10 @@
 
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2019-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
 
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -49,7 +48,7 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
-public class SuggesterControllerProjectsDisabledTest extends JerseyTest {
+public class SuggesterControllerProjectsDisabledTest extends OGKJerseyTest {
 
     private static final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -19,12 +19,11 @@
 
 /*
  * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2019-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
 
 import org.apache.lucene.index.Term;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.*;
 import org.junit.runners.MethodSorters;
 import org.opengrok.suggest.Suggester;
@@ -61,7 +60,7 @@ import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class SuggesterControllerTest extends JerseyTest {
+public class SuggesterControllerTest extends OGKJerseyTest {
 
     public static class Result {
         public long time;

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -1,9 +1,28 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
 package org.opengrok.web.api.v1.controller;
 
-
-import org.glassfish.jersey.test.JerseyTest;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -16,7 +35,6 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
@@ -27,7 +45,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-public class SystemControllerTest extends JerseyTest {
+public class SystemControllerTest extends OGKJerseyTest {
 
     private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 


### PR DESCRIPTION
Let's see if this improves the reliability of tests on Windows.

Inspired by Hadoop's similar problem, "MAPREDUCE-6733, MapReduce JerseyTest tests failing with 'java.net. BindException: Address already in use'", but all new implementation since Hadoop's patch was to customize com.sun.jersey.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
