### PR TITLE
check the value before putting to average key lengths map

### DIFF
--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest;
 
@@ -261,8 +261,10 @@ class SuggesterProjectData implements Closeable {
         WFSTCompletionLookup lookup = createWFST();
         lookup.build(iterator);
 
-        double averageLength = (double) iterator.termLengthAccumulator / lookup.getCount();
-        averageLengths.put(field, averageLength);
+        if (lookup.getCount() > 0) {
+            double averageLength = (double) iterator.termLengthAccumulator / lookup.getCount();
+            averageLengths.put(field, averageLength);
+        }
 
         return lookup;
     }

--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
@@ -300,6 +300,10 @@ class SuggesterProjectData implements Closeable {
             ChronicleMapAdapter m;
             try {
                 m = new ChronicleMapAdapter(field, conf.getAverageKeySize(), conf.getEntries(), f);
+            } catch (IllegalArgumentException e) {
+                logger.log(Level.SEVERE, "Could not create ChronicleMap due to invalid key size: "
+                        + conf.getAverageKeySize(), e);
+                return;
             } catch (Throwable t) {
                 logger.log(Level.SEVERE,
                         "Could not create ChronicleMap, most popular completion disabled, if you are using "


### PR DESCRIPTION
This change sanitizes the values before putting them to `averageLengths` map in suggester project data, thus preventing the `IllegalArgumentException` exception in `initSearchCountMap()`.