### PR TITLE
delete ctags temp files at the end of indexing

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
  * Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
  */
@@ -1089,6 +1089,8 @@ public final class Indexer {
                     " for executor to finish", exp);
         }
         elapsed.report(LOGGER, "Done indexing data of all repositories");
+
+        CtagsUtil.deleteTempFiles();
     }
 
     public void refreshSearcherManagers(RuntimeEnvironment env, List<String> projects, String host) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
@@ -91,7 +91,7 @@ public class CtagsUtil {
         return result;
     }
 
-    public static void deleteTempFiles() throws IOException {
+    public static void deleteTempFiles() {
         String[] dirs = {System.getProperty("java.io.tmpdir"),
                 System.getenv("TMPDIR"), System.getenv("TMP")};
 
@@ -100,7 +100,7 @@ public class CtagsUtil {
         }
     }
 
-    private static void deleteTempFiles(String directoryName) throws IOException {
+    private static void deleteTempFiles(String directoryName) {
         final Pattern pattern = Pattern.compile("tags\\.\\S{6}"); // ctags uses this pattern to call mkstemp()
 
         if (directoryName == null) {
@@ -115,7 +115,11 @@ public class CtagsUtil {
 
         for (File file : files) {
             if (file.isFile()) {
-                Files.deleteIfExists(file.toPath());
+                try {
+                    Files.deleteIfExists(file.toPath());
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING, "cannot delete file", e);
+                }
             }
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
@@ -114,8 +114,9 @@ public class CtagsUtil {
         });
 
         for (File file : files) {
-            System.out.println(file);
-            Files.deleteIfExists(file.toPath());
+            if (file.isFile()) {
+                Files.deleteIfExists(file.toPath());
+            }
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
@@ -30,8 +30,6 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
@@ -90,8 +90,8 @@ public class CtagsUtil {
     }
 
     /**
-     * Deletes ctags temporary files left over after terminating ctags processes
-     * in case of timeout, {@see Ctags#doCtags}.
+     * Deletes Ctags temporary files left over after terminating Ctags processes
+     * in case of timeout, @see Ctags#doCtags.
      */
     public static void deleteTempFiles() {
         String[] dirs = {System.getProperty("java.io.tmpdir"),

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
@@ -118,12 +118,8 @@ public class CtagsUtil {
         });
 
         for (File file : files) {
-            if (file.isFile()) {
-                try {
-                    Files.deleteIfExists(file.toPath());
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "cannot delete file", e);
-                }
+            if (file.isFile() && !file.delete()) {
+                LOGGER.log(Level.WARNING, "cannot delete file {0}", file);
             }
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
@@ -91,6 +91,10 @@ public class CtagsUtil {
         return result;
     }
 
+    /**
+     * Deletes ctags temporary files left over after terminating ctags processes
+     * in case of timeout, {@see Ctags#doCtags}.
+     */
     public static void deleteTempFiles() {
         String[] dirs = {System.getProperty("java.io.tmpdir"),
                 System.getenv("TMPDIR"), System.getenv("TMP")};


### PR DESCRIPTION
This change should get rid of temporary files left around after killed Ctags processes.

I verified that ctags creates the temporary files with names matching given pattern (on Linux):
```
$ strace -e trace=openat ctags -f - opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/LinkageType.java 2>&1 >/dev/null | grep tags\.
...
openat(AT_FDCWD, "/tmp/tags.Z1MYq4", O_RDWR|O_CREAT|O_EXCL, 0600) = 3
```
and made sure the files are properly cleaned up at the end of the indexing.

Also created entries with name matching the pattern and having extra properties such as:
- non-empty directory
- file owned by `root:root` (while the indexer running as non-root user)

to verify the behavior in case of failure.