### PR TITLE
reduce logging emitted from running Java tests

### DIFF
--- a/dev/logging.properties
+++ b/dev/logging.properties
@@ -1,0 +1,18 @@
+handlers= java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overridden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+#
+# Available logging levels: OFF, SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL
+# OFF will give no output, SEVERE will give very little output, FINEST and ALL will give lots of output.
+#
+.level = SEVERE
+
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.ConsoleHandler.formatter = org.opengrok.indexer.logger.formatter.SimpleConsoleFormatter
+
+org.opengrok.level = SEVERE

--- a/dev/main
+++ b/dev/main
@@ -36,7 +36,7 @@ if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
 fi
 
 ret=0
-./mvnw -B -V verify $extra_args || ret=1
+./mvnw -D java.util.logging.config.file=dev/logging.properties -B -V verify $extra_args || ret=1
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 	echo "Checking Apiary blueprint format"


### PR DESCRIPTION
This change limits the amount of logs produced by each build significantly by setting Java log level to SEVERE, avoiding Travis build failure. Some of the indexer tests still produce small output since they use `System.out.println()`, nothing to worry about.

If some of the tests fail, it would be necessary to re-run the build with changed `mvn` invocation in the `dev/main` (i.e. add `-Dtest` per https://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html and remove the `logging.properties` argument).