### PR TITLE
Bugfix/SOL max-show

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
@@ -110,7 +110,7 @@ public class Scripts implements Iterable<Scripts.Script> {
         putjs("jquery-ui", "js/jquery-ui-1.12.1-custom", 11);
         putjs("jquery-tablesorter", "js/jquery-tablesorter-2.26.6", 12);
         putjs("tablesorter-parsers", "js/tablesorter-parsers-0.0.2", 13, true);
-        putjs("searchable-option-list", "js/searchable-option-list-2.0.10", 14);
+        putjs("searchable-option-list", "js/searchable-option-list-2.0.11", 14);
         putjs("utils", "js/utils-0.0.34", 15, true);
         putjs("repos", "js/repos-0.0.2", 20, true);
         putjs("diff", "js/diff-0.0.4", 20, true);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
@@ -106,19 +106,26 @@ public class Scripts implements Iterable<Scripts.Script> {
      * @see HttpServletRequest#getContextPath()
      */
     static {
-        SCRIPTS.put("jquery", new FileScript("js/jquery-3.4.1.min.js", 10));
-        SCRIPTS.put("jquery-ui", new FileScript("js/jquery-ui-1.12.1-custom.min.js", 11));
-        SCRIPTS.put("jquery-tablesorter", new FileScript("js/jquery-tablesorter-2.26.6.min.js", 12));
-        SCRIPTS.put("tablesorter-parsers", new FileScript("js/tablesorter-parsers-0.0.2.min.js", 13));
-        SCRIPTS.put("tablesorter-parsers" + DEBUG_SUFFIX, new FileScript("js/tablesorter-parsers-0.0.2.js", 13));
-        SCRIPTS.put("searchable-option-list", new FileScript("js/searchable-option-list-2.0.10.min.js", 14));
-        SCRIPTS.put("utils", new FileScript("js/utils-0.0.34.min.js", 15));
-        SCRIPTS.put("utils" + DEBUG_SUFFIX, new FileScript("js/utils-0.0.34.js", 15));
-        SCRIPTS.put("repos", new FileScript("js/repos-0.0.2.min.js", 20));
-        SCRIPTS.put("repos" + DEBUG_SUFFIX, new FileScript("js/repos-0.0.2.js", 20));
-        SCRIPTS.put("diff", new FileScript("js/diff-0.0.4.min.js", 20));
-        SCRIPTS.put("diff" + DEBUG_SUFFIX, new FileScript("js/diff-0.0.4.js", 20));
-        SCRIPTS.put("jquery-caret", new FileScript("js/jquery.caret-1.5.2.min.js", 25));
+        putjs("jquery", "js/jquery-3.4.1", 10);
+        putjs("jquery-ui", "js/jquery-ui-1.12.1-custom", 11);
+        putjs("jquery-tablesorter", "js/jquery-tablesorter-2.26.6", 12);
+        putjs("tablesorter-parsers", "js/tablesorter-parsers-0.0.2", 13, true);
+        putjs("searchable-option-list", "js/searchable-option-list-2.0.10", 14);
+        putjs("utils", "js/utils-0.0.34", 15, true);
+        putjs("repos", "js/repos-0.0.2", 20, true);
+        putjs("diff", "js/diff-0.0.4", 20, true);
+        putjs("jquery-caret", "js/jquery.caret-1.5.2", 25);
+    }
+
+    private static void putjs(String key, String pathPrefix, int priority) {
+        putjs(key, pathPrefix, priority, false);
+    }
+
+    private static void putjs(String key, String pathPrefix, int priority, boolean debug) {
+        SCRIPTS.put(key, new FileScript(pathPrefix + ".min.js", priority));
+        if (debug) {
+            SCRIPTS.put(key + DEBUG_SUFFIX, new FileScript(pathPrefix + ".js", priority));
+        }
     }
 
     private static final Comparator<Script> SCRIPTS_COMPARATOR = Comparator


### PR DESCRIPTION
This fixes the bug I accidentally introduced in 5cac8be5c7 when `maxShow` is in effect and a user clicks × to remove an item. Another item should appear but does not do that.

The meat of this fix is in `_removeSelectionDisplayItem`, which Github-diff shows fine below.

Github-diff is showing a much bigger diff than this patch truly is because its diff algorithm is not finding good alignment from my extraction of `_buildSelectionDisplayItem` from `_addSelectionDisplayItem`, and also it shows the whitespace changes.

Following is a picture of a better diff showing just the straight-forward extraction of `_buildSelectionDisplayItem`:
<img width="1194" alt="image" src="https://user-images.githubusercontent.com/1166243/79178855-f32f0700-7dcb-11ea-8913-c821dc263301.png">

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
