### PR TITLE
report directory traversal time

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -483,6 +483,8 @@ public class IndexDatabase {
                     Statistics elapsed = new Statistics();
                     LOGGER.log(Level.INFO, "Starting traversal of directory {0}", dir);
                     indexDown(sourceRoot, dir, args);
+                    elapsed.report(LOGGER, String.format("Done traversal of directory %s", dir));
+
                     showFileCount(dir, args, elapsed);
 
                     args.cur_count = 0;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -344,10 +344,9 @@ public class IndexDatabase {
         return false;
     }
 
-    private void showFileCount(
-            String dir, IndexDownArgs args, Statistics elapsed) {
+    private void showFileCount(String dir, IndexDownArgs args) {
         if (RuntimeEnvironment.getInstance().isPrintProgress()) {
-            elapsed.report(LOGGER, String.format("Need to process: %d files for %s",
+            LOGGER.log(Level.INFO, String.format("Need to process: %d files for %s",
                     args.cur_count, dir));
         }
     }
@@ -485,7 +484,7 @@ public class IndexDatabase {
                     indexDown(sourceRoot, dir, args);
                     elapsed.report(LOGGER, String.format("Done traversal of directory %s", dir));
 
-                    showFileCount(dir, args, elapsed);
+                    showFileCount(dir, args);
 
                     args.cur_count = 0;
                     elapsed = new Statistics();


### PR DESCRIPTION
When discussing slow indexer time in https://github.com/oracle/opengrok/issues/3071#issuecomment-600007923 I found that the traversal time is not reported even though the `Statistics` object is created before hand.