### PR TITLE
introduce command timeout types

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/CommandTimeoutType.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/CommandTimeoutType.java
@@ -1,0 +1,31 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.configuration;
+
+public enum CommandTimeoutType {
+    INTERACTIVE,
+    INDEXER,
+    RESTFUL,
+    WEBAPP_START;
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -211,8 +211,10 @@ public final class Configuration {
     private boolean chattyStatusPage;
     private final Map<String, String> cmds;  // repository type -> command
     private int tabSize;
-    private int commandTimeout; // in seconds
+    private int indexerCommandTimeout; // in seconds
     private int interactiveCommandTimeout; // in seconds
+    private int webappStartCommandTimeout; // in seconds
+    private int restfulCommandTimeout; // in seconds
     private long ctagsTimeout; // in seconds
     private boolean scopesEnabled;
     private boolean projectsEnabled;
@@ -375,22 +377,58 @@ public final class Configuration {
         this.nestingMaximum = nestingMaximum;
     }
 
-    public int getCommandTimeout() {
-        return commandTimeout;
+    public int getIndexerCommandTimeout() {
+        return indexerCommandTimeout;
     }
 
     /**
      * Set the command timeout to a new value.
      *
-     * @param commandTimeout the new value
+     * @param timeout the new value
      * @throws IllegalArgumentException when the timeout is negative
      */
-    public void setCommandTimeout(int commandTimeout) throws IllegalArgumentException {
-        if (commandTimeout < 0) {
+    public void setIndexerCommandTimeout(int timeout) throws IllegalArgumentException {
+        if (timeout < 0) {
             throw new IllegalArgumentException(
-                    String.format(NEGATIVE_NUMBER_ERROR, "commandTimeout", commandTimeout));
+                    String.format(NEGATIVE_NUMBER_ERROR, "commandTimeout", timeout));
         }
-        this.commandTimeout = commandTimeout;
+        this.indexerCommandTimeout = timeout;
+    }
+
+    public int getRestfulCommandTimeout() {
+        return restfulCommandTimeout;
+    }
+
+    /**
+     * Set the command timeout to a new value.
+     *
+     * @param timeout the new value
+     * @throws IllegalArgumentException when the timeout is negative
+     */
+    public void setRestfulCommandTimeout(int timeout) throws IllegalArgumentException {
+        if (timeout < 0) {
+            throw new IllegalArgumentException(
+                    String.format(NEGATIVE_NUMBER_ERROR, "restfulCommandTimeout", timeout));
+        }
+        this.restfulCommandTimeout = timeout;
+    }
+
+    public int getWebappStartCommandTimeout() {
+        return webappStartCommandTimeout;
+    }
+
+    /**
+     * Set the command timeout to a new value.
+     *
+     * @param timeout the new value
+     * @throws IllegalArgumentException when the timeout is negative
+     */
+    public void setWebappStartCommandTimeout(int timeout) throws IllegalArgumentException {
+        if (timeout < 0) {
+            throw new IllegalArgumentException(
+                    String.format(NEGATIVE_NUMBER_ERROR, "webappStartCommandTimeout", timeout));
+        }
+        this.webappStartCommandTimeout = timeout;
     }
 
     public int getInteractiveCommandTimeout() {
@@ -400,15 +438,15 @@ public final class Configuration {
     /**
      * Set the interactive command timeout to a new value.
      *
-     * @param commandTimeout the new value
+     * @param timeout the new value
      * @throws IllegalArgumentException when the timeout is negative
      */
-    public void setInteractiveCommandTimeout(int commandTimeout) throws IllegalArgumentException {
-        if (commandTimeout < 0) {
+    public void setInteractiveCommandTimeout(int timeout) throws IllegalArgumentException {
+        if (timeout < 0) {
             throw new IllegalArgumentException(
-                    String.format(NEGATIVE_NUMBER_ERROR, "interactiveCommandTimeout", commandTimeout));
+                    String.format(NEGATIVE_NUMBER_ERROR, "interactiveCommandTimeout", timeout));
         }
-        this.interactiveCommandTimeout = commandTimeout;
+        this.interactiveCommandTimeout = timeout;
     }
 
     public long getCtagsTimeout() {
@@ -422,7 +460,7 @@ public final class Configuration {
      * @throws IllegalArgumentException when the timeout is negative
      */
     public void setCtagsTimeout(long timeout) throws IllegalArgumentException {
-        if (commandTimeout < 0) {
+        if (timeout < 0) {
             throw new IllegalArgumentException(
                     String.format(NEGATIVE_NUMBER_ERROR, "ctagsTimeout", timeout));
         }
@@ -476,8 +514,10 @@ public final class Configuration {
         setBugPattern("\\b([12456789][0-9]{6})\\b");
         setCachePages(5);
         setCanonicalRoots(new HashSet<>());
-        setCommandTimeout(600); // 10 minutes
+        setIndexerCommandTimeout(600); // 10 minutes
+        setRestfulCommandTimeout(60);
         setInteractiveCommandTimeout(30);
+        setWebappStartCommandTimeout(5);
         setCompressXref(true);
         setContextLimit((short) 10);
         //contextSurround is default(short)

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -240,7 +240,7 @@ public final class RuntimeEnvironment {
                 return getRestfulCommandTimeout();
         }
 
-        throw new InvalidParameterException("invalid command timeout type");
+        throw new IllegalArgumentException("invalid command timeout type");
     }
 
     public int getRestfulCommandTimeout() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarRepository.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
@@ -177,7 +179,7 @@ public class BazaarRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file, boolean interactive) {
+    boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         if (file.isDirectory()) {
             File f = new File(file, ".bzr");
             return f.exists() && f.isDirectory();
@@ -225,16 +227,15 @@ public class BazaarRepository extends Repository {
      * @param directory Directory where we list tags
      */
     @Override
-    protected void buildTagList(File directory, boolean interactive) {
+    protected void buildTagList(File directory, CommandTimeoutType cmdType) {
         this.tagList = new TreeSet<>();
         ArrayList<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         argv.add(RepoCommand);
         argv.add("tags");
 
-        Executor executor = new Executor(argv, directory, interactive ?
-                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
-                RuntimeEnvironment.getInstance().getCommandTimeout());
+        Executor executor = new Executor(argv, directory,
+                RuntimeEnvironment.getInstance().getCommandTimeout(cmdType));
         final BazaarTagParser parser = new BazaarTagParser();
         int status = executor.exec(true, parser);
         if (status != 0) {
@@ -247,7 +248,7 @@ public class BazaarRepository extends Repository {
     }
 
     @Override
-    String determineParent(boolean interactive) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) throws IOException {
         File directory = new File(getDirectoryName());
 
         List<String> cmd = new ArrayList<>();
@@ -255,9 +256,8 @@ public class BazaarRepository extends Repository {
         cmd.add(RepoCommand);
         cmd.add("config");
         cmd.add("parent_location");
-        Executor executor = new Executor(cmd, directory, interactive ?
-                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
-                RuntimeEnvironment.getInstance().getCommandTimeout());
+        Executor executor = new Executor(cmd, directory,
+                RuntimeEnvironment.getInstance().getCommandTimeout(cmdType));
         if (executor.exec(false) != 0) {
             throw new IOException(executor.getErrorString());
         }
@@ -266,12 +266,12 @@ public class BazaarRepository extends Repository {
     }
 
     @Override
-    String determineBranch(boolean interactive) {
+    String determineBranch(CommandTimeoutType cmdType) {
         return null;
     }
 
     @Override
-    String determineCurrentVersion(boolean interactive) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BitKeeperRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BitKeeperRepository.java
@@ -33,6 +33,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.util.BufferSink;
 import org.suigeneris.jrcs.rcs.InvalidVersionNumberException;
 import org.suigeneris.jrcs.rcs.Version;
@@ -132,7 +133,7 @@ public class BitKeeperRepository extends Repository {
      * @return ret a boolean denoting whether it is or not
      */
     @Override
-    boolean isRepositoryFor(File file, boolean interactive) {
+    boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         if (file.isDirectory()) {
             final File f = new File(file, ".bk");
             return f.exists() && f.isDirectory();
@@ -167,7 +168,7 @@ public class BitKeeperRepository extends Repository {
      * @return null
      */
     @Override
-    String determineBranch(boolean interactive) throws IOException {
+    String determineBranch(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 
@@ -177,7 +178,7 @@ public class BitKeeperRepository extends Repository {
      * @return parent a string denoting the parent, or null.
      */
     @Override
-    String determineParent(boolean interactive) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) throws IOException {
         final File directory = new File(getDirectoryName());
 
         final ArrayList<String> argv = new ArrayList<String>();
@@ -186,9 +187,8 @@ public class BitKeeperRepository extends Repository {
         argv.add("parent");
         argv.add("-1il");
 
-        final Executor executor = new Executor(argv, directory, interactive ?
-                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
-                RuntimeEnvironment.getInstance().getCommandTimeout());
+        final Executor executor = new Executor(argv, directory,
+                RuntimeEnvironment.getInstance().getCommandTimeout(cmdType));
         final int rc = executor.exec(false);
         final String parent = executor.getOutputString().trim();
         if (rc == 0) {
@@ -413,19 +413,17 @@ public class BitKeeperRepository extends Repository {
      * Constructs a set of tags up front.
      *
      * @param directory the repository directory
-     * @param interactive true if in interactive mode
+     * @param cmdType command timeout type
      */
     @Override
-    public void buildTagList(File directory, boolean interactive) {
+    public void buildTagList(File directory, CommandTimeoutType cmdType) {
         final ArrayList<String> argv = new ArrayList<>();
         argv.add("bk");
         argv.add("tags");
         argv.add("-d" + getTagDspec());
 
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        final Executor executor = new Executor(argv, directory,
-                interactive ? env.getInteractiveCommandTimeout() :
-                        env.getCommandTimeout());
+        final Executor executor = new Executor(argv, directory, env.getCommandTimeout(cmdType));
         final BitKeeperTagParser parser = new BitKeeperTagParser(datePatterns[0]);
         int status = executor.exec(true, parser);
         if (status != 0) {
@@ -438,7 +436,7 @@ public class BitKeeperRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(boolean interactive) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSRepository.java
@@ -35,6 +35,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.Executor;
@@ -133,7 +135,7 @@ public class CVSRepository extends RCSRepository {
     }
 
     @Override
-    public boolean isRepositoryFor(File file, boolean interactive) {
+    public boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         if (file.isDirectory()) {
             File cvsDir = new File(file, "CVS");
             return cvsDir.isDirectory();
@@ -142,7 +144,7 @@ public class CVSRepository extends RCSRepository {
     }
 
     @Override
-    String determineBranch(boolean interactive) throws IOException {
+    String determineBranch(CommandTimeoutType cmdType) throws IOException {
         String branch = null;
 
         File tagFile = new File(getDirectoryName(), "CVS/Tag");
@@ -282,7 +284,7 @@ public class CVSRepository extends RCSRepository {
     }
 
     @Override
-    String determineParent(boolean interactive) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) throws IOException {
         File rootFile = new File(getDirectoryName() + File.separator + "CVS"
                 + File.separator + "Root");
         String parent = null;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/ClearCaseRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/ClearCaseRepository.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
+
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
@@ -194,7 +196,7 @@ public class ClearCaseRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file, boolean interactive) {
+    boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         // if the parent contains a file named "[.]view.dat" or
         // the parent is named "vobs" or the canonical path
         // is found in "cleartool lsvob -s"
@@ -221,7 +223,7 @@ public class ClearCaseRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(boolean interactive) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 
@@ -272,12 +274,12 @@ public class ClearCaseRepository extends Repository {
     }
 
     @Override
-    String determineParent(boolean interactive) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 
     @Override
-    String determineBranch(boolean interactive) {
+    String determineBranch(CommandTimeoutType cmdType) {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -45,6 +45,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.Configuration.RemoteSCM;
 import org.opengrok.indexer.configuration.PathAccepter;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -411,7 +413,7 @@ public final class HistoryGuru {
 
                 Repository repository = null;
                 try {
-                    repository = RepositoryFactory.getRepository(file, false, isNested);
+                    repository = RepositoryFactory.getRepository(file, CommandTimeoutType.INDEXER, isNested);
                 } catch (InstantiationException | NoSuchMethodException | InvocationTargetException e) {
                     LOGGER.log(Level.WARNING, "Could not create repository for '"
                             + file + "', could not instantiate the repository.", e);
@@ -804,9 +806,9 @@ public final class HistoryGuru {
      * Set list of known repositories which match the list of directories.
      * @param repos list of repositories
      * @param dirs list of directories that might correspond to the repositories
-     * @param interactive interactive mode flag
+     * @param cmdType command timeout type
      */
-    public void invalidateRepositories(Collection<? extends RepositoryInfo> repos, List<String> dirs, boolean interactive) {
+    public void invalidateRepositories(Collection<? extends RepositoryInfo> repos, List<String> dirs, CommandTimeoutType cmdType) {
         if (repos != null && !repos.isEmpty() && dirs != null && !dirs.isEmpty()) {
             List<RepositoryInfo> newrepos = new ArrayList<>();
             for (RepositoryInfo i : repos) {
@@ -821,7 +823,7 @@ public final class HistoryGuru {
             repos = newrepos;
         }
 
-        invalidateRepositories(repos, interactive);
+        invalidateRepositories(repos, cmdType);
     }
 
     /**
@@ -837,9 +839,9 @@ public final class HistoryGuru {
      *
      * @param repos collection of repositories to invalidate.
      * If null or empty, the internal map of repositories will be cleared.
-     * @param interactive interactive mode flag
+     * @param cmdType command timeout type
      */
-    public void invalidateRepositories(Collection<? extends RepositoryInfo> repos, boolean interactive) {
+    public void invalidateRepositories(Collection<? extends RepositoryInfo> repos, CommandTimeoutType cmdType) {
         if (repos == null || repos.isEmpty()) {
             repositoryRoots.clear();
             repositories.clear();
@@ -874,7 +876,7 @@ public final class HistoryGuru {
                 @Override
                 public void run() {
                     try {
-                        Repository r = RepositoryFactory.getRepository(rinfo, interactive);
+                        Repository r = RepositoryFactory.getRepository(rinfo, cmdType);
                         if (r == null) {
                             LOGGER.log(Level.WARNING,
                                     "Failed to instantiate internal repository data for {0} in {1}",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -36,6 +36,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
@@ -117,15 +119,14 @@ public class MercurialRepository extends Repository {
      * Return name of the branch or "default".
      */
     @Override
-    String determineBranch(boolean interactive) throws IOException {
+    String determineBranch(CommandTimeoutType cmdType) throws IOException {
         List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         cmd.add(RepoCommand);
         cmd.add("branch");
 
         Executor executor = new Executor(cmd, new File(getDirectoryName()),
-                interactive ? RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
-                        RuntimeEnvironment.getInstance().getCommandTimeout());
+                RuntimeEnvironment.getInstance().getCommandTimeout(cmdType));
         if (executor.exec(false) != 0) {
             throw new IOException(executor.getErrorString());
         }
@@ -452,7 +453,7 @@ public class MercurialRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file, boolean interactive) {
+    boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         if (file.isDirectory()) {
             File f = new File(file, ".hg");
             return f.exists() && f.isDirectory();
@@ -531,16 +532,15 @@ public class MercurialRepository extends Repository {
     }
 
     @Override
-    protected void buildTagList(File directory, boolean interactive) {
+    protected void buildTagList(File directory, CommandTimeoutType cmdType) {
         this.tagList = new TreeSet<>();
         ArrayList<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         argv.add(RepoCommand);
         argv.add("tags");
 
-        Executor executor = new Executor(argv, directory, interactive ?
-                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
-                RuntimeEnvironment.getInstance().getCommandTimeout());
+        Executor executor = new Executor(argv, directory,
+                RuntimeEnvironment.getInstance().getCommandTimeout(cmdType));
         MercurialTagParser parser = new MercurialTagParser();
         int status = executor.exec(true, parser);
         if (status != 0) {
@@ -553,7 +553,7 @@ public class MercurialRepository extends Repository {
     }
 
     @Override
-    String determineParent(boolean interactive) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) throws IOException {
         File directory = new File(getDirectoryName());
 
         List<String> cmd = new ArrayList<>();
@@ -561,9 +561,8 @@ public class MercurialRepository extends Repository {
         cmd.add(RepoCommand);
         cmd.add("paths");
         cmd.add("default");
-        Executor executor = new Executor(cmd, directory, interactive ?
-                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
-                RuntimeEnvironment.getInstance().getCommandTimeout());
+        Executor executor = new Executor(cmd, directory,
+                RuntimeEnvironment.getInstance().getCommandTimeout(cmdType));
         if (executor.exec(false) != 0) {
             throw new IOException(executor.getErrorString());
         }
@@ -572,7 +571,7 @@ public class MercurialRepository extends Repository {
     }
 
     @Override
-    public String determineCurrentVersion(boolean interactive) throws IOException {
+    public String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
         String line = null;
         File directory = new File(getDirectoryName());
 
@@ -585,9 +584,8 @@ public class MercurialRepository extends Repository {
         cmd.add("--template");
         cmd.add("{date|isodate} {node|short} {author} {desc|strip}");
 
-        Executor executor = new Executor(cmd, directory, interactive ?
-                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
-                RuntimeEnvironment.getInstance().getCommandTimeout());
+        Executor executor = new Executor(cmd, directory,
+                RuntimeEnvironment.getInstance().getCommandTimeout(cmdType));
         if (executor.exec(false) != 0) {
             throw new IOException(executor.getErrorString());
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MonotoneRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MonotoneRepository.java
@@ -31,6 +31,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
@@ -162,7 +164,7 @@ public class MonotoneRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file, boolean interactive) {
+    boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         File f = new File(file, "_MTN");
         return f.exists() && f.isDirectory();
     }
@@ -208,7 +210,7 @@ public class MonotoneRepository extends Repository {
     }
 
     @Override
-    String determineParent(boolean interactive) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) throws IOException {
         String parent = null;
         File directory = new File(getDirectoryName());
 
@@ -218,9 +220,8 @@ public class MonotoneRepository extends Repository {
         cmd.add("ls");
         cmd.add("vars");
         cmd.add("database");
-        Executor executor = new Executor(cmd, directory, interactive ?
-                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
-                RuntimeEnvironment.getInstance().getCommandTimeout());
+        Executor executor = new Executor(cmd, directory,
+                RuntimeEnvironment.getInstance().getCommandTimeout(cmdType));
         executor.exec();
 
         try (BufferedReader in = new BufferedReader(executor.getOutputReader())) {
@@ -242,12 +243,12 @@ public class MonotoneRepository extends Repository {
     }
 
     @Override
-    String determineBranch(boolean interactive) {
+    String determineBranch(CommandTimeoutType cmdType) {
         return null;
     }
 
     @Override
-    String determineCurrentVersion(boolean interactive) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java
@@ -43,6 +43,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.Executor;
 
@@ -93,7 +94,7 @@ class PerforceHistoryParser {
      */
     History parse(File file, String sinceRevision) throws HistoryException {
 
-        if (!repo.isInP4Depot(file, false)) {
+        if (!repo.isInP4Depot(file, CommandTimeoutType.INDEXER)) {
             return null;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
@@ -146,10 +147,10 @@ public class PerforceRepository extends Repository {
      * Check if a given file is in the depot.
      *
      * @param file The file to test
-     * @param interactive interactive mode flag
+     * @param cmdType command timeout type
      * @return true if the given file is in the depot, false otherwise
      */
-    boolean isInP4Depot(File file, boolean interactive) {
+    boolean isInP4Depot(File file, CommandTimeoutType cmdType) {
         boolean status = false;
         if (isWorking()) {
             RuntimeEnvironment env = RuntimeEnvironment.getInstance();
@@ -162,8 +163,7 @@ public class PerforceRepository extends Repository {
                 cmd.add(RepoCommand);
                 cmd.add("dirs");
                 cmd.add(name);
-                Executor executor = new Executor(cmd, dir, interactive ?
-                        env.getInteractiveCommandTimeout() : env.getCommandTimeout());
+                Executor executor = new Executor(cmd, dir, env.getCommandTimeout(cmdType));
                 executor.exec();
                 /* OUTPUT:
                  stdout: //depot_path/name
@@ -180,8 +180,7 @@ public class PerforceRepository extends Repository {
                 cmd.add(RepoCommand);
                 cmd.add("files");
                 cmd.add(name);
-                Executor executor = new Executor(cmd, dir, interactive ?
-                        env.getInteractiveCommandTimeout() : env.getCommandTimeout());
+                Executor executor = new Executor(cmd, dir, env.getCommandTimeout(cmdType));
                 executor.exec();
                 /* OUTPUT:
                  stdout: //depot_path/name
@@ -198,8 +197,8 @@ public class PerforceRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file, boolean interactive) {
-        return isInP4Depot(file, interactive);
+    boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
+        return isInP4Depot(file, cmdType);
     }
 
     @Override
@@ -229,12 +228,12 @@ public class PerforceRepository extends Repository {
     }
 
     @Override
-    String determineParent(boolean interactive) {
+    String determineParent(CommandTimeoutType cmdType) {
         return null;
     }
 
     @Override
-    String determineBranch(boolean interactive) {
+    String determineBranch(CommandTimeoutType cmdType) {
         return null;
     }
     /**
@@ -274,7 +273,7 @@ public class PerforceRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(boolean interactive) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
         File directory = new File(getDirectoryName());
         List<String> cmd = new ArrayList<>();
 
@@ -286,9 +285,8 @@ public class PerforceRepository extends Repository {
         cmd.add("1");
         cmd.add("...#have");
 
-        Executor executor = new Executor(cmd, directory, interactive ?
-                RuntimeEnvironment.getInstance().getInteractiveCommandTimeout() :
-                RuntimeEnvironment.getInstance().getCommandTimeout());
+        Executor executor = new Executor(cmd, directory,
+                RuntimeEnvironment.getInstance().getCommandTimeout(cmdType));
         if (executor.exec(false) != 0) {
             throw new IOException(executor.getErrorString());
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RCSRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RCSRepository.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.BufferSink;
 import org.opengrok.indexer.util.Executor;
@@ -123,7 +124,7 @@ public class RCSRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file, boolean interactive) {
+    boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         File rcsDir = new File(file, "RCS");
         if (!rcsDir.isDirectory()) {
             return false;
@@ -170,17 +171,17 @@ public class RCSRepository extends Repository {
     }
 
     @Override
-    String determineParent(boolean interactive) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 
     @Override
-    String determineBranch(boolean interactive) throws IOException {
+    String determineBranch(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 
     @Override
-    String determineCurrentVersion(boolean interactive) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RazorRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RazorRepository.java
@@ -31,6 +31,8 @@ import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
+
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
 
@@ -331,7 +333,7 @@ public class RazorRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file, boolean interactive) {
+    boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         File f = new File(file, ".razor");
         return f.exists() && f.isDirectory();
     }
@@ -347,17 +349,17 @@ public class RazorRepository extends Repository {
     }
 
     @Override
-    String determineParent(boolean interactive) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 
     @Override
-    String determineBranch(boolean interactive) {
+    String determineBranch(CommandTimeoutType cmdType) {
         return null;
     }
 
     @Override
-    String determineCurrentVersion(boolean interactive) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepoRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepoRepository.java
@@ -27,6 +27,7 @@ package org.opengrok.indexer.history;
 import java.io.File;
 import java.io.IOException;
 
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.util.BufferSink;
 
 /**
@@ -61,7 +62,7 @@ public class RepoRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file, boolean interactive) {
+    boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         if (file.isDirectory()) {
             File f = new File(file, ".repo");
             return f.exists() && f.isDirectory();
@@ -106,17 +107,17 @@ public class RepoRepository extends Repository {
     }
 
     @Override
-    String determineParent(boolean interactive) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 
     @Override
-    String determineBranch(boolean interactive) {
+    String determineBranch(CommandTimeoutType cmdType) {
         return null;
     }
 
     @Override
-    String determineCurrentVersion(boolean interactive) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -44,6 +44,8 @@ import java.util.Locale;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
@@ -321,9 +323,9 @@ public abstract class Repository extends RepositoryInfo {
      * Create internal list of all tags in this repository.
      *
      * @param directory directory of the repository
-     * @param interactive true if in interactive mode
+     * @param cmdType command timeout type
      */
-    protected void buildTagList(File directory, boolean interactive) {
+    protected void buildTagList(File directory, CommandTimeoutType cmdType) {
         this.tagList = null;
     }
     
@@ -409,7 +411,7 @@ public abstract class Repository extends RepositoryInfo {
         // We need to refresh list of tags for incremental reindex.
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         if (env.isTagsEnabled() && this.hasFileBasedTags()) {
-            this.buildTagList(new File(this.getDirectoryName()), false);
+            this.buildTagList(new File(this.getDirectoryName()), CommandTimeoutType.INDEXER);
         }
 
         if (history != null) {
@@ -421,19 +423,19 @@ public abstract class Repository extends RepositoryInfo {
      * Check if this it the right repository type for the given file.
      *
      * @param file File to check if this is a repository for.
-     * @param interactive is this run from interactive mode
+     * @param cmdType command timeout type
      * @return true if this is the correct repository for this file/directory.
      */
-    abstract boolean isRepositoryFor(File file, boolean interactive);
+    abstract boolean isRepositoryFor(File file, CommandTimeoutType cmdType);
     
     public final boolean isRepositoryFor(File file) {
-        return isRepositoryFor(file, false);
+        return isRepositoryFor(file, CommandTimeoutType.INDEXER);
     }
 
     /**
      * Determine parent of this repository.
      */
-    abstract String determineParent(boolean interactive) throws IOException;
+    abstract String determineParent(CommandTimeoutType cmdType) throws IOException;
     
     /**
      * Determine parent of this repository.
@@ -441,13 +443,13 @@ public abstract class Repository extends RepositoryInfo {
      * @throws java.io.IOException I/O exception
      */
     public final String determineParent() throws IOException {
-        return determineParent(false);
+        return determineParent(CommandTimeoutType.INDEXER);
     }
 
     /**
      * Determine branch of this repository.
      */
-    abstract String determineBranch(boolean interactive) throws IOException;
+    abstract String determineBranch(CommandTimeoutType cmdType) throws IOException;
 
     /**
      * Determine branch of this repository.
@@ -455,7 +457,7 @@ public abstract class Repository extends RepositoryInfo {
      * @throws java.io.IOException I/O exception
      */
     public final String determineBranch() throws IOException {
-        return determineBranch(false);
+        return determineBranch(CommandTimeoutType.INDEXER);
     }
     
     /**
@@ -480,14 +482,14 @@ public abstract class Repository extends RepositoryInfo {
      * This operation is consider "heavy" so this function should not be
      * called on every web request.
      *
-     * @param interactive true if interactive mode
+     * @param cmdType command timeout type
      * @return the version
      * @throws IOException if I/O exception occurred
      */
-    abstract String determineCurrentVersion(boolean interactive) throws IOException;
+    abstract String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException;
     
     public final String determineCurrentVersion() throws IOException {
-        return determineCurrentVersion(false);
+        return determineCurrentVersion(CommandTimeoutType.INDEXER);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSRepository.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
@@ -149,7 +151,7 @@ public class SCCSRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file, boolean interactive) {
+    boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         if (file.isDirectory()) {
             File f = new File(file, CODEMGR_WSDATA.toLowerCase()); // OK no ROOT
             if (f.isDirectory()) {
@@ -187,7 +189,7 @@ public class SCCSRepository extends Repository {
     }
 
     @Override
-    String determineParent(boolean interactive) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) throws IOException {
         File parentFile = Paths.get(getDirectoryName(), CODEMGR_WSDATA, "parent").toFile();
         String parent = null;
 
@@ -217,12 +219,12 @@ public class SCCSRepository extends Repository {
     }
 
     @Override
-    String determineBranch(boolean interactive) {
+    String determineBranch(CommandTimeoutType cmdType) {
         return null;
     }
 
     @Override
-    String determineCurrentVersion(boolean interactive) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SSCMRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SSCMRepository.java
@@ -38,6 +38,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
@@ -334,7 +336,7 @@ public class SSCMRepository extends Repository {
     }
 
     @Override
-    boolean isRepositoryFor(File file, boolean interactive) {
+    boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         if (file.isDirectory()) {
             File f = new File(file, MYSCMSERVERINFO_FILE);
             return f.exists() && f.isFile();
@@ -343,17 +345,17 @@ public class SSCMRepository extends Repository {
     }
 
     @Override
-    String determineParent(boolean interactive) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 
     @Override
-    String determineBranch(boolean interactive) {
+    String determineBranch(CommandTimeoutType cmdType) {
         return null;
     }
 
     @Override
-    String determineCurrentVersion(boolean interactive) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionHistoryParser.java
@@ -41,6 +41,7 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.Executor;
@@ -176,7 +177,7 @@ class SubversionHistoryParser implements Executor.StreamHandler {
      * @return object representing the file's history
      */
     History parse(File file, SubversionRepository repos, String sinceRevision,
-            int numEntries, boolean interactive)
+            int numEntries, CommandTimeoutType cmdType)
             throws HistoryException {
 
         initSaxParser();
@@ -187,7 +188,7 @@ class SubversionHistoryParser implements Executor.StreamHandler {
         Executor executor;
         try {
             executor = repos.getHistoryLogExecutor(file, sinceRevision,
-                    numEntries, interactive);
+                    numEntries, cmdType);
         } catch (IOException e) {
             throw new HistoryException("Failed to get history for: \"" +
                     file.getAbsolutePath() + "\"", e);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1245,6 +1245,7 @@ public class IndexDatabase {
                     int tries = 0;
                     Ctags pctags = null;
                     boolean ret;
+                    Statistics stats = new Statistics();
                     while (true) {
                         try {
                             if (alreadyClosedCounter.get() > 0) {
@@ -1284,6 +1285,8 @@ public class IndexDatabase {
                         }
 
                         progress.increment();
+                        stats.report(LOGGER, Level.FINEST,
+                                String.format("file ''%s'' %s", x.file, ret ? "indexed" : "failed indexing"));
                         return ret;
                     }
                 }))).get();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -55,6 +55,7 @@ import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.analysis.AnalyzerGuruHelp;
 import org.opengrok.indexer.analysis.Ctags;
 import org.opengrok.indexer.configuration.CanonicalRootValidator;
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.configuration.ConfigurationHelp;
 import org.opengrok.indexer.configuration.LuceneLockName;
@@ -241,7 +242,7 @@ public final class Indexer {
             }
 
             // Set updated configuration in RuntimeEnvironment.
-            env.setConfiguration(cfg, subFilesList, false);
+            env.setConfiguration(cfg, subFilesList, CommandTimeoutType.INDEXER);
 
             // Check version of index(es) versus current Lucene version and exit
             // with return code upon failure.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -186,6 +186,7 @@ public class Executor {
 
         Process process = null;
         try {
+            Statistics stat = new Statistics();
             process = processBuilder.start();
             final Process proc = process;
 
@@ -230,7 +231,9 @@ public class Executor {
             handler.processStream(process.getInputStream());
 
             ret = process.waitFor();
-            
+
+            stat.report(LOGGER, Level.FINE, String.format("Finished command [%s] in directory %s with exit code %d",
+                    cmd_str, dir_str, ret));
             LOGGER.log(Level.FINE,
                 "Finished command [{0}] in directory {1} with exit code {2}",
                 new Object[] {cmd_str, dir_str, ret});

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -90,7 +90,7 @@ public class Executor {
     public Executor(List<String> cmdList, File workingDirectory) {
         this.cmdList = cmdList;
         this.workingDirectory = workingDirectory;
-        this.timeout = RuntimeEnvironment.getInstance().getCommandTimeout() * 1000;
+        this.timeout = RuntimeEnvironment.getInstance().getIndexerCommandTimeout() * 1000;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
@@ -28,28 +28,47 @@ import java.util.logging.Logger;
 import static org.opengrok.indexer.util.StringUtils.getReadableTime;
 
 public class Statistics {
-        
-  private final long startTime;  
 
-  public Statistics() {
+    private final long startTime;
+
+    public Statistics() {
       startTime = System.currentTimeMillis();    
   }
 
-  public void report(Logger log, String msg) {
-      long stopTime = System.currentTimeMillis();
-      String time_str = StringUtils.getReadableTime(stopTime - startTime);
-      log.log(Level.INFO, msg + " (took {0})", time_str);
-  }
+    /**
+     * log a message along with how much time it took since the constructor was called.
+     * @param logger logger instance
+     * @param logLevel log level
+     * @param msg message string
+     */
+    public void report(Logger logger, Level logLevel, String msg) {
+        long stopTime = System.currentTimeMillis();
+        String time_str = StringUtils.getReadableTime(stopTime - startTime);
+        logger.log(Level.INFO, msg + " (took {0})", time_str);
+    }
 
-  public void report(Logger log) {
-    long stopTime = System.currentTimeMillis() - startTime;
-    log.log(Level.INFO, "Total time: {0}", getReadableTime(stopTime));
+    /**
+     * log a message along with how much time it took since the constructor was called.
+     * The log level is Level.INFO.
+     * @param logger logger instance
+     * @param msg message string
+     */
+    public void report(Logger logger, String msg) {
+        report(logger, Level.INFO, msg);
+    }
 
-    System.gc();
-    Runtime r = Runtime.getRuntime();
-    long mb = 1024L * 1024;
-    log.log(Level.INFO, "Final Memory: {0}M/{1}M", 
-            new Object[]{(r.totalMemory() - r.freeMemory()) / 
-                    mb, r.totalMemory() / mb});    
-  }    
+    /**
+     * log a message along with how much time and memory it took since the constructor was called.
+     * @param logger
+     */
+    public void report(Logger logger) {
+        long stopTime = System.currentTimeMillis() - startTime;
+        logger.log(Level.INFO, "Total time: {0}", getReadableTime(stopTime));
+
+        System.gc();
+        Runtime r = Runtime.getRuntime();
+        long mb = 1024L * 1024;
+        logger.log(Level.INFO, "Final Memory: {0}M/{1}M",
+                new Object[]{(r.totalMemory() - r.freeMemory()) / mb, r.totalMemory() / mb});
+    }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
@@ -23,16 +23,18 @@
 
 package org.opengrok.indexer.util;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import static org.opengrok.indexer.util.StringUtils.getReadableTime;
 
 public class Statistics {
 
-    private final long startTime;
+    private final Instant startTime;
 
     public Statistics() {
-      startTime = System.currentTimeMillis();    
+      startTime = Instant.now();
   }
 
     /**
@@ -42,14 +44,13 @@ public class Statistics {
      * @param msg message string
      */
     public void report(Logger logger, Level logLevel, String msg) {
-        long stopTime = System.currentTimeMillis();
-        String timeStr = StringUtils.getReadableTime(stopTime - startTime);
-        logger.log(Level.INFO, msg + " (took {0})", timeStr);
+        String timeStr = StringUtils.getReadableTime(Duration.between(startTime, Instant.now()).toMillis());
+        logger.log(logLevel, msg + " (took {0})", timeStr);
     }
 
     /**
      * log a message along with how much time it took since the constructor was called.
-     * The log level is Level.INFO.
+     * The log level is {@code INFO}.
      * @param logger logger instance
      * @param msg message string
      */
@@ -59,11 +60,12 @@ public class Statistics {
 
     /**
      * log a message along with how much time and memory it took since the constructor was called.
-     * @param logger
+     * The message will be logged with the {@code INFO} level.
+     * @param logger logger instance
      */
     public void report(Logger logger) {
-        long stopTime = System.currentTimeMillis() - startTime;
-        logger.log(Level.INFO, "Total time: {0}", getReadableTime(stopTime));
+        logger.log(Level.INFO, "Total time: {0}",
+                getReadableTime(Duration.between(startTime, Instant.now()).toMillis()));
 
         System.gc();
         Runtime r = Runtime.getRuntime();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
@@ -43,8 +43,8 @@ public class Statistics {
      */
     public void report(Logger logger, Level logLevel, String msg) {
         long stopTime = System.currentTimeMillis();
-        String time_str = StringUtils.getReadableTime(stopTime - startTime);
-        logger.log(Level.INFO, msg + " (took {0})", time_str);
+        String timeStr = StringUtils.getReadableTime(stopTime - startTime);
+        logger.log(Level.INFO, msg + " (took {0})", timeStr);
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryTest.java
@@ -29,6 +29,7 @@ import java.text.ParseException;
 import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.util.BufferSink;
 
 /**
@@ -174,22 +175,22 @@ public class RepositoryTest {
         }
 
         @Override
-        public boolean isRepositoryFor(File file, boolean interactive) {
+        public boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
             return false;
         }
 
         @Override
-        public String determineParent(boolean interactive) throws IOException {
+        public String determineParent(CommandTimeoutType cmdType) throws IOException {
             return "";
         }
 
         @Override
-        public String determineBranch(boolean interactive) throws IOException {
+        public String determineBranch(CommandTimeoutType cmdType) throws IOException {
             return "";
         }
 
         @Override
-        String determineCurrentVersion(boolean interactive) throws IOException {
+        String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
             return null;
         }
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -57,6 +57,7 @@ import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.condition.ConditionalRun;
 import org.opengrok.indexer.condition.ConditionalRunRule;
 import org.opengrok.indexer.condition.RepositoryInstalled;
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.HistoryGuru;
@@ -232,7 +233,7 @@ public class IndexerTest {
         Repository r = null;
         for (RepositoryInfo ri : repos) {
             if (ri.getDirectoryName().equals(repository.getSourceRoot() + "/rfe2575")) {
-                r = RepositoryFactory.getRepository(ri, false);
+                r = RepositoryFactory.getRepository(ri, CommandTimeoutType.INDEXER);
                 break;
             }
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigRequestedProjectsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/PageConfigRequestedProjectsTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opengrok.indexer.authorization.AuthorizationStack;
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.Group;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -59,7 +60,7 @@ public class PageConfigRequestedProjectsTest {
         env.setProjectsEnabled(true);
         env.setPluginStack(null);
 
-        env.applyConfig(false, false);
+        env.applyConfig(false, CommandTimeoutType.INDEXER);
     }
 
     @After

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -26,6 +26,7 @@ package org.opengrok.web;
 import org.opengrok.indexer.Info;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.authorization.AuthorizationFramework;
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.web.PageConfig;
@@ -71,7 +72,7 @@ public final class WebappListener
             throw new Error("CONFIGURATION parameter missing in the web.xml file");
         } else {
             try {
-                env.readConfiguration(new File(config), true);
+                env.readConfiguration(new File(config), CommandTimeoutType.WEBAPP_START);
             } catch (IOException ex) {
                 LOGGER.log(Level.WARNING, "Configuration error. Failed to read config file: ", ex);
             }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
@@ -24,6 +24,7 @@
  */
 package org.opengrok.web.api.v1.controller;
 
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.ClassUtil;
 import org.opengrok.web.api.v1.suggester.provider.service.SuggesterService;
@@ -59,7 +60,7 @@ public class ConfigurationController {
     @PUT
     @Consumes(MediaType.APPLICATION_XML)
     public void set(final String body, @QueryParam("reindex") final boolean reindex) {
-        env.applyConfig(body, reindex, !reindex);
+        env.applyConfig(body, reindex, reindex ? CommandTimeoutType.INDEXER : CommandTimeoutType.RESTFUL);
         suggesterService.refresh();
     }
 
@@ -75,7 +76,7 @@ public class ConfigurationController {
     public void setField(@PathParam("field") final String field, final String value) {
         setConfigurationValueException(field, value);
         // apply the configuration - let the environment reload the configuration if necessary
-        env.applyConfig(false, true);
+        env.applyConfig(false, CommandTimeoutType.RESTFUL);
         suggesterService.refresh();
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -49,6 +49,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.Group;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -255,7 +257,7 @@ public class ProjectsController {
             List<RepositoryInfo> riList = env.getProjectRepositoriesMap().get(project);
             if (riList != null) {
                 for (RepositoryInfo ri : riList) {
-                    Repository repo = getRepository(ri, false);
+                    Repository repo = getRepository(ri, CommandTimeoutType.RESTFUL);
 
                     if (repo != null && repo.getCurrentVersion() != null && repo.getCurrentVersion().length() > 0) {
                         // getRepository() always creates fresh instance
@@ -297,7 +299,7 @@ public class ProjectsController {
             List<RepositoryInfo> riList = env.getProjectRepositoriesMap().get(project);
             if (riList != null) {
                 for (RepositoryInfo ri : riList) {
-                    Repository repo = getRepository(ri, false);
+                    Repository repo = getRepository(ri, CommandTimeoutType.RESTFUL);
 
                     // set the property
                     ClassUtil.setFieldValue(repo, field, value);

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ConcurrentConfigurationControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ConcurrentConfigurationControllerTest.java
@@ -50,6 +50,7 @@ import org.mockito.MockitoAnnotations;
 import org.opengrok.indexer.condition.ConditionalRun;
 import org.opengrok.indexer.condition.ConditionalRunRule;
 import org.opengrok.indexer.condition.RepositoryInstalled;
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.HistoryGuru;
@@ -187,7 +188,7 @@ public class ConcurrentConfigurationControllerTest extends OGKJerseyTest {
          */
         for (int i = 0; i < TASK_COUNT; i++) {
             futures.add(threadPool.submit(() -> {
-                env.applyConfig(false, false);
+                env.applyConfig(false, CommandTimeoutType.RESTFUL);
                 assertTestedProjects();
             }));
         }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
@@ -34,6 +34,7 @@ import org.mockito.MockitoAnnotations;
 import org.opengrok.indexer.condition.ConditionalRun;
 import org.opengrok.indexer.condition.ConditionalRunRule;
 import org.opengrok.indexer.condition.RepositoryInstalled;
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.Group;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -304,7 +305,7 @@ public class ProjectsControllerTest extends OGKJerseyTest {
         // For per project reindex this is called from setConfiguration() because
         // of the -R option is present.
         HistoryGuru.getInstance().invalidateRepositories(
-                env.getRepositories(), null, false);
+                env.getRepositories(), null, CommandTimeoutType.INDEXER);
         env.setHistoryEnabled(true);
         Indexer.getInstance().prepareIndexer(
                 env,
@@ -514,7 +515,7 @@ public class ProjectsControllerTest extends OGKJerseyTest {
             List<RepositoryInfo> riList = env.getProjectRepositoriesMap().get(project);
             assertNotNull(riList);
             for (RepositoryInfo ri : riList) {
-                Repository repo = getRepository(ri, false);
+                Repository repo = getRepository(ri, CommandTimeoutType.RESTFUL);
                 assertFalse(repo.isHandleRenamedFiles());
             }
         }


### PR DESCRIPTION
This change makes the `Executor` command timeout more generic. Instead of setting the timeout based on interactivity, there will be 4 types of timeout:
  - indexer
  - interactive (think webapp through UI)
  - webapp start (think deploy)
  - RESTful

Each will be tunable.