### PR TITLE
Regular readable time

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.index;
@@ -46,9 +46,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.Progress;
+import org.opengrok.indexer.util.StringUtils;
 import org.opengrok.indexer.util.TandemPath;
 
 /**
@@ -173,24 +173,27 @@ class PendingFileCompleter {
     public int complete() throws IOException {
         Instant start = Instant.now();
         int numDeletions = completeDeletions();
-        LOGGER.log(Level.FINE, "deleted {0} file(s) (took {1})",
-                new Object[]{numDeletions, DurationFormatUtils.
-                        formatDurationWords(Duration.between(start, Instant.now()).toMillis(),
-                        true, true)});
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, "deleted {0} file(s) (took {1})",
+                    new Object[] {numDeletions, StringUtils.getReadableTime(
+                            Duration.between(start, Instant.now()).toMillis())});
+        }
 
         start = Instant.now();
         int numRenamings = completeRenamings();
-        LOGGER.log(Level.FINE, "renamed {0} file(s) (took {1})",
-                new Object[]{numRenamings, DurationFormatUtils.
-                        formatDurationWords(Duration.between(start, Instant.now()).toMillis(),
-                true, true)});
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, "renamed {0} file(s) (took {1})",
+                    new Object[] {numRenamings, StringUtils.getReadableTime(
+                            Duration.between(start, Instant.now()).toMillis())});
+        }
 
         start = Instant.now();
         int numLinkages = completeLinkages();
-        LOGGER.log(Level.FINE, "affirmed links for {0} path(s) (took {1})",
-                new Object[]{numLinkages, DurationFormatUtils.
-                        formatDurationWords(Duration.between(start, Instant.now()).toMillis(),
-                        true, true)});
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, "affirmed links for {0} path(s) (took {1})",
+                    new Object[] {numLinkages, StringUtils.getReadableTime(
+                            Duration.between(start, Instant.now()).toMillis())});
+        }
 
         return numDeletions + numRenamings + numLinkages;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StringUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StringUtils.java
@@ -124,45 +124,53 @@ public final class StringUtils {
         return javaClassPattern.matcher(s).matches();
     }
 
-  /**
-   * Convert value in milliseconds to readable time.
-   * @param time_ms delta in milliseconds
-   * @return human readable string   
-   */
-  public static String getReadableTime(long time_ms) {
-      String output = "";
-      long time_delta = time_ms;
+    /**
+     * Convert value in milliseconds to readable time.
+     * @param time_ms delta in milliseconds
+     * @return human readable string
+     */
+    public static String getReadableTime(long time_ms) {
+        StringBuilder output = new StringBuilder();
+        long time_delta = time_ms;
 
-      int milliseconds = (int) (time_delta % 1000);
-      time_delta /= 1000;
-      int seconds = (int) (time_delta % 60);
-      time_delta /= 60;
-      int minutes = (int) (time_delta % 60);
-      time_delta /= 60;
-      int hours = (int) (time_delta % 24);
-      int days = (int) (time_delta / 24);
+        int milliseconds = (int) (time_delta % 1000);
+        time_delta /= 1000;
+        int seconds = (int) (time_delta % 60);
+        time_delta /= 60;
+        int minutes = (int) (time_delta % 60);
+        time_delta /= 60;
+        int hours = (int) (time_delta % 24);
+        int days = (int) (time_delta / 24);
 
-      if (days != 0) {
-          output += String.format("%d day", days);
-          if (days > 1) {
-              output += "s";
-          }
-          if ((hours != 0) || (minutes != 0) || (seconds != 0)) {
-              output += " ";
-          }
-      }
-      if ((hours != 0) || (minutes != 0)) {
-          return output + String.format("%d:%02d:%02d", hours, minutes, seconds);
-      }
-      if (seconds != 0) {
-          return output + String.format("%d.%d seconds", seconds, milliseconds);
-      }
-      if (milliseconds != 0) {
-          return output + String.format("%d ms", milliseconds);
-      }
+        if (days != 0) {
+            output.append(days);
+            output.append(" day");
+            if (days > 1) {
+                output.append("s");
+            }
+        }
+        if ((hours != 0) || (minutes != 0)) {
+            if (output.length() > 0) {
+                // Use zero-padded hours here as it's longer than a day.
+                output.append(String.format(" %02d:%02d:%02d", hours, minutes, seconds));
+            } else {
+                // Don't pad hours if less than a day.
+                output.append(String.format("%d:%02d:%02d", hours, minutes, seconds));
+            }
+        } else if (output.length() > 0) {
+            /*
+             * If a day+ with zero hours and zero minutes, just report the days.
+             * E.g. "1 day", and not "1 day 35 ms".
+             */
+            return output.toString();
+        } else if (seconds != 0) {
+            output.append(String.format("%d.%d seconds", seconds, milliseconds));
+        } else if (milliseconds != 0) {
+            output.append(String.format("%d ms", milliseconds));
+        }
 
-      return (output.length() == 0 ? "0" : output);
-  }
+        return (output.length() == 0 ? "0 ms" : output.toString());
+    }
 
     /**
      * Finds n-th index of a given substring in a string.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StringUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StringUtils.java
@@ -116,13 +116,13 @@ public final class StringUtils {
      * @return true if string could be a java class name
     */
     public static boolean isPossiblyJavaClass(String s) {
-    // Only match a small subset of possible class names to prevent false
-    // positives:
-    //    - class must be qualified with a package name
-    //    - only letters in package name, starting with lower case
-    //    - class name must be in CamelCase, starting with upper case
-    return javaClassPattern.matcher(s).matches();
-  }
+        // Only match a small subset of possible class names to prevent false
+        // positives:
+        //    - class must be qualified with a package name
+        //    - only letters in package name, starting with lower case
+        //    - class name must be in CamelCase, starting with upper case
+        return javaClassPattern.matcher(s).matches();
+    }
 
   /**
    * Convert value in milliseconds to readable time.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StringUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/StringUtils.java
@@ -110,17 +110,18 @@ public final class StringUtils {
     static final Pattern javaClassPattern =
         Pattern.compile("([a-z][A-Za-z]*\\.)+[A-Z][A-Za-z0-9]*");
     /**
-     * Returns true if the string is possibly a full java class name.
+     * Returns true if the string is possibly a Java class name, and only
+     * matching a subset of possible class names to prevent false positives.
+     * <p><ul>
+     *     <li>class must be qualified with a package name</li>
+     *     <li>package name must contain only letters and start lower case</li>
+     *     <li>class name must be in CamelCase and start upper case</li>
+     * </ul>
      *
      * @param s the string to be checked
      * @return true if string could be a java class name
     */
     public static boolean isPossiblyJavaClass(String s) {
-        // Only match a small subset of possible class names to prevent false
-        // positives:
-        //    - class must be qualified with a package name
-        //    - only letters in package name, starting with lower case
-        //    - class name must be in CamelCase, starting with upper case
         return javaClassPattern.matcher(s).matches();
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/StringUtilsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/StringUtilsTest.java
@@ -39,12 +39,12 @@ public class StringUtilsTest {
         int i;
         long[] values = {
             0, 100, 1000, 1500, 64000, 124531, 3651782, 86400000, 86434349,
-            1075634299, 86480001
+            1075634299, 86480001, 86400001
         };
         String[] expected = {
             "0 ms", "100 ms", "1.0 seconds", "1.500 seconds", "0:01:04",
             "0:02:04", "1:00:51", "1 day", "1 day",
-            "12 days 10:47:14", "1 day 00:01:20"
+            "12 days 10:47:14", "1 day 00:01:20", "1 day"
         };
 
         for (i = 0; i < values.length; i++) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/StringUtilsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/StringUtilsTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.util;
 
@@ -39,12 +39,12 @@ public class StringUtilsTest {
         int i;
         long[] values = {
             0, 100, 1000, 1500, 64000, 124531, 3651782, 86400000, 86434349,
-            1075634299
+            1075634299, 86480001
         };
         String[] expected = {
-            "0", "100 ms", "1.0 seconds", "1.500 seconds", "0:01:04",
-            "0:02:04", "1:00:51", "1 day", "1 day 34.349 seconds",
-            "12 days 10:47:14"
+            "0 ms", "100 ms", "1.0 seconds", "1.500 seconds", "0:01:04",
+            "0:02:04", "1:00:51", "1 day", "1 day",
+            "12 days 10:47:14", "1 day 00:01:20"
         };
 
         for (i = 0; i < values.length; i++) {


### PR DESCRIPTION
Hello,

Please consider for integration this patch so `PendingFileCompleter` uses the regular OpenGrok `getReadableTime()` instead of `DurationFormatUtils` so that sub-second detail is provided.

`StringUtils.getReadableTime()` is updated to use `StringBuilder` and to avoid some pointless high-precision (e.g., "1 day 35 ms") when for other intervals milliseconds are not shown. It is also updated not just to report "0" for near-instant intervals but "0 ms".

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
