### PR TITLE
Fix to expand tabs as necessary for matchOffset

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1791,6 +1791,13 @@ public final class PageConfig {
         return Paths.get(root).relativize(Paths.get(path)).toString();
     }
 
+    /**
+     * Determines whether a match offset from a search result has been
+     * indicated, and if so tries to calculate a translated xref fragment
+     * identifier.
+     * @return {@code true} if an xref fragment identifier was calculated by
+     * the call to this method
+     */
     public boolean evaluateMatchOffset() {
         if (fragmentIdentifier == null) {
             int matchOffset = getIntParam(QueryParameters.MATCH_OFFSET_PARAM, -1);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/PageConfig.java
@@ -1800,7 +1800,7 @@ public final class PageConfig {
                     LineBreaker breaker = new LineBreaker();
                     StreamSource streamSource = StreamSource.fromFile(resourceFile);
                     try {
-                        breaker.reset(streamSource);
+                        breaker.reset(streamSource, in -> ExpandTabsReader.wrap(in, getProject()));
                         int matchLine = breaker.findLineIndex(matchOffset);
                         if (matchLine >= 0) {
                             // Convert to 1-based offset to accord with OpenGrok line number.


### PR DESCRIPTION
Hello,

This is a fix for redirect-to-match-offset to accommodate projects where tabs are expanded.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
