### PR TITLE
[WIP] Move to Java 11 as the minimum version to anticipate Lucene

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,7 @@ addons:
 jobs:
   include:
   - stage: test
-    name: Linux + OpenJDK 8
-    os: linux
-    dist: xenial
-    sudo: required
-    jdk: openjdk8
-    install: true
-    script: dev/main
-    before_install: dev/before_install
-    before_script: dev/before
-  - stage: test
-    name: Linux + Oracle JDK 11
+    name: Linux + OpenJDK 11
     os: linux
     dist: xenial
     sudo: required
@@ -42,26 +32,27 @@ jobs:
     before_install: dev/before_install
     before_script: dev/before
   - stage: test
-    name: macOS + Oracle JDK 8
+    name: macOS + Oracle JDK 11
     os: osx
-    osx_image: xcode8.3
+    osx_image: xcode10.1
+    jdk: oraclejdk11
     install: true
     script: dev/main
     before_install: dev/before_install
     before_script: dev/before
   - stage: test
-    name: Windows + Open JDK 8
+    name: Windows + Open JDK 11
     # Use shell until Travis supports Java on Windows proper.
     language: shell
     os: windows
     install: true
     script: dev/main
-    before_install: dev/before_install.windows openjdk8
+    before_install: dev/before_install.windows openjdk11
     before_script: dev/before
   - stage: deploy
     name: Github Release
     dist: xenial
-    jdk: openjdk8
+    jdk: openjdk11
     if: repo = "oracle/opengrok" AND tag IS present
     before_install: dev/before_install
     install: true
@@ -79,7 +70,7 @@ jobs:
   - stage: docker
     name: Docker image build
     dist: xenial
-    jdk: openjdk8
+    jdk: openjdk11
     install: true
     services:
     - docker
@@ -89,7 +80,7 @@ jobs:
     name: Upload javadocs to Github pages
     os: linux
     dist: xenial
-    jdk: openjdk8
+    jdk: openjdk11
     script: dev/javadoc.sh
     install: true
     if: repo = "oracle/opengrok" AND tag IS NOT present

--- a/dev/main
+++ b/dev/main
@@ -21,7 +21,7 @@ fi
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
 	JAVA_BASE="/c/Program Files/OpenJDK"
-	JDK_DIR=$(find "$JAVA_BASE/" -type d -name 'openjdk*' -maxdepth 1 | head -1)
+	JDK_DIR=$(find "$JAVA_BASE/" -type d -name '*jdk*' -maxdepth 1 | head -1)
 	export JAVA_HOME=${JAVA_HOME:-$JDK_DIR}
 	echo "JAVA_HOME set to $JAVA_HOME"
 	export PATH=${JAVA_HOME}/bin:${PATH}

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -385,38 +385,16 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
                         <!-- Test helper class with name that confuses surefire -->
                         <exclude>**/TestRepository.java</exclude>
                     </excludes>
-                    <argLine>@{surefireArgLine}</argLine>
+                    <argLine>
+                        @{surefireArgLine}
+                        --illegal-access=permit
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>
     </build>
 
     <profiles>
-        <profile>
-            <id>java9plus</id>
-            <activation>
-                <jdk>[9,18]</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <!-- Test helper class with name that confuses surefire -->
-                                <exclude>**/TestRepository.java</exclude>
-                            </excludes>
-                            <argLine>
-                                @{surefireArgLine}
-                                --illegal-access=permit
-                            </argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <profile>
             <id>Windows environment</id>
             <activation>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/PascalUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/PascalUtils.java
