### PR TITLE
Resolve #3010 : add --nestingMaximum switch

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, Aleksandr Kirillov <alexkirillovsamara@gmail.com>.
  */
 package org.opengrok.indexer.configuration;
@@ -206,6 +206,7 @@ public final class Configuration {
     private boolean lastEditedDisplayMode;
     private String CTagsExtraOptionsFile;
     private int scanningDepth;
+    private int nestingMaximum;
     private Set<String> allowedSymlinks;
     private Set<String> canonicalRoots;
     private boolean obfuscatingEMailAddresses;
@@ -356,6 +357,26 @@ public final class Configuration {
         this.scanningDepth = scanningDepth;
     }
 
+    /**
+     * Gets the nesting maximum of repositories. Default is 1.
+     */
+    public int getNestingMaximum() {
+        return nestingMaximum;
+    }
+
+    /**
+     * Sets the nesting maximum of repositories to a specified value.
+     * @param nestingMaximum the new value
+     * @throws IllegalArgumentException if {@code nestingMaximum} is negative
+     */
+    public void setNestingMaximum(int nestingMaximum) throws IllegalArgumentException {
+        if (nestingMaximum < 0) {
+            throw new IllegalArgumentException(
+                    String.format(NEGATIVE_NUMBER_ERROR, "nestingMaximum", nestingMaximum));
+        }
+        this.nestingMaximum = nestingMaximum;
+    }
+
     public int getCommandTimeout() {
         return commandTimeout;
     }
@@ -487,6 +508,7 @@ public final class Configuration {
         setMaxRevisionThreadCount(Runtime.getRuntime().availableProcessors());
         setMessageLimit(500);
         setNavigateWindowEnabled(false);
+        setNestingMaximum(1);
         setOptimizeDatabase(true);
         setPluginDirectory(null);
         setPluginStack(new AuthorizationStack(AuthControlFlag.REQUIRED, "default stack"));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -214,6 +214,14 @@ public final class RuntimeEnvironment {
         syncWriteConfiguration(scanningDepth, Configuration::setScanningDepth);
     }
 
+    public int getNestingMaximum() {
+        return syncReadConfiguration(Configuration::getNestingMaximum);
+    }
+
+    public void setNestingMaximum(int nestingMaximum) {
+        syncWriteConfiguration(nestingMaximum, Configuration::setNestingMaximum);
+    }
+
     public int getCommandTimeout() {
         return syncReadConfiguration(Configuration::getCommandTimeout);
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -599,6 +599,10 @@ public final class Indexer {
                     "files), but process all other command line options.").Do(v ->
                     runIndex = false);
 
+            parser.on("--nestingMaximum", "=number",
+                    "Maximum of nested repositories. Default is 1.").Do(v ->
+                    cfg.setNestingMaximum((Integer) v));
+
             parser.on("-O", "--optimize", "=on|off", ON_OFF, Boolean.class,
                     "Turn on/off the optimization of the index database as part of the",
                     "indexing step. Default is on.").

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -208,7 +208,7 @@ public class ProjectsController {
 
     @DELETE
     @Path("/{project}/historycache")
-    public void deleteHistoryCache(@PathParam("project") String projectName) throws HistoryException {
+    public void deleteHistoryCache(@PathParam("project") String projectName) {
         // Avoid classification as a taint bug.
         projectName = Laundromat.launderInput(projectName);
 


### PR DESCRIPTION
Hello,

Please consider for integration this patch to add a `--nestingMaximum` switch to help user @sirisan who has a `RepoRepository` setup with two levels of nesting.

Default will continue to be just one level.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
