### PR TITLE
the /metrics endpoint is accessible from everywhere

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4,7 +4,7 @@ HIFORMAT: 1A
 
 OpenGrok RESTful API documentation. The following endpoints are accessible under `/api/v1`
 
-Besides `/suggester` and `/search` endpoints, everything is accessible from `localhost` only.
+Besides `/suggester`, `/search` and `/metrics` endpoints, everything is accessible from `localhost` only.
 
 ## Annotation [/annotation{?path}]
 


### PR DESCRIPTION
This change adds `/metric` endpoint to the list of generally allowed endpoints in the Apiary documentation.