@@ -36,7 +36,7 @@ public class PascalUtils {
      * ¹Correctness in a long sequence of apostrophes is limited because Java
      * look-behind is not variable length but instead must have a definite
      * upper bound in the regex definition.
-     * </p>
+     *
      */
     public static final Pattern CHARLITERAL_APOS_DELIMITER =
         Pattern.compile("\\'((?<=^.(?!\\'))|(?<=[^\\'].(?!\\'))|(?<=^(\\'\\'){1,3}.(?!\\'))|(?<=[^\\'](\\'\\'){1,3}.(?!\\')))");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationFramework.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationFramework.java
@@ -268,18 +268,18 @@ public final class AuthorizationFramework extends PluginFramework<IAuthorization
 
     /**
      * Add a plug-in into the plug-in array.
-     *
-     * <h3>Configured plugin</h3>
-     * For plug-in that has an entry in configuration, the new plug-in is put
-     * in the place respecting the user-defined order of execution.
-     *
-     * <h3>New plugin</h3>
-     * If there is no entry in configuration for this class, the plugin is
-     * appended to the end of the plugin stack with flag <code>flag</code>
-     *
-     * <p><b>The plug-in's load method is NOT invoked at this point</b></p>
      * <p>
-     * This has the same effect as invoking
+     * <p>Configured plugin:
+     * <p>For plug-in that has an entry in configuration, the new plug-in is put
+     * in the place respecting the user-defined order of execution.
+     * <p>
+     * <p>New plugin:
+     * <p>If there is no entry in configuration for this class, the plugin is
+     * appended to the end of the plugin stack with flag <code>flag</code>
+     * <p>
+     * <p><b>The plug-in's load method is NOT invoked at this point</b>
+     * <p>
+     * <p>This has the same effect as invoking
      * {@code addPlugin(new AuthorizationEntity(stack, flag,
      * getClassName(plugin), plugin)}.
      *
@@ -358,17 +358,14 @@ public final class AuthorizationFramework extends PluginFramework<IAuthorization
 
     /**
      * Calling this function forces the framework to reload its stack.
-     *
      * <p>
-     * Plugins are taken from the pluginDirectory.</p>
-     *
+     * <p>Plugins are taken from the pluginDirectory.
      * <p>
-     * Old instances in stack are removed and new list of stack is constructed.
-     * Unload and load event is fired on each plugin.</p>
-     *
+     * <p>Old instances in stack are removed and new list of stack is constructed.
+     * Unload and load event is fired on each plugin.
      * <p>
-     * This method is thread safe with respect to the currently running
-     * authorization checks.</p>
+     * <p>This method is thread safe with respect to the currently running
+     * authorization checks.
      *
      * @see IAuthorizationPlugin#load(java.util.Map)
      * @see IAuthorizationPlugin#unload()
@@ -453,43 +450,40 @@ public final class AuthorizationFramework extends PluginFramework<IAuthorization
     /**
      * Checks if the request should have an access to a resource. This method is
      * thread safe with respect to the concurrent reload of plugins.
-     *
      * <p>
-     * Internally performed with a predicate. Using cache in request
-     * attributes.</p>
-     *
-     * <h3>Order of plugin invocation</h3>
-     *
+     * <p>Internally performed with a predicate. Using cache in request
+     * attributes.
+     * <p>
+     * <p>Order of plugin invocation:
      * <p>
      * The order of plugin invocation is given by the stack and appropriate
      * actions are taken when traversing the stack with set of keywords,
-     * such as:</p>
-     *
-     * <h4>required</h4>
+     * such as:
+     * <p>
+     * <p>required:
      * Failure of such a plugin will ultimately lead to the authorization
      * framework returning failure but only after the remaining plugins have
      * been invoked.
-     *
-     * <h4>requisite</h4>
+     * <p>
+     * <p>requisite:
      * Like required, however, in the case that such a plugin returns a failure,
      * control is directly returned to the application. The return value is that
      * associated with the first required or requisite plugin to fail.
-     *
-     * <h4>sufficient</h4>
-     * If such a plugin succeeds and no prior required plugin has failed the
+     * <p>
+     * <p>sufficient
+     * <p>If such a plugin succeeds and no prior required plugin has failed the
      * authorization framework returns success to the application immediately
      * without calling any further plugins in the stack. A failure of a
      * sufficient plugin is ignored and processing of the plugin list continues
      * unaffected.
-     *
+     * <p>
      * <p>
      * Loaded plugins which do not occur in the configuration are appended to
      * the list with "required" keyword. As of the nature of the class discovery
      * this means that the order of invocation of these plugins is rather
-     * random.</p>
-     *
+     * random.
      * <p>
-     * Plugins in the configuration which have not been loaded are skipped.</p>
+     * <p>Plugins in the configuration which have not been loaded are skipped.
      *
      * @param request           request object
      * @param cache             cache

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationPlugin.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationPlugin.java
@@ -82,13 +82,11 @@ public class AuthorizationPlugin extends AuthorizationStack {
      * Call the load method on the underlying plugin if the plugin exists. Note
      * that the load method can throw any throwable from its body and it should
      * not stop the application.
-     *
      * <p>
-     * If the method is unable to load the plugin because of any reason (mostly
+     * <p>If the method is unable to load the plugin because of any reason (mostly
      * the class is not found, not instantiable or the load method throws an
      * exception) then any authorization check should fail for this plugin in
      * the future.
-     * </p>
      *
      * @param parameters parameters given in the configuration
      *

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationStack.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationStack.java
@@ -116,12 +116,10 @@ public class AuthorizationStack extends AuthorizationEntity {
 
     /**
      * Load all authorization entities in this stack.
-     *
      * <p>
-     * If the method is unable to load any of the entities contained in this
+     * <p>If the method is unable to load any of the entities contained in this
      * stack then this stack is marked as failed. Note that it does not affect
      * the authorization decision made by this stack.
-     * </p>
      *
      * @param parameters parameters given in the configuration
      *
@@ -286,13 +284,11 @@ public class AuthorizationStack extends AuthorizationEntity {
      * Set the plugin to all classes in this stack which requires this class in
      * the configuration. This creates a new instance of the plugin for each
      * class which needs it.
-     *
      * <p>
-     * This is where the loaded plugin classes get to be a part of the
+     * <p>This is where the loaded plugin classes get to be a part of the
      * authorization process. When the {@link AuthorizationPlugin} does not get
      * its {@link IAuthorizationPlugin} it is marked as failed and returns false
      * to all authorization decisions.
-     * </p>
      *
      * @param plugin the new instance of a plugin
      * @return true if there is such case; false otherwise

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
@@ -186,11 +186,9 @@ public abstract class PluginFramework<PluginType> {
     /**
      * Load a class into JVM with custom class loader. Call a non-parametric
      * constructor to create a new instance of that class.
-     *
      * <p>
-     * The classes implementing/extending the {@code PluginType} type are
+     * <p>The classes implementing/extending the {@code PluginType} type are
      * returned and initialized with a call to a non-parametric constructor.
-     * </p>
      *
      * @param classname the full name of the class to load
      * @return the class implementing/extending the {@code PluginType} class
@@ -345,9 +343,8 @@ public abstract class PluginFramework<PluginType> {
 
     /**
      * Calling this function forces the framework to reload the plugins.
-     *
      * <p>
-     * Plugins are taken from the pluginDirectory.</p>
+     * <p>Plugins are taken from the pluginDirectory.
      */
     public final void reload() {
         if (pluginDirectory == null || !pluginDirectory.isDirectory() || !pluginDirectory.canRead()) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -124,15 +124,12 @@ public abstract class Repository extends RepositoryInfo {
     /**
      * <p>
      * Get the history after a specified revision.
-     * </p>
-     *
      * <p>
-     * The default implementation first fetches the full history and then throws
+     * <p>The default implementation first fetches the full history and then throws
      * away the oldest revisions. This is not efficient, so subclasses should
      * override it in order to get good performance. Once every subclass has
      * implemented a more efficient method, the default implementation should be
      * removed and made abstract.
-     * </p>
      *
      * @param file the file to get the history for
      * @param sinceRevision the revision right before the first one to return,

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/JFlexXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/JFlexXrefTest.java
@@ -272,11 +272,9 @@ public class JFlexXrefTest {
     }
 
     /**
-     * <p>
      * Test the handling of #include in C and C++. In particular, these issues
      * are tested:
-     * </p>
-     *
+     * <p>
      * <ul>
      *
      * <li>

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/DummyHttpServletRequest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/DummyHttpServletRequest.java
@@ -51,19 +51,15 @@ import javax.servlet.http.Part;
 import static org.opengrok.indexer.util.RandomString.generate;
 
 /**
- * <p>
  * An dummy implementation of {@code HttpServletRequest} in which most methods
  * simply throw an exception. Unit tests that need an instance of
  * {@code HttpServletRequest} can create sub-classes that implement those
  * methods needed by the test case.
- * </p>
- *
  * <p>
- * Some methods that would have similar implementations in all sub-classes,
+ * <p>Some methods that would have similar implementations in all sub-classes,
  * like set/get pairs, could be implemented here. Methods that would require
  * different implementations depending on the test, should rather just throw
  * an exception and let the tests override them.
- * </p>
  */
 public class DummyHttpServletRequest implements HttpServletRequest {
 

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -246,8 +246,12 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>
-                        -Djna.nosys=true
                         @{surefireArgLine}
+                        -Djna.nosys=true
+                        --illegal-access=permit
+                        --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                        --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+                        --add-exports java.base/sun.nio.ch=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>
@@ -277,33 +281,6 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>java9plus</id>
-            <activation>
-                <jdk>[9,18]</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>
-                                @{surefireArgLine}
-                                -Djna.nosys=true
-                                --illegal-access=permit
-                                --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
-                                --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
-                                --add-exports java.base/sun.nio.ch=ALL-UNNAMED
-                            </argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
     <pluginRepositories>
         <pluginRepository>

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -430,7 +430,7 @@ public final class PageConfig {
      *
      * <p>
      * For the root directory (/xref/) an authorization is performed for each
-     * project in case that projects are used.</p>
+     * project in case that projects are used.
      *
      * @see #getResourceFile()
      * @see #isDir()
@@ -1748,7 +1748,7 @@ public final class PageConfig {
      * <p>
      * The resource is modified since the weak ETag value in the request, the ETag is
      * computed using:
-     * </p>
+     *
      * <ul>
      * <li>the source file modification</li>
      * <li>project messages</li>
@@ -1758,7 +1758,7 @@ public final class PageConfig {
      *
      * <p>
      * If the resource was modified, appropriate headers in the response are filled.
-     * </p>
+     *
      *
      * @param request the http request containing the headers
      * @param response the http response for setting the headers

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -106,33 +106,13 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
                     <systemPropertyVariables>
                         <junit-force-all>true</junit-force-all>
                     </systemPropertyVariables>
-                    <argLine>@{surefireArgLine}</argLine>
+                    <argLine>
+                        @{surefireArgLine}
+                        --illegal-access=permit
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>java9plus</id>
-            <activation>
-                <jdk>[9,18]</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>
-                                @{surefireArgLine}
-                                --illegal-access=permit
-                            </argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
 </project>

--- a/plugins/src/main/java/opengrok/auth/plugin/AbstractLdapPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/AbstractLdapPlugin.java
@@ -37,7 +37,7 @@ import org.opengrok.indexer.configuration.Project;
 
 /**
  * Abstract class for all plug-ins working with LDAP. Takes care of
- * <ul>
+ * <p><ul>
  * <li>controlling the established session</li>
  * <li>controlling if the session belongs to the user</li>
  * </ul>
@@ -46,7 +46,6 @@ import org.opengrok.indexer.configuration.Project;
  * The intended methods to implement are the
  * {@link #checkEntity(HttpServletRequest, Project)} and
  * {@link #checkEntity(HttpServletRequest, Group)}.
- * </p>
  *
  * @author Krystof Tulinger
  */

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,9 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
     <properties>
         <lucene.version>8.6.2</lucene.version>
         <mavenjavadocplugin.version>3.0.1</mavenjavadocplugin.version>
-        <compileSource>1.8</compileSource>
-        <compileTarget>1.8</compileTarget>
+        <!-- The following changed syntax from e.g. 1.8 to 11. -->
+        <compileSource>11</compileSource>
+        <compileTarget>11</compileTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jersey.version>2.30.1</jersey.version>
         <!-- Jackson version needs to match the version of Jackson which Jersey
@@ -150,21 +151,21 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 
     <repositories>
         <repository>
-            <id>maven.org</id>
-            <name>maven.org</name>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>Central Repository</name>
             <url>https://repo.maven.apache.org/maven2/</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
-            <id>apache.snapshots</id>
-            <name>apache.snapshots</name>
-            <url>https://repository.apache.org/snapshots/</url>
-            <layout>default</layout>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
-            <id>maven.org</id>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>Central Repository</name>
             <url>https://repo.maven.apache.org/maven2/</url>
         </pluginRepository>
     </pluginRepositories>
@@ -183,9 +184,13 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                     </goals>
                     <configuration>
                       <rules>
+                        <banDuplicatePomDependencyVersions/>
                         <requireMavenVersion>
                           <version>3.0.5</version>
                         </requireMavenVersion>
+                        <requireJavaVersion>
+                          <version>11</version>
+                        </requireJavaVersion>
                       </rules>
                     </configuration>
                   </execution>
@@ -215,7 +220,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                       <arg>-Xlint:-fallthrough</arg>
                     </compilerArgs>
                 </configuration>
-                <version>3.6.1</version>
+                <version>3.8.1</version>
             </plugin>
             <plugin>
                 <!-- UNIT TEST RUNNER -->
@@ -239,7 +244,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
+                <version>0.8.5</version>
                 <executions>
                     <!-- Prepare execution with Surefire -->
                     <execution>
@@ -359,16 +364,16 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 
     <profiles>
         <profile>
-            <id>java9plus-8-release</id>
+            <id>java12plus-11-release</id>
             <activation>
-                <jdk>[9,18]</jdk>
+                <jdk>[12,20]</jdk>
             </activation>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
-                            <release>8</release>
+                            <release>11</release>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -408,7 +413,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                     <rulesets>
                         <ruleset>dev/pmd_ruleset.xml</ruleset>
                     </rulesets>
-                    <targetJdk>${compileSource}</targetJdk>
+                    <targetJdk>${compileTarget}</targetJdk>
                     <aggregate>true</aggregate>
                 </configuration>
             </plugin>

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+CDDL HEADER START
+
+The contents of this file are subject to the terms of the
+Common Development and Distribution License (the "License").
+You may not use this file except in compliance with the License.
+
+See LICENSE.txt included in this distribution for the specific
+language governing permissions and limitations under the License.
+
+When distributing Covered Code, include this CDDL HEADER in each
+file and include the License file at LICENSE.txt.
+If applicable, add the following below this CDDL HEADER, with the
+fields enclosed by brackets "[]" replaced with your own identifying
+information: Portions Copyright [yyyy] [name of copyright owner]
+
+CDDL HEADER END
+
+Copyright (c) 2018-2020, Oracle and/or its affiliates. All rights reserved.
+Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -124,39 +147,16 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>
-                        -Djna.nosys=true
                         @{surefireArgLine}
+                        -Djna.nosys=true
+                        --illegal-access=permit
+                        --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                        --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+                        --add-exports java.base/sun.nio.ch=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>java9plus</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>
-                                @{surefireArgLine}
-                                -Djna.nosys=true
-                                --illegal-access=permit
-                                --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
-                                --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
-                                --add-exports java.base/sun.nio.ch=ALL-UNNAMED
-                            </argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
 </project>


### PR DESCRIPTION
Upcoming Lucene 9.0.0 has updated its System Requirements with LUCENE-8738: Move to Java 11 as minimum Java version.

This is a patch to try a revised configuration to move OpenGrok to 11 too.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
