### PR TITLE
do not deep copy history entries

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -215,6 +215,11 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <artifactId>micrometer-registry-statsd</artifactId>
             <version>${micrometer.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>20.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -51,6 +51,8 @@ import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
 import org.opengrok.indexer.util.Executor;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * An interface for an external repository.
  *
@@ -95,6 +97,7 @@ public abstract class Repository extends RepositoryInfo {
      *
      * @return {@code true} if the repository can get history for directories
      */
+    @NotNull
     abstract boolean hasHistoryForDirectories();
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -276,24 +276,25 @@ public abstract class Repository extends RepositoryInfo {
      * tags to changesets which actually exist in the history of given file.
      * Must be implemented repository-specific.
      *
-     * @see getTagList
-     * @param hist History we want to assign tags to.
+     * @see #getTagList
+     * @param hist History object we want to assign tags to.
      */
     void assignTagsInHistory(History hist) {
         if (hist == null) {
             return;
         }
+
         if (this.getTagList() == null) {
             throw new IllegalStateException("getTagList() is null");
         }
+
         Iterator<TagEntry> it = this.getTagList().descendingIterator();
         TagEntry lastTagEntry = null;
-        // Go through all commits of given file
         for (HistoryEntry ent : hist.getHistoryEntries()) {
             // Assign all tags created since the last revision
-            // Revision in this HistoryEntry must be already specified!
-            // TODO is there better way to do this? We need to "repeat"
-            // last element returned by call to next()
+            // Revision in this HistoryEntry must be already specified !
+            // TODO: is there better way to do this? We need to "repeat"
+            //   last element returned by call to next()
             while (lastTagEntry != null || it.hasNext()) {
                 if (lastTagEntry == null) {
                     lastTagEntry = it.next();


### PR DESCRIPTION
This was meant to help a bit #3243 however it does not do much for my particular use case as described in the issue. Still, should save some heap memory in case of running the indexer with -G.