### PR TITLE
add debug logging to LDAP authorization plugins

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin.ldap;
 
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import javax.naming.CommunicationException;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingEnumeration;
@@ -431,8 +430,7 @@ public class LdapFacade extends AbstractLdapProvider {
     }
 
     public String toString() {
-        return "{servers=" + String.join(",",
-                getServers().stream().map(LdapServer::getUrl).collect(Collectors.toList())) +
+        return "{server=" + (actualServer != -1 ? servers.get(actualServer) : "no active server") +
                 ", searchBase=" + getSearchBase() + "}";
     }
 }

--- a/plugins/src/test/java/opengrok/auth/plugin/ldap/LdapFacadeTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/ldap/LdapFacadeTest.java
@@ -54,7 +54,7 @@ public class LdapFacadeTest {
         int timeoutValue = 42;
         config.setConnectTimeout(timeoutValue);
         LdapFacade facade = new LdapFacade(config);
-        assertEquals("{servers=http://foo.foo,http://bar.bar, searchBase=dc=foo,dc=com}",
+        assertEquals("{server=no active server, searchBase=dc=foo,dc=com}",
                 facade.toString());
     }
 


### PR DESCRIPTION
Yet another change to logging in LDAP authorization plugins. This will facilitate debugging when LDAP searches/servers/... go south. Overwhelming majority of added log messages have the `FINEST` level.

To use this, the Tomcat `logging.properties` can look like this:
```
handlers = 1request-dumper.org.apache.juli.FileHandler, 1catalina.org.apache.juli.AsyncFileHandler, 2localhost.org.apache.juli.AsyncFileHandler, 3manager.org.apache.juli.AsyncFileHandler, 4host-manager.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler

.handlers = 1catalina.org.apache.juli.AsyncFileHandler, java.util.logging.ConsoleHandler

...

# this limits OpenGrok logging
java.util.logging.ConsoleHandler.level = FINEST
java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter

opengrok.auth.level = FINEST
```