### PR TITLE
Fix --help {ctags,repos}

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoriesHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoriesHelp.java
@@ -37,8 +37,27 @@ public class RepositoriesHelp {
         builder.append("Enabled repositories:");
         builder.append(System.lineSeparator());
         builder.append(System.lineSeparator());
-
         List<Class<? extends Repository>> clazzes = RepositoryFactory.getRepositoryClasses();
+        appendClassesHelp(builder, clazzes);
+
+        List<Class<? extends Repository>> disabledClazzes =
+                RepositoryFactory.getDisabledRepositoryClasses();
+        if (!disabledClazzes.isEmpty()) {
+            if (!clazzes.isEmpty()) {
+                builder.append(System.lineSeparator());
+            }
+            builder.append("Disabled repositories:");
+            builder.append(System.lineSeparator());
+            builder.append(System.lineSeparator());
+            appendClassesHelp(builder, disabledClazzes);
+        }
+
+        return builder.toString();
+    }
+
+    private static void appendClassesHelp(
+            StringBuilder builder, List<Class<? extends Repository>> clazzes) {
+
         clazzes.sort((o1, o2) -> o1.getSimpleName().compareToIgnoreCase(o2.getSimpleName()));
         for (Class<?> clazz : clazzes) {
             String simpleName = clazz.getSimpleName();
@@ -49,7 +68,6 @@ public class RepositoriesHelp {
             }
             builder.append(System.lineSeparator());
         }
-        return builder.toString();
     }
 
     private static boolean toAka(StringBuilder builder, String repoSimpleName) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
@@ -106,16 +106,30 @@ public final class RepositoryFactory {
      * @return a list that contains non-{@code null} values only
      */
     public static List<Class<? extends Repository>> getRepositoryClasses() {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-
         ArrayList<Class<? extends Repository>> list = new ArrayList<>(repositories.length);
         for (int i = repositories.length - 1; i >= 0; i--) {
             Class<? extends Repository> clazz = repositories[i].getClass();
-            if (isEnabled(clazz, env)) {
+            if (isEnabled(clazz)) {
                 list.add(clazz);
             }
         }
-        
+
+        return list;
+    }
+
+    /**
+     * Gets a list of all disabled repository handlers.
+     * @return a list that contains non-{@code null} values only
+     */
+    public static List<Class<? extends Repository>> getDisabledRepositoryClasses() {
+        ArrayList<Class<? extends Repository>> list = new ArrayList<>();
+        for (int i = repositories.length - 1; i >= 0; i--) {
+            Class<? extends Repository> clazz = repositories[i].getClass();
+            if (!isEnabled(clazz)) {
+                list.add(clazz);
+            }
+        }
+
         return list;
     }
 
@@ -169,7 +183,7 @@ public final class RepositoryFactory {
         for (Repository referenceRepo : repositories) {
             Class<? extends Repository> clazz = referenceRepo.getClass();
 
-            if ((!isNested || referenceRepo.isNestable()) && isEnabled(clazz, env) &&
+            if ((!isNested || referenceRepo.isNestable()) && isEnabled(clazz) &&
                     referenceRepo.isRepositoryFor(file, interactive)) {
                 repo = clazz.getDeclaredConstructor().newInstance();
 
@@ -274,7 +288,7 @@ public final class RepositoryFactory {
     public static void initializeIgnoredNames(RuntimeEnvironment env) {
         IgnoredNames ignoredNames = env.getIgnoredNames();
         for (Repository repo : repositories) {
-            if (isEnabled(repo.getClass(), env)) {
+            if (isEnabled(repo.getClass())) {
                 for (String file : repo.getIgnoredFiles()) {
                     ignoredNames.add("f:" + file);
                 }
@@ -299,8 +313,8 @@ public final class RepositoryFactory {
         return null;
     }
 
-    private static boolean isEnabled(Class<? extends Repository> clazz, RuntimeEnvironment env) {
-        Set<String> disabledRepos = env.getDisabledRepositories();
+    private static boolean isEnabled(Class<? extends Repository> clazz) {
+        Set<String> disabledRepos = RuntimeEnvironment.getInstance().getDisabledRepositories();
         return disabledRepos == null || !disabledRepos.contains(clazz.getSimpleName());
     }
 }


### PR DESCRIPTION
Hello,

Please consider for integration this patch to fix `--help ctags` and `--help repos`. As `exitWithHelp()` is called before the runtime environment has had its configuration updated with parsed options, `exitWithHelp()` needs to force in some settings for ctags or repos help.

Also this patch shows any user-disabled repositories with `--help repos`.

Thank you.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
