### PR TITLE
treat all Command arguments as strings when substituting

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/utils/command.py
@@ -333,6 +333,7 @@ class Command:
         newcmd = []
         subst_done = -1
         for i, cmdarg in enumerate(self.cmd):
+            cmdarg = str(cmdarg)
             if args_subst:
                 for pattern in args_subst.keys():
                     if pattern in cmdarg:

--- a/opengrok-tools/src/test/python/test_command.py
+++ b/opengrok-tools/src/test/python/test_command.py
@@ -34,10 +34,10 @@ from opengrok_tools.utils.command import Command
 
 
 def test_subst_append_default():
-    cmd = Command(['foo', '=ARG=', 'bar'],
+    cmd = Command(['foo', '=ARG=', 33, 'bar'],
                   args_subst={"ARG": "blah"},
                   args_append=["1", "2"])
-    assert cmd.cmd == ['foo', '=blah=', 'bar', '1', '2']
+    assert cmd.cmd == ['foo', '=blah=', 33, 'bar', '1', '2']
 
 
 def test_subst_append_exclsubst():


### PR DESCRIPTION
After adding numeric argument to the `sync.py` configuration, I got this exception:
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/multiprocessing/pool.py", line 121, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.7/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/opengrok/dist/bin/venv/lib/python3.7/site-packages/opengrok_tools/sync.py", line 63, in worker
    x.run()
  File "/opengrok/dist/bin/venv/lib/python3.7/site-packages/opengrok_tools/utils/commandsequence.py", line 121, in run
    args_append=[self.name], excl_subst=True)
  File "/opengrok/dist/bin/venv/lib/python3.7/site-packages/opengrok_tools/utils/command.py", line 77, in __init__
    self.fill_arg(args_append, args_subst)
  File "/opengrok/dist/bin/venv/lib/python3.7/site-packages/opengrok_tools/utils/command.py", line 338, in fill_arg
    if pattern in cmdarg:
TypeError: argument of type 'int' is not iterable
```
This change treats all arguments as strings.