### PR TITLE
use tags for metrics

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/WatchDogService.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/WatchDogService.java
@@ -141,6 +141,6 @@ public class WatchDogService {
                 LOGGER.log(Level.WARNING, "Cannot join WatchDogService thread: ", ex);
             }
         }
-        LOGGER.log(Level.INFO, "Watchdog stoped");
+        LOGGER.log(Level.INFO, "Watchdog stopped");
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginClassLoader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginClassLoader.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.framework;
@@ -56,7 +56,8 @@ public class PluginClassLoader extends ClassLoader {
             "org.opengrok.indexer.authorization.plugins.*",
             "org.opengrok.indexer.authorization.AuthorizationException",
             "org.opengrok.indexer.util.*",
-            "org.opengrok.indexer.logger.*"
+            "org.opengrok.indexer.logger.*",
+            "org.opengrok.indexer.Metrics"
     };
 
     private static final String[] PACKAGE_BLACKLIST = new String[]{

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -18,7 +18,7 @@
  */
 
  /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search;
@@ -73,9 +73,8 @@ import org.opengrok.indexer.web.Prefix;
 import org.opengrok.indexer.web.ProjectHelper;
 
 /**
- * This is an encapsulation of the details on how to search in the index
- * database.
- * This is used for searching from the command line tool and also via the JSON interface.
+ * This is an encapsulation of the details on how to search in the index database.
+ * This is used for searching via the REST API.
  *
  * @author Trond Norbye 2005
  * @author Lubos Kosco - upgrade to lucene 3.x, 4.x, 5.x

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkReloadTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkReloadTest.java
@@ -146,7 +146,7 @@ public class AuthorizationFrameworkReloadTest {
         }
 
         // Double check that at least one reload() was done.
-        long reloads = (long) Metrics.getRegistry().counter("authorization_stack_reload").count();
+        long reloads = (long) Metrics.getRegistry().counter("authorization.stack.reload").count();
         assertTrue(reloads > 0);
     }
 


### PR DESCRIPTION
This changes metric handling in `AuthorizationFramework` to use tags. Looks like this:
```
$ curl -s -X GET http://localhost:8080/source/metrics/prometheus | grep ^auth
authorization_latency_seconds_max{outcome="negative",} 0.0
authorization_latency_seconds_max{outcome="positive",} 0.0
authorization_latency_seconds_count{outcome="negative",} 0.0
authorization_latency_seconds_sum{outcome="negative",} 0.0
authorization_latency_seconds_count{outcome="positive",} 83.0
authorization_latency_seconds_sum{outcome="positive",} 0.001039
authorization_sessions_invalidated_total 0.0
authorization_stack_reload_total 0.0
authorization_cache_total{what="misses",} 83.0
authorization_cache_total{what="hits",} 58.0
```
which allows for easier creation of all-in-one graphs just like they are available for some of the JVM metrics:

![grafana-opengrok-auth](https://user-images.githubusercontent.com/2934284/93380135-1ec48a80-f85f-11ea-8578-7c4f479ad46d.png)

Had to use build pattern to avoid https://github.com/micrometer-metrics/micrometer/issues/877

Also, I changed the metric names to use the dotted notation so they can be converted to native naming conventions used in the respective backend (https://micrometer.io/docs/concepts#_naming_meters).