### PR TITLE
skip Python lint if tests are skipped

### DIFF
--- a/opengrok-tools/pom.xml
+++ b/opengrok-tools/pom.xml
@@ -284,6 +284,7 @@ Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
                                 <argument>${project.build.sourceDirectory}/opengrok_tools</argument>
                                 <argument>${project.build.directory}/setup.py</argument>
                             </arguments>
+                            <skip>${skipPythonTests}</skip>
                         </configuration>
                         <phase>verify</phase>
                         <goals>


### PR DESCRIPTION
Running ` mvn -Dtest=SuggesterControllerTest -DfailIfNoTests=false clean verify` with the changes in 30788c18ae11181fec0a0e18c8fec2c15be8410e fails with:
```
[INFO] --- exec-maven-plugin:1.6.0:exec (Python lint) @ opengrok-tools ---
************* Module opengrok_tools.mirror
/home/travis/build/vladak/OpenGrok/opengrok-tools/src/main/python/opengrok_tools/mirror.py:40:0: E0401: Unable to import 'filelock' (import-error)
...
```
due to Python test/lint being skipped. This change fixes that.