### PR TITLE
Monitoring responses

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
@@ -73,7 +73,13 @@ public enum Prefix {
     /** Related source file or directory not found/unavailable/ignored. */
     NOT_FOUND("/enoent"),
     /** Misc error occurred. */
-    ERROR("/error");
+    ERROR("/error"),
+    /** RESTful API */
+    REST_API("/api"),
+    /** Monitoring */
+    METRICS("/metrics"),
+    /** CSS and images */
+    STATIC("/default");
 
     private final String prefix;
     Prefix(String prefix) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
@@ -74,11 +74,11 @@ public enum Prefix {
     NOT_FOUND("/enoent"),
     /** Misc error occurred. */
     ERROR("/error"),
-    /** RESTful API */
+    /** RESTful API. */
     REST_API("/api"),
-    /** Monitoring */
+    /** Monitoring. */
     METRICS("/metrics"),
-    /** CSS and images */
+    /** CSS and images. */
     STATIC("/default");
 
     private final String prefix;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
@@ -79,7 +79,9 @@ public enum Prefix {
     /** Monitoring. */
     METRICS("/metrics"),
     /** CSS and images. */
-    STATIC("/default");
+    STATIC("/default"),
+    /** JavaScript. */
+    JS("/js");
 
     private final String prefix;
     Prefix(String prefix) {

--- a/opengrok-web/src/main/java/org/opengrok/web/AuthorizationFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/AuthorizationFilter.java
@@ -51,7 +51,7 @@ public class AuthorizationFilter implements Filter {
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationFilter.class);
 
     private final DistributionSummary requests = Metrics.getRegistry().summary(StatisticsFilter.REQUESTS_METRIC);
-    private final Timer requestsForbidden = Metrics.getRegistry().timer("requests_forbidden");
+    private final Timer requestsForbidden = Metrics.getRegistry().timer("requests.forbidden");
 
     @Override
     public void init(FilterConfig fc) {

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -60,6 +60,12 @@ public class StatisticsFilter implements Filter {
     @Override
     public void doFilter(ServletRequest sr, ServletResponse sr1, FilterChain fc)
             throws IOException, ServletException {
+        /*
+         * Add the request to the statistics. Be aware of the colliding call in
+         * {@code AuthorizationFilter#doFilter}.
+         */
+        requests.record(1);
+
         HttpServletRequest httpReq = (HttpServletRequest) sr;
 
         Instant start = Instant.now();
@@ -79,13 +85,7 @@ public class StatisticsFilter implements Filter {
             return;
         }
 
-        /*
-         * Add the request to the statistics. Be aware of the colliding call in
-         * {@code AuthorizationFilter#doFilter}.
-         */
-        requests.record(1);
-
-        Timer categoryTimer = Timer.builder("requests.latency.category").
+        Timer categoryTimer = Timer.builder("requests.latency").
                 tags("category", category).
                 register(Metrics.getRegistry());
         categoryTimer.record(duration);

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -46,9 +46,12 @@ public class StatisticsFilter implements Filter {
 
     private final DistributionSummary requests = Metrics.getRegistry().summary(REQUESTS_METRIC);
 
-    private final Timer genericTimer = Metrics.getRegistry().timer("*");
-    private final Timer emptySearch = Metrics.getRegistry().timer("empty_search");
-    private final Timer successfulSearch = Metrics.getRegistry().timer("successful_search");
+    private final Timer emptySearch = Timer.builder("search.latency").
+            tags("outcome", "empty").
+            register(Metrics.getRegistry());
+    private final Timer successfulSearch = Timer.builder("search.latency").
+            tags("outcome", "success").
+            register(Metrics.getRegistry());
 
     @Override
     public void init(FilterConfig fc) throws ServletException {
@@ -81,7 +84,6 @@ public class StatisticsFilter implements Filter {
          * {@code AuthorizationFilter#doFilter}.
          */
         requests.record(1);
-        genericTimer.record(duration);
 
         Metrics.getRegistry().timer(category).record(duration);
 

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -85,13 +85,6 @@ public class StatisticsFilter implements Filter {
 
         Metrics.getRegistry().timer(category).record(duration);
 
-        /* supplementary categories */
-        if (config.getProject() != null) {
-            Metrics.getRegistry()
-                    .timer("viewing_of_" + config.getProject().getName())
-                    .record(duration);
-        }
-
         SearchHelper helper = (SearchHelper) config.getRequestAttribute(SearchHelper.REQUEST_ATTR);
         if (helper != null) {
             if (helper.hits == null || helper.hits.length == 0) {

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -80,7 +80,12 @@ public class StatisticsFilter implements Filter {
         if (isRoot(httpReq)) {
             category = "root";
         } else {
-            category = config.getPrefix().toString().substring(1);
+            String prefix = config.getPrefix().toString();
+            if (prefix.isEmpty()) {
+                category = "unknown";
+            } else {
+                category = prefix.substring(1);
+            }
         }
 
         Timer categoryTimer = Timer.builder("requests.latency").

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -85,7 +85,10 @@ public class StatisticsFilter implements Filter {
          */
         requests.record(1);
 
-        Metrics.getRegistry().timer(category).record(duration);
+        Timer categoryTimer = Timer.builder("requests.latency.category").
+                tags("category", category).
+                register(Metrics.getRegistry());
+        categoryTimer.record(duration);
 
         SearchHelper helper = (SearchHelper) config.getRequestAttribute(SearchHelper.REQUEST_ATTR);
         if (helper != null) {

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -79,10 +79,8 @@ public class StatisticsFilter implements Filter {
         String category;
         if (isRoot(httpReq)) {
             category = "root";
-        } else if (config.getPrefix() != Prefix.UNKNOWN) {
-            category = config.getPrefix().toString().substring(1);
         } else {
-            return;
+            category = config.getPrefix().toString().substring(1);
         }
 
         Timer categoryTimer = Timer.builder("requests.latency").

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -56,12 +56,17 @@ public final class WebappListener
         implements ServletContextListener, ServletRequestListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WebappListener.class);
+    private Timer startupTimer = Timer.builder("webapp.startup.latency").
+                description("web application startup latency").
+                register(Metrics.getRegistry());
 
     /**
      * {@inheritDoc}
      */
     @Override
     public void contextInitialized(final ServletContextEvent servletContextEvent) {
+        Instant start = Instant.now();
+
         ServletContext context = servletContextEvent.getServletContext();
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
@@ -97,6 +102,7 @@ public final class WebappListener
         }
 
         env.startExpirationTimer();
+        startupTimer.record(Duration.between(start, Instant.now()));
     }
 
     /**

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -129,6 +129,14 @@ public final class WebappListener
      * {@inheritDoc}
      */
     @Override
+    public void requestInitialized(ServletRequestEvent e) {
+        e.getServletRequest().setAttribute(TIMER_ATTR_NAME, Instant.now());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void requestDestroyed(ServletRequestEvent e) {
         Instant start = (Instant) e.getServletRequest().getAttribute(TIMER_ATTR_NAME);
         if (start != null) {
@@ -143,13 +151,5 @@ public final class WebappListener
         }
 
         AnalyzerGuru.returnAnalyzers();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void requestInitialized(ServletRequestEvent e) {
-        e.getServletRequest().setAttribute(TIMER_ATTR_NAME, Instant.now());
     }
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -57,9 +57,6 @@ public final class WebappListener
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WebappListener.class);
 
-    private static final String TIMER_ATTR_NAME = WebappListener.class.getName() + ".request_start";
-    private Timer requestTimer;
-
     /**
      * {@inheritDoc}
      */
@@ -67,9 +64,6 @@ public final class WebappListener
     public void contextInitialized(final ServletContextEvent servletContextEvent) {
         ServletContext context = servletContextEvent.getServletContext();
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        requestTimer = Timer.builder("request.latency").
-                description("web application request latency").
-                register(Metrics.getRegistry());
 
         LOGGER.log(Level.INFO, "Starting webapp with version {0} ({1})",
                     new Object[]{Info.getVersion(), Info.getRevision()});
@@ -130,7 +124,7 @@ public final class WebappListener
      */
     @Override
     public void requestInitialized(ServletRequestEvent e) {
-        e.getServletRequest().setAttribute(TIMER_ATTR_NAME, Instant.now());
+        // pass
     }
 
     /**
@@ -138,12 +132,6 @@ public final class WebappListener
      */
     @Override
     public void requestDestroyed(ServletRequestEvent e) {
-        Instant start = (Instant) e.getServletRequest().getAttribute(TIMER_ATTR_NAME);
-        if (start != null) {
-            Duration duration = Duration.between(start, Instant.now());
-            requestTimer.record(duration);
-        }
-
         PageConfig.cleanup(e.getServletRequest());
         SearchHelper sh = (SearchHelper) e.getServletRequest().getAttribute(SearchHelper.REQUEST_ATTR);
         if (sh != null) {

--- a/opengrok-web/src/main/webapp/WEB-INF/web.xml
+++ b/opengrok-web/src/main/webapp/WEB-INF/web.xml
@@ -16,19 +16,19 @@
         <listener-class>org.opengrok.web.WebappListener</listener-class>
     </listener>
     <filter>
-        <filter-name>AuthorizationFilter</filter-name>
-        <filter-class>org.opengrok.web.AuthorizationFilter</filter-class>
-    </filter>
-    <filter-mapping>
-        <filter-name>AuthorizationFilter</filter-name>
-        <url-pattern>/*</url-pattern>
-    </filter-mapping>
-    <filter>
         <filter-name>StatisticsFilter</filter-name>
         <filter-class>org.opengrok.web.StatisticsFilter</filter-class>
     </filter>
     <filter-mapping>
         <filter-name>StatisticsFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter>
+        <filter-name>AuthorizationFilter</filter-name>
+        <filter-class>org.opengrok.web.AuthorizationFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>AuthorizationFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <filter>


### PR DESCRIPTION
This change simplifies handling of meters by concentrating most of the request related meters to `StatisticsFilter`. It addresses most of the outstanding metrics issues.

Example:
```
requests_latency_seconds_count{category="metrics",code="200",} 6.0
requests_latency_seconds_sum{category="metrics",code="200",} 0.065338
requests_latency_seconds_count{category="history",code="200",} 1.0
requests_latency_seconds_sum{category="history",code="200",} 0.121469
requests_latency_seconds_count{category="api",code="200",} 3.0
requests_latency_seconds_sum{category="api",code="200",} 0.311119
requests_latency_seconds_count{category="root",code="200",} 2.0
requests_latency_seconds_sum{category="root",code="200",} 0.656422
requests_latency_seconds_count{category="xref",code="302",} 1.0
requests_latency_seconds_sum{category="xref",code="302",} 0.010452
requests_latency_seconds_count{category="xref",code="304",} 1.0
requests_latency_seconds_sum{category="xref",code="304",} 0.030628
requests_latency_seconds_max{category="metrics",code="200",} 0.018831
requests_latency_seconds_max{category="history",code="200",} 0.121469
requests_latency_seconds_max{category="api",code="200",} 0.306253
requests_latency_seconds_max{category="root",code="200",} 0.603779
requests_latency_seconds_max{category="xref",code="302",} 0.010452
requests_latency_seconds_max{category="xref",code="304",} 0.030628
requests_max 1.0
requests_count 15.0
requests_sum 15.0
```