### PR TITLE
Fix #3028 : on Clear, reset the radio to Any

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Scripts.java
@@ -110,8 +110,8 @@ public class Scripts implements Iterable<Scripts.Script> {
         putjs("jquery-ui", "js/jquery-ui-1.12.1-custom", 11);
         putjs("jquery-tablesorter", "js/jquery-tablesorter-2.26.6", 12);
         putjs("tablesorter-parsers", "js/tablesorter-parsers-0.0.2", 13, true);
-        putjs("searchable-option-list", "js/searchable-option-list-2.0.13", 14);
-        putjs("utils", "js/utils-0.0.35", 15, true);
+        putjs("searchable-option-list", "js/searchable-option-list-2.0.14", 14);
+        putjs("utils", "js/utils-0.0.36", 15, true);
         putjs("repos", "js/repos-0.0.2", 20, true);
         putjs("diff", "js/diff-0.0.4", 20, true);
         putjs("jquery-caret", "js/jquery.caret-1.5.2", 25);

--- a/opengrok-web/src/main/webapp/js/searchable-option-list-2.0.14.js
+++ b/opengrok-web/src/main/webapp/js/searchable-option-list-2.0.14.js
@@ -1317,6 +1317,19 @@
             }
         },
 
+        selectRadio: function(val) {
+            this.$selectionContainer.find('input[type="radio"]')
+                .each(function (index, item) {
+                    var $currentOptionItem = $(item);
+                    if ($currentOptionItem.val() === val) {
+                        if (!$currentOptionItem.is(':checked')) {
+                            $currentOptionItem.prop("checked", true).trigger('change', true);
+                        }
+                        return false;
+                    }
+                });
+        },
+
         getSelection: function () {
             return this.$selection.find('input:checked');
         }

--- a/opengrok-web/src/main/webapp/js/utils-0.0.36.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.36.js
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 
 /**
@@ -2169,7 +2169,7 @@ function clearSearchFrom() {
     $("#sbox input[type='text']").each(function () {
         $(this).val("");
     });
-    $("#type :selected").prop("selected", false);
+    $("#type").searchableOptionList().selectRadio("");
 }
 
 function getSelectedProjectNames() {


### PR DESCRIPTION
Hello,

Please consider for integration this patch to reset the `#type` radio to Any when one clicks to Clear.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
