### PR TITLE
Feature/help modes

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoriesHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoriesHelp.java
@@ -1,0 +1,71 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.history;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Represents a utility to show the user details of supported {@link Repository}
+ * types for -h,--help.
+ */
+public class RepositoriesHelp {
+
+    public static String getText() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Enabled repositories:");
+        builder.append(System.lineSeparator());
+        builder.append(System.lineSeparator());
+
+        List<Class<? extends Repository>> clazzes = RepositoryFactory.getRepositoryClasses();
+        clazzes.sort((o1, o2) -> o1.getSimpleName().compareToIgnoreCase(o2.getSimpleName()));
+        for (Class<?> clazz : clazzes) {
+            String simpleName = clazz.getSimpleName();
+            if (toAka(builder, simpleName)) {
+                builder.append(" (");
+                builder.append(simpleName);
+                builder.append(")");
+            }
+            builder.append(System.lineSeparator());
+        }
+        return builder.toString();
+    }
+
+    private static boolean toAka(StringBuilder builder, String repoSimpleName) {
+        final String REPOSITORY = "Repository";
+        if (!repoSimpleName.endsWith(REPOSITORY)) {
+            builder.append(repoSimpleName);
+            return false;
+        } else {
+            String aka = repoSimpleName.substring(0,
+                    repoSimpleName.length() - REPOSITORY.length());
+            builder.append(aka.toLowerCase(Locale.ROOT));
+            return true;
+        }
+    }
+
+    /* private to enforce static */
+    private RepositoriesHelp() {
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -250,7 +250,7 @@ public final class Indexer {
                     IndexVersion.check(subFilesList);
                 } catch (IndexVersionException e) {
                     System.err.printf("Index version check failed: %s\n", e);
-                    System.err.printf("You might want to remove " +
+                    System.err.print("You might want to remove " +
                             (subFilesList.size() > 0 ?
                                     "data for projects " + String.join(",", subFilesList) : "all data") +
                             " under the DATA_ROOT and to reindex\n");
@@ -407,17 +407,16 @@ public final class Indexer {
         boolean preHelp = Arrays.stream(argv).anyMatch(s -> HELP_OPT_1.equals(s) ||
                 HELP_OPT_2.equals(s) || HELP_OPT_3.equals(s));
 
-        OptionParser configure = OptionParser.scan(parser -> {
-            parser.on("-R configPath").Do(cfgFile -> {
-                try {
-                    if (!preHelp) {
-                        cfg = Configuration.read(new File((String) cfgFile));
-                    }
-                } catch (IOException e) {
-                    die(e.getMessage());
+        OptionParser configure = OptionParser.scan(parser ->
+                parser.on("-R configPath").Do(cfgFile -> {
+            try {
+                if (!preHelp) {
+                    cfg = Configuration.read(new File((String) cfgFile));
                 }
-            });
-        });
+            } catch (IOException e) {
+                die(e.getMessage());
+            }
+        }));
 
         searchPaths.clear();
 
@@ -450,9 +449,9 @@ public final class Indexer {
                     "/(\\.\\w+|\\w+\\.):(-|[a-zA-Z_0-9.]+)/",
                     "Associates files with the specified prefix or extension (case-",
                     "insensitive) to be analyzed with the given analyzer, where 'analyzer'",
-                    "may be specified using a simple class name (case-sensitive e.g.",
-                    "RubyAnalyzer) or language name (case-sensitive e.g. C) prefix. Option",
-                    "may be repeated.",
+                    "may be specified using a class name (case-sensitive e.g. RubyAnalyzer)",
+                    "or analyzer language name (case-sensitive e.g. C). Option may be",
+                    "repeated.",
                     "  Ex: -A .foo:CAnalyzer",
                     "      will use the C analyzer for all files ending with .FOO",
                     "  Ex: -A bar.:Perl",
@@ -469,9 +468,8 @@ public final class Indexer {
             );
 
             parser.on("-c", "--ctags", "=/path/to/ctags",
-                    "Path to Universal Ctags. Default is ctags in PATH.").Do(ctagsPath ->
-                    cfg.setCtags((String) ctagsPath)
-            );
+                    "Path to Universal Ctags. Default is ctags in environment PATH.").Do(
+                            v -> cfg.setCtags((String) v));
 
             parser.on("--canonicalRoot", "=/path/",
                     "Allow symlinks to canonical targets starting with the specified root",
@@ -487,9 +485,8 @@ public final class Indexer {
             });
 
             parser.on("--checkIndexVersion",
-                    "Check if current Lucene version matches index version.").Do(v -> {
-                checkIndexVersion = true;
-            });
+                    "Check if current Lucene version matches index version.").Do(v ->
+                    checkIndexVersion = true);
 
             parser.on("-d", "--dataRoot", "=/path/to/data/root",
                 "The directory where OpenGrok stores the generated data.").
@@ -511,9 +508,8 @@ public final class Indexer {
 
             parser.on("--depth", "=number", Integer.class,
                 "Scanning depth for repositories in directory structure relative to",
-                "source root. Default is " + Configuration.defaultScanningDepth + ".").Do(depth -> {
-                cfg.setScanningDepth((Integer) depth);
-            });
+                "source root. Default is " + Configuration.defaultScanningDepth + ".").Do(depth ->
+                    cfg.setScanningDepth((Integer) depth));
 
             parser.on("--disableRepository", "=type_name",
                     "Disables operation of an OpenGrok-supported repository. See also",
@@ -537,13 +533,10 @@ public final class Indexer {
                     "be slightly slow.").Do(v -> cfg.setGenerateHtml(false));
 
             parser.on("-G", "--assignTags",
-                "Assign commit tags to all entries in history for all repositories.").Do(v -> {
-                cfg.setTagsEnabled(true);
-            });
+                "Assign commit tags to all entries in history for all repositories.").Do(v ->
+                    cfg.setTagsEnabled(true));
 
-            parser.on("-H", "--history", "Enable history.").Do(v -> {
-                cfg.setHistoryEnabled(true);
-            });
+            parser.on("-H", "--history", "Enable history.").Do(v -> cfg.setHistoryEnabled(true));
 
             parser.on("-I", "--include", "=pattern",
                     "Only files matching this pattern will be examined. Pattern supports",
@@ -571,9 +564,8 @@ public final class Indexer {
             });
 
             parser.on("--leadingWildCards", "=on|off", ON_OFF, Boolean.class,
-                "Allow or disallow leading wildcards in a search. Default is on.").Do(v -> {
-                cfg.setAllowLeadingWildcard((Boolean) v);
-            });
+                "Allow or disallow leading wildcards in a search. Default is on.").Do(v ->
+                    cfg.setAllowLeadingWildcard((Boolean) v));
 
             parser.on("-m", "--memory", "=number", Double.class,
                     "Amount of memory (MB) that may be used for buffering added documents and",
@@ -661,9 +653,8 @@ public final class Indexer {
                     cfg.setQuickContextScan((Boolean) v));
 
             parser.on("-q", "--quiet",
-                    "Run as quietly as possible. Sets logging level to WARNING.").Do(v -> {
-                LoggerUtil.setBaseConsoleLogLevel(Level.WARNING);
-            });
+                    "Run as quietly as possible. Sets logging level to WARNING.").Do(v ->
+                    LoggerUtil.setBaseConsoleLogLevel(Level.WARNING));
 
             parser.on("-R /path/to/configuration",
                 "Read configuration from the specified file.").Do(v -> {
@@ -821,7 +812,7 @@ public final class Indexer {
         }
 
         if (repositories.size() > 0 && !cfg.isHistoryEnabled()) {
-            die("Repositories were specified; however history is off");
+            die("Repositories were specified; history is off however");
         }
     }
 
@@ -988,7 +979,7 @@ public final class Indexer {
             // Even if history is disabled globally, it can be enabled for some repositories.
             if (repositories != null && !repositories.isEmpty()) {
                 LOGGER.log(Level.INFO, "Generating history cache for repositories: " +
-                        repositories.stream().collect(Collectors.joining(",")));
+                        String.join(",", repositories));
                 HistoryGuru.getInstance().createCache(repositories);
                 LOGGER.info("Done...");
             } else {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -61,6 +61,7 @@ import org.opengrok.indexer.configuration.LuceneLockName;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.HistoryGuru;
+import org.opengrok.indexer.history.RepositoriesHelp;
 import org.opengrok.indexer.history.Repository;
 import org.opengrok.indexer.history.RepositoryFactory;
 import org.opengrok.indexer.history.RepositoryInfo;
@@ -167,6 +168,9 @@ public final class Indexer {
                         break;
                     case GURU:
                         helpStream.println(AnalyzerGuruHelp.getUsage());
+                        break;
+                    case REPOS:
+                        helpStream.println(RepositoriesHelp.getText());
                         break;
                     default:
                         helpStream.println(helpUsage);
@@ -448,7 +452,8 @@ public final class Indexer {
                     "With no mode specified, display this usage summary. Or specify a mode:",
                     "  config - display configuration.xml examples.",
                     "   ctags - display ctags command-line.",
-                    "    guru - display AnalyzerGuru details.").Do(v -> {
+                    "    guru - display AnalyzerGuru details.",
+                    "   repos - display enabled repositories.").Do(v -> {
                         help = true;
                         helpUsage = parser.getUsage();
                         String mode = (String) v;
@@ -1148,7 +1153,7 @@ public final class Indexer {
     }
 
     private enum HelpMode {
-        CONFIG, CTAGS, DEFAULT, GURU
+        CONFIG, CTAGS, DEFAULT, GURU, REPOS
     }
 
     private Indexer() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -720,9 +720,8 @@ public final class Indexer {
                     "Option may be repeated.").Do(v -> repositories.add((String) v));
 
             parser.on("-S", "--search", "=[path/to/repository]",
-                    "Search for source repositories under -s,--source, and add them." +
-                    "Path (relative to the source root) to repository is optional. " +
-                    "Option may be repeated.").Do(v -> {
+                    "Search for source repositories under -s,--source, and add them. Path",
+                    "(relative to the source root) is optional. Option may be repeated.").Do(v -> {
                         searchRepositories = true;
                         String repoPath = (String) v;
                         if (!repoPath.isEmpty()) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoriesHelpTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoriesHelpTest.java
@@ -1,0 +1,42 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.history;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Represents a container for tests of {@link RepositoriesHelp}.
+ */
+public class RepositoriesHelpTest {
+    @Test
+    public void shouldCreateReadableUsage() {
+        String helpText = RepositoriesHelp.getText();
+        assertFalse("help text should not be empty", helpText.isEmpty());
+        assertTrue("help text should contain 'git (GitRepository)'",
+                helpText.contains("git (GitRepository)"));
+    }
+}


### PR DESCRIPTION
Hello,

Please consider for integration this patch to make `-h,--help` take an optional `mode`, and add modes `config`, `ctags`, and `guru` for the existing help details got by `-h -h -h`.

Added anew is a mode, `repos`, to get a list of enabled repositories (below).

I also fixed up some help descriptions.

Thank you.

```
Enabled repositories:

accurev (AccuRevRepository)
bazaar (BazaarRepository)
bitkeeper (BitKeeperRepository)
clearcase (ClearCaseRepository)
cvs (CVSRepository)
git (GitRepository)
mercurial (MercurialRepository)
monotone (MonotoneRepository)
perforce (PerforceRepository)
razor (RazorRepository)
rcs (RCSRepository)
repo (RepoRepository)
sccs (SCCSRepository)
sscm (SSCMRepository)
subversion (SubversionRepository)
```
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
