### PR TITLE
exit on failure when installing Choco packages on Windows 

### DIFF
--- a/dev/before_install.windows
+++ b/dev/before_install.windows
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 [[ "$TRAVIS_OS_NAME" == "windows" ]] || exit 1
 
 JDK="$1"


### PR DESCRIPTION
Sometimes Windows builds fail because Chocolatey cannot install a package for some reason (e.g. SVN install fails because a request to sourceforge.net timed out). This will manifest later on in the build. The failures in the install phase should short circuit the build immediately.