### PR TITLE
append string to Message text for disabled messages

### DIFF
--- a/opengrok-tools/requirements.txt
+++ b/opengrok-tools/requirements.txt
@@ -11,4 +11,4 @@ requests==2.20.0
 Resource==0.2.1
 six==1.11.0
 urllib3==1.23
-GitPython==3.0.2
+GitPython==3.0.6

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -54,6 +54,7 @@ IGNORED_REPOS_PROPERTY = 'ignored_repos'
 PROXY_PROPERTY = 'proxy'
 COMMANDS_PROPERTY = 'commands'
 DISABLED_PROPERTY = 'disabled'
+DISABLED_REASON_PROPERTY = 'disabled-reason'
 HOOKDIR_PROPERTY = 'hookdir'
 HOOKS_PROPERTY = 'hooks'
 LOGDIR_PROPERTY = 'logdir'
@@ -378,9 +379,9 @@ def mirror_project(config, project_name, check_changes, uri,
 
     # We want this to be logged to the log file (if any).
     if project_config:
-        disabled_value = project_config.get(DISABLED_PROPERTY)
-        if disabled_value:
-            handle_disabled_project(config, project_name, disabled_value)
+        if project_config.get(DISABLED_PROPERTY):
+            handle_disabled_project(config, project_name,
+                                    project_config.get(DISABLED_REASON_PROPERTY))
             logger.info("Project '{}' disabled, exiting".
                         format(project_name))
             return CONTINUE_EXITVAL
@@ -446,7 +447,8 @@ def check_project_configuration(multiple_project_config, hookdir=False,
     # Quick sanity check.
     known_project_tunables = [DISABLED_PROPERTY, CMD_TIMEOUT_PROPERTY,
                               HOOK_TIMEOUT_PROPERTY, PROXY_PROPERTY,
-                              IGNORED_REPOS_PROPERTY, HOOKS_PROPERTY]
+                              IGNORED_REPOS_PROPERTY, HOOKS_PROPERTY,
+                              DISABLED_REASON_PROPERTY]
 
     if not multiple_project_config:
         return True

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -317,7 +317,7 @@ def handle_disabled_project(config, project_name, disabled_msg):
             # If so and there was a string supplied, append it
             # to the message text.
             text = command_args[2].get("text")
-            if uri.find("/api/v1/") > 0 and disabled_msg and type(disabled_msg) is str and text:
+            if text and uri.find("/api/v1/") > 0 and type(disabled_msg) is str:
                 logger.debug("Appending text to message: {}".format(disabled_msg))
                 command_args[2]["text"] = text + ": " + disabled_msg
 

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -322,7 +322,8 @@ def handle_disabled_project(config, project_name, disabled_msg):
             if type(data) is dict:
                 text = data.get("text")
             if text and uri.find("/api/v1/") > 0 and type(disabled_msg) is str:
-                logger.debug("Appending text to message: {}".format(disabled_msg))
+                logger.debug("Appending text to message: {}".
+                             format(disabled_msg))
                 command_args[2]["text"] = text + ": " + disabled_msg
 
             r = call_rest_api(disabled_command, PROJECT_SUBST, project_name)
@@ -381,7 +382,8 @@ def mirror_project(config, project_name, check_changes, uri,
     if project_config:
         if project_config.get(DISABLED_PROPERTY):
             handle_disabled_project(config, project_name,
-                                    project_config.get(DISABLED_REASON_PROPERTY))
+                                    project_config.
+                                    get(DISABLED_REASON_PROPERTY))
             logger.info("Project '{}' disabled, exiting".
                         format(project_name))
             return CONTINUE_EXITVAL

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -316,7 +316,10 @@ def handle_disabled_project(config, project_name, disabled_msg):
             # Is this perhaps OpenGrok API call to supply a Message ?
             # If so and there was a string supplied, append it
             # to the message text.
-            text = command_args[2].get("text")
+            data = command_args[2]
+            text = None
+            if type(data) is dict:
+                text = data.get("text")
             if text and uri.find("/api/v1/") > 0 and type(disabled_msg) is str:
                 logger.debug("Appending text to message: {}".format(disabled_msg))
                 command_args[2]["text"] = text + ": " + disabled_msg

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -226,15 +226,17 @@ def test_disabled_command_api_text_append(monkeypatch):
                   mock_call_rest_api)
 
         project_name = "foo"
