### PR TITLE
Fix #3145 : buffer for analysis

### DIFF
--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -239,7 +239,7 @@ document.pageReady.push(function() { pageReadyList();});
             if (cfg.annotate()) {
                 // annotate
                 BufferedInputStream bin =
-                    new BufferedInputStream(new FileInputStream(resourceFile));
+                        new BufferedInputStream(new FileInputStream(resourceFile));
                 try {
                     AnalyzerFactory a = AnalyzerGuru.find(basename);
                     AbstractAnalyzer.Genre g = AnalyzerGuru.getGenre(a);
@@ -310,13 +310,12 @@ Click <a href="<%= rawPath %>">download <%= basename %></a><%
                 File tempf = null;
                 try {
                     if (rev.equals(DUMMY_REVISION)) {
-                        in = new FileInputStream(resourceFile);
+                        in = new BufferedInputStream(new FileInputStream(resourceFile));
                     } else {
                         tempf = File.createTempFile("ogtags", basename);
                         if (HistoryGuru.getInstance().getRevision(tempf,
                                 resourceFile.getParent(), basename, rev)) {
-                            in = new BufferedInputStream(
-                                    new FileInputStream(tempf));
+                            in = new BufferedInputStream(new FileInputStream(tempf));
                         } else {
                             tempf.delete();
                             tempf = null;


### PR DESCRIPTION
Hello,

Please consider for integration this patch to create a `BufferedInputStream` for when `AnalyzerGuru` needs to `mark()` and `reset()` in `--economical` mode.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
