### PR TITLE
add argument separator before path to Mercurial history executor

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -195,6 +195,7 @@ public class MercurialRepository extends Repository {
         }
 
         if (!filename.isEmpty()) {
+            cmd.add("--");
             cmd.add(filename);
         }
 


### PR DESCRIPTION
When watching the indexer I noticed that executions of `hg log` is missing separator between arguments and the file path.