### PR TITLE
fix LDAP timeout handling for LdapCtx

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/configuration/Configuration.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/configuration/Configuration.java
@@ -18,7 +18,7 @@
  */
 
  /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin.configuration;
 
@@ -39,6 +39,9 @@ import java.util.List;
 import opengrok.auth.plugin.ldap.LdapServer;
 import opengrok.auth.plugin.util.WebHooks;
 
+/**
+ * Encapsulates configuration for LDAP plugins.
+ */
 public class Configuration implements Serializable {
 
     private static final long serialVersionUID = -1;
@@ -49,6 +52,7 @@ public class Configuration implements Serializable {
     private WebHooks webHooks;
     private int searchTimeout;
     private int connectTimeout;
+    private int readTimeout;
     private int countLimit;
 
     public void setServers(List<LdapServer> servers) {
@@ -89,6 +93,14 @@ public class Configuration implements Serializable {
 
     public void setConnectTimeout(int timeout) {
         this.connectTimeout = timeout;
+    }
+
+    public int getReadTimeout() {
+        return this.readTimeout;
+    }
+
+    public void setReadTimeout(int timeout) {
+        this.readTimeout = timeout;
     }
 
     public int getCountLimit() {

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
@@ -179,7 +179,7 @@ public class LdapFacade extends AbstractLdapProvider {
     }
 
     public LdapFacade(Configuration cfg) {
-        setServers(cfg.getServers(), cfg.getConnectTimeout());
+        setServers(cfg.getServers(), cfg.getConnectTimeout(), cfg.getReadTimeout());
         setInterval(cfg.getInterval());
         setSearchBase(cfg.getSearchBase());
         setWebHooks(cfg.getWebHooks());
@@ -219,12 +219,15 @@ public class LdapFacade extends AbstractLdapProvider {
         return servers;
     }
 
-    public LdapFacade setServers(List<LdapServer> servers, int timeout) {
+    public LdapFacade setServers(List<LdapServer> servers, int connectTimeout, int readTimeout) {
         this.servers = servers;
-        // Inherit connect timeout from server pool configuration.
+        // Inherit timeout values from server pool configuration.
         for (LdapServer server : servers) {
-            if (server.getConnectTimeout() == 0 && timeout != 0) {
-                server.setConnectTimeout(timeout);
+            if (server.getConnectTimeout() == 0 && connectTimeout != 0) {
+                server.setConnectTimeout(connectTimeout);
+            }
+            if (server.getReadTimeout() == 0 && readTimeout != 0) {
+                server.setReadTimeout(readTimeout);
             }
         }
         return this;

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin.ldap;
 
@@ -48,17 +48,20 @@ public class LdapServer implements Serializable {
 
     private static final Logger LOGGER = Logger.getLogger(LdapServer.class.getName());
 
-    private static final String LDAP_TIMEOUT_PARAMETER = "com.sun.jndi.ldap.connect.connectTimeout";
+    private static final String LDAP_CONNECT_TIMEOUT_PARAMETER = "com.sun.jndi.ldap.connect.timeout";
+    private static final String LDAP_READ_TIMEOUT_PARAMETER = "com.sun.jndi.ldap.read.timeout";
     private static final String LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
-    /**
-     * Default connectTimeout for connecting.
-     */
-    private static final int LDAP_CONNECT_TIMEOUT = 5000; // ms
+
+    // default connectTimeout value in milliseconds
+    private static final int LDAP_CONNECT_TIMEOUT = 5000;
+    // default readTimeout value in milliseconds
+    private static final int LDAP_READ_TIMEOUT = 3000;
 
     private String url;
     private String username;
     private String password;
     private int connectTimeout;
+    private int readTimeout;
     private int interval = 10 * 1000;
 
     private Hashtable<String, String> env;
@@ -118,6 +121,15 @@ public class LdapServer implements Serializable {
 
     public LdapServer setConnectTimeout(int connectTimeout) {
         this.connectTimeout = connectTimeout;
+        return this;
+    }
+
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    public LdapServer setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
         return this;
     }
 
@@ -248,7 +260,10 @@ public class LdapServer implements Serializable {
                 env.put(Context.SECURITY_CREDENTIALS, this.password);
             }
             if (this.connectTimeout > 0) {
-                env.put(LDAP_TIMEOUT_PARAMETER, Integer.toString(this.connectTimeout));
+                env.put(LDAP_CONNECT_TIMEOUT_PARAMETER, Integer.toString(this.connectTimeout));
+            }
+            if (this.readTimeout > 0) {
+                env.put(LDAP_READ_TIMEOUT_PARAMETER, Integer.toString(this.readTimeout));
             }
 
             try {
@@ -341,7 +356,8 @@ public class LdapServer implements Serializable {
         Hashtable<String, String> e = new Hashtable<String, String>();
 
         e.put(Context.INITIAL_CONTEXT_FACTORY, LDAP_CONTEXT_FACTORY);
-        e.put(LDAP_TIMEOUT_PARAMETER, Integer.toString(LDAP_CONNECT_TIMEOUT));
+        e.put(LDAP_CONNECT_TIMEOUT_PARAMETER, Integer.toString(LDAP_CONNECT_TIMEOUT));
+        e.put(LDAP_READ_TIMEOUT_PARAMETER, Integer.toString(LDAP_READ_TIMEOUT));
 
         return e;
     }
@@ -353,12 +369,16 @@ public class LdapServer implements Serializable {
         sb.append(getUrl());
 
         if (getConnectTimeout() > 0) {
-            sb.append(" timeout: ");
+            sb.append(", connect timeout: ");
             sb.append(getConnectTimeout());
+        }
+        if (getReadTimeout() > 0) {
+            sb.append(", read timeout: ");
+            sb.append(getReadTimeout());
         }
 
         if (getUsername() != null && !getUsername().isEmpty()) {
-            sb.append(" username: ");
+            sb.append(", username: ");
             sb.append(getUsername());
         }
 

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -107,4 +107,13 @@ public class LdapServerTest {
         Mockito.when(serverSpy.getAddresses(any())).thenReturn(new InetAddress[]{});
         assertFalse(serverSpy.isReachable());
     }
+
+    @Test
+    public void testToString() {
+        LdapServer server = new LdapServer("ldaps://foo.bar.com", "foo", "bar");
+        server.setConnectTimeout(2000);
+        server.setReadTimeout(1000);
+        assertEquals("ldaps://foo.bar.com, connect timeout: 2000, read timeout: 1000, username: foo",
+                server.toString());
+    }
 }


### PR DESCRIPTION
Another post-mortem induced change: when a LDAP server went down so that it accepted TCP connections without replying to received data, the authorization reload API endpoint call got stuck when the LDAP server was being reconnected. Leaving aside whether API call that can require potentially expensive server side processing should be synchronous for now.

The `connectTimeout` set in `LdapServer` (or plugin `Configuration`) only works for TCP connect. Also, looking at the source of `/jdk8u/jdk/src/share/classes/com/sun/jndi/ldap/LdapCtx.java`, it is using wrong name. It is using `com.sun.jndi.ldap.connect.connectTimeout` and it should be:
```java
181      // Timeout for socket connect
182      private static final String CONNECT_TIMEOUT =
183          "com.sun.jndi.ldap.connect.timeout";
```

To fix the stalled communication issue, this change introduces the possibility to change the read timeout. This should work also for TLS handshake (https://bugs.java.com/bugdatabase/view_bug.do?bug_id=7094377).