### PR TITLE
add options to set history parallelism level

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -546,6 +546,17 @@ public final class Indexer {
 
             parser.on("-H", "--history", "Enable history.").Do(v -> cfg.setHistoryEnabled(true));
 
+            parser.on("--historyThreads", "=number", Integer.class,
+                    "The number of threads to use for history cache generation. By default the number",
+                    "of threads will be set to the number of available CPUs. Assumes -H/--history.").Do(threadCount ->
+                    cfg.setHistoryParallelism((Integer) threadCount));
+
+            parser.on("--historyRenamedThreads", "=number", Integer.class,
+                    "The number of threads to use for history cache generation when dealing with renamed files.",
+                    "By default the number of threads will be set to the number of available CPUs.",
+                    "Assumes --renamedHistory=on").Do(threadCount ->
+                    cfg.setHistoryRenamedParallelism((Integer) threadCount));
+
             parser.on("-I", "--include", "=pattern",
                     "Only files matching this pattern will be examined. Pattern supports",
                     "wildcards (example: -I '*.java' -I '*.c'). Option may be repeated.").Do(
@@ -742,17 +753,6 @@ public final class Indexer {
                     "of threads will be set to the number of available CPUs. This influences the number",
                     "of spawned ctags processes as well.").Do(threadCount ->
                     cfg.setIndexingParallelism((Integer) threadCount));
-
-            parser.on("--historyThreads", "=number", Integer.class,
-                    "The number of threads to use for history cache generation. By default the number",
-                    "of threads will be set to the number of available CPUs. Assumes -H/--history.").Do(threadCount ->
-                    cfg.setHistoryParallelism((Integer) threadCount));
-
-            parser.on("--historyRenamedThreads", "=number", Integer.class,
-                    "The number of threads to use for history cache generation when dealing with renamed files.",
-                    "By default the number of threads will be set to the number of available CPUs.",
-                    "Assumes --renamedHistory=on").Do(threadCount ->
-                    cfg.setHistoryRenamedParallelism((Integer) threadCount));
 
             parser.on("-t", "--tabSize", "=number", Integer.class,
                 "Default tab size to use (number of spaces per tab character).")

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -739,8 +739,20 @@ public final class Indexer {
 
             parser.on("-T", "--threads", "=number", Integer.class,
                     "The number of threads to use for index generation. By default the number",
-                    "of threads will be set to the number of available CPUs.").Do(threadCount ->
+                    "of threads will be set to the number of available CPUs. This influences the number",
+                    "of spawned ctags processes as well.").Do(threadCount ->
                     cfg.setIndexingParallelism((Integer) threadCount));
+
+            parser.on("--historyThreads", "=number", Integer.class,
+                    "The number of threads to use for history cache generation. By default the number",
+                    "of threads will be set to the number of available CPUs. Assumes -H/--history.").Do(threadCount ->
+                    cfg.setHistoryParallelism((Integer) threadCount));
+
+            parser.on("--historyRenamedThreads", "=number", Integer.class,
+                    "The number of threads to use for history cache generation when dealing with renamed files.",
+                    "By default the number of threads will be set to the number of available CPUs.",
+                    "Assumes --renamedHistory=on").Do(threadCount ->
+                    cfg.setHistoryRenamedParallelism((Integer) threadCount));
 
             parser.on("-t", "--tabSize", "=number", Integer.class,
                 "Default tab size to use (number of spaces per tab character).")


### PR DESCRIPTION
Adds 2 options. This is how the help looks like for the tread count related options:
``` 
  --historyThreads number
	The number of threads to use for history cache generation. By default the number
	of threads will be set to the number of available CPUs. Assumes -H/--history.
	
  --historyRenamedThreads number
	The number of threads to use for history cache generation when dealing with renamed files.
	By default the number of threads will be set to the number of available CPUs.
	Assumes --renamedHistory=on


 -T, --threads number
	The number of threads to use for index generation. By default the number
	of threads will be set to the number of available CPUs. This influences the number
	of spawned ctags processes as well.
```