### PR TITLE
changes to LdapAttrPlugin

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
@@ -159,7 +159,7 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
 
                     records = res.getAttrs();
                 } else {
-                    LOGGER.log(Level.FINE, "no DN for user {0} on {1}",
+                    LOGGER.log(Level.FINE, "no DN for LDAP user {0} on {1}",
                             new Object[]{ldapUser, ldapProvider});
                 }
             } catch (LdapException ex) {

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
@@ -128,9 +128,8 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
     public void fillSession(HttpServletRequest req, User user) {
         updateSession(req, false);
 
-        LdapUser ldapUser;
-        if ((ldapUser = (LdapUser) req.getSession().
-                getAttribute(LdapUserPlugin.getSessionAttrName(ldapUserInstance))) == null) {
+        LdapUser ldapUser = (LdapUser) req.getSession().                getAttribute(LdapUserPlugin.getSessionAttrName(ldapUserInstance));
+        if (ldapUser == null) {
             LOGGER.log(Level.WARNING, "cannot get {0} attribute from {1}",
                     new Object[]{LdapUserPlugin.SESSION_ATTR, user});
             return;

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
@@ -128,7 +128,7 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
     public void fillSession(HttpServletRequest req, User user) {
         updateSession(req, false);
 
-        LdapUser ldapUser = (LdapUser) req.getSession().                getAttribute(LdapUserPlugin.getSessionAttrName(ldapUserInstance));
+        LdapUser ldapUser = (LdapUser) req.getSession().getAttribute(LdapUserPlugin.getSessionAttrName(ldapUserInstance));
         if (ldapUser == null) {
             LOGGER.log(Level.WARNING, "cannot get {0} attribute from {1}",
                     new Object[]{LdapUserPlugin.SESSION_ATTR, user});

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
@@ -135,7 +135,8 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
 
         if ((ldapUser = (LdapUser) req.getSession().
                 getAttribute(LdapUserPlugin.getSessionAttrName(ldapUserInstance))) == null) {
-            LOGGER.log(Level.WARNING, "cannot get {0} attribute", LdapUserPlugin.SESSION_ATTR);
+            LOGGER.log(Level.WARNING, "cannot get {0} attribute from {1}",
+                    new Object[]{LdapUserPlugin.SESSION_ATTR, user});
             return;
         }
 
@@ -152,14 +153,14 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
                     AbstractLdapProvider.LdapSearchResult<Map<String, Set<String>>> res;
                     if ((res = ldapProvider.lookupLdapContent(dn, new String[]{ldapAttr})) == null) {
                         LOGGER.log(Level.WARNING, "cannot lookup attributes {0} for user {1} on {2})",
-                                new Object[]{ldapAttr, user, ldapProvider});
+                                new Object[]{ldapAttr, ldapUser, ldapProvider});
                         return;
                     }
 
                     records = res.getAttrs();
                 } else {
                     LOGGER.log(Level.FINE, "no DN for user {0} on {1}",
-                            new Object[]{user, ldapProvider});
+                            new Object[]{ldapUser, ldapProvider});
                 }
             } catch (LdapException ex) {
                 throw new AuthorizationException(ex);
@@ -167,7 +168,7 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
 
             if (records == null || records.isEmpty() || (attributeValues = records.get(ldapAttr)) == null) {
                 LOGGER.log(Level.WARNING, "empty records or attribute values {0} for user {1} on {2}",
-                        new Object[]{ldapAttr, user, ldapProvider});
+                        new Object[]{ldapAttr, ldapUser, ldapProvider});
                 return;
             }
 

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
@@ -126,13 +126,9 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
 
     @Override
     public void fillSession(HttpServletRequest req, User user) {
-        boolean sessionAllowed;
-        LdapUser ldapUser;
-        Map<String, Set<String>> records = null;
-        Set<String> attributeValues;
-
         updateSession(req, false);
 
+        LdapUser ldapUser;
         if ((ldapUser = (LdapUser) req.getSession().
                 getAttribute(LdapUserPlugin.getSessionAttrName(ldapUserInstance))) == null) {
             LOGGER.log(Level.WARNING, "cannot get {0} attribute from {1}",
@@ -142,8 +138,9 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
 
         // Check attributes cached in LDAP user object first, then query LDAP server
         // (and if found, cache the result in the LDAP user object).
-        attributeValues = ldapUser.getAttribute(ldapAttr);
+        Set<String> attributeValues = ldapUser.getAttribute(ldapAttr);
         if (attributeValues == null) {
+            Map<String, Set<String>> records = null;
             AbstractLdapProvider ldapProvider = getLdapProvider();
             try {
                 String dn = ldapUser.getDn();
@@ -175,7 +172,7 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
             ldapUser.setAttribute(ldapAttr, attributeValues);
         }
 
-        sessionAllowed = attributeValues.stream().anyMatch(whitelist::contains);
+        boolean sessionAllowed = attributeValues.stream().anyMatch(whitelist::contains);
         LOGGER.log(Level.FINEST, "LDAP user {0} {1} against {2}",
                 new Object[]{ldapUser, sessionAllowed ? "allowed" : "denied", filePath});
         updateSession(req, sessionAllowed);


### PR DESCRIPTION
Seeing failures of `LdapAttrPlugin` in the log where log entries referenced `User` object instead of `LdapUser` object:
```
21-Aug-2020 16:31:47.512 WARNING [http-nio-8080-exec-92] opengrok.auth.plugin.LdapAttrPlugin.fillSession empty records or attribute values ou for user User{id=foo@bar.com, username=null, cookieTimestamp=null, timeouted=false, attrs={}}
```
made me realize this is the wrong user to log as `LdapAttrPlugin` deals with `LdapUser` when getting the attribute.

While at it, I followed IDEA's advice to refactor this part to avoid the else branch.