### PR TITLE
Fix #1665 : searchable-option-list bulk operations are slow

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
 
@@ -111,7 +111,7 @@ public class Scripts implements Iterable<Scripts.Script> {
         SCRIPTS.put("jquery-tablesorter", new FileScript("js/jquery-tablesorter-2.26.6.min.js", 12));
         SCRIPTS.put("tablesorter-parsers", new FileScript("js/tablesorter-parsers-0.0.2.min.js", 13));
         SCRIPTS.put("tablesorter-parsers" + DEBUG_SUFFIX, new FileScript("js/tablesorter-parsers-0.0.2.js", 13));
-        SCRIPTS.put("searchable-option-list", new FileScript("js/searchable-option-list-2.0.8.min.js", 14));
+        SCRIPTS.put("searchable-option-list", new FileScript("js/searchable-option-list-2.0.9.min.js", 14));
         SCRIPTS.put("utils", new FileScript("js/utils-0.0.34.min.js", 15));
         SCRIPTS.put("utils" + DEBUG_SUFFIX, new FileScript("js/utils-0.0.34.js", 15));
         SCRIPTS.put("repos", new FileScript("js/repos-0.0.2.min.js", 20));


### PR DESCRIPTION
Hello,

Please consider for integration this patch to fix the bulk operations that are slow when the project count in the thousands (`Select-All`, `Invert-Selection`, `Clear`) by adding a `Map` by `val()` and also avoiding creating HTML elements when exceeding a defined `maxShow`.

When a bulk operation is in-progress, the `X-Items-Selected` update is deferred and only done at the end of the operation.

I encountered one testing problem which I need advice for: I was running with a thousand test projects, but my system could not actually support a query for all 1000 projects, and it showed a page with just `0`. On hitting Back, the page was not in a consistent state, and `Select-All`, `Invert-Selection`, and `Clear` did not work as expected. Any advice?

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
