### PR TITLE
fix incoming check and test for newer git verions

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
@@ -46,7 +46,7 @@ class GitRepository(Repository):
                               env_vars=self.env, logger=self.logger)
         cmd.execute()
         if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
-            cmd.log_error("failed to perform pull")
+            cmd.log_error("failed to configure git pull.ff")
 
     def reposync(self):
         git_command = [self.command, "pull", "--ff-only"]

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
@@ -39,6 +39,15 @@ class GitRepository(Repository):
         if not self.command:
             raise RepositoryException("Cannot get git command")
 
+        # The incoming() check relies on empty output so configure
+        # the repository first to avoid getting extra output.
+        git_command = [self.command, "config", "--local", "pull.ff", "only"]
+        cmd = self.getCommand(git_command, work_dir=self.path,
+                              env_vars=self.env, logger=self.logger)
+        cmd.execute()
+        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
+            cmd.log_error("failed to perform pull")
+
     def reposync(self):
         git_command = [self.command, "pull", "--ff-only"]
         cmd = self.getCommand(git_command, work_dir=self.path,
@@ -58,7 +67,7 @@ class GitRepository(Repository):
                               env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info("output of {}:".format(git_command))
-        self.logger.info(cmd.geterroutputstr())
+        self.logger.info(len(cmd.geterroutputstr()))
         if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
             cmd.log_error("failed to perform pull")
             raise RepositoryException('failed to check for incoming in '

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
@@ -67,7 +67,6 @@ class GitRepository(Repository):
                               env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info("output of {}:".format(git_command))
-        self.logger.info(len(cmd.geterroutputstr()))
         if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
             cmd.log_error("failed to perform pull")
             raise RepositoryException('failed to check for incoming in '

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -160,6 +160,13 @@ def test_incoming_retval(monkeypatch):
 
         # Clone a Git repository so that it can pull.
         repo = Repo.init(repo_path)
+        new_file_path = os.path.join(repo_path, 'foo')
+        with open(new_file_path, 'w'):
+            pass
+        assert os.path.isfile(new_file_path)
+        index = repo.index
+        index.add([new_file_path])
+        index.commit("add file")
         repo.clone(cloned_repo_path)
 
         with monkeypatch.context() as m:


### PR DESCRIPTION
This fixes a build failure which is preventing a release.

The `git config` command works with both old and new version of Git.