### PR TITLE
Minimize reflection into Configuration

### DIFF
--- a/dev/checkstyle/suppressions.xml
+++ b/dev/checkstyle/suppressions.xml
@@ -33,7 +33,8 @@ Portions Copyright (c) 2018-2020, Chris Fraire <cfraire@me.com>.
         |Summary\.java|OGKUnifiedHighlighter\.java|ResponseHeaderFilter\.java|BoundedBlockingObjectPool\.java|
         |ObjectPool\.java|ObjectValidator\.java|ObjectFactory\.java|AbstractObjectPool\.java|
         |BlockingObjectPool\.java|OGKTextVecField\.java|OGKTextField\.java|
-        |LazilyInstantiate\.java|PortChecker\.java" />
+        |LazilyInstantiate\.java|PortChecker\.java|CloseableReentrantReadWriteLock\.java|
+        |ResourceLock\.java" />
 
     <suppress checks="ParameterNumber" files="CtagsReader\.java|Definitions\.java|
         |JFlexXrefUtils\.java|FileAnalyzerFactory\.java|SearchController\.java|

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationValueConsumer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationValueConsumer.java
@@ -1,0 +1,33 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.configuration;
+
+/**
+ * Represents an API for consuming a {@link Configuration} instance along with
+ * a specified value.
+ */
+@FunctionalInterface
+public interface ConfigurationValueConsumer<V> {
+    void accept(Configuration configuration, V v);
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -19,13 +19,11 @@
 
  /*
   * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
-  * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
+  * Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
   */
 package org.opengrok.indexer.configuration;
 
 import static org.opengrok.indexer.configuration.Configuration.makeXMLStringAsConfiguration;
-import static org.opengrok.indexer.util.ClassUtil.getFieldValue;
-import static org.opengrok.indexer.util.ClassUtil.setFieldValue;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -46,8 +44,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -70,10 +67,12 @@ import org.opengrok.indexer.index.IgnoredNames;
 import org.opengrok.indexer.index.IndexDatabase;
 import org.opengrok.indexer.index.IndexerParallelizer;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.CloseableReentrantReadWriteLock;
 import org.opengrok.indexer.util.CtagsUtil;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
 import org.opengrok.indexer.util.LazilyInstantiate;
 import org.opengrok.indexer.util.PathUtils;
+import org.opengrok.indexer.util.ResourceLock;
 import org.opengrok.indexer.web.Prefix;
 import org.opengrok.indexer.web.Statistics;
 import org.opengrok.indexer.web.Util;
@@ -92,7 +91,7 @@ public final class RuntimeEnvironment {
     private static final String URL_PREFIX = "/source" + Prefix.SEARCH_R + "?";
 
     private Configuration configuration;
-    private final ReentrantReadWriteLock configLock;
+    private final CloseableReentrantReadWriteLock configLock;
     private final LazilyInstantiate<IndexerParallelizer> lzIndexerParallelizer;
     private final LazilyInstantiate<ExecutorService> lzSearchExecutor;
     private final LazilyInstantiate<ExecutorService> lzRevisionExecutor;
@@ -103,7 +102,7 @@ public final class RuntimeEnvironment {
 
     private String configURI;
     private Statistics statistics = new Statistics();
-    public IncludeFiles includeFiles = new IncludeFiles();
+    IncludeFiles includeFiles = new IncludeFiles();
     private final MessagesContainer messagesContainer = new MessagesContainer();
 
     private static final IndexTimestamp indexTime = new IndexTimestamp();
@@ -134,7 +133,7 @@ public final class RuntimeEnvironment {
      */
     private RuntimeEnvironment() {
         configuration = new Configuration();
-        configLock = new ReentrantReadWriteLock();
+        configLock = new CloseableReentrantReadWriteLock();
         watchDog = new WatchDogService();
         lzIndexerParallelizer = LazilyInstantiate.using(() ->
                 new IndexerParallelizer(this));
@@ -207,131 +206,36 @@ public final class RuntimeEnvironment {
         }
     }
 
-    /**
-     * Get value of configuration field.
-     * @param fieldName name of the field
-     * @return object value
-     */
-    public Object getConfigurationValue(String fieldName) {
-        try {
-            configLock.readLock().lock();
-            return getFieldValue(configuration, fieldName);
-        } catch (IOException e) {
-            return null;
-        } finally {
-            configLock.readLock().unlock();
-        }
-    }
-
-    /**
-     * Get value of configuration field.
-     * @param fieldName name of the field
-     * @return object value
-     * @throws IOException I/O
-     */
-    public Object getConfigurationValueException(String fieldName) throws IOException {
-        try {
-            configLock.readLock().lock();
-            return getFieldValue(configuration, fieldName);
-        } catch (IOException e) {
-            throw new IOException("getter", e);
-        } finally {
-            configLock.readLock().unlock();
-        }
-    }
-
-    /**
-     * Set configuration value.
-     * @param fieldName name of the field
-     * @param value string value
-     */
-    public void setConfigurationValue(String fieldName, String value) {
-        try {
-            configLock.writeLock().lock();
-            setFieldValue(configuration, fieldName, value);
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "failed to set value of field {}: {}", new Object[]{fieldName, e});
-        } finally {
-            configLock.writeLock().unlock();
-        }
-    }
-
-    /**
-     * Set configuration value.
-     * @param fieldName name of the field
-     * @param value value
-     */
-    public void setConfigurationValue(String fieldName, Object value) {
-        try {
-            configLock.writeLock().lock();
-            setFieldValue(configuration, fieldName, value);
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "failed to set value of field {}: {}", new Object[]{fieldName, e});
-        } finally {
-            configLock.writeLock().unlock();
-        }
-    }
-
-    /**
-     * Set configuration value.
-     * @param fieldName name of the field
-     * @param value value
-     * @throws IOException I/O exception
-     */
-    public void setConfigurationValueException(String fieldName, Object value) throws IOException {
-        try {
-            configLock.writeLock().lock();
-            setFieldValue(configuration, fieldName, value);
-        } finally {
-            configLock.writeLock().unlock();
-        }
-    }
-
-    /**
-     * Set configuration value.
-     * @param fieldName name of the field
-     * @param value string value
-     * @throws IOException I/O exception
-     */
-    public void setConfigurationValueException(String fieldName, String value) throws IOException {
-        try {
-            configLock.writeLock().lock();
-            setFieldValue(configuration, fieldName, value);
-        } finally {
-            configLock.writeLock().unlock();
-        }
-    }
-
     public int getScanningDepth() {
-        return (int) getConfigurationValue("scanningDepth");
+        return syncReadConfiguration(Configuration::getScanningDepth);
     }
 
     public void setScanningDepth(int scanningDepth) {
-        setConfigurationValue("scanningDepth", scanningDepth);
+        syncWriteConfiguration(Configuration::setScanningDepth, scanningDepth);
     }
 
     public int getCommandTimeout() {
-        return (int) getConfigurationValue("commandTimeout");
+        return syncReadConfiguration(Configuration::getCommandTimeout);
     }
 
     public void setCommandTimeout(int timeout) {
-        setConfigurationValue("commandTimeout", timeout);
+        syncWriteConfiguration(Configuration::setCommandTimeout, timeout);
     }
 
     public int getInteractiveCommandTimeout() {
-        return (int) getConfigurationValue("interactiveCommandTimeout");
+        return syncReadConfiguration(Configuration::getInteractiveCommandTimeout);
     }
 
     public void setInteractiveCommandTimeout(int timeout) {
-        setConfigurationValue("interactiveCommandTimeout", timeout);
+        syncWriteConfiguration(Configuration::setInteractiveCommandTimeout, timeout);
     }
 
     public long getCtagsTimeout() {
-        return (long) getConfigurationValue("ctagsTimeout");
+        return syncReadConfiguration(Configuration::getCtagsTimeout);
     }
 
     public void setCtagsTimeout(long timeout) {
-        setConfigurationValue("ctagsTimeout", timeout);
+        syncWriteConfiguration(Configuration::setCtagsTimeout, timeout);
     }
     
     public Statistics getStatistics() {
@@ -343,11 +247,11 @@ public final class RuntimeEnvironment {
     }
 
     public void setLastEditedDisplayMode(boolean lastEditedDisplayMode) {
-        setConfigurationValue("lastEditedDisplayMode", lastEditedDisplayMode);
+        syncWriteConfiguration(Configuration::setLastEditedDisplayMode, lastEditedDisplayMode);
     }
 
     public boolean isLastEditedDisplayMode() {
-        return (boolean) getConfigurationValue("lastEditedDisplayMode");
+        return syncReadConfiguration(Configuration::isLastEditedDisplayMode);
     }
 
     /**
@@ -356,7 +260,7 @@ public final class RuntimeEnvironment {
      * @return the path to the web application include files
      */
     public String getIncludeRootPath() {
-        return (String) getConfigurationValue("includeRoot");
+        return syncReadConfiguration(Configuration::getIncludeRoot);
     }
 
     /**
@@ -364,7 +268,7 @@ public final class RuntimeEnvironment {
      * @param includeRoot path
      */
     public void setIncludeRoot(String includeRoot) {
-        setConfigurationValue("includeRoot", getCanonicalPath(includeRoot));
+        syncWriteConfiguration(Configuration::setIncludeRoot, getCanonicalPath(includeRoot));
     }
 
     /**
@@ -373,7 +277,7 @@ public final class RuntimeEnvironment {
      * @return the path to the index database
      */
     public String getDataRootPath() {
-        return (String) getConfigurationValue("dataRoot");
+        return syncReadConfiguration(Configuration::getDataRoot);
     }
 
     /**
@@ -397,7 +301,7 @@ public final class RuntimeEnvironment {
      * @param dataRoot the index database
      */
     public void setDataRoot(String dataRoot) {
-        setConfigurationValue("dataRoot", getCanonicalPath(dataRoot));
+        syncWriteConfiguration(Configuration::setDataRoot, getCanonicalPath(dataRoot));
     }
 
     /**
@@ -406,7 +310,7 @@ public final class RuntimeEnvironment {
      * @return path to where the sources are located
      */
     public String getSourceRootPath() {
-        return (String) getConfigurationValue("sourceRoot");
+        return syncReadConfiguration(Configuration::getSourceRoot);
     }
 
     /**
@@ -430,7 +334,7 @@ public final class RuntimeEnvironment {
      * @param sourceRoot the location of the sources
      */
     public void setSourceRoot(String sourceRoot) {
-        setConfigurationValue("sourceRoot", getCanonicalPath(sourceRoot));
+        syncWriteConfiguration(Configuration::setSourceRoot, getCanonicalPath(sourceRoot));
     }
 
     /**
@@ -493,9 +397,8 @@ public final class RuntimeEnvironment {
      *
      * @return a Map with all of the projects
      */
-    @SuppressWarnings("unchecked")
     public Map<String, Project> getProjects() {
-        return (Map<String, Project>) getConfigurationValue("projects");
+        return syncReadConfiguration(Configuration::getProjects);
     }
 
     /**
@@ -513,15 +416,12 @@ public final class RuntimeEnvironment {
      * @param projects the map of projects to use
      */
     public void setProjects(Map<String, Project> projects) {
-        try {
-            configLock.writeLock().lock();
-            if (projects != null) {
-                populateGroups(getGroups(), new TreeSet<>(projects.values()));
+        syncWriteConfiguration((c, p) -> {
+            if (p != null) {
+                populateGroups(getGroups(), new TreeSet<>(p.values()));
             }
-            setConfigurationValue("projects", projects);
-        } finally {
-            configLock.writeLock().unlock();
-        }
+            c.setProjects(p);
+        }, projects);
     }
 
     /**
@@ -538,9 +438,8 @@ public final class RuntimeEnvironment {
      *
      * @return a set containing all of the groups (may be null)
      */
-    @SuppressWarnings("unchecked")
     public Set<Group> getGroups() {
-        return (Set<Group>) getConfigurationValue("groups");
+        return syncReadConfiguration(Configuration::getGroups);
     }
 
     /**
@@ -549,8 +448,10 @@ public final class RuntimeEnvironment {
      * @param groups the set of groups to use
      */
     public void setGroups(Set<Group> groups) {
-        populateGroups(groups, new TreeSet<>(getProjects().values()));
-        setConfigurationValue("groups", groups);
+        syncWriteConfiguration((c, g) -> {
+            populateGroups(g, new TreeSet<>(getProjects().values()));
+            c.setGroups(g);
+        }, groups);
     }
 
     /**
@@ -581,9 +482,12 @@ public final class RuntimeEnvironment {
      * @return a defined value
      */
     public String getCtags() {
-        String value;
-        return ctags != null ? ctags :
-                (value = (String) getConfigurationValue("ctags")) != null ? value :
+        if (ctags != null) {
+            return ctags;
+        }
+
+        String value = syncReadConfiguration(Configuration::getCtags);
+        return value != null ? value :
                 System.getProperty(CtagsUtil.SYSTEM_CTAGS_PROPERTY, "ctags");
     }
 
@@ -610,10 +514,13 @@ public final class RuntimeEnvironment {
      * @return a defined instance or {@code null}
      */
     public String getMandoc() {
-        String value;
-        return mandoc != null ? mandoc : (value =
-                (String) getConfigurationValue("mandoc")) != null ? value :
-            System.getProperty("org.opengrok.indexer.analysis.Mandoc");
+        if (mandoc != null) {
+            return mandoc;
+        }
+
+        String value = syncReadConfiguration(Configuration::getMandoc);
+        return value != null ? value :
+                System.getProperty("org.opengrok.indexer.analysis.Mandoc");
     }
 
     /**
@@ -631,19 +538,19 @@ public final class RuntimeEnvironment {
     }
 
     public int getCachePages() {
-        return (int) getConfigurationValue("cachePages");
+        return syncReadConfiguration(Configuration::getCachePages);
     }
 
     public void setCachePages(int cachePages) {
-        setConfigurationValue("cachePages", cachePages);
+        syncWriteConfiguration(Configuration::setCachePages, cachePages);
     }
 
     public int getHitsPerPage() {
-        return (int) getConfigurationValue("hitsPerPage");
+        return syncReadConfiguration(Configuration::getHitsPerPage);
     }
 
     public void setHitsPerPage(int hitsPerPage) {
-        setConfigurationValue("hitsPerPage", hitsPerPage);
+        syncWriteConfiguration(Configuration::setHitsPerPage, hitsPerPage);
     }
 
     /**
@@ -654,8 +561,9 @@ public final class RuntimeEnvironment {
     public boolean validateUniversalCtags() {
         if (ctagsFound == null) {
             String ctagsBinary = getCtags();
-            configLock.writeLock().lock();
-            try {
+            try (ResourceLock resourceLock = configLock.writeLockAsResource()) {
+                //noinspection ConstantConditions to avoid warning of no reference to auto-closeable
+                assert resourceLock != null;
                 if (ctagsFound == null) {
                     ctagsFound = CtagsUtil.validate(ctagsBinary);
                     if (ctagsFound) {
@@ -665,8 +573,6 @@ public final class RuntimeEnvironment {
                         }
                     }
                 }
-            } finally {
-                configLock.writeLock().unlock();
             }
         }
         return ctagsFound;
@@ -688,7 +594,7 @@ public final class RuntimeEnvironment {
      * @return the max time
      */
     public int getHistoryReaderTimeLimit() {
-        return (int) getConfigurationValue("historyCacheTime");
+        return syncReadConfiguration(Configuration::getHistoryCacheTime);
     }
 
     /**
@@ -698,7 +604,7 @@ public final class RuntimeEnvironment {
      * @param historyReaderTimeLimit the max time in ms before it is cached
      */
     public void setHistoryReaderTimeLimit(int historyReaderTimeLimit) {
-        setConfigurationValue("historyCacheTime", historyReaderTimeLimit);
+        syncWriteConfiguration(Configuration::setHistoryCacheTime, historyReaderTimeLimit);
     }
 
     /**
@@ -707,7 +613,7 @@ public final class RuntimeEnvironment {
      * @return true if history cache is enabled
      */
     public boolean useHistoryCache() {
-        return (boolean) getConfigurationValue("historyCache");
+        return syncReadConfiguration(Configuration::isHistoryCache);
     }
 
     /**
@@ -716,7 +622,7 @@ public final class RuntimeEnvironment {
      * @param useHistoryCache set false if you do not want to use history cache
      */
     public void setUseHistoryCache(boolean useHistoryCache) {
-        setConfigurationValue("historyCache", useHistoryCache);
+        syncWriteConfiguration(Configuration::setHistoryCache, useHistoryCache);
     }
 
     /**
@@ -725,7 +631,7 @@ public final class RuntimeEnvironment {
      * @return true if HTML should be generated during the indexing phase
      */
     public boolean isGenerateHtml() {
-        return (boolean) getConfigurationValue("generateHtml");
+        return syncReadConfiguration(Configuration::isGenerateHtml);
     }
 
     /**
@@ -734,7 +640,7 @@ public final class RuntimeEnvironment {
      * @param generateHtml set this to true to pregenerate HTML
      */
     public void setGenerateHtml(boolean generateHtml) {
-        setConfigurationValue("generateHtml", generateHtml);
+        syncWriteConfiguration(Configuration::setGenerateHtml, generateHtml);
     }
 
     /**
@@ -744,7 +650,7 @@ public final class RuntimeEnvironment {
      * compressed
      */
     public void setCompressXref(boolean compressXref) {
-        setConfigurationValue("compressXref", compressXref);
+        syncWriteConfiguration(Configuration::setCompressXref, compressXref);
     }
 
     /**
@@ -753,20 +659,19 @@ public final class RuntimeEnvironment {
      * @return {@code true} if the html-files should be compressed.
      */
     public boolean isCompressXref() {
-        return (boolean) getConfigurationValue("compressXref");
+        return syncReadConfiguration(Configuration::isCompressXref);
     }
 
     public boolean isQuickContextScan() {
-        return (boolean) getConfigurationValue("quickContextScan");
+        return syncReadConfiguration(Configuration::isQuickContextScan);
     }
 
     public void setQuickContextScan(boolean quickContextScan) {
-        setConfigurationValue("quickContextScan", quickContextScan);
+        syncWriteConfiguration(Configuration::setQuickContextScan, quickContextScan);
     }
 
-    @SuppressWarnings("unchecked")
     public List<RepositoryInfo> getRepositories() {
-        return (List<RepositoryInfo>) getConfigurationValue("repositories");
+        return syncReadConfiguration(Configuration::getRepositories);
     }
 
     /**
@@ -775,16 +680,11 @@ public final class RuntimeEnvironment {
      * @param repositories the repositories to use
      */
     public void setRepositories(List<RepositoryInfo> repositories) {
-        setConfigurationValue("repositories", repositories);
+        syncWriteConfiguration(Configuration::setRepositories, repositories);
     }
     
     public void removeRepositories() {
-        try {
-            configLock.writeLock().lock();
-            configuration.setRepositories(null);
-        } finally {
-            configLock.writeLock().unlock();
-        }
+        syncWriteConfiguration(Configuration::setRepositories, null);
     }
     
     /**
@@ -796,8 +696,8 @@ public final class RuntimeEnvironment {
     public void setRepositories(String... dir) {
         List<RepositoryInfo> repos = new ArrayList<>(HistoryGuru.getInstance().
                 addRepositories(Arrays.stream(dir).map(File::new).toArray(File[]::new),
-                    RuntimeEnvironment.getInstance().getIgnoredNames()));
-        RuntimeEnvironment.getInstance().setRepositories(repos);
+                        getIgnoredNames()));
+        setRepositories(repos);
     }
 
     /**
@@ -805,13 +705,7 @@ public final class RuntimeEnvironment {
      * @param repositories list of repositories
      */
     public void addRepositories(List<RepositoryInfo> repositories) {
-        Lock writeLock = configLock.writeLock();
-        try {
-            writeLock.lock();
-            configuration.addRepositories(repositories);
-        } finally {
-            writeLock.unlock();
-        }
+        syncWriteConfiguration(Configuration::addRepositories, repositories);
     }
 
     /**
@@ -851,7 +745,7 @@ public final class RuntimeEnvironment {
      * @param defaultProjects The default project to use
      */
     public void setDefaultProjects(Set<Project> defaultProjects) {
-        setConfigurationValue("defaultProjects", defaultProjects);
+        syncWriteConfiguration(Configuration::setDefaultProjects, defaultProjects);
     }
 
     /**
@@ -861,9 +755,8 @@ public final class RuntimeEnvironment {
      *
      * @return the default projects (may be null if not specified)
      */
-    @SuppressWarnings("unchecked")
     public Set<Project> getDefaultProjects() {
-        Set<Project> projects = (Set<Project>) getConfigurationValue("defaultProjects");
+        Set<Project> projects = syncReadConfiguration(Configuration::getDefaultProjects);
         if (projects == null) {
             return null;
         }
@@ -875,7 +768,7 @@ public final class RuntimeEnvironment {
      * @return at what size (in MB) we should flush the buffer
      */
     public double getRamBufferSize() {
-        return (double) getConfigurationValue("ramBufferSize");
+        return syncReadConfiguration(Configuration::getRamBufferSize);
     }
 
     /**
@@ -886,31 +779,32 @@ public final class RuntimeEnvironment {
      * @param ramBufferSize the size(in MB) when we should flush the docs
      */
     public void setRamBufferSize(double ramBufferSize) {
-        setConfigurationValue("ramBufferSize", ramBufferSize);
+        syncWriteConfiguration(Configuration::setRamBufferSize, ramBufferSize);
     }
 
     public void setPluginDirectory(String pluginDirectory) {
-        setConfigurationValue("pluginDirectory", pluginDirectory);
+        syncWriteConfiguration(Configuration::setPluginDirectory, pluginDirectory);
     }
 
     public String getPluginDirectory() {
-        return (String) getConfigurationValue("pluginDirectory");
+        return syncReadConfiguration(Configuration::getPluginDirectory);
     }
 
     public boolean isAuthorizationWatchdog() {
-        return (boolean) getConfigurationValue("authorizationWatchdogEnabled");
+        return syncReadConfiguration(Configuration::isAuthorizationWatchdogEnabled);
     }
 
     public void setAuthorizationWatchdog(boolean authorizationWatchdogEnabled) {
-        setConfigurationValue("authorizationWatchdogEnabled", authorizationWatchdogEnabled);
+        syncWriteConfiguration(Configuration::setAuthorizationWatchdogEnabled,
+                authorizationWatchdogEnabled);
     }
 
     public AuthorizationStack getPluginStack() {
-        return (AuthorizationStack) getConfigurationValue("pluginStack");
+        return syncReadConfiguration(Configuration::getPluginStack);
     }
 
     public void setPluginStack(AuthorizationStack pluginStack) {
-        setConfigurationValue("pluginStack", pluginStack);
+        syncWriteConfiguration(Configuration::setPluginStack, pluginStack);
     }
 
     /**
@@ -919,7 +813,7 @@ public final class RuntimeEnvironment {
      * @return true if we can print per project progress %
      */
     public boolean isPrintProgress() {
-        return (boolean) getConfigurationValue("printProgress");
+        return syncReadConfiguration(Configuration::isPrintProgress);
     }
 
     /**
@@ -928,7 +822,7 @@ public final class RuntimeEnvironment {
      * @param printProgress new value
      */
     public void setPrintProgress(boolean printProgress) {
-        setConfigurationValue("printProgress", printProgress);
+        syncWriteConfiguration(Configuration::setPrintProgress, printProgress);
     }
 
     /**
@@ -939,7 +833,7 @@ public final class RuntimeEnvironment {
      * @param allowLeadingWildcard set to true to activate (disabled by default)
      */
     public void setAllowLeadingWildcard(boolean allowLeadingWildcard) {
-        setConfigurationValue("allowLeadingWildcard", allowLeadingWildcard);
+        syncWriteConfiguration(Configuration::setAllowLeadingWildcard, allowLeadingWildcard);
     }
 
     /**
@@ -948,23 +842,23 @@ public final class RuntimeEnvironment {
      * @return true if a search may start with a wildcard
      */
     public boolean isAllowLeadingWildcard() {
-        return (boolean) getConfigurationValue("allowLeadingWildcard");
+        return syncReadConfiguration(Configuration::isAllowLeadingWildcard);
     }
 
     public IgnoredNames getIgnoredNames() {
-        return (IgnoredNames) getConfigurationValue("ignoredNames");
+        return syncReadConfiguration(Configuration::getIgnoredNames);
     }
 
     public void setIgnoredNames(IgnoredNames ignoredNames) {
-        setConfigurationValue("ignoredNames", ignoredNames);
+        syncWriteConfiguration(Configuration::setIgnoredNames, ignoredNames);
     }
 
     public Filter getIncludedNames() {
-        return (Filter) getConfigurationValue("includedNames");
+        return syncReadConfiguration(Configuration::getIncludedNames);
     }
 
     public void setIncludedNames(Filter includedNames) {
-        setConfigurationValue("includedNames", includedNames);
+        syncWriteConfiguration(Configuration::setIncludedNames, includedNames);
     }
 
     /**
@@ -973,7 +867,7 @@ public final class RuntimeEnvironment {
      * @return the URL string fragment preceeding the username
      */
     public String getUserPage() {
-        return (String) getConfigurationValue("userPage");
+        return syncReadConfiguration(Configuration::getUserPage);
     }
 
     /**
@@ -984,16 +878,7 @@ public final class RuntimeEnvironment {
      * @return {@code null} if not yet set, the client command otherwise.
      */
     public String getRepoCmd(String clazzName) {
-        Lock readLock = configLock.readLock();
-        String cmd = null;
-        try {
-            readLock.lock();
-            cmd = configuration.getRepoCmd(clazzName);
-        } finally {
-            readLock.unlock();
-        }
-
-        return cmd;
+        return syncReadConfiguration(c -> c.getRepoCmd(clazzName));
     }
 
     /**
@@ -1007,25 +892,12 @@ public final class RuntimeEnvironment {
      * @return the client command previously set, which might be {@code null}.
      */
     public String setRepoCmd(String clazzName, String cmd) {
-        Lock writeLock = configLock.writeLock();
-        try {
-            writeLock.lock();
-            configuration.setRepoCmd(clazzName, cmd);
-        } finally {
-            writeLock.unlock();
-        }
-
+        syncWriteConfiguration((c, ignored) -> c.setRepoCmd(clazzName, cmd), null);
         return cmd;
     }
 
     public void setRepoCmds(Map<String, String> cmds) {
-        Lock writeLock = configLock.writeLock();
-        writeLock.lock();
-        try {
-            configuration.setCmds(cmds);
-        } finally {
-            writeLock.unlock();
-        }
+        syncWriteConfiguration(Configuration::setCmds, cmds);
     }
 
     /**
@@ -1034,7 +906,7 @@ public final class RuntimeEnvironment {
      * @param userPage the URL fragment preceeding the username from history
      */
     public void setUserPage(String userPage) {
-        setConfigurationValue("userPage", userPage);
+        syncWriteConfiguration(Configuration::setUserPage, userPage);
     }
 
     /**
@@ -1043,7 +915,7 @@ public final class RuntimeEnvironment {
      * @return the URL string fragment following the username
      */
     public String getUserPageSuffix() {
-        return (String) getConfigurationValue("userPageSuffix");
+        return syncReadConfiguration(Configuration::getUserPageSuffix);
     }
 
     /**
@@ -1053,7 +925,7 @@ public final class RuntimeEnvironment {
      * history
      */
     public void setUserPageSuffix(String userPageSuffix) {
-        setConfigurationValue("userPageSuffix", userPageSuffix);
+        syncWriteConfiguration(Configuration::setUserPageSuffix, userPageSuffix);
     }
 
     /**
@@ -1062,7 +934,7 @@ public final class RuntimeEnvironment {
      * @return the URL string fragment preceeding the bug ID
      */
     public String getBugPage() {
-        return (String) getConfigurationValue("bugPage");
+        return syncReadConfiguration(Configuration::getBugPage);
     }
 
     /**
@@ -1071,7 +943,7 @@ public final class RuntimeEnvironment {
      * @param bugPage the URL fragment preceeding the bug ID
      */
     public void setBugPage(String bugPage) {
-        setConfigurationValue("bugPage", bugPage);
+        syncWriteConfiguration(Configuration::setBugPage, bugPage);
     }
 
     /**
@@ -1080,17 +952,16 @@ public final class RuntimeEnvironment {
      * @return the regex that is looked for in history comments
      */
     public String getBugPattern() {
-        return (String) getConfigurationValue("bugPattern");
+        return syncReadConfiguration(Configuration::getBugPattern);
     }
 
     /**
      * Sets the bug regex for the history listing.
      *
      * @param bugPattern the regex to search history comments
-     * @throws IOException I/O
      */
-    public void setBugPattern(String bugPattern) throws IOException {
-        setConfigurationValueException("bugPattern", bugPattern);
+    public void setBugPattern(String bugPattern) {
+        syncWriteConfiguration(Configuration::setBugPattern, bugPattern);
     }
 
     /**
@@ -1099,7 +970,7 @@ public final class RuntimeEnvironment {
      * @return the URL string fragment preceeding the review page ID
      */
     public String getReviewPage() {
-        return (String) getConfigurationValue("reviewPage");
+        return syncReadConfiguration(Configuration::getReviewPage);
     }
 
     /**
@@ -1108,7 +979,7 @@ public final class RuntimeEnvironment {
      * @param reviewPage the URL fragment preceeding the review page ID
      */
     public void setReviewPage(String reviewPage) {
-        setConfigurationValue("reviewPage", reviewPage);
+        syncWriteConfiguration(Configuration::setReviewPage, reviewPage);
     }
 
     /**
@@ -1117,25 +988,24 @@ public final class RuntimeEnvironment {
      * @return the regex that is looked for in history comments
      */
     public String getReviewPattern() {
-        return (String) getConfigurationValue("reviewPattern");
+        return syncReadConfiguration(Configuration::getReviewPattern);
     }
 
     /**
      * Sets the review(ARC) regex for the history listing.
      *
      * @param reviewPattern the regex to search history comments
-     * @throws IOException I/O
      */
-    public void setReviewPattern(String reviewPattern) throws IOException {
-        setConfigurationValueException("reviewPattern", reviewPattern);
+    public void setReviewPattern(String reviewPattern) {
+        syncWriteConfiguration(Configuration::setReviewPattern, reviewPattern);
     }
 
     public String getWebappLAF() {
-        return (String) getConfigurationValue("webappLAF");
+        return syncReadConfiguration(Configuration::getWebappLAF);
     }
 
     public void setWebappLAF(String laf) {
-        setConfigurationValue("webappLAF", laf);
+        syncWriteConfiguration(Configuration::setWebappLAF, laf);
     }
 
     /**
@@ -1143,35 +1013,36 @@ public final class RuntimeEnvironment {
      * @return the value of {@link Configuration#isWebappCtags()}
      */
     public boolean isWebappCtags() {
-        return (boolean) getConfigurationValue("webappCtags");
+        return syncReadConfiguration(Configuration::isWebappCtags);
     }
 
     public Configuration.RemoteSCM getRemoteScmSupported() {
-        return (Configuration.RemoteSCM) getConfigurationValue("remoteScmSupported");
+        return syncReadConfiguration(Configuration::getRemoteScmSupported);
     }
 
     public void setRemoteScmSupported(Configuration.RemoteSCM supported) {
-        setConfigurationValue("remoteScmSupported", supported);
+        syncWriteConfiguration(Configuration::setRemoteScmSupported, supported);
     }
 
     public boolean isOptimizeDatabase() {
-        return (boolean) getConfigurationValue("optimizeDatabase");
+        return syncReadConfiguration(Configuration::isOptimizeDatabase);
     }
 
     public void setOptimizeDatabase(boolean optimizeDatabase) {
-        setConfigurationValue("optimizeDatabase", optimizeDatabase);
+        syncWriteConfiguration(Configuration::setOptimizeDatabase, optimizeDatabase);
     }
 
     public LuceneLockName getLuceneLocking() {
-        return (LuceneLockName) getConfigurationValue("luceneLocking");
+        return syncReadConfiguration(Configuration::getLuceneLocking);
     }
 
     public boolean isIndexVersionedFilesOnly() {
-        return (boolean) getConfigurationValue("indexVersionedFilesOnly");
+        return syncReadConfiguration(Configuration::isIndexVersionedFilesOnly);
     }
 
     public void setIndexVersionedFilesOnly(boolean indexVersionedFilesOnly) {
-        setConfigurationValue("indexVersionedFilesOnly", indexVersionedFilesOnly);
+        syncWriteConfiguration(Configuration::setIndexVersionedFilesOnly,
+                indexVersionedFilesOnly);
     }
 
     /**
@@ -1180,9 +1051,9 @@ public final class RuntimeEnvironment {
      * @return a natural number &gt;= 1
      */
     public int getIndexingParallelism() {
-        int parallelism = (int) getConfigurationValue("indexingParallelism");
+        int parallelism = syncReadConfiguration(Configuration::getIndexingParallelism);
         return parallelism < 1 ? Runtime.getRuntime().availableProcessors() :
-            parallelism;
+                parallelism;
     }
 
     /**
@@ -1191,9 +1062,9 @@ public final class RuntimeEnvironment {
      * @return a natural number &gt;= 1
      */
     public int getHistoryParallelism() {
-        int parallelism = (int) getConfigurationValue("historyParallelism");
+        int parallelism = syncReadConfiguration(Configuration::getHistoryParallelism);
         return parallelism < 1 ? Runtime.getRuntime().availableProcessors() :
-            parallelism;
+                parallelism;
     }
 
     /**
@@ -1202,41 +1073,41 @@ public final class RuntimeEnvironment {
      * @return a natural number &gt;= 1
      */
     public int getHistoryRenamedParallelism() {
-        int parallelism = (int) getConfigurationValue("historyRenamedParallelism");
+        int parallelism = syncReadConfiguration(Configuration::getHistoryRenamedParallelism);
         return parallelism < 1 ? Runtime.getRuntime().availableProcessors() :
-            parallelism;
+                parallelism;
     }
 
     public boolean isTagsEnabled() {
-        return (boolean) getConfigurationValue("tagsEnabled");
+        return syncReadConfiguration(Configuration::isTagsEnabled);
     }
 
     public void setTagsEnabled(boolean tagsEnabled) {
-        setConfigurationValue("tagsEnabled", tagsEnabled);
+        syncWriteConfiguration(Configuration::setTagsEnabled, tagsEnabled);
     }
 
     public boolean isScopesEnabled() {
-        return (boolean) getConfigurationValue("scopesEnabled");
+        return syncReadConfiguration(Configuration::isScopesEnabled);
     }
 
     public void setScopesEnabled(boolean scopesEnabled) {
-        setConfigurationValue("scopesEnabled", scopesEnabled);
+        syncWriteConfiguration(Configuration::setScopesEnabled, scopesEnabled);
     }
 
     public boolean isProjectsEnabled() {
-        return (boolean) getConfigurationValue("projectsEnabled");
+        return syncReadConfiguration(Configuration::isProjectsEnabled);
     }
 
     public void setProjectsEnabled(boolean projectsEnabled) {
-        setConfigurationValue("projectsEnabled", projectsEnabled);
+        syncWriteConfiguration(Configuration::setProjectsEnabled, projectsEnabled);
     }
 
     public boolean isFoldingEnabled() {
-        return (boolean) getConfigurationValue("foldingEnabled");
+        return syncReadConfiguration(Configuration::isFoldingEnabled);
     }
 
     public void setFoldingEnabled(boolean foldingEnabled) {
-        setConfigurationValue("foldingEnabled", foldingEnabled);
+        syncWriteConfiguration(Configuration::setFoldingEnabled, foldingEnabled);
     }
 
     public Date getDateForLastIndexRun() {
@@ -1244,29 +1115,27 @@ public final class RuntimeEnvironment {
     }
 
     public String getCTagsExtraOptionsFile() {
-        return (String) getConfigurationValue("CTagsExtraOptionsFile");
+        return syncReadConfiguration(Configuration::getCTagsExtraOptionsFile);
     }
 
     public void setCTagsExtraOptionsFile(String filename) {
-        setConfigurationValue("CTagsExtraOptionsFile", filename);
+        syncWriteConfiguration(Configuration::setCTagsExtraOptionsFile, filename);
     }
 
-    @SuppressWarnings("unchecked")
     public Set<String> getAllowedSymlinks() {
-        return (Set<String>) getConfigurationValue("allowedSymlinks");
+        return syncReadConfiguration(Configuration::getAllowedSymlinks);
     }
 
     public void setAllowedSymlinks(Set<String> allowedSymlinks) {
-        setConfigurationValue("allowedSymlinks", allowedSymlinks);
+        syncWriteConfiguration(Configuration::setAllowedSymlinks, allowedSymlinks);
     }
 
-    @SuppressWarnings("unchecked")
     public Set<String> getCanonicalRoots() {
-        return (Set<String>) getConfigurationValue("canonicalRoots");
+        return syncReadConfiguration(Configuration::getCanonicalRoots);
     }
 
     public void setCanonicalRoots(Set<String> canonicalRoots) {
-        setConfigurationValue("canonicalRoots", canonicalRoots);
+        syncWriteConfiguration(Configuration::setCanonicalRoots, canonicalRoots);
     }
 
     /**
@@ -1274,7 +1143,7 @@ public final class RuntimeEnvironment {
      * @return if we obfuscate emails
      */
     public boolean isObfuscatingEMailAddresses() {
-        return (boolean) getConfigurationValue("obfuscatingEMailAddresses");
+        return syncReadConfiguration(Configuration::isObfuscatingEMailAddresses);
     }
 
     /**
@@ -1282,7 +1151,7 @@ public final class RuntimeEnvironment {
      * @param obfuscate should we obfuscate emails?
      */
     public void setObfuscatingEMailAddresses(boolean obfuscate) {
-        setConfigurationValue("obfuscatingEMailAddresses", obfuscate);
+        syncWriteConfiguration(Configuration::setObfuscatingEMailAddresses, obfuscate);
     }
 
     /**
@@ -1292,7 +1161,7 @@ public final class RuntimeEnvironment {
      * {@code false} otherwise
      */
     public boolean isChattyStatusPage() {
-        return (boolean) getConfigurationValue("chattyStatusPage");
+        return syncReadConfiguration(Configuration::isChattyStatusPage);
     }
 
     /**
@@ -1302,71 +1171,72 @@ public final class RuntimeEnvironment {
      * {@code false} otherwise
      */
     public void setChattyStatusPage(boolean chatty) {
-        setConfigurationValue("chattyStatusPage", chatty);
+        syncWriteConfiguration(Configuration::setChattyStatusPage, chatty);
     }
 
     public void setFetchHistoryWhenNotInCache(boolean nofetch) {
-        setConfigurationValue("fetchHistoryWhenNotInCache", nofetch);
+        syncWriteConfiguration(Configuration::setFetchHistoryWhenNotInCache, nofetch);
     }
 
     public boolean isFetchHistoryWhenNotInCache() {
-        return (boolean) getConfigurationValue("fetchHistoryWhenNotInCache");
+        return syncReadConfiguration(Configuration::isFetchHistoryWhenNotInCache);
     }
 
     public boolean isHistoryCache() {
-        return (boolean) getConfigurationValue("historyCache");
+        return syncReadConfiguration(Configuration::isHistoryCache);
     }
 
     public void setHandleHistoryOfRenamedFiles(boolean enable) {
-        setConfigurationValue("handleHistoryOfRenamedFiles", enable);
+        syncWriteConfiguration(Configuration::setHandleHistoryOfRenamedFiles, enable);
     }
 
     public boolean isHandleHistoryOfRenamedFiles() {
-        return (boolean) getConfigurationValue("handleHistoryOfRenamedFiles");
+        return syncReadConfiguration(Configuration::isHandleHistoryOfRenamedFiles);
     }
 
     public void setNavigateWindowEnabled(boolean enable) {
-        setConfigurationValue("navigateWindowEnabled", enable);
+        syncWriteConfiguration(Configuration::setNavigateWindowEnabled, enable);
     }
 
     public boolean isNavigateWindowEnabled() {
-        return (boolean) getConfigurationValue("navigateWindowEnabled");
+        return syncReadConfiguration(Configuration::isNavigateWindowEnabled);
     }
 
     public void setRevisionMessageCollapseThreshold(int threshold) {
-        setConfigurationValue("revisionMessageCollapseThreshold", threshold);
+        syncWriteConfiguration(Configuration::setRevisionMessageCollapseThreshold, threshold);
     }
 
     public int getRevisionMessageCollapseThreshold() {
-        return (int) getConfigurationValue("revisionMessageCollapseThreshold");
+        return syncReadConfiguration(Configuration::getRevisionMessageCollapseThreshold);
     }
 
     public void setMaxSearchThreadCount(int count) {
-        setConfigurationValue("maxSearchThreadCount", count);
+        syncWriteConfiguration(Configuration::setMaxSearchThreadCount, count);
     }
 
     public int getMaxSearchThreadCount() {
-        return (int) getConfigurationValue("maxSearchThreadCount");
+        return syncReadConfiguration(Configuration::getMaxSearchThreadCount);
     }
 
     public void setMaxRevisionThreadCount(int count) {
-        setConfigurationValue("maxRevisionThreadCount", count);
+        syncWriteConfiguration(Configuration::setMaxRevisionThreadCount, count);
     }
 
     public int getMaxRevisionThreadCount() {
-        return (int) getConfigurationValue("maxRevisionThreadCount");
+        return syncReadConfiguration(Configuration::getMaxRevisionThreadCount);
     }
 
     public int getCurrentIndexedCollapseThreshold() {
-        return (int) getConfigurationValue("currentIndexedCollapseThreshold");
+        return syncReadConfiguration(Configuration::getCurrentIndexedCollapseThreshold);
     }
 
     public void setCurrentIndexedCollapseThreshold(int currentIndexedCollapseThreshold) {
-        setConfigurationValue("currentIndexedCollapseThreshold", currentIndexedCollapseThreshold);
+        syncWriteConfiguration(Configuration::setCurrentIndexedCollapseThreshold,
+                currentIndexedCollapseThreshold);
     }
 
     public int getGroupsCollapseThreshold() {
-        return (int) getConfigurationValue("groupsCollapseThreshold");
+        return syncReadConfiguration(Configuration::getGroupsCollapseThreshold);
     }
 
     // The URI is not necessary to be present in the configuration
@@ -1381,35 +1251,35 @@ public final class RuntimeEnvironment {
     }
 
     public boolean isHistoryEnabled() {
-        return (boolean) getConfigurationValue("historyEnabled");
+        return syncReadConfiguration(Configuration::isHistoryEnabled);
     }
 
     public void setHistoryEnabled(boolean flag) {
-        setConfigurationValue("historyEnabled", flag);
+        syncWriteConfiguration(Configuration::setHistoryEnabled, flag);
     }
 
     public boolean getDisplayRepositories() {
-        return (boolean) getConfigurationValue("displayRepositories");
+        return syncReadConfiguration(Configuration::getDisplayRepositories);
     }
 
     public void setDisplayRepositories(boolean flag) {
-        setConfigurationValue("displayRepositories", flag);
+        syncWriteConfiguration(Configuration::setDisplayRepositories, flag);
     }
 
     public boolean getListDirsFirst() {
-        return (boolean) getConfigurationValue("listDirsFirst");
+        return syncReadConfiguration(Configuration::getListDirsFirst);
     }
 
     public void setListDirsFirst(boolean flag) {
-        setConfigurationValue("listDirsFirst", flag);
+        syncWriteConfiguration(Configuration::setListDirsFirst, flag);
     }
 
     public void setTabSize(int size) {
-        setConfigurationValue("tabSize", size);
+        syncWriteConfiguration(Configuration::setTabSize, size);
     }
 
     public int getTabSize() {
-        return (int) getConfigurationValue("tabSize");
+        return syncReadConfiguration(Configuration::getTabSize);
     }
 
     /**
@@ -1417,7 +1287,7 @@ public final class RuntimeEnvironment {
      * @return a value greater than zero
      */
     public short getContextLimit() {
-        return (short) getConfigurationValue("contextLimit");
+        return syncReadConfiguration(Configuration::getContextLimit);
     }
 
     /**
@@ -1425,16 +1295,15 @@ public final class RuntimeEnvironment {
      * @return a value greater than or equal to zero
      */
     public short getContextSurround() {
-        return (short) getConfigurationValue("contextSurround");
+        return syncReadConfiguration(Configuration::getContextSurround);
     }
 
-    @SuppressWarnings("unchecked")
     public Set<String> getDisabledRepositories() {
-        return (Set<String>) getConfigurationValue("disabledRepositories");
+        return syncReadConfiguration(Configuration::getDisabledRepositories);
     }
 
     public void setDisabledRepositories(Set<String> disabledRepositories) {
-        setConfigurationValue("disabledRepositories", disabledRepositories);
+        syncWriteConfiguration(Configuration::setDisabledRepositories, disabledRepositories);
     }
 
     /**
@@ -1444,6 +1313,7 @@ public final class RuntimeEnvironment {
      * @throws IOException if an error occurs
      */
     public void readConfiguration(File file) throws IOException {
+        // The following method handles the locking.
         setConfiguration(Configuration.read(file));
     }
 
@@ -1454,6 +1324,7 @@ public final class RuntimeEnvironment {
      * @throws IOException I/O
      */
     public void readConfiguration(File file, boolean interactive) throws IOException {
+        // The following method handles the locking.
         setConfiguration(Configuration.read(file), null, interactive);
     }
 
@@ -1464,25 +1335,15 @@ public final class RuntimeEnvironment {
      * @throws IOException if an error occurs
      */
     public void writeConfiguration(File file) throws IOException {
-        Lock readLock = configLock.readLock();
-        try {
-            readLock.lock();
-
+        try (ResourceLock resourceLock = configLock.readLockAsResource()) {
+            //noinspection ConstantConditions to avoid warning of no reference to auto-closeable
+            assert resourceLock != null;
             configuration.write(file);
-        } finally {
-            readLock.unlock();
         }
     }
 
     public String getConfigurationXML() {
-        String configXML;
-        try {
-            configLock.readLock().lock();
-            configXML = configuration.getXMLRepresentationAsString();
-        } finally {
-            configLock.readLock().unlock();
-        }
-        return configXML;
+        return syncReadConfiguration(Configuration::getXMLRepresentationAsString);
     }
 
     /**
@@ -1492,13 +1353,7 @@ public final class RuntimeEnvironment {
      * @throws IOException if an error occurs
      */
     public void writeConfiguration(String host) throws IOException {
-        String configXML;
-        try {
-            configLock.readLock().lock();
-            configXML = configuration.getXMLRepresentationAsString();
-        } finally {
-            configLock.readLock().unlock();
-        }
+        String configXML = syncReadConfiguration(Configuration::getXMLRepresentationAsString);
 
         Response r = ClientBuilder.newClient()
                 .target(host)
@@ -1637,11 +1492,10 @@ public final class RuntimeEnvironment {
      * @param interactive   true if in interactive mode
      */
     public synchronized void setConfiguration(Configuration configuration, List<String> subFileList, boolean interactive) {
-        try {
-            configLock.writeLock().lock();
+        try (ResourceLock resourceLock = configLock.writeLockAsResource()) {
+            //noinspection ConstantConditions to avoid warning of no reference to auto-closeable
+            assert resourceLock != null;
             this.configuration = configuration;
-        } finally {
-            configLock.writeLock().unlock();
         }
 
         // HistoryGuru constructor needs environment properties so no locking is done here.
@@ -1678,11 +1532,11 @@ public final class RuntimeEnvironment {
     }
 
     public String getStatisticsFilePath() {
-        return (String) getConfigurationValue("statisticsFilePath");
+        return syncReadConfiguration(Configuration::getStatisticsFilePath);
     }
 
     public void setStatisticsFilePath(String path) {
-        setConfigurationValue("statisticsFilePath", path);
+        syncWriteConfiguration(Configuration::setStatisticsFilePath, path);
     }
 
     /**
@@ -1896,7 +1750,7 @@ public final class RuntimeEnvironment {
         // TODO might need to rewrite to Project instead of String, need changes in projects.jspf too.
         for (String proj : projects) {
             try {
-                SuperIndexSearcher searcher = RuntimeEnvironment.getInstance().getIndexSearcher(proj);
+                SuperIndexSearcher searcher = getIndexSearcher(proj);
                 subreaders[ii++] = searcher.getIndexReader();
                 searcherList.add(searcher);
             } catch (IOException | NullPointerException ex) {
@@ -1916,7 +1770,7 @@ public final class RuntimeEnvironment {
     }
 
     public void startExpirationTimer() {
-        messagesContainer.setMessageLimit((int) getConfigurationValue("messageLimit"));
+        messagesContainer.setMessageLimit(getMessageLimit());
         messagesContainer.startExpirationTimer();
     }
 
@@ -1970,14 +1824,7 @@ public final class RuntimeEnvironment {
     }
 
     public Path getDtagsEftarPath() {
-        Path path;
-        try {
-            configLock.readLock().lock();
-            path = configuration.getDtagsEftarPath();
-        } finally {
-            configLock.readLock().unlock();
-        }
-        return path;
+        return syncReadConfiguration(Configuration::getDtagsEftarPath);
     }
 
     /**
@@ -1996,14 +1843,45 @@ public final class RuntimeEnvironment {
     }
 
     public SuggesterConfig getSuggesterConfig() {
-        return (SuggesterConfig) getConfigurationValue("suggesterConfig");
+        return syncReadConfiguration(Configuration::getSuggesterConfig);
     }
 
     public void setSuggesterConfig(SuggesterConfig config) {
-        setConfigurationValue("suggesterConfig", config);
+        syncWriteConfiguration(Configuration::setSuggesterConfig, config);
     }
 
-    public int getMessageLimit() {
-        return (int) getConfigurationValue("messageLimit");
+    /**
+     * Applies the specified function to the runtime configuration, after having
+     * obtained the configuration read-lock (and releasing afterward).
+     * @param function a defined function
+     * @param <R> the type of the result of the function
+     * @return the function result
+     */
+    public <R> R syncReadConfiguration(Function<Configuration, R> function) {
+        try (ResourceLock resourceLock = configLock.readLockAsResource()) {
+            //noinspection ConstantConditions to silence unreference auto-closeable
+            assert resourceLock != null;
+            return function.apply(configuration);
+        }
+    }
+
+    /**
+     * Performs the specified operation which is provided the runtime
+     * configuration and the specified argument, after first having obtained the
+     * configuration write-lock (and releasing afterward).
+     * @param consumer a defined consumer
+     * @param v the input argument
+     * @param <V> the type of the input to the operation
+     */
+    public <V> void syncWriteConfiguration(ConfigurationValueConsumer<V> consumer, V v) {
+        try (ResourceLock resourceLock = configLock.writeLockAsResource()) {
+            //noinspection ConstantConditions to silence unreference auto-closeable
+            assert resourceLock != null;
+            consumer.accept(configuration, v);
+        }
+    }
+
+    private int getMessageLimit() {
+        return syncReadConfiguration(Configuration::getMessageLimit);
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -211,31 +211,32 @@ public final class RuntimeEnvironment {
     }
 
     public void setScanningDepth(int scanningDepth) {
-        syncWriteConfiguration(Configuration::setScanningDepth, scanningDepth);
+        syncWriteConfiguration(scanningDepth, Configuration::setScanningDepth);
     }
 
     public int getCommandTimeout() {
         return syncReadConfiguration(Configuration::getCommandTimeout);
     }
 
-    public void setCommandTimeout(int timeout) {
-        syncWriteConfiguration(Configuration::setCommandTimeout, timeout);
+    public void setCommandTimeout(int commandTimeout) {
+        syncWriteConfiguration(commandTimeout, Configuration::setCommandTimeout);
     }
 
     public int getInteractiveCommandTimeout() {
         return syncReadConfiguration(Configuration::getInteractiveCommandTimeout);
     }
 
-    public void setInteractiveCommandTimeout(int timeout) {
-        syncWriteConfiguration(Configuration::setInteractiveCommandTimeout, timeout);
+    public void setInteractiveCommandTimeout(int interactiveCommandTimeout) {
+        syncWriteConfiguration(interactiveCommandTimeout,
+                Configuration::setInteractiveCommandTimeout);
     }
 
     public long getCtagsTimeout() {
         return syncReadConfiguration(Configuration::getCtagsTimeout);
     }
 
-    public void setCtagsTimeout(long timeout) {
-        syncWriteConfiguration(Configuration::setCtagsTimeout, timeout);
+    public void setCtagsTimeout(long ctagsTimeout) {
+        syncWriteConfiguration(ctagsTimeout, Configuration::setCtagsTimeout);
     }
     
     public Statistics getStatistics() {
@@ -247,7 +248,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setLastEditedDisplayMode(boolean lastEditedDisplayMode) {
-        syncWriteConfiguration(Configuration::setLastEditedDisplayMode, lastEditedDisplayMode);
+        syncWriteConfiguration(lastEditedDisplayMode, Configuration::setLastEditedDisplayMode);
     }
 
     public boolean isLastEditedDisplayMode() {
@@ -268,7 +269,7 @@ public final class RuntimeEnvironment {
      * @param includeRoot path
      */
     public void setIncludeRoot(String includeRoot) {
-        syncWriteConfiguration(Configuration::setIncludeRoot, getCanonicalPath(includeRoot));
+        syncWriteConfiguration(getCanonicalPath(includeRoot), Configuration::setIncludeRoot);
     }
 
     /**
@@ -301,7 +302,7 @@ public final class RuntimeEnvironment {
      * @param dataRoot the index database
      */
     public void setDataRoot(String dataRoot) {
-        syncWriteConfiguration(Configuration::setDataRoot, getCanonicalPath(dataRoot));
+        syncWriteConfiguration(getCanonicalPath(dataRoot), Configuration::setDataRoot);
     }
 
     /**
@@ -334,7 +335,7 @@ public final class RuntimeEnvironment {
      * @param sourceRoot the location of the sources
      */
     public void setSourceRoot(String sourceRoot) {
-        syncWriteConfiguration(Configuration::setSourceRoot, getCanonicalPath(sourceRoot));
+        syncWriteConfiguration(getCanonicalPath(sourceRoot), Configuration::setSourceRoot);
     }
 
     /**
@@ -416,12 +417,12 @@ public final class RuntimeEnvironment {
      * @param projects the map of projects to use
      */
     public void setProjects(Map<String, Project> projects) {
-        syncWriteConfiguration((c, p) -> {
+        syncWriteConfiguration(projects, (c, p) -> {
             if (p != null) {
                 populateGroups(getGroups(), new TreeSet<>(p.values()));
             }
             c.setProjects(p);
-        }, projects);
+        });
     }
 
     /**
@@ -448,10 +449,10 @@ public final class RuntimeEnvironment {
      * @param groups the set of groups to use
      */
     public void setGroups(Set<Group> groups) {
-        syncWriteConfiguration((c, g) -> {
+        syncWriteConfiguration(groups, (c, g) -> {
             populateGroups(g, new TreeSet<>(getProjects().values()));
             c.setGroups(g);
-        }, groups);
+        });
     }
 
     /**
@@ -542,7 +543,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setCachePages(int cachePages) {
-        syncWriteConfiguration(Configuration::setCachePages, cachePages);
+        syncWriteConfiguration(cachePages, Configuration::setCachePages);
     }
 
     public int getHitsPerPage() {
@@ -550,7 +551,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setHitsPerPage(int hitsPerPage) {
-        syncWriteConfiguration(Configuration::setHitsPerPage, hitsPerPage);
+        syncWriteConfiguration(hitsPerPage, Configuration::setHitsPerPage);
     }
 
     /**
@@ -601,10 +602,10 @@ public final class RuntimeEnvironment {
      * Specify the maximum time a SCM operation should take before it will be
      * cached (in ms).
      *
-     * @param historyReaderTimeLimit the max time in ms before it is cached
+     * @param historyCacheTime the max time in ms before it is cached
      */
-    public void setHistoryReaderTimeLimit(int historyReaderTimeLimit) {
-        syncWriteConfiguration(Configuration::setHistoryCacheTime, historyReaderTimeLimit);
+    public void setHistoryReaderTimeLimit(int historyCacheTime) {
+        syncWriteConfiguration(historyCacheTime, Configuration::setHistoryCacheTime);
     }
 
     /**
@@ -622,7 +623,7 @@ public final class RuntimeEnvironment {
      * @param useHistoryCache set false if you do not want to use history cache
      */
     public void setUseHistoryCache(boolean useHistoryCache) {
-        syncWriteConfiguration(Configuration::setHistoryCache, useHistoryCache);
+        syncWriteConfiguration(useHistoryCache, Configuration::setHistoryCache);
     }
 
     /**
@@ -640,7 +641,7 @@ public final class RuntimeEnvironment {
      * @param generateHtml set this to true to pregenerate HTML
      */
     public void setGenerateHtml(boolean generateHtml) {
-        syncWriteConfiguration(Configuration::setGenerateHtml, generateHtml);
+        syncWriteConfiguration(generateHtml, Configuration::setGenerateHtml);
     }
 
     /**
@@ -650,7 +651,7 @@ public final class RuntimeEnvironment {
      * compressed
      */
     public void setCompressXref(boolean compressXref) {
-        syncWriteConfiguration(Configuration::setCompressXref, compressXref);
+        syncWriteConfiguration(compressXref, Configuration::setCompressXref);
     }
 
     /**
@@ -667,7 +668,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setQuickContextScan(boolean quickContextScan) {
-        syncWriteConfiguration(Configuration::setQuickContextScan, quickContextScan);
+        syncWriteConfiguration(quickContextScan, Configuration::setQuickContextScan);
     }
 
     public List<RepositoryInfo> getRepositories() {
@@ -680,11 +681,11 @@ public final class RuntimeEnvironment {
      * @param repositories the repositories to use
      */
     public void setRepositories(List<RepositoryInfo> repositories) {
-        syncWriteConfiguration(Configuration::setRepositories, repositories);
+        syncWriteConfiguration(repositories, Configuration::setRepositories);
     }
     
     public void removeRepositories() {
-        syncWriteConfiguration(Configuration::setRepositories, null);
+        syncWriteConfiguration(null, Configuration::setRepositories);
     }
     
     /**
@@ -705,7 +706,7 @@ public final class RuntimeEnvironment {
      * @param repositories list of repositories
      */
     public void addRepositories(List<RepositoryInfo> repositories) {
-        syncWriteConfiguration(Configuration::addRepositories, repositories);
+        syncWriteConfiguration(repositories, Configuration::addRepositories);
     }
 
     /**
@@ -745,7 +746,7 @@ public final class RuntimeEnvironment {
      * @param defaultProjects The default project to use
      */
     public void setDefaultProjects(Set<Project> defaultProjects) {
-        syncWriteConfiguration(Configuration::setDefaultProjects, defaultProjects);
+        syncWriteConfiguration(defaultProjects, Configuration::setDefaultProjects);
     }
 
     /**
@@ -779,11 +780,11 @@ public final class RuntimeEnvironment {
      * @param ramBufferSize the size(in MB) when we should flush the docs
      */
     public void setRamBufferSize(double ramBufferSize) {
-        syncWriteConfiguration(Configuration::setRamBufferSize, ramBufferSize);
+        syncWriteConfiguration(ramBufferSize, Configuration::setRamBufferSize);
     }
 
     public void setPluginDirectory(String pluginDirectory) {
-        syncWriteConfiguration(Configuration::setPluginDirectory, pluginDirectory);
+        syncWriteConfiguration(pluginDirectory, Configuration::setPluginDirectory);
     }
 
     public String getPluginDirectory() {
@@ -795,8 +796,8 @@ public final class RuntimeEnvironment {
     }
 
     public void setAuthorizationWatchdog(boolean authorizationWatchdogEnabled) {
-        syncWriteConfiguration(Configuration::setAuthorizationWatchdogEnabled,
-                authorizationWatchdogEnabled);
+        syncWriteConfiguration(authorizationWatchdogEnabled,
+                Configuration::setAuthorizationWatchdogEnabled);
     }
 
     public AuthorizationStack getPluginStack() {
@@ -804,7 +805,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setPluginStack(AuthorizationStack pluginStack) {
-        syncWriteConfiguration(Configuration::setPluginStack, pluginStack);
+        syncWriteConfiguration(pluginStack, Configuration::setPluginStack);
     }
 
     /**
@@ -822,7 +823,7 @@ public final class RuntimeEnvironment {
      * @param printProgress new value
      */
     public void setPrintProgress(boolean printProgress) {
-        syncWriteConfiguration(Configuration::setPrintProgress, printProgress);
+        syncWriteConfiguration(printProgress, Configuration::setPrintProgress);
     }
 
     /**
@@ -833,7 +834,7 @@ public final class RuntimeEnvironment {
      * @param allowLeadingWildcard set to true to activate (disabled by default)
      */
     public void setAllowLeadingWildcard(boolean allowLeadingWildcard) {
-        syncWriteConfiguration(Configuration::setAllowLeadingWildcard, allowLeadingWildcard);
+        syncWriteConfiguration(allowLeadingWildcard, Configuration::setAllowLeadingWildcard);
     }
 
     /**
@@ -850,7 +851,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setIgnoredNames(IgnoredNames ignoredNames) {
-        syncWriteConfiguration(Configuration::setIgnoredNames, ignoredNames);
+        syncWriteConfiguration(ignoredNames, Configuration::setIgnoredNames);
     }
 
     public Filter getIncludedNames() {
@@ -858,7 +859,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setIncludedNames(Filter includedNames) {
-        syncWriteConfiguration(Configuration::setIncludedNames, includedNames);
+        syncWriteConfiguration(includedNames, Configuration::setIncludedNames);
     }
 
     /**
@@ -892,12 +893,12 @@ public final class RuntimeEnvironment {
      * @return the client command previously set, which might be {@code null}.
      */
     public String setRepoCmd(String clazzName, String cmd) {
-        syncWriteConfiguration((c, ignored) -> c.setRepoCmd(clazzName, cmd), null);
+        syncWriteConfiguration(null, (c, ignored) -> c.setRepoCmd(clazzName, cmd));
         return cmd;
     }
 
     public void setRepoCmds(Map<String, String> cmds) {
-        syncWriteConfiguration(Configuration::setCmds, cmds);
+        syncWriteConfiguration(cmds, Configuration::setCmds);
     }
 
     /**
@@ -906,7 +907,7 @@ public final class RuntimeEnvironment {
      * @param userPage the URL fragment preceeding the username from history
      */
     public void setUserPage(String userPage) {
-        syncWriteConfiguration(Configuration::setUserPage, userPage);
+        syncWriteConfiguration(userPage, Configuration::setUserPage);
     }
 
     /**
@@ -925,7 +926,7 @@ public final class RuntimeEnvironment {
      * history
      */
     public void setUserPageSuffix(String userPageSuffix) {
-        syncWriteConfiguration(Configuration::setUserPageSuffix, userPageSuffix);
+        syncWriteConfiguration(userPageSuffix, Configuration::setUserPageSuffix);
     }
 
     /**
@@ -943,7 +944,7 @@ public final class RuntimeEnvironment {
      * @param bugPage the URL fragment preceeding the bug ID
      */
     public void setBugPage(String bugPage) {
-        syncWriteConfiguration(Configuration::setBugPage, bugPage);
+        syncWriteConfiguration(bugPage, Configuration::setBugPage);
     }
 
     /**
@@ -961,7 +962,7 @@ public final class RuntimeEnvironment {
      * @param bugPattern the regex to search history comments
      */
     public void setBugPattern(String bugPattern) {
-        syncWriteConfiguration(Configuration::setBugPattern, bugPattern);
+        syncWriteConfiguration(bugPattern, Configuration::setBugPattern);
     }
 
     /**
@@ -979,7 +980,7 @@ public final class RuntimeEnvironment {
      * @param reviewPage the URL fragment preceeding the review page ID
      */
     public void setReviewPage(String reviewPage) {
-        syncWriteConfiguration(Configuration::setReviewPage, reviewPage);
+        syncWriteConfiguration(reviewPage, Configuration::setReviewPage);
     }
 
     /**
@@ -997,15 +998,15 @@ public final class RuntimeEnvironment {
      * @param reviewPattern the regex to search history comments
      */
     public void setReviewPattern(String reviewPattern) {
-        syncWriteConfiguration(Configuration::setReviewPattern, reviewPattern);
+        syncWriteConfiguration(reviewPattern, Configuration::setReviewPattern);
     }
 
     public String getWebappLAF() {
         return syncReadConfiguration(Configuration::getWebappLAF);
     }
 
-    public void setWebappLAF(String laf) {
-        syncWriteConfiguration(Configuration::setWebappLAF, laf);
+    public void setWebappLAF(String webappLAF) {
+        syncWriteConfiguration(webappLAF, Configuration::setWebappLAF);
     }
 
     /**
@@ -1020,8 +1021,8 @@ public final class RuntimeEnvironment {
         return syncReadConfiguration(Configuration::getRemoteScmSupported);
     }
 
-    public void setRemoteScmSupported(Configuration.RemoteSCM supported) {
-        syncWriteConfiguration(Configuration::setRemoteScmSupported, supported);
+    public void setRemoteScmSupported(Configuration.RemoteSCM remoteScmSupported) {
+        syncWriteConfiguration(remoteScmSupported, Configuration::setRemoteScmSupported);
     }
 
     public boolean isOptimizeDatabase() {
@@ -1029,7 +1030,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setOptimizeDatabase(boolean optimizeDatabase) {
-        syncWriteConfiguration(Configuration::setOptimizeDatabase, optimizeDatabase);
+        syncWriteConfiguration(optimizeDatabase, Configuration::setOptimizeDatabase);
     }
 
     public LuceneLockName getLuceneLocking() {
@@ -1041,8 +1042,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setIndexVersionedFilesOnly(boolean indexVersionedFilesOnly) {
-        syncWriteConfiguration(Configuration::setIndexVersionedFilesOnly,
-                indexVersionedFilesOnly);
+        syncWriteConfiguration(indexVersionedFilesOnly, Configuration::setIndexVersionedFilesOnly);
     }
 
     /**
@@ -1083,7 +1083,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setTagsEnabled(boolean tagsEnabled) {
-        syncWriteConfiguration(Configuration::setTagsEnabled, tagsEnabled);
+        syncWriteConfiguration(tagsEnabled, Configuration::setTagsEnabled);
     }
 
     public boolean isScopesEnabled() {
@@ -1091,7 +1091,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setScopesEnabled(boolean scopesEnabled) {
-        syncWriteConfiguration(Configuration::setScopesEnabled, scopesEnabled);
+        syncWriteConfiguration(scopesEnabled, Configuration::setScopesEnabled);
     }
 
     public boolean isProjectsEnabled() {
@@ -1099,7 +1099,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setProjectsEnabled(boolean projectsEnabled) {
-        syncWriteConfiguration(Configuration::setProjectsEnabled, projectsEnabled);
+        syncWriteConfiguration(projectsEnabled, Configuration::setProjectsEnabled);
     }
 
     public boolean isFoldingEnabled() {
@@ -1107,7 +1107,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setFoldingEnabled(boolean foldingEnabled) {
-        syncWriteConfiguration(Configuration::setFoldingEnabled, foldingEnabled);
+        syncWriteConfiguration(foldingEnabled, Configuration::setFoldingEnabled);
     }
 
     public Date getDateForLastIndexRun() {
@@ -1118,8 +1118,8 @@ public final class RuntimeEnvironment {
         return syncReadConfiguration(Configuration::getCTagsExtraOptionsFile);
     }
 
-    public void setCTagsExtraOptionsFile(String filename) {
-        syncWriteConfiguration(Configuration::setCTagsExtraOptionsFile, filename);
+    public void setCTagsExtraOptionsFile(String ctagsExtraOptionsFile) {
+        syncWriteConfiguration(ctagsExtraOptionsFile, Configuration::setCTagsExtraOptionsFile);
     }
 
     public Set<String> getAllowedSymlinks() {
@@ -1127,7 +1127,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setAllowedSymlinks(Set<String> allowedSymlinks) {
-        syncWriteConfiguration(Configuration::setAllowedSymlinks, allowedSymlinks);
+        syncWriteConfiguration(allowedSymlinks, Configuration::setAllowedSymlinks);
     }
 
     public Set<String> getCanonicalRoots() {
@@ -1135,7 +1135,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setCanonicalRoots(Set<String> canonicalRoots) {
-        syncWriteConfiguration(Configuration::setCanonicalRoots, canonicalRoots);
+        syncWriteConfiguration(canonicalRoots, Configuration::setCanonicalRoots);
     }
 
     /**
@@ -1148,10 +1148,11 @@ public final class RuntimeEnvironment {
 
     /**
      * Set whether e-mail addresses should be obfuscated in the xref.
-     * @param obfuscate should we obfuscate emails?
+     * @param obfuscatingEMailAddresses should we obfuscate emails?
      */
-    public void setObfuscatingEMailAddresses(boolean obfuscate) {
-        syncWriteConfiguration(Configuration::setObfuscatingEMailAddresses, obfuscate);
+    public void setObfuscatingEMailAddresses(boolean obfuscatingEMailAddresses) {
+        syncWriteConfiguration(obfuscatingEMailAddresses,
+                Configuration::setObfuscatingEMailAddresses);
     }
 
     /**
@@ -1167,15 +1168,16 @@ public final class RuntimeEnvironment {
     /**
      * Set whether status.jsp should print internal settings.
      *
-     * @param chatty {@code true} if internal settings should be printed,
+     * @param chattyStatusPage {@code true} if internal settings should be printed,
      * {@code false} otherwise
      */
-    public void setChattyStatusPage(boolean chatty) {
-        syncWriteConfiguration(Configuration::setChattyStatusPage, chatty);
+    public void setChattyStatusPage(boolean chattyStatusPage) {
+        syncWriteConfiguration(chattyStatusPage, Configuration::setChattyStatusPage);
     }
 
-    public void setFetchHistoryWhenNotInCache(boolean nofetch) {
-        syncWriteConfiguration(Configuration::setFetchHistoryWhenNotInCache, nofetch);
+    public void setFetchHistoryWhenNotInCache(boolean fetchHistoryWhenNotInCache) {
+        syncWriteConfiguration(fetchHistoryWhenNotInCache,
+                Configuration::setFetchHistoryWhenNotInCache);
     }
 
     public boolean isFetchHistoryWhenNotInCache() {
@@ -1186,40 +1188,42 @@ public final class RuntimeEnvironment {
         return syncReadConfiguration(Configuration::isHistoryCache);
     }
 
-    public void setHandleHistoryOfRenamedFiles(boolean enable) {
-        syncWriteConfiguration(Configuration::setHandleHistoryOfRenamedFiles, enable);
+    public void setHandleHistoryOfRenamedFiles(boolean handleHistoryOfRenamedFiles) {
+        syncWriteConfiguration(handleHistoryOfRenamedFiles,
+                Configuration::setHandleHistoryOfRenamedFiles);
     }
 
     public boolean isHandleHistoryOfRenamedFiles() {
         return syncReadConfiguration(Configuration::isHandleHistoryOfRenamedFiles);
     }
 
-    public void setNavigateWindowEnabled(boolean enable) {
-        syncWriteConfiguration(Configuration::setNavigateWindowEnabled, enable);
+    public void setNavigateWindowEnabled(boolean navigateWindowEnabled) {
+        syncWriteConfiguration(navigateWindowEnabled, Configuration::setNavigateWindowEnabled);
     }
 
     public boolean isNavigateWindowEnabled() {
         return syncReadConfiguration(Configuration::isNavigateWindowEnabled);
     }
 
-    public void setRevisionMessageCollapseThreshold(int threshold) {
-        syncWriteConfiguration(Configuration::setRevisionMessageCollapseThreshold, threshold);
+    public void setRevisionMessageCollapseThreshold(int revisionMessageCollapseThreshold) {
+        syncWriteConfiguration(revisionMessageCollapseThreshold,
+                Configuration::setRevisionMessageCollapseThreshold);
     }
 
     public int getRevisionMessageCollapseThreshold() {
         return syncReadConfiguration(Configuration::getRevisionMessageCollapseThreshold);
     }
 
-    public void setMaxSearchThreadCount(int count) {
-        syncWriteConfiguration(Configuration::setMaxSearchThreadCount, count);
+    public void setMaxSearchThreadCount(int maxSearchThreadCount) {
+        syncWriteConfiguration(maxSearchThreadCount, Configuration::setMaxSearchThreadCount);
     }
 
     public int getMaxSearchThreadCount() {
         return syncReadConfiguration(Configuration::getMaxSearchThreadCount);
     }
 
-    public void setMaxRevisionThreadCount(int count) {
-        syncWriteConfiguration(Configuration::setMaxRevisionThreadCount, count);
+    public void setMaxRevisionThreadCount(int maxRevisionThreadCount) {
+        syncWriteConfiguration(maxRevisionThreadCount, Configuration::setMaxRevisionThreadCount);
     }
 
     public int getMaxRevisionThreadCount() {
@@ -1231,8 +1235,8 @@ public final class RuntimeEnvironment {
     }
 
     public void setCurrentIndexedCollapseThreshold(int currentIndexedCollapseThreshold) {
-        syncWriteConfiguration(Configuration::setCurrentIndexedCollapseThreshold,
-                currentIndexedCollapseThreshold);
+        syncWriteConfiguration(currentIndexedCollapseThreshold,
+                Configuration::setCurrentIndexedCollapseThreshold);
     }
 
     public int getGroupsCollapseThreshold() {
@@ -1254,28 +1258,28 @@ public final class RuntimeEnvironment {
         return syncReadConfiguration(Configuration::isHistoryEnabled);
     }
 
-    public void setHistoryEnabled(boolean flag) {
-        syncWriteConfiguration(Configuration::setHistoryEnabled, flag);
+    public void setHistoryEnabled(boolean historyEnabled) {
+        syncWriteConfiguration(historyEnabled, Configuration::setHistoryEnabled);
     }
 
     public boolean getDisplayRepositories() {
         return syncReadConfiguration(Configuration::getDisplayRepositories);
     }
 
-    public void setDisplayRepositories(boolean flag) {
-        syncWriteConfiguration(Configuration::setDisplayRepositories, flag);
+    public void setDisplayRepositories(boolean displayRepositories) {
+        syncWriteConfiguration(displayRepositories, Configuration::setDisplayRepositories);
     }
 
     public boolean getListDirsFirst() {
         return syncReadConfiguration(Configuration::getListDirsFirst);
     }
 
-    public void setListDirsFirst(boolean flag) {
-        syncWriteConfiguration(Configuration::setListDirsFirst, flag);
+    public void setListDirsFirst(boolean listDirsFirst) {
+        syncWriteConfiguration(listDirsFirst, Configuration::setListDirsFirst);
     }
 
-    public void setTabSize(int size) {
-        syncWriteConfiguration(Configuration::setTabSize, size);
+    public void setTabSize(int tabSize) {
+        syncWriteConfiguration(tabSize, Configuration::setTabSize);
     }
 
     public int getTabSize() {
@@ -1303,7 +1307,7 @@ public final class RuntimeEnvironment {
     }
 
     public void setDisabledRepositories(Set<String> disabledRepositories) {
-        syncWriteConfiguration(Configuration::setDisabledRepositories, disabledRepositories);
+        syncWriteConfiguration(disabledRepositories, Configuration::setDisabledRepositories);
     }
 
     /**
@@ -1535,8 +1539,8 @@ public final class RuntimeEnvironment {
         return syncReadConfiguration(Configuration::getStatisticsFilePath);
     }
 
-    public void setStatisticsFilePath(String path) {
-        syncWriteConfiguration(Configuration::setStatisticsFilePath, path);
+    public void setStatisticsFilePath(String statisticsFilePath) {
+        syncWriteConfiguration(statisticsFilePath, Configuration::setStatisticsFilePath);
     }
 
     /**
@@ -1846,8 +1850,8 @@ public final class RuntimeEnvironment {
         return syncReadConfiguration(Configuration::getSuggesterConfig);
     }
 
-    public void setSuggesterConfig(SuggesterConfig config) {
-        syncWriteConfiguration(Configuration::setSuggesterConfig, config);
+    public void setSuggesterConfig(SuggesterConfig suggesterConfig) {
+        syncWriteConfiguration(suggesterConfig, Configuration::setSuggesterConfig);
     }
 
     /**
@@ -1859,7 +1863,7 @@ public final class RuntimeEnvironment {
      */
     public <R> R syncReadConfiguration(Function<Configuration, R> function) {
         try (ResourceLock resourceLock = configLock.readLockAsResource()) {
-            //noinspection ConstantConditions to silence unreference auto-closeable
+            //noinspection ConstantConditions to avoid warning of no reference to auto-closeable
             assert resourceLock != null;
             return function.apply(configuration);
         }
@@ -1869,13 +1873,13 @@ public final class RuntimeEnvironment {
      * Performs the specified operation which is provided the runtime
      * configuration and the specified argument, after first having obtained the
      * configuration write-lock (and releasing afterward).
-     * @param consumer a defined consumer
-     * @param v the input argument
      * @param <V> the type of the input to the operation
+     * @param v the input argument
+     * @param consumer a defined consumer
      */
-    public <V> void syncWriteConfiguration(ConfigurationValueConsumer<V> consumer, V v) {
+    public <V> void syncWriteConfiguration(V v, ConfigurationValueConsumer<V> consumer) {
         try (ResourceLock resourceLock = configLock.writeLockAsResource()) {
-            //noinspection ConstantConditions to silence unreference auto-closeable
+            //noinspection ConstantConditions to avoid warning of no reference to auto-closeable
             assert resourceLock != null;
             consumer.accept(configuration, v);
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CloseableReentrantReadWriteLock.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CloseableReentrantReadWriteLock.java
@@ -53,7 +53,7 @@ public final class CloseableReentrantReadWriteLock extends ReentrantReadWriteLoc
     }
 
     /**
-     * @return a defined {@link ResourceLock} once the {@link #writeLock()} ()}
+     * @return a defined {@link ResourceLock} once the {@link #writeLock()}
      * has been acquired
      */
     public ResourceLock writeLockAsResource() {
@@ -76,10 +76,10 @@ public final class CloseableReentrantReadWriteLock extends ReentrantReadWriteLoc
     }
 
     private ResourceLock newReadUnlocker() {
-        return () -> CloseableReentrantReadWriteLock.this.readLock().unlock();
+        return () -> this.readLock().unlock();
     }
 
     private ResourceLock newWriteUnlocker() {
-        return () -> CloseableReentrantReadWriteLock.this.writeLock().unlock();
+        return () -> this.writeLock().unlock();
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CloseableReentrantReadWriteLock.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CloseableReentrantReadWriteLock.java
@@ -1,0 +1,85 @@
+/*
+ * This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
+ * International License. To view a copy of this license, visit
+ * https://creativecommons.org/licenses/by-sa/4.0/ or send a letter to
+ * Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+ *
+ * Copyright (c) 2017, https://stackoverflow.com/users/7583219/skoskav
+ * Copyright (c) 2011, https://stackoverflow.com/questions/6965731/are-locks-autocloseable
+ * Portions Copyright (c) 2019-2020, Chris Fraire <cfraire@me.com>.
+ *
+ * Used under CC 4 with modifications noted as follows as required by license:
+ * 2019-09-10 -- cfraire@me.com, derived to use for ReentrantReadWriteLock.
+ * 2020-04-21 -- cfraire@me.com, updated for proper handling re Serializable.
+ */
+
+package org.opengrok.indexer.util;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Represents a subclass of {@link ReentrantReadWriteLock} that can return
+ * {@link ResourceLock} instances.
+ */
+public final class CloseableReentrantReadWriteLock extends ReentrantReadWriteLock {
+
+    private static final long serialVersionUID = 95L;
+
+    private transient ResourceLock readUnlocker = newReadUnlocker();
+
+    private transient ResourceLock writeUnlocker = newWriteUnlocker();
+
+    /**
+     * @return a defined {@link ResourceLock} once the {@link #readLock()} has
+     * been acquired
+     */
+    public ResourceLock readLockAsResource() {
+        /*
+         * A subclass of ReentrantReadWriteLock is forced to be serializable, so
+         * we would have to handle where serialization can short-circuit field
+         * initialization above and leave the instance's fields null.
+         * Consequently, the fields cannot be final. They are encapsulating
+         * fixed logic, so we can optimize and choose not to even bother
+         * serializing by declaring transient and handling below.
+         */
+        ResourceLock unlocker = readUnlocker;
+        if (unlocker == null) {
+            unlocker = newReadUnlocker();
+            // No synchronization necessary since overwrite is of no matter.
+            readUnlocker = unlocker;
+        }
+        readLock().lock();
+        return unlocker;
+    }
+
+    /**
+     * @return a defined {@link ResourceLock} once the {@link #writeLock()} ()}
+     * has been acquired
+     */
+    public ResourceLock writeLockAsResource() {
+        /*
+         * A subclass of ReentrantReadWriteLock is forced to be serializable, so
+         * we would have to handle where serialization can short-circuit field
+         * initialization above and leave the instance's fields null.
+         * Consequently, the fields cannot be final. They are encapsulating
+         * fixed logic, so we can optimize and choose not to even bother
+         * serializing by declaring transient and handling below.
+         */
+        ResourceLock unlocker = writeUnlocker;
+        if (unlocker == null) {
+            unlocker = newWriteUnlocker();
+            // No synchronization necessary since overwrite is of no matter.
+            writeUnlocker = unlocker;
+        }
+        writeLock().lock();
+        return unlocker;
+    }
+
+    private ResourceLock newReadUnlocker() {
+        return () -> CloseableReentrantReadWriteLock.this.readLock().unlock();
+    }
+
+    private ResourceLock newWriteUnlocker() {
+        return () -> CloseableReentrantReadWriteLock.this.writeLock().unlock();
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/ResourceLock.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/ResourceLock.java
@@ -1,0 +1,29 @@
+/*
+ * This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
+ * International License. To view a copy of this license, visit
+ * https://creativecommons.org/licenses/by-sa/4.0/ or send a letter to
+ * Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+ *
+ * Copyright (c) 2017, https://stackoverflow.com/users/7583219/skoskav
+ * Copyright (c) 2011, https://stackoverflow.com/questions/6965731/are-locks-autocloseable
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ *
+ * Used under CC 4 with modifications noted as follows as required by license:
+ * 2019-09-10 -- cfraire@me.com, solely Javadoc changes.
+ */
+
+package org.opengrok.indexer.util;
+
+import java.util.concurrent.locks.Lock;
+
+/**
+ * Represents an API for try-with-resources management of a {@link Lock}.
+ */
+public interface ResourceLock extends AutoCloseable {
+
+    /**
+     * Unlocking doesn't throw any checked exception.
+     */
+    @Override
+    void close();
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;
 
@@ -333,9 +333,8 @@ public class RuntimeEnvironmentTest {
             try {
                 instance.setBugPattern(test);
                 assertEquals(test, instance.getBugPattern());
-            } catch (IOException ex) {
+            } catch (IllegalArgumentException ex) {
                 fail("The pattern '" + test + "' should not throw an exception");
-
             }
         }
     }
@@ -355,7 +354,7 @@ public class RuntimeEnvironmentTest {
             try {
                 instance.setBugPattern(test);
                 fail("The pattern '" + test + "' should throw an exception");
-            } catch (IOException ex) {
+            } catch (IllegalArgumentException ignored) {
             }
         }
     }
@@ -382,9 +381,8 @@ public class RuntimeEnvironmentTest {
             try {
                 instance.setReviewPattern(test);
                 assertEquals(test, instance.getReviewPattern());
-            } catch (IOException ex) {
+            } catch (IllegalArgumentException ex) {
                 fail("The pattern '" + test + "' should not throw an exception");
-
             }
         }
     }
@@ -404,7 +402,7 @@ public class RuntimeEnvironmentTest {
             try {
                 instance.setReviewPattern(test);
                 fail("The pattern '" + test + "' should throw an exception");
-            } catch (IOException ex) {
+            } catch (IllegalArgumentException ignored) {
             }
         }
     }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
@@ -67,22 +67,13 @@ public class ConfigurationController {
     @Path("/{field}")
     @Produces(MediaType.APPLICATION_JSON)
     public Object getField(@PathParam("field") final String field) {
-        try {
-            return getConfigurationValueException(field);
-        } catch (IOException e) {
-            throw new WebApplicationException(e, Response.Status.BAD_REQUEST);
-        }
+        return getConfigurationValueException(field);
     }
 
     @PUT
     @Path("/{field}")
     public void setField(@PathParam("field") final String field, final String value) {
-        try {
-            setConfigurationValueException(field, value);
-        } catch (IOException e) {
-            throw new WebApplicationException(e, Response.Status.BAD_REQUEST);
-        }
-
+        setConfigurationValueException(field, value);
         // apply the configuration - let the environment reload the configuration if necessary
         env.applyConfig(false, true);
         suggesterService.refresh();
@@ -94,37 +85,37 @@ public class ConfigurationController {
         env.getAuthorizationFramework().reload();
     }
 
-    private Object getConfigurationValueException(String fieldName) throws IOException {
+    private Object getConfigurationValueException(String fieldName) throws WebApplicationException {
         final IOException[] capture = new IOException[1];
-        final int EXCEPTION_INDEX = 0;
+        final int IOE_INDEX = 0;
         Object result = env.syncReadConfiguration(configuration -> {
             try {
                 return ClassUtil.getFieldValue(configuration, fieldName);
             } catch (IOException ex) {
-                capture[EXCEPTION_INDEX] = ex;
+                capture[IOE_INDEX] = ex;
                 return null;
             }
         });
-        if (capture[EXCEPTION_INDEX] != null) {
-            throw capture[EXCEPTION_INDEX];
+        if (capture[IOE_INDEX] != null) {
+            throw new WebApplicationException(capture[IOE_INDEX], Response.Status.BAD_REQUEST);
         }
         return result;
     }
 
     private void setConfigurationValueException(String fieldName, String value)
-            throws IOException {
+            throws WebApplicationException {
 
         final IOException[] capture = new IOException[1];
-        final int EXCEPTION_INDEX = 0;
-        env.syncWriteConfiguration((configuration, v) -> {
+        final int IOE_INDEX = 0;
+        env.syncWriteConfiguration(value, (configuration, v) -> {
             try {
                 ClassUtil.setFieldValue(configuration, fieldName, v);
             } catch (IOException ex) {
-                capture[EXCEPTION_INDEX] = ex;
+                capture[IOE_INDEX] = ex;
             }
-        }, value);
-        if (capture[EXCEPTION_INDEX] != null) {
-            throw capture[EXCEPTION_INDEX];
+        });
+        if (capture[IOE_INDEX] != null) {
+            throw new WebApplicationException(capture[IOE_INDEX], Response.Status.BAD_REQUEST);
         }
     }
 }


### PR DESCRIPTION
Hello,

Please consider for integration this patch to minimize reflection into `Configuration` and shift that logic to `ConfigurationController` where it's more difficult to avoid given the REST-exposure of all configuration through a single web method.

`RuntimeEnvironment` can use functional interfaces to achieve the equivalent of the former reflection without having to identify methods by `String`; thereby we get compile-time checks.

I also imported an auto-disposable wrapper around `Lock` so that try-with-resources can be used instead of try-finally.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