-        data = {'messageLevel': 'info', 'duration': 'PT5M', 'tags': ['%PROJECT%'],
+        data = {'messageLevel': 'info', 'duration': 'PT5M',
+                'tags': ['%PROJECT%'],
                 'text': 'disabled project'}
         config = {DISABLED_CMD_PROPERTY:
-                      {COMMAND_PROPERTY:
-                           ["http://localhost:8080/source/api/v1/foo",
-                            "POST", data]},
+                  {COMMAND_PROPERTY:
+                   ["http://localhost:8080/source/api/v1/foo",
+                    "POST", data]},
                   PROJECTS_PROPERTY: {project_name:
-                                          {DISABLED_REASON_PROPERTY: text_to_append,
-                                           DISABLED_PROPERTY: True}}}
+                                      {DISABLED_REASON_PROPERTY:
+                                       text_to_append,
+                                       DISABLED_PROPERTY: True}}}
 
         mirror_project(config, project_name, False, None, None)
 

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -39,7 +39,7 @@ from opengrok_tools.utils.mirror import check_project_configuration, \
     check_configuration, mirror_project, run_command, get_repos_for_project, \
     HOOKS_PROPERTY, PROXY_PROPERTY, IGNORED_REPOS_PROPERTY, \
     PROJECTS_PROPERTY, DISABLED_CMD_PROPERTY, DISABLED_PROPERTY, \
-    CMD_TIMEOUT_PROPERTY, HOOK_TIMEOUT_PROPERTY
+    CMD_TIMEOUT_PROPERTY, HOOK_TIMEOUT_PROPERTY, DISABLED_REASON_PROPERTY
 import opengrok_tools.mirror
 from opengrok_tools.utils.exitvals import (
     CONTINUE_EXITVAL, FAILURE_EXITVAL
@@ -232,7 +232,9 @@ def test_disabled_command_api_text_append(monkeypatch):
                       {COMMAND_PROPERTY:
                            ["http://localhost:8080/source/api/v1/foo",
                             "POST", data]},
-                  PROJECTS_PROPERTY: {project_name: {DISABLED_PROPERTY: text_to_append}}}
+                  PROJECTS_PROPERTY: {project_name:
+                                          {DISABLED_REASON_PROPERTY: text_to_append,
+                                           DISABLED_PROPERTY: True}}}
 
         mirror_project(config, project_name, False, None, None)
 

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -181,6 +181,10 @@ def test_empty_project_config():
 
 
 def test_disabled_command_api():
+    """
+    Test that mirror_project() calls call_rest_api() if API
+    call is specified in the configuration for disabled project.
+    """
     with patch(opengrok_tools.utils.mirror.call_rest_api,
                lambda a, b, c: mock(spec=requests.Response)):
         project_name = "foo"


### PR DESCRIPTION
In order to make operational aspect easier, it would help if the cause of disabled projects could be propagated to the UI when using the `opengrok-mirror` script. The `disabled: true` behavior will be preserved however if the value is a string, it will be appended to the message. I.e. when running the tool with this config:
```yaml
disabled_command:
  command:
    - http://localhost:8080/source/api/v1/messages
    - POST
    - messageLevel: info
      duration: PT5M
      tags: ['%PROJECT%']
      text: disabled project
projects:
  opengrok:
    disabled: true
  opengrok-1.0:
    disabled: true
    disabled-reason: "foo bar"
```
the `opengrok` project's disabled message will be:
```json
{"messageLevel": "info", "duration": "PT5M", "tags": ["opengrok"], "text": "disabled project"}
```
while `opengrok-1.0`'s will be:
```json
{"messageLevel": "info", "duration": "PT5M", "tags": ["opengrok-1.0"], "text": "disabled project: foo bar"}
```