### PR TITLE
fix equivalence check in Command class

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/projadm.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/projadm.py
@@ -66,7 +66,7 @@ def exec_command(doit, logger, cmd, msg):
         logger.info(cmd)
         return
     cmd.execute()
-    if cmd.getstate() is not Command.FINISHED \
+    if cmd.getstate() != Command.FINISHED \
             or cmd.getretcode() != SUCCESS_EXITVAL:
         logger.error(msg)
         logger.error("Standard output: {}".format(cmd.getoutput()))

--- a/opengrok-tools/src/main/python/opengrok_tools/projadm.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/projadm.py
@@ -27,7 +27,6 @@
 """
 
 import argparse
-import io
 import os
 import shutil
 import sys

--- a/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
@@ -380,19 +380,19 @@ class Command:
             self.set_resource_limit(name, value)
 
     def getretcode(self):
-        if self.state is not Command.FINISHED:
+        if self.state != Command.FINISHED:
             return None
         else:
             return self.returncode
 
     def getoutputstr(self):
-        if self.state is Command.FINISHED:
+        if self.state != Command.FINISHED:
             return "".join(self.out).strip()
         else:
             return None
 
     def getoutput(self):
-        if self.state is Command.FINISHED:
+        if self.state != Command.FINISHED:
             return self.out
         else:
             return None


### PR DESCRIPTION
This change fixes some equivalence checks (as opposed to identity checks) as reported by lgtm.com.
