### PR TITLE
make suggester popularity tests wait on rebuild

### DIFF
--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/TestCasePrinterRule.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/TestCasePrinterRule.java
@@ -1,0 +1,88 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ */
+
+// taken from https://technicaltesting.wordpress.com/2012/10/23/junit-rule-for-printing-test-case-start-and-end-information/
+
+package org.opengrok.indexer.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.text.DecimalFormat;
+
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class TestCasePrinterRule implements TestRule {
+
+    private OutputStream out;
+    private final TestCasePrinter printer = new TestCasePrinter();
+
+    private String beforeContent = null;
+    private String afterContent = null;
+    private long timeStart;
+
+    public TestCasePrinterRule() {
+        this(System.out);
+    }
+
+    public TestCasePrinterRule(OutputStream os) {
+        out = os;
+    }
+
+    private class TestCasePrinter extends ExternalResource {
+        @Override
+        protected void before() throws Throwable {
+            timeStart = System.currentTimeMillis();
+            out.write(beforeContent.getBytes());
+        }
+
+        @Override
+        protected void after() {
+            try {
+                long timeEnd = System.currentTimeMillis();
+                double seconds = (timeEnd - timeStart) / 1000.0;
+                out.write((afterContent + "Time elapsed: " + new DecimalFormat("0.000").format(seconds) + " sec\n").
+                        getBytes());
+            } catch (IOException ioe) { /* ignore */
+            }
+        }
+    }
+
+    private static String getClassBasename(String inputName) {
+        int idx;
+        if (((idx = inputName.lastIndexOf('.')) > 0) && (idx < inputName.length())) {
+            return inputName.substring(idx + 1);
+        } else {
+            return inputName;
+        }
+    }
+
+    public final Statement apply(Statement statement, Description description) {
+        final String testDescription = getClassBasename(description.getClassName()) + "#" +  description.getMethodName();
+        beforeContent = String.format("\n[TEST START: %s]\n", testDescription);
+        afterContent =  String.format("[TEST ENDED: %s] ", testDescription);
+        return printer.apply(statement, description);
+    }
+}

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
@@ -79,8 +79,9 @@ public interface SuggesterService {
      * @param project project to update
      * @param term term to update
      * @param value value by which to change the data, represents how many times was the {@code term} searched
+     * @return false if update failed, otherwise true
      */
-    void increaseSearchCount(String project, Term term, int value);
+    boolean increaseSearchCount(String project, Term term, int value);
 
     /**
      * Returns the searched terms sorted according to their popularity.

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
@@ -31,6 +31,7 @@ import org.opengrok.suggest.query.SuggesterQuery;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 public interface SuggesterService {
 
@@ -60,6 +61,13 @@ public interface SuggesterService {
      * @param project project name
      */
     void rebuild(String project);
+
+    /**
+     * Wait for the initial rebuild. For testing.
+     * @param timeout timeout to wait for
+     * @param unit timeout unit
+     */
+    void waitForRebuild(long timeout, TimeUnit unit) throws InterruptedException;
 
     /**
      * Deletes all suggester data for the {@code project}.
@@ -107,5 +115,4 @@ public interface SuggesterService {
      * Closes the underlying service explicitly.
      */
     void close();
-
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
@@ -84,6 +84,16 @@ public interface SuggesterService {
     boolean increaseSearchCount(String project, Term term, int value);
 
     /**
+     * Increments most popular completion data for the specified {@code term} by {@code value}.
+     * @param project project to update
+     * @param term term to update
+     * @param value value by which to change the data, represents how many times was the {@code term} searched
+     * @param waitForLock wait for lock
+     * @return false if update failed, otherwise true
+     */
+    boolean increaseSearchCount(String project, Term term, int value, boolean waitForLock);
+
+    /**
      * Returns the searched terms sorted according to their popularity.
      * @param project project for which to return the data
      * @param field field for which to return the data

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
@@ -70,6 +70,13 @@ public interface SuggesterService {
     void waitForRebuild(long timeout, TimeUnit unit) throws InterruptedException;
 
     /**
+     * Wait for the initialization. For testing.
+     * @param timeout timeout to wait for
+     * @param unit timeout unit
+     */
+    void waitForInit(long timeout, TimeUnit unit) throws InterruptedException;
+
+    /**
      * Deletes all suggester data for the {@code project}.
      * @param project name of the project to delete
      */

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
@@ -63,7 +63,7 @@ public interface SuggesterService {
     void rebuild(String project);
 
     /**
-     * Wait for the initial rebuild. For testing.
+     * Wait for rebuild. For testing.
      * @param timeout timeout to wait for
      * @param unit timeout unit
      */

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -399,6 +399,10 @@ public class SuggesterServiceImpl implements SuggesterService {
         return d.get();
     }
 
+    public void waitForRebuild(long timeout, TimeUnit unit) throws InterruptedException {
+        suggester.waitForRebuild(timeout, unit);
+    }
+
     /** {@inheritDoc} */
     @Override
     public void close() {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -403,6 +403,10 @@ public class SuggesterServiceImpl implements SuggesterService {
         suggester.waitForRebuild(timeout, unit);
     }
 
+    public void waitForInit(long timeout, TimeUnit unit) throws InterruptedException {
+        suggester.waitForInit(timeout, unit);
+    }
+
     /** {@inheritDoc} */
     @Override
     public void close() {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -249,13 +249,13 @@ public class SuggesterServiceImpl implements SuggesterService {
 
     /** {@inheritDoc} */
     @Override
-    public void increaseSearchCount(final String project, final Term term, final int value) {
+    public boolean increaseSearchCount(final String project, final Term term, final int value) {
         lock.readLock().lock();
         try {
             if (suggester == null) {
-                return;
+                return false;
             }
-            suggester.increaseSearchCount(project, term, value);
+            return suggester.increaseSearchCount(project, term, value);
         } finally {
             lock.readLock().unlock();
         }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -255,7 +255,21 @@ public class SuggesterServiceImpl implements SuggesterService {
             if (suggester == null) {
                 return false;
             }
-            return suggester.increaseSearchCount(project, term, value);
+            return suggester.increaseSearchCount(project, term, value, false);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean increaseSearchCount(final String project, final Term term, final int value, boolean waitForLock) {
+        lock.readLock().lock();
+        try {
+            if (suggester == null) {
+                return false;
+            }
+            return suggester.increaseSearchCount(project, term, value, waitForLock);
         } finally {
             lock.readLock().unlock();
         }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -611,7 +611,7 @@ public class SuggesterControllerTest extends OGKJerseyTest {
     @SuppressWarnings("unchecked") // for contains
     public void testGetPopularityDataSimple() {
         assertTrue(SuggesterServiceImpl.getInstance().increaseSearchCount("rust",
-                new Term(QueryBuilder.FULL, "main"), 10));
+                new Term(QueryBuilder.FULL, "main"), 10, true));
 
         List<Entry<String, Integer>> res = target(SuggesterController.PATH)
                 .path("popularity")
@@ -626,9 +626,9 @@ public class SuggesterControllerTest extends OGKJerseyTest {
     @SuppressWarnings("unchecked") // for contains
     public void testGetPopularityDataAll() {
         assertTrue(SuggesterServiceImpl.getInstance().increaseSearchCount("csharp",
-                new Term(QueryBuilder.FULL, "mynamespace"), 10));
+                new Term(QueryBuilder.FULL, "mynamespace"), 10, true));
         assertTrue(SuggesterServiceImpl.getInstance().increaseSearchCount("csharp",
-                new Term(QueryBuilder.FULL, "topclass"), 15));
+                new Term(QueryBuilder.FULL, "topclass"), 15, true));
 
         List<Entry<String, Integer>> res = target(SuggesterController.PATH)
                 .path("popularity")
@@ -645,9 +645,9 @@ public class SuggesterControllerTest extends OGKJerseyTest {
     @SuppressWarnings("unchecked") // for contains
     public void testGetPopularityDataDifferentField() {
         assertTrue(SuggesterServiceImpl.getInstance().increaseSearchCount("swift",
-                new Term(QueryBuilder.FULL, "print"), 10));
+                new Term(QueryBuilder.FULL, "print"), 10, true));
         assertTrue(SuggesterServiceImpl.getInstance().increaseSearchCount("swift",
-                new Term(QueryBuilder.DEFS, "greet"), 4));
+                new Term(QueryBuilder.DEFS, "greet"), 4, true));
 
         List<Entry<String, Integer>> res = target(SuggesterController.PATH)
                 .path("popularity")

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -32,7 +32,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.opengrok.indexer.util.TestCasePrinterRule;
-import org.opengrok.suggest.Suggester;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.configuration.SuggesterConfig;
 import org.opengrok.indexer.index.Indexer;
@@ -46,18 +45,15 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
-import java.lang.reflect.Field;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertEquals;
@@ -129,22 +125,10 @@ public class SuggesterControllerTest extends OGKJerseyTest {
     }
 
     @Before
-    public void before() {
-        await().atMost(15, TimeUnit.SECONDS).until(() ->
-                getSuggesterProjectDataSize() == env.getProjectList().size());
+    public void before() throws InterruptedException {
+        SuggesterServiceImpl.getInstance().waitForInit(15, TimeUnit.SECONDS);
 
         env.setSuggesterConfig(new SuggesterConfig());
-    }
-
-    private static int getSuggesterProjectDataSize() throws Exception {
-        Field f = SuggesterServiceImpl.class.getDeclaredField("suggester");
-        f.setAccessible(true);
-        Suggester suggester = (Suggester) f.get(SuggesterServiceImpl.getInstance());
-
-        Field f2 = Suggester.class.getDeclaredField("projectData");
-        f2.setAccessible(true);
-
-        return ((Map) f2.get(suggester)).size();
     }
 
     @Test

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -28,7 +28,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -673,17 +672,18 @@ public class SuggesterControllerTest extends OGKJerseyTest {
     }
 
     @Test
-    public void ZtestRebuild() {
+    public void ZtestRebuild() throws InterruptedException {
         Response res = target(SuggesterController.PATH)
                 .path("rebuild")
                 .request()
                 .put(Entity.text(""));
 
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), res.getStatus());
+        SuggesterServiceImpl.getInstance().waitForRebuild(15, TimeUnit.SECONDS);
     }
 
     @Test
-    public void ZtestRebuildProject() {
+    public void ZtestRebuildProject() throws InterruptedException {
         Response res = target(SuggesterController.PATH)
                 .path("rebuild")
                 .path("c")
@@ -691,5 +691,6 @@ public class SuggesterControllerTest extends OGKJerseyTest {
                 .put(Entity.text(""));
 
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), res.getStatus());
+        SuggesterServiceImpl.getInstance().waitForRebuild(15, TimeUnit.SECONDS);
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -63,6 +63,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
 
@@ -609,7 +610,8 @@ public class SuggesterControllerTest extends OGKJerseyTest {
     @Test
     @SuppressWarnings("unchecked") // for contains
     public void testGetPopularityDataSimple() {
-        SuggesterServiceImpl.getInstance().increaseSearchCount("rust", new Term(QueryBuilder.FULL, "main"), 10);
+        assertTrue(SuggesterServiceImpl.getInstance().increaseSearchCount("rust",
+                new Term(QueryBuilder.FULL, "main"), 10));
 
         List<Entry<String, Integer>> res = target(SuggesterController.PATH)
                 .path("popularity")
@@ -617,17 +619,16 @@ public class SuggesterControllerTest extends OGKJerseyTest {
                 .request()
                 .get(popularityDataType);
 
-
         assertThat(res, contains(new SimpleEntry<>("main", 10)));
     }
 
     @Test
     @SuppressWarnings("unchecked") // for contains
     public void testGetPopularityDataAll() {
-        SuggesterServiceImpl.getInstance().increaseSearchCount("csharp",
-                new Term(QueryBuilder.FULL, "mynamespace"), 10);
-        SuggesterServiceImpl.getInstance().increaseSearchCount("csharp",
-                new Term(QueryBuilder.FULL, "topclass"), 15);
+        assertTrue(SuggesterServiceImpl.getInstance().increaseSearchCount("csharp",
+                new Term(QueryBuilder.FULL, "mynamespace"), 10));
+        assertTrue(SuggesterServiceImpl.getInstance().increaseSearchCount("csharp",
+                new Term(QueryBuilder.FULL, "topclass"), 15));
 
         List<Entry<String, Integer>> res = target(SuggesterController.PATH)
                 .path("popularity")
@@ -643,8 +644,10 @@ public class SuggesterControllerTest extends OGKJerseyTest {
     @Test
     @SuppressWarnings("unchecked") // for contains
     public void testGetPopularityDataDifferentField() {
-        SuggesterServiceImpl.getInstance().increaseSearchCount("swift", new Term(QueryBuilder.FULL, "print"), 10);
-        SuggesterServiceImpl.getInstance().increaseSearchCount("swift", new Term(QueryBuilder.DEFS, "greet"), 4);
+        assertTrue(SuggesterServiceImpl.getInstance().increaseSearchCount("swift",
+                new Term(QueryBuilder.FULL, "print"), 10));
+        assertTrue(SuggesterServiceImpl.getInstance().increaseSearchCount("swift",
+                new Term(QueryBuilder.DEFS, "greet"), 4));
 
         List<Entry<String, Integer>> res = target(SuggesterController.PATH)
                 .path("popularity")

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -263,8 +263,6 @@ public class SuggesterControllerTest extends OGKJerseyTest {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), r.getStatus());
     }
 
-    // temporarily disabled, see https://github.com/oracle/opengrok/issues/2030
-    @Ignore
     @Test
     public void testGetSuggestionsMultipleProjects() {
         Result res = target(SuggesterController.PATH)

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -24,8 +24,15 @@
 package org.opengrok.web.api.v1.controller;
 
 import org.apache.lucene.index.Term;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runners.MethodSorters;
+import org.opengrok.indexer.util.TestCasePrinterRule;
 import org.opengrok.suggest.Suggester;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.configuration.SuggesterConfig;
@@ -61,6 +68,9 @@ import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class SuggesterControllerTest extends OGKJerseyTest {
+
+    @Rule
+    public TestCasePrinterRule pr = new TestCasePrinterRule();
 
     public static class Result {
         public long time;

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -92,7 +92,7 @@ public final class Suggester implements Closeable {
 
     private boolean rebuilding;
     private final Lock rebuildLock = new ReentrantLock();
-    private final Condition initialRebuildDone = rebuildLock.newCondition();
+    private final Condition rebuildDone = rebuildLock.newCondition();
 
     // do NOT use fork join thread pool (work stealing thread pool) because it does not send interrupts upon cancellation
     private final ExecutorService executorService = Executors.newFixedThreadPool(
@@ -268,7 +268,7 @@ public final class Suggester implements Closeable {
         rebuildLock.lock();
         try {
             rebuilding = false;
-            initialRebuildDone.signalAll();
+            rebuildDone.signalAll();
         } finally {
             rebuildLock.unlock();
         }
@@ -279,7 +279,7 @@ public final class Suggester implements Closeable {
         rebuildLock.lock();
         try {
             while (rebuilding) {
-                initialRebuildDone.await(timeout, unit);
+                rebuildDone.await(timeout, unit);
             }
         } finally {
             rebuildLock.unlock();

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -467,10 +467,11 @@ public final class Suggester implements Closeable {
      * @param project project where the term resides
      * @param term term for which to increase search count
      * @param value positive value by which to increase the search count
+     * @return false if update failed, otherwise true
      */
-    public void increaseSearchCount(final String project, final Term term, final int value) {
+    public boolean increaseSearchCount(final String project, final Term term, final int value) {
         if (!allowMostPopular) {
-            return;
+            return false;
         }
         SuggesterProjectData data;
         if (!projectsEnabled) {
@@ -482,10 +483,10 @@ public final class Suggester implements Closeable {
         if (data == null) {
             logger.log(Level.WARNING, "Cannot update search count because of missing suggester data{}",
                     projectsEnabled ? " for project " + project : "");
-            return;
+            return false;
         }
 
-        data.incrementSearchCount(term, value);
+        return data.incrementSearchCount(term, value);
     }
 
     /**

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -469,7 +469,7 @@ public final class Suggester implements Closeable {
      * @param value positive value by which to increase the search count
      * @return false if update failed, otherwise true
      */
-    public boolean increaseSearchCount(final String project, final Term term, final int value) {
+    public boolean increaseSearchCount(final String project, final Term term, final int value, final boolean waitForLock) {
         if (!allowMostPopular) {
             return false;
         }
@@ -486,7 +486,7 @@ public final class Suggester implements Closeable {
             return false;
         }
 
-        return data.incrementSearchCount(term, value);
+        return data.incrementSearchCount(term, value, waitForLock);
     }
 
     /**

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -173,6 +173,12 @@ public final class Suggester implements Closeable {
         }
     }
 
+    /**
+     * wait for initialization to finish.
+     * @param timeout timeout value
+     * @param unit timeout unit
+     * @throws InterruptedException
+     */
     public void waitForInit(long timeout, TimeUnit unit) throws InterruptedException {
         initDone.await(timeout, unit);
     }
@@ -249,7 +255,6 @@ public final class Suggester implements Closeable {
             return;
         }
 
-        // for testing
         rebuildLock.lock();
         rebuilding = true;
         rebuildLock.unlock();
@@ -272,7 +277,6 @@ public final class Suggester implements Closeable {
             shutdownAndAwaitTermination(executor, start, "Suggesters for " + indexDirs + " were successfully rebuilt");
         }
 
-        // for testing
         rebuildLock.lock();
         try {
             rebuilding = false;
@@ -282,7 +286,12 @@ public final class Suggester implements Closeable {
         }
     }
 
-    // for testing
+    /**
+     * wait for rebuild to finish.
+     * @param timeout timeout value
+     * @param unit timeout unit
+     * @throws InterruptedException
+     */
     public void waitForRebuild(long timeout, TimeUnit unit) throws InterruptedException {
         rebuildLock.lock();
         try {

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -91,7 +91,7 @@ public final class Suggester implements Closeable {
 
     private final int rebuildParallelismLevel;
 
-    private boolean rebuilding;
+    private volatile boolean rebuilding;
     private final Lock rebuildLock = new ReentrantLock();
     private final Condition rebuildDone = rebuildLock.newCondition();
 

--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
@@ -282,7 +282,7 @@ public class SuggesterTest {
     public void testIncreaseSearchCount() throws IOException {
         SuggesterTestData t = initSuggester();
 
-        t.s.increaseSearchCount("test", new Term("test", "term2"), 100);
+        t.s.increaseSearchCount("test", new Term("test", "term2"), 100, true);
 
         List<Entry<BytesRef, Integer>> res = t.s.getSearchCounts("test", "test", 0, 10);
 


### PR DESCRIPTION
This change fixes the popularity data related test failures tracked by #2704. After making `increaseSearchCount()` testable and adding logging it became evident that the failures stem from bailing on waiting on suggester rebuild.