### PR TITLE
communication error should be logged with WARNING

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
@@ -374,7 +374,7 @@ public class LdapFacade extends AbstractLdapProvider {
             actualServer = getNextServer();
             return lookup(dn, filter, attributes, mapper, fail + 1);
         } catch (CommunicationException ex) {
-            LOGGER.log(Level.INFO, String.format("Communication error received on server %s, " +
+            LOGGER.log(Level.WARNING, String.format("Communication error received on server %s, " +
                     "reconnecting to next server.", server), ex);
             closeActualServer();
             actualServer = getNextServer();


### PR DESCRIPTION
This log entry should really be logged with at least WARNING level:
```
28-Aug-2020 08:18:10.680 INFO [http-nio-8080-exec-113] opengrok.auth.plugin.ldap.LdapFacade.lookup Communication error received on server ldaps://foo.bar.com timeout: 3000 username: cn=XXX
,ou=XXX,dc=bar,dc=com, reconnecting to next server.
        javax.naming.CommunicationException: LDAP server "ldaps://foo.bar.com" is down
                at opengrok.auth.plugin.ldap.LdapServer.search(LdapServer.java:212)
                at opengrok.auth.plugin.ldap.LdapServer.search(LdapServer.java:193)
                at opengrok.auth.plugin.ldap.LdapFacade.lookup(LdapFacade.java:347)
                at opengrok.auth.plugin.ldap.LdapFacade.lookup(LdapFacade.java:381)
                at opengrok.auth.plugin.ldap.LdapFacade.lookup(LdapFacade.java:295)
...
```