### PR TITLE
Fix rare uncounted Ruby LOC

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/RubyAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/RubyAnalyzer.java
@@ -58,11 +58,11 @@ public class RubyAnalyzer extends AbstractSourceCodeAnalyzer {
      * Gets a version number to be used to tag processed documents so that
      * re-analysis can be re-done later if a stored version number is different
      * from the current implementation.
-     * @return 20190118_01
+     * @return 20200410_00
      */
     @Override
     protected int getSpecializedVersionNo() {
-        return 20190118_01; // Edit comment above too!
+        return 20200410_00; // Edit comment above too!
     }
 
     /**

--- a/opengrok-indexer/src/main/resources/analysis/ruby/RubyProductions.lexh
+++ b/opengrok-indexer/src/main/resources/analysis/ruby/RubyProductions.lexh
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019-2020, Chris Fraire <cfraire@me.com>.
  */
 
 /*
@@ -483,6 +483,7 @@ Here_EOF3 = [\`][^\r\n\`]*[\`]
     }
     // Only one char at a time due to restriction on {WhspChar} above.
     [^\n\r]    {
+        chkLOC();
         maybeIntraState();
         offer(yytext());
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ruby/RubyXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ruby/RubyXrefTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019-2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.analysis.ruby;
@@ -45,7 +45,7 @@ public class RubyXrefTest extends XrefTestBase {
         writeAndCompare(new RubyAnalyzerFactory(),
                 "analysis/ruby/sample.rb",
                 "analysis/ruby/ruby_xrefres.html",
-                readTagsFromResource("analysis/ruby/sampletags"), 159);
+                readTagsFromResource("analysis/ruby/sampletags"), 161);
     }
 
     @Test

--- a/opengrok-indexer/src/test/resources/analysis/ruby/ruby_xrefres.html
+++ b/opengrok-indexer/src/test/resources/analysis/ruby/ruby_xrefres.html
@@ -183,5 +183,7 @@ function get_sym_list(){return [["Class","xc",[["Board",4]]],["Method","xmt",[["
 <a class="l" name="177" href="#177">177</a><b>print</b> <span class="s">&apos;<a href="http://example.com">http://example.com</a>&apos;</span>
 <a class="l" name="178" href="#178">178</a><b>puts</b> <span class="s">&quot;Last #{</span><a href="/source/s?defs=log_lines" class="intelliWindow-symbol" data-definition-place="undefined-in-file">log_lines</a><span class="s">} lines from #{</span><a href="/source/s?defs=logfn" class="intelliWindow-symbol" data-definition-place="undefined-in-file">logfn</a><span class="s">}:&quot;</span>
 <a class="l" name="179" href="#179">179</a><b>print</b> <span class="s">&quot;\n&quot;</span>
-<a class="hl" name="180" href="#180">180</a></body>
+<a class="hl" name="180" href="#180">180</a>;
+<a class="l" name="181" href="#181">181</a>;
+<a class="l" name="182" href="#182">182</a></body>
 </html>

--- a/opengrok-indexer/src/test/resources/analysis/ruby/sample.rb
+++ b/opengrok-indexer/src/test/resources/analysis/ruby/sample.rb
@@ -177,3 +177,5 @@ print "\n"
 print 'http://example.com'
 puts "Last #{log_lines} lines from #{logfn}:"
 print "\n"
+;
+;


### PR DESCRIPTION
Hello,

Please consider for integration this patch with a fix for a rare uncounted Ruby LOC. I spotted it when studying my Ruby HERE-doc support to apply it for HCL and Terraform.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
