### PR TITLE
re-enable testGetSuggestionsMultipleProjects()

### DIFF
--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -253,8 +253,6 @@ public class SuggesterControllerTest extends OGKJerseyTest {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), r.getStatus());
     }
 
-    // temporarily disabled, see https://github.com/oracle/opengrok/issues/2030
-    @Ignore
     @Test
     public void testGetSuggestionsMultipleProjects() {
         Result res = target(SuggesterController.PATH)


### PR DESCRIPTION
with #2030 fixed it should be possible to re-enable the `testGetSuggestionsMultipleProjects()` test.