### PR TITLE
Redirect when 1 hit for query of just PATH

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/QueryBuilder.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/QueryBuilder.java
@@ -347,6 +347,19 @@ public class QueryBuilder {
     }
 
     /**
+     * Gets a value indicating if this search only has defined the {@link #PATH}
+     * query field.
+     */
+    public boolean isPathSearch() {
+        return ((getQueryText(FULL) == null)
+                && (getQueryText(REFS) == null)
+                && (getQueryText(PATH) != null)
+                && (getQueryText(HIST) == null)
+                && (getQueryText(DIRPATH) == null)
+                && (getQueryText(DEFS) == null));
+    }
+
+    /**
      * Build a new query based on the query text that has been passed in to this
      * builder.
      *

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -400,7 +400,11 @@ public class SearchHelper {
                 if (isCrossRefSearch && query instanceof TermQuery && builder.getDefs() != null) {
                     maybeRedirectToDefinition(docID, (TermQuery) query);
                 } else if (isGuiSearch) {
-                    maybeRedirectToMatchOffset(docID, builder.getContextFields());
+                    if (builder.isPathSearch()) {
+                        redirectToFile(docID);
+                    } else {
+                        maybeRedirectToMatchOffset(docID, builder.getContextFields());
+                    }
                 }
             }
         } catch (IOException | ClassNotFoundException e) {
@@ -475,6 +479,11 @@ public class SearchHelper {
                         + '?' + QueryParameters.MATCH_OFFSET_PARAM_EQ + offset;
             }
         }
+    }
+
+    private void redirectToFile(int docID) throws IOException {
+        Document doc = searcher.doc(docID);
+        redirect = contextPath + Prefix.XREF_P + Util.URIEncodePath(doc.get(QueryBuilder.PATH));
     }
 
     private static final Pattern TABSPACE = Pattern.compile("[\t ]+");


### PR DESCRIPTION
Hello,

Please consider for integration this patch to redirect directly to a file when a search by `PATH` alone produces a single hit.

I noticed this when clicking on OpenGrok's linking of something file-like or path-like (in a comment for example), and I was taken to a search result with one item. This feels weird given the recent #3053.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
