### PR TITLE
docker: Fix OPENGROK_WEBAPP_CONTEXT behaviour.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,13 +69,6 @@ ENV CATALINA_TMPDIR /usr/local/tomcat/temp
 ENV PATH $CATALINA_HOME/bin:$PATH
 ENV CLASSPATH /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
 
-# custom deployment to / with redirect from /source
-RUN rm -rf /usr/local/tomcat/webapps/* && \
-    opengrok-deploy -c /opengrok/etc/configuration.xml \
-        /opengrok/lib/source.war /usr/local/tomcat/webapps/ROOT.war && \
-    mkdir "/usr/local/tomcat/webapps/source" && \
-    echo '<% response.sendRedirect("/"); %>' > "/usr/local/tomcat/webapps/source/index.jsp"
-
 # disable all file logging
 ADD docker/logging.properties /usr/local/tomcat/conf/logging.properties
 RUN sed -i -e 's/Valve/Disabled/' /usr/local/tomcat/conf/server.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,7 @@ RUN python3 -m pip install /opengrok/tools/opengrok-tools*
 # environment variables
 ENV SRC_ROOT /opengrok/src
 ENV DATA_ROOT /opengrok/data
-ENV OPENGROK_WEBAPP_CONTEXT /
-ENV OPENGROK_TOMCAT_BASE /usr/local/tomcat
+ENV URL_ROOT /
 ENV CATALINA_HOME /usr/local/tomcat
 ENV CATALINA_BASE /usr/local/tomcat
 ENV CATALINA_TMPDIR /usr/local/tomcat/temp

--- a/docker/README.md
+++ b/docker/README.md
@@ -75,6 +75,7 @@ The volume mounted to `/opengrok/src` should contain the projects you want to ma
 `REINDEX: <time_in_minutes>`<br/> *Optional* *Default: 10* | Period of automatic mirroring/reindexing. Setting to `0` will disable automatic indexing. You can manually trigger an reindex using docker exec: `docker exec <container> /scripts/index.sh`
 `INDEXER_OPT` | pass extra options to opengrok-indexer. For example, "-i d:vendor" will remove all the `*/vendor/*` files from the index. You can check the indexer options on https://github.com/oracle/opengrok/wiki/Python-scripts-transition-guide
 `NOMIRROR` | To avoid the mirroring step, set the variable to non-empty value.
+`OPENGROK_WEBAPP_CONTEXT`<br/> *Default: /* | Override the sub-URL that OpenGrok should run on.
 
 To specify environment variable for `docker run`, use the `-e` option, e.g. `-e REINDEX=30`
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -75,7 +75,7 @@ The volume mounted to `/opengrok/src` should contain the projects you want to ma
 `REINDEX: <time_in_minutes>`<br/> *Optional* *Default: 10* | Period of automatic mirroring/reindexing. Setting to `0` will disable automatic indexing. You can manually trigger an reindex using docker exec: `docker exec <container> /scripts/index.sh`
 `INDEXER_OPT` | pass extra options to opengrok-indexer. For example, "-i d:vendor" will remove all the `*/vendor/*` files from the index. You can check the indexer options on https://github.com/oracle/opengrok/wiki/Python-scripts-transition-guide
 `NOMIRROR` | To avoid the mirroring step, set the variable to non-empty value.
-`OPENGROK_WEBAPP_CONTEXT`<br/> *Default: /* | Override the sub-URL that OpenGrok should run on.
+`URL_ROOT`<br/> *Default: /* | Override the sub-URL that OpenGrok should run on.
 
 To specify environment variable for `docker run`, use the `-e` option, e.g. `-e REINDEX=30`
 

--- a/docker/index.sh
+++ b/docker/index.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 LOCKFILE=/var/run/opengrok-indexer
-URI="http://localhost:8080"
+URI="http://localhost:8080/${OPENGROK_WEBAPP_CONTEXT#/}"
 # $OPS can be overwritten by environment variable
 OPS=${INDEXER_FLAGS:='-H -P -S -G'}
 

--- a/docker/index.sh
+++ b/docker/index.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 LOCKFILE=/var/run/opengrok-indexer
-URI="http://localhost:8080/${OPENGROK_WEBAPP_CONTEXT#/}"
+URI="http://localhost:8080/${URL_ROOT#/}"
 # $OPS can be overwritten by environment variable
 OPS=${INDEXER_FLAGS:='-H -P -S -G'}
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,10 +5,29 @@ if [ -z "$REINDEX" ]; then
 	REINDEX=10
 fi
 
+if [ "${OPENGROK_WEBAPP_CONTEXT}" = "/" ]; then
+	WAR_NAME="ROOT.war"
+else
+	WAR_NAME="${OPENGROK_WEBAPP_CONTEXT#/}.war"
+fi
+
+if [ ! -f "/usr/local/tomcat/webapps/${WAR_NAME}" ]; then
+	date +"%F %T Deployment path changed. Redeploying..."
+
+	# Delete old deployment and (re)deploy
+	rm -rf /usr/local/tomcat/webapps/*
+	opengrok-deploy -c /opengrok/etc/configuration.xml \
+            /opengrok/lib/source.war /usr/local/tomcat/webapps/${WAR_NAME}
+
+	# Set up redirect from /source
+	mkdir "/usr/local/tomcat/webapps/source"
+	echo "<% response.sendRedirect(\"${OPENGROK_WEBAPP_CONTEXT}\"); %>" > "/usr/local/tomcat/webapps/source/index.jsp"
+fi
+
 indexer(){
 	# Wait for Tomcat startup.
 	date +"%F %T Waiting for Tomcat startup..."
-	while [ "`curl --silent --write-out '%{response_code}' -o /dev/null 'http://localhost:8080/'`" == "000" ]; do
+	while [ "`curl --silent --write-out '%{response_code}' -o /dev/null 'http://localhost:8080/${OPENGROK_WEBAPP_CONTEXT#/}'`" == "000" ]; do
 		sleep 1;
 	done
 	date +"%F %T Startup finished"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -17,7 +17,7 @@ if [ ! -f "/usr/local/tomcat/webapps/${WAR_NAME}" ]; then
 	# Delete old deployment and (re)deploy
 	rm -rf /usr/local/tomcat/webapps/*
 	opengrok-deploy -c /opengrok/etc/configuration.xml \
-            /opengrok/lib/source.war /usr/local/tomcat/webapps/${WAR_NAME}
+            /opengrok/lib/source.war "/usr/local/tomcat/webapps/${WAR_NAME}"
 
 	# Set up redirect from /source
 	mkdir "/usr/local/tomcat/webapps/source"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,19 +5,19 @@ if [ -z "$REINDEX" ]; then
 	REINDEX=10
 fi
 
-if [[ "${OPENGROK_WEBAPP_CONTEXT}" = *" "* ]]; then
+if [[ "${URL_ROOT}" = *" "* ]]; then
 	date +"%F %T Deployment path contains spaces. Deploying to root..."
-	export OPENGROK_WEBAPP_CONTEXT="/"
+	export URL_ROOT="/"
 fi
 
 # Remove leading and trailing slashes
-OPENGROK_WEBAPP_CONTEXT="${OPENGROK_WEBAPP_CONTEXT#/}"
-OPENGROK_WEBAPP_CONTEXT="${OPENGROK_WEBAPP_CONTEXT%/}"
+URL_ROOT="${URL_ROOT#/}"
+URL_ROOT="${URL_ROOT%/}"
 
-if [ "${OPENGROK_WEBAPP_CONTEXT}" = "" ]; then
+if [ "${URL_ROOT}" = "" ]; then
 	WAR_NAME="ROOT.war"
 else
-	WAR_NAME="${OPENGROK_WEBAPP_CONTEXT//\//#}.war"
+	WAR_NAME="${URL_ROOT//\//#}.war"
 fi
 
 if [ ! -f "/usr/local/tomcat/webapps/${WAR_NAME}" ]; then
@@ -30,13 +30,13 @@ if [ ! -f "/usr/local/tomcat/webapps/${WAR_NAME}" ]; then
 
 	# Set up redirect from /source
 	mkdir "/usr/local/tomcat/webapps/source"
-	echo "<% response.sendRedirect(\"/${OPENGROK_WEBAPP_CONTEXT}\"); %>" > "/usr/local/tomcat/webapps/source/index.jsp"
+	echo "<% response.sendRedirect(\"/${URL_ROOT}\"); %>" > "/usr/local/tomcat/webapps/source/index.jsp"
 fi
 
 indexer(){
 	# Wait for Tomcat startup.
 	date +"%F %T Waiting for Tomcat startup..."
-	while [ "`curl --silent --write-out '%{response_code}' -o /dev/null 'http://localhost:8080/${OPENGROK_WEBAPP_CONTEXT#/}'`" == "000" ]; do
+	while [ "`curl --silent --write-out '%{response_code}' -o /dev/null 'http://localhost:8080/${URL_ROOT}'`" == "000" ]; do
 		sleep 1;
 	done
 	date +"%F %T Startup finished"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,15 +5,19 @@ if [ -z "$REINDEX" ]; then
 	REINDEX=10
 fi
 
-if [[ -z "${OPENGROK_WEBAPP_CONTEXT}" || "${OPENGROK_WEBAPP_CONTEXT}" = *" "* ]]; then
-	date +"%F %T Deployment path is empty or contains spaces. Deploying to root..."
+if [[ "${OPENGROK_WEBAPP_CONTEXT}" = *" "* ]]; then
+	date +"%F %T Deployment path contains spaces. Deploying to root..."
 	export OPENGROK_WEBAPP_CONTEXT="/"
 fi
 
-if [ "${OPENGROK_WEBAPP_CONTEXT}" = "/" ]; then
+# Remove leading and trailing slashes
+OPENGROK_WEBAPP_CONTEXT="${OPENGROK_WEBAPP_CONTEXT#/}"
+OPENGROK_WEBAPP_CONTEXT="${OPENGROK_WEBAPP_CONTEXT%/}"
+
+if [ "${OPENGROK_WEBAPP_CONTEXT}" = "" ]; then
 	WAR_NAME="ROOT.war"
 else
-	WAR_NAME="${OPENGROK_WEBAPP_CONTEXT#/}.war"
+	WAR_NAME="${OPENGROK_WEBAPP_CONTEXT//\//#}.war"
 fi
 
 if [ ! -f "/usr/local/tomcat/webapps/${WAR_NAME}" ]; then
@@ -26,7 +30,7 @@ if [ ! -f "/usr/local/tomcat/webapps/${WAR_NAME}" ]; then
 
 	# Set up redirect from /source
 	mkdir "/usr/local/tomcat/webapps/source"
-	echo "<% response.sendRedirect(\"${OPENGROK_WEBAPP_CONTEXT}\"); %>" > "/usr/local/tomcat/webapps/source/index.jsp"
+	echo "<% response.sendRedirect(\"/${OPENGROK_WEBAPP_CONTEXT}\"); %>" > "/usr/local/tomcat/webapps/source/index.jsp"
 fi
 
 indexer(){

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,6 +5,11 @@ if [ -z "$REINDEX" ]; then
 	REINDEX=10
 fi
 
+if [[ -z "${OPENGROK_WEBAPP_CONTEXT}" || "${OPENGROK_WEBAPP_CONTEXT}" = *" "* ]]; then
+	date +"%F %T Deployment path is empty or contains spaces. Deploying to root..."
+	export OPENGROK_WEBAPP_CONTEXT="/"
+fi
+
 if [ "${OPENGROK_WEBAPP_CONTEXT}" = "/" ]; then
 	WAR_NAME="ROOT.war"
 else


### PR DESCRIPTION
This allows the user to correctly specify the URL subfolder that OpenGrok should run on,
and the container appropriately reacts without having to fully rebuild it.

Fixes: #3153 