### PR TITLE
Use `--extras=+F` instead of --file-scope=yes

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -170,8 +170,8 @@ public class Ctags implements Resettable {
         command.add("--kinds-sql=+l");
         command.add("--kinds-Fortran=+L");
         command.add("--kinds-C++=+l");
-        command.add("--file-scope=yes");
-        command.add("-u");
+        command.add("--extras=+F"); // Replacement for `--file-scope=yes` since 2017
+        command.add("-u"); // Equivalent to `--sort=no` (i.e. "unsorted")
         command.add("--filter=yes");
         command.add("--filter-terminator=" + CTAGS_FILTER_TERMINATOR + "\n");
         command.add("--fields=-af+iKnS");


### PR DESCRIPTION
This is just to silence the following warning:

```
ctags: Warning: "--file-scope" option is obsolete; use "--extras=+F" instead
```

u-ctags has had the `--extras` option since early 2017.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
