### PR TITLE
add suggester related meters

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -30,6 +30,7 @@ import com.cronutils.parser.CronParser;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
+import org.opengrok.indexer.Metrics;
 import org.opengrok.suggest.Suggester;
 import org.opengrok.suggest.Suggester.NamedIndexDir;
 import org.opengrok.suggest.Suggester.NamedIndexReader;
@@ -316,7 +317,8 @@ public class SuggesterServiceImpl implements SuggesterService {
                 env.isProjectsEnabled(),
                 suggesterConfig.getAllowedFields(),
                 suggesterConfig.getTimeThreshold(),
-                rebuildParalleismLevel);
+                rebuildParalleismLevel,
+                Metrics.getRegistry());
 
         new Thread(() -> {
             suggester.init(getAllProjectIndexDirs());

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -95,6 +95,23 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.5.4</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.5.4</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -100,18 +100,6 @@
             <artifactId>micrometer-core</artifactId>
             <version>${micrometer.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
-            <version>1.5.4</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
-            <version>1.5.4</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -100,8 +100,6 @@ public final class Suggester implements Closeable {
 
     private final CountDownLatch initDone = new CountDownLatch(1);
 
-    private final MeterRegistry registry;
-
     private final Counter suggesterRebuildCounter;
     private final Timer suggesterRebuildTimer;
     private final Timer suggesterInitTimer;
@@ -153,17 +151,16 @@ public final class Suggester implements Closeable {
         this.allowedFields = new HashSet<>(allowedFields);
         this.timeThreshold = timeThreshold;
         this.rebuildParallelismLevel = rebuildParallelismLevel;
-        this.registry = registry;
 
         suggesterRebuildCounter = Counter.builder("suggester.rebuild").
                 description("suggester rebuild count").
-                register(this.registry);
+                register(registry);
         suggesterRebuildTimer = Timer.builder("suggester.rebuild.latency").
                 description("suggester rebuild latency").
-                register(this.registry);
+                register(registry);
         suggesterInitTimer = Timer.builder("suggester.init.latency").
                 description("suggester initialization latency").
-                register(this.registry);
+                register(registry);
     }
 
     /**

--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
@@ -22,6 +22,8 @@
  */
 package org.opengrok.suggest;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -63,6 +65,8 @@ import static org.junit.Assert.assertTrue;
 
 public class SuggesterTest {
 
+    private MeterRegistry registry = new SimpleMeterRegistry();
+
     private static class SuggesterTestData {
 
         private Suggester s;
@@ -98,14 +102,14 @@ public class SuggesterTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testNullSuggesterDir() {
-        new Suggester(null, 10, Duration.ofMinutes(5), false, true, null, Integer.MAX_VALUE, 1);
+        new Suggester(null, 10, Duration.ofMinutes(5), false, true, null, Integer.MAX_VALUE, 1, registry);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNullDuration() throws IOException {
         Path tempFile = Files.createTempFile("opengrok", "test");
         try {
-            new Suggester(tempFile.toFile(), 10, null, false, true, null, Integer.MAX_VALUE, 1);
+            new Suggester(tempFile.toFile(), 10, null, false, true, null, Integer.MAX_VALUE, 1, registry);
         } finally {
             tempFile.toFile().delete();
         }
@@ -115,7 +119,7 @@ public class SuggesterTest {
     public void testNegativeDuration() throws IOException {
         Path tempFile = Files.createTempFile("opengrok", "test");
         try {
-            new Suggester(tempFile.toFile(), 10, Duration.ofMinutes(-4), false, true, null, Integer.MAX_VALUE, 1);
+            new Suggester(tempFile.toFile(), 10, Duration.ofMinutes(-4), false, true, null, Integer.MAX_VALUE, 1, registry);
         } finally {
             tempFile.toFile().delete();
         }
@@ -132,7 +136,7 @@ public class SuggesterTest {
         Path tempSuggesterDir = Files.createTempDirectory("opengrok");
 
         Suggester s = new Suggester(tempSuggesterDir.toFile(), 10, Duration.ofMinutes(1), true,
-                true, Collections.singleton("test"), Integer.MAX_VALUE, Runtime.getRuntime().availableProcessors());
+                true, Collections.singleton("test"), Integer.MAX_VALUE, Runtime.getRuntime().availableProcessors(), registry);
 
         s.init(Collections.singleton(new Suggester.NamedIndexDir("test", tempIndexDir)));
 
@@ -206,7 +210,7 @@ public class SuggesterTest {
 
         t.s = new Suggester(t.suggesterDir.toFile(), 10, Duration.ofMinutes(1), false,
                 true, Collections.singleton("test"), Integer.MAX_VALUE,
-                Runtime.getRuntime().availableProcessors());
+                Runtime.getRuntime().availableProcessors(), registry);
 
         t.s.init(Collections.singleton(t.getNamedIndexDir()));
 


### PR DESCRIPTION
Add basic suggester meters:
```
# HELP suggester_init_latency_seconds suggester initialization latency
# TYPE suggester_init_latency_seconds summary
suggester_init_latency_seconds_count 1.0
suggester_init_latency_seconds_sum 0.035
# HELP suggester_init_latency_seconds_max suggester initialization latency
# TYPE suggester_init_latency_seconds_max gauge
suggester_init_latency_seconds_max 0.035
# HELP suggester_rebuild_latency_seconds_max suggester rebuild latency
# TYPE suggester_rebuild_latency_seconds_max gauge
suggester_rebuild_latency_seconds_max 0.0
# HELP suggester_rebuild_latency_seconds suggester rebuild latency
# TYPE suggester_rebuild_latency_seconds summary
suggester_rebuild_latency_seconds_count 0.0
suggester_rebuild_latency_seconds_sum 0.0
# HELP suggester_rebuild_total suggester rebuild count
# TYPE suggester_rebuild_total counter
suggester_rebuild_total 0.0
```