### PR TITLE
P4 filelog parsing update

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
@@ -53,7 +53,7 @@ import org.opengrok.indexer.util.Executor;
 class PerforceHistoryParser {
     private static final Logger LOGGER = LoggerFactory.getLogger(PerforceHistoryParser.class);
 
-    private static final Pattern FILENAME_PATTERN = Pattern.compile("//[^/]+/(.+)");
+    private static final Pattern FILENAME_PATTERN = Pattern.compile("^//[^/]+/(.+)");
 
     private static final String PAT_P4_DATE_TIME_BY =
             "on (\\d{4})/(\\d{2})/(\\d{2}) (\\d{2}):(\\d{2}):(\\d{2}) by ([^@]+)";
@@ -122,7 +122,7 @@ class PerforceHistoryParser {
         cmd.clear();
         cmd.add(repo.RepoCommand);
         cmd.add("filelog");
-        cmd.add("-ti");
+        cmd.add("-sti");
         cmd.add(directorySpec);
         executor = new Executor(cmd, file);
         executor.exec();
@@ -141,7 +141,7 @@ class PerforceHistoryParser {
         ArrayList<String> cmd = new ArrayList<>();
         cmd.add(repo.RepoCommand);
         cmd.add("filelog");
-        cmd.add("-lti");
+        cmd.add("-slti");
         cmd.add(protectPerforceFilename(file.getName()) + asRevisionSuffix(sinceRevision));
 
         Executor executor = new Executor(cmd, file.getParentFile());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
@@ -21,6 +21,7 @@
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Ross <cross@distal.com>.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2020, Chris Quick <gtoph00@gmail.com>.
  */
 
 package org.opengrok.indexer.history;


### PR DESCRIPTION
Adding -s option to limit the history to only include integrations that affect the file as there can be hundreds of branches listed where where it's not touched and shouldn't be included in the history.
Because the current regex can find p4 path information in the comment sections, only search for P4 paths at the start of the line.

