### PR TITLE
Add maven dependency check plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                 <version>6.0.2</version>
                 <configuration>
                     <skipSystemScope>true</skipSystemScope>
+                    <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 
 -->
@@ -310,6 +310,21 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>2.9</version>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>6.0.2</version>
+                <configuration>
+                    <skipSystemScope>true</skipSystemScope>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <pluginManagement>


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
When doing security cup at work I've noticed this plugin and I found it really helpful. It will list all the dependencies with known CVEs and create a report.

I debated whether to add it among `reporting` plugins but I found the usage easier like this since I could call it directly from IDEA.

Output from console:
```
One or more dependencies were identified with known vulnerabilities in Distribution:

ant-1.10.1.jar (pkg:maven/org.apache.ant/ant@1.10.1, cpe:2.3:a:apache:ant:1.10.1:*:*:*:*:*:*:*) : CVE-2020-1945
source.war: chronicle-wire-2.20.4.jar (pkg:maven/net.openhft/chronicle-wire@2.20.4, cpe:2.3:a:wire:wire:2.20.4:*:*:*:*:*:*:*) : CVE-2018-8909
source.war: jquery-3.4.1.min.js (pkg:javascript/jquery@3.4.1.min) : CVE-2020-11022, CVE-2020-11023
source.war: jstl-1.2.jar (cpe:2.3:a:apache:standard_taglibs:1.2:*:*:*:*:*:*:*) : CVE-2015-0254
```

It will also generate a report in html which looks like this:
<img width="1421" alt="Screenshot 2020-09-30 at 10 49 41" src="https://user-images.githubusercontent.com/12401160/94664014-a8b62e00-030a-11eb-8d08-91b6f6d37dda.png">
