### PR TITLE
switch Docker image to JDK 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,6 @@ ENV CATALINA_HOME /usr/local/tomcat
 ENV CATALINA_BASE /usr/local/tomcat
 ENV CATALINA_TMPDIR /usr/local/tomcat/temp
 ENV PATH $CATALINA_HOME/bin:$PATH
-# ENV JRE_HOME /usr
 ENV CLASSPATH /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
 
 # custom deployment to / with redirect from /source

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM ubuntu:bionic as build
 
-RUN apt-get update && apt-get install -y openjdk-8-jdk maven python3 python3-venv
+RUN apt-get update && apt-get install -y maven python3 python3-venv
 
 # Create a first layer to cache the "Maven World" in the local repository.
 # Incremental docker builds will always resume after that, unless you update the pom

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /opengrok-source
 RUN mvn -DskipTests=true -Dmaven.javadoc.skip=true -B -V package
 RUN cp distribution/target/*.tar.gz /opengrok.tar.gz
 
-FROM tomcat:9-jre8
+FROM tomcat:9-jdk11
 LABEL maintainer="opengrok-dev@yahoogroups.com"
 
 # install dependencies and Python tools
@@ -67,7 +67,7 @@ ENV CATALINA_HOME /usr/local/tomcat
 ENV CATALINA_BASE /usr/local/tomcat
 ENV CATALINA_TMPDIR /usr/local/tomcat/temp
 ENV PATH $CATALINA_HOME/bin:$PATH
-ENV JRE_HOME /usr
+# ENV JRE_HOME /usr
 ENV CLASSPATH /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
 
 # custom deployment to / with redirect from /source

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY ./ /opengrok-source
 WORKDIR /opengrok-source
 
 RUN mvn -DskipTests=true -Dmaven.javadoc.skip=true -B -V package
-RUN cp distribution/target/*.tar.gz /opengrok.tar.gz
+RUN cp `ls -t distribution/target/*.tar.gz | head -1` /opengrok.tar.gz
 
 FROM tomcat:9-jdk11
 LABEL maintainer="opengrok-dev@yahoogroups.com"

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -324,8 +324,8 @@ public final class Indexer {
                 }
             }
 
-            LOGGER.log(Level.INFO, "Indexer version {0} ({1})",
-                    new Object[]{Info.getVersion(), Info.getRevision()});
+            LOGGER.log(Level.INFO, "Indexer version {0} ({1}) running on Java {2}",
+                    new Object[]{Info.getVersion(), Info.getRevision(), System.getProperty("java.version")});
 
             // Create history cache first.
             if (searchRepositories) {


### PR DESCRIPTION
This change switches the Docker image to JDK 11. It helps with growing RSS of the Tomcat process (presumably by using different GC implementation).