### PR TITLE
Add mirroring support for Perforce repositories

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
@@ -1,0 +1,52 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+#
+
+from ..utils.command import Command
+from .repository import Repository, RepositoryException
+from shutil import which
+
+
+class PerforceRepository(Repository):
+    def __init__(self, logger, path, project, command, env, hooks, timeout):
+
+        super().__init__(logger, path, project, command, env, hooks, timeout)
+
+        if command:
+            self.command = command
+        else:
+            self.command = which("p4")
+
+        if not self.command:
+            raise RepositoryException("Cannot get perforce command")
+
+    def reposync(self):
+        perforce_command = [self.command, "sync"]
+        cmd = self.getCommand(perforce_command, work_dir=self.path,
+                              env_vars=self.env, logger=self.logger)
+        cmd.execute()
+        self.logger.info("output of {}:".format(perforce_command))
+        self.logger.info(cmd.getoutputstr())
+        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
+            cmd.log_error("failed to perform sync")
+            return 1
+        return 0

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
@@ -20,6 +20,7 @@
 #
 # Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 #
+# Portions Copyright 2020 Robert Williams
 
 from ..utils.command import Command
 from .repository import Repository, RepositoryException

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repofactory.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repofactory.py
@@ -20,6 +20,7 @@
 #
 # Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
 #
+# Portions Copyright 2020 Robert Williams
 
 import logging
 

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repofactory.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repofactory.py
@@ -26,6 +26,7 @@ import logging
 from .cvs import CVSRepository
 from .git import GitRepository
 from .mercurial import MercurialRepository
+from .perforce import PerforceRepository
 from .repo import RepoRepository
 from .svn import SubversionRepository
 from .teamware import TeamwareRepository
@@ -74,6 +75,10 @@ def get_repository(path, repo_type, project,
         return GitRepository(logger, path, project,
                              commands.get("git"),
                              env, hooks, timeout)
+    elif repo_lower == "perforce":
+        return PerforceRepository(logger, path, project,
+                                  commands.get("perforce"),
+                                  env, hooks, timeout)
     elif repo_lower == "repo":
         return RepoRepository(logger, path, project,
                               commands.get("repo"),


### PR DESCRIPTION
Although opengrok supports Perforce for history, the opengrok-mirror tool does not support syncing the repositories. It has some prerequisites, but only the same as for the history functionality. 

# OCA
I am signing on behalf of myself as an individual and no other person or entity, including my employer, has or will have rights with respect my contributions.