### PR TITLE
LdapFacade to verify LDAP servers

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
@@ -189,7 +189,7 @@ public class LdapFacade extends AbstractLdapProvider {
     /**
      * Go through all servers in the pool and record the first working.
      */
-    private void prepareServers() {
+    void prepareServers() {
         for (int i = 0; i < servers.size(); i++) {
             LdapServer server = servers.get(i);
             if (server.isWorking() && actualServer == -1) {

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
@@ -192,7 +192,7 @@ public class LdapFacade extends AbstractLdapProvider {
     private void prepareServers() {
         for (int i = 0; i < servers.size(); i++) {
             LdapServer server = servers.get(i);
-            if (server.isWorking() && actualServer != -1) {
+            if (server.isWorking() && actualServer == -1) {
                 actualServer = i;
             }
         }

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
@@ -100,7 +100,7 @@ public class LdapFacade extends AbstractLdapProvider {
     private WebHooks webHooks;
 
     private SearchControls controls;
-    private int actualServer = 0;
+    private int actualServer = -1;
     private long errorTimestamp = 0;
     private boolean reported = false;
 
@@ -187,14 +187,13 @@ public class LdapFacade extends AbstractLdapProvider {
     }
 
     /**
-     * Finds first working server in the pool.
+     * Go through all servers in the pool and record the first working.
      */
     private void prepareServers() {
         for (int i = 0; i < servers.size(); i++) {
             LdapServer server = servers.get(i);
-            if (server.isWorking()) {
+            if (server.isWorking() && actualServer != -1) {
                 actualServer = i;
-                return;
             }
         }
     }
@@ -245,7 +244,7 @@ public class LdapFacade extends AbstractLdapProvider {
 
     @Override
     public boolean isConfigured() {
-        return servers != null && servers.size() > 0 && LDAP_FILTER != null && searchBase != null;
+        return servers != null && servers.size() > 0 && LDAP_FILTER != null && searchBase != null && actualServer != -1;
     }
 
     /**

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -160,7 +160,6 @@ public class LdapServer implements Serializable {
             }
             return true;
         } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, String.format("LDAP server %s is not reachable", this), e);
             return false;
         }
     }

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -138,7 +138,7 @@ public class LdapServer implements Serializable {
      * This method converts the scheme from URI to port number.
      * It is limited to the ldap/ldaps schemes.
      * The method could be static however then it cannot be easily mocked in testing.
-     * @return port number
+     * @return port number or -1 if the scheme in given URI is not known
      * @throws URISyntaxException if the URI is not valid
      */
     public int getPort() throws URISyntaxException {

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -181,7 +181,13 @@ public class LdapServer implements Serializable {
      */
     public boolean isReachable() {
         try {
-            for (InetAddress addr : getAddresses(urlToHostname(getUrl()))) {
+            InetAddress[] addresses = getAddresses(urlToHostname(getUrl()));
+            if (addresses.length == 0) {
+                LOGGER.log(Level.WARNING, "LDAP server {0} does not resolve to any IP address",this);
+                return false;
+            }
+
+            for (InetAddress addr : addresses) {
                 // InetAddr.isReachable() is not sufficient as it can only check ICMP and TCP echo.
                 int port = getPort();
                 if (!isReachable(addr, port, getConnectTimeout())) {

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -183,7 +183,7 @@ public class LdapServer implements Serializable {
         try {
             InetAddress[] addresses = getAddresses(urlToHostname(getUrl()));
             if (addresses.length == 0) {
-                LOGGER.log(Level.WARNING, "LDAP server {0} does not resolve to any IP address",this);
+                LOGGER.log(Level.WARNING, "LDAP server {0} does not resolve to any IP address", this);
                 return false;
             }
 

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -137,11 +137,12 @@ public class LdapServer implements Serializable {
     /**
      * This method converts the scheme from URI to port number.
      * It is limited to the ldap/ldaps schemes.
+     * The method could be static however then it cannot be easily mocked in testing.
      * @param urlStr URI
      * @return port number
      * @throws URISyntaxException if the URI is not valid
      */
-    private static int getPort(String urlStr) throws URISyntaxException {
+    public int getPort(String urlStr) throws URISyntaxException {
         URI uri = new URI(urlStr);
         switch (uri.getScheme()) {
             case "ldaps":
@@ -184,9 +185,10 @@ public class LdapServer implements Serializable {
         try {
             for (InetAddress addr : getAddresses(urlToHostname(getUrl()))) {
                 // InetAddr.isReachable() is not sufficient as it can only check ICMP and TCP echo.
-                if (!isReachable(addr, getPort(getUrl()), getConnectTimeout())) {
-                    LOGGER.log(Level.WARNING, "LDAP server {0} is not reachable on {1}",
-                            new Object[]{this, addr});
+                int port = getPort(getUrl());
+                if (!isReachable(addr, port, getConnectTimeout())) {
+                    LOGGER.log(Level.WARNING, "LDAP server {0} is not reachable on {1}:{2}",
+                            new Object[]{this, addr, Integer.toString(port)});
                     return false;
                 }
             }

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -138,12 +138,11 @@ public class LdapServer implements Serializable {
      * This method converts the scheme from URI to port number.
      * It is limited to the ldap/ldaps schemes.
      * The method could be static however then it cannot be easily mocked in testing.
-     * @param urlStr URI
      * @return port number
      * @throws URISyntaxException if the URI is not valid
      */
-    public int getPort(String urlStr) throws URISyntaxException {
-        URI uri = new URI(urlStr);
+    public int getPort() throws URISyntaxException {
+        URI uri = new URI(getUrl());
         switch (uri.getScheme()) {
             case "ldaps":
                 return 636;
@@ -185,7 +184,7 @@ public class LdapServer implements Serializable {
         try {
             for (InetAddress addr : getAddresses(urlToHostname(getUrl()))) {
                 // InetAddr.isReachable() is not sufficient as it can only check ICMP and TCP echo.
-                int port = getPort(getUrl());
+                int port = getPort();
                 if (!isReachable(addr, port, getConnectTimeout())) {
                     LOGGER.log(Level.WARNING, "LDAP server {0} is not reachable on {1}:{2}",
                             new Object[]{this, addr, Integer.toString(port)});

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -49,6 +49,7 @@ public class LdapServerTest {
                 startLatch.countDown();
                 Socket client = socket.accept();
                 client.close();
+                socket.close();
             } catch (IOException e) {
                 e.printStackTrace();
             }
@@ -71,5 +72,9 @@ public class LdapServerTest {
         thread.join(5000);
         thread.interrupt();
         assertTrue(reachable);
+
+        // Test non-reachability.
+        reachable = serverSpy.isReachable();
+        assertFalse(reachable);
     }
 }

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -1,0 +1,65 @@
+package opengrok.auth.plugin;
+
+import opengrok.auth.plugin.ldap.LdapServer;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+
+public class LdapServerTest {
+
+    @Test
+    public void testInvalidURI() {
+        LdapServer server = new LdapServer("foo:/\\/\\foo.bar");
+        assertFalse(server.isReachable());
+    }
+
+    @Test
+    public void testIsReachable() throws UnknownHostException, InterruptedException, URISyntaxException {
+        // Start simple TCP server on port 6336. It has to be > 1024 to avoid BindException
+        // due to permission denied.
+        int testPort = 6336;
+        InetAddress localhostAddr = InetAddress.getLocalHost();
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        Thread thread = new Thread(() -> {
+            try {
+                ServerSocket socket = new ServerSocket(testPort, 1, localhostAddr);
+                startLatch.countDown();
+                Socket client = socket.accept();
+                client.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+
+        // TODO:
+        //  There is still a tiny window between when the latch unblocks and the server actually starts accept().
+        //  We can make the server loop for connections and connect here with a timeout to make sure it is up.
+        thread.start();
+        startLatch.await();
+
+        // Mock getAddresses() to return single localhost IP address.
+        LdapServer server = new LdapServer("ldaps://foo.bar.com");
+        LdapServer serverSpy = Mockito.spy(server);
+        Mockito.when(serverSpy.getAddresses(any())).thenReturn(new InetAddress[]{localhostAddr});
+        doReturn(testPort).when(serverSpy).getPort(anyString());
+
+        // Test reachability.
+        boolean reachable = serverSpy.isReachable();
+        thread.join(5000);
+        thread.interrupt();
+        assertTrue(reachable);
+    }
+}

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -12,8 +12,7 @@ import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -24,6 +23,15 @@ public class LdapServerTest {
     public void testInvalidURI() {
         LdapServer server = new LdapServer("foo:/\\/\\foo.bar");
         assertFalse(server.isReachable());
+    }
+
+    @Test
+    public void testGetPort() throws URISyntaxException {
+        LdapServer server = new LdapServer("ldaps://foo.bar");
+        assertEquals(636, server.getPort());
+
+        server = new LdapServer("ldap://foo.bar");
+        assertEquals(389, server.getPort());
     }
 
     @Test
@@ -54,7 +62,7 @@ public class LdapServerTest {
         LdapServer server = new LdapServer("ldaps://foo.bar.com");
         LdapServer serverSpy = Mockito.spy(server);
         Mockito.when(serverSpy.getAddresses(any())).thenReturn(new InetAddress[]{localhostAddr});
-        doReturn(testPort).when(serverSpy).getPort(anyString());
+        doReturn(testPort).when(serverSpy).getPort();
 
         // Test reachability.
         boolean reachable = serverSpy.isReachable();

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -14,7 +14,6 @@ import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
 public class LdapServerTest {

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -37,6 +37,22 @@ public class LdapServerTest {
     }
 
     @Test
+    public void testSetGetUsername() {
+        LdapServer server = new LdapServer();
+
+        assertNull(server.getUsername());
+        assertNull(server.getPassword());
+
+        final String testUsername = "foo";
+        server.setUsername(testUsername);
+        assertEquals(testUsername, server.getUsername());
+
+        final String testPassword = "bar";
+        server.setPassword(testPassword);
+        assertEquals(testPassword, server.getPassword());
+    }
+
+    @Test
     public void testIsReachable() throws UnknownHostException, InterruptedException, URISyntaxException {
         // Start simple TCP server on port 6336. It has to be > 1024 to avoid BindException
         // due to permission denied.

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -94,4 +94,12 @@ public class LdapServerTest {
         reachable = serverSpy.isReachable();
         assertFalse(reachable);
     }
+
+    @Test
+    public void testEmptyAddressArray() throws UnknownHostException {
+        LdapServer server = new LdapServer("ldaps://foo.bar.com");
+        LdapServer serverSpy = Mockito.spy(server);
+        Mockito.when(serverSpy.getAddresses(any())).thenReturn(new InetAddress[]{});
+        assertFalse(serverSpy.isReachable());
+    }
 }

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -11,6 +11,7 @@ import java.net.Socket;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -75,7 +76,7 @@ public class LdapServerTest {
         //  There is still a tiny window between when the latch unblocks and the server actually starts accept().
         //  We can make the server loop for connections and connect here with a timeout to make sure it is up.
         thread.start();
-        startLatch.await();
+        startLatch.await(3, TimeUnit.SECONDS);
 
         // Mock getAddresses() to return single localhost IP address.
         LdapServer server = new LdapServer("ldaps://foo.bar.com");

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -31,6 +31,9 @@ public class LdapServerTest {
 
         server = new LdapServer("ldap://foo.bar");
         assertEquals(389, server.getPort());
+
+        server = new LdapServer("crumble://foo.bar");
+        assertEquals(-1, server.getPort());
     }
 
     @Test


### PR DESCRIPTION
With this change `LdapFacade` will check the LDAP servers before using them, namely it will check:
  - hostname resolves to IP address
  - connect succeeds to the TCP port matching the protocol on all the IP addresses for given hostname
