### PR TITLE
parallelize repository scan

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -195,7 +195,6 @@ public final class Configuration {
     private int indexingParallelism;
     private int historyParallelism;
     private int historyRenamedParallelism;
-    private int repositorySearchParallelism;
     private boolean tagsEnabled;
     private int hitsPerPage;
     private int cachePages;
@@ -1144,14 +1143,6 @@ public final class Configuration {
 
     public void setHistoryRenamedParallelism(int value) {
         this.historyRenamedParallelism = value > 0 ? value : 0;
-    }
-
-    public int getRepositorySearchParallelism() {
-        return repositorySearchParallelism;
-    }
-
-    public void setRepositorySearchParallelism(int value) {
-        this.repositorySearchParallelism = value > 0 ? value : 0;
     }
 
     public boolean isTagsEnabled() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -195,6 +195,7 @@ public final class Configuration {
     private int indexingParallelism;
     private int historyParallelism;
     private int historyRenamedParallelism;
+    private int repositorySearchParallelism;
     private boolean tagsEnabled;
     private int hitsPerPage;
     private int cachePages;
@@ -238,9 +239,9 @@ public final class Configuration {
      * The directory hierarchy depth to limit the scanning for repositories.
      * E.g. if the /mercurial/ directory (relative to source root) is a repository
      * and /mercurial/usr/closed/ is sub-repository, the latter will be discovered
-     * only if the depth is set to 3 or greater.
+     * only if the depth is set to 2 or greater.
      */
-    public static final int defaultScanningDepth = 3;
+    public static final int defaultScanningDepth = 2;
 
     /**
      * The name of the eftar file relative to the <var>DATA_ROOT</var>, which
@@ -1143,6 +1144,14 @@ public final class Configuration {
 
     public void setHistoryRenamedParallelism(int value) {
         this.historyRenamedParallelism = value > 0 ? value : 0;
+    }
+
+    public int getRepositorySearchParallelism() {
+        return repositorySearchParallelism;
+    }
+
+    public void setRepositorySearchParallelism(int value) {
+        this.repositorySearchParallelism = value > 0 ? value : 0;
     }
 
     public boolean isTagsEnabled() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1110,17 +1110,6 @@ public final class RuntimeEnvironment {
                 parallelism;
     }
 
-    /**
-     * Gets the value of {@link Configuration#getRepositorySearchParallelism()} -- or
-     * if zero, then as a default gets the number of available processors.
-     * @return a natural number &gt;= 1
-     */
-    public int getRepositorySearchParallelism() {
-        int parallelism = syncReadConfiguration(Configuration::getRepositorySearchParallelism);
-        return parallelism < 1 ? Runtime.getRuntime().availableProcessors() :
-                parallelism;
-    }
-
     public boolean isTagsEnabled() {
         return syncReadConfiguration(Configuration::isTagsEnabled);
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1110,6 +1110,17 @@ public final class RuntimeEnvironment {
                 parallelism;
     }
 
+    /**
+     * Gets the value of {@link Configuration#getRepositorySearchParallelism()} -- or
+     * if zero, then as a default gets the number of available processors.
+     * @return a natural number &gt;= 1
+     */
+    public int getRepositorySearchParallelism() {
+        int parallelism = syncReadConfiguration(Configuration::getRepositorySearchParallelism);
+        return parallelism < 1 ? Runtime.getRuntime().availableProcessors() :
+                parallelism;
+    }
+
     public boolean isTagsEnabled() {
         return syncReadConfiguration(Configuration::isTagsEnabled);
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -478,7 +478,7 @@ public final class HistoryGuru {
      * @return collection of added repositories
      */
     public Collection<RepositoryInfo> addRepositories(File[] files) {
-        ExecutorService executor = env.getIndexerParallelizer().getRepositorySearchExecutor();
+        ExecutorService executor = env.getIndexerParallelizer().getFixedExecutor();
         List<Future<Collection<RepositoryInfo>>> futures = new ArrayList<>();
         for (File file: files) {
             futures.add(executor.submit(() -> addRepositories(new File[]{file},
@@ -493,8 +493,6 @@ public final class HistoryGuru {
                 LOGGER.log(Level.WARNING, "failed to get results of repository scan");
             }
         });
-
-        env.getIndexerParallelizer().bounceRepositorySearchExecutor();
 
         return repoList;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -336,12 +336,16 @@ public final class Indexer {
             // Create history cache first.
             if (searchRepositories) {
                 if (searchPaths.isEmpty()) {
-                    searchPaths.add(env.getSourceRootPath());
-                } else {
-                    searchPaths = searchPaths.stream().
-                            map(t -> Paths.get(env.getSourceRootPath(), t).toString()).
-                            collect(Collectors.toSet());
+                    String[] dirs = env.getSourceRootFile().
+                            list((f, name) -> f.isDirectory() && env.getPathAccepter().accept(f));
+                    if (dirs != null) {
+                        searchPaths.addAll(Arrays.asList(dirs));
+                    }
                 }
+
+                searchPaths = searchPaths.stream().
+                        map(t -> Paths.get(env.getSourceRootPath(), t).toString()).
+                        collect(Collectors.toSet());
             }
             getInstance().prepareIndexer(env, searchPaths, addProjects,
                     createDict, runIndex, subFiles, new ArrayList<>(repositories));
@@ -619,7 +623,7 @@ public final class Indexer {
                     runIndex = false);
 
             parser.on("--nestingMaximum", "=number",
-                    "Maximum of nested repositories. Default is 1.").execute(v ->
+                    "Maximum depth of nested repositories. Default is 1.").execute(v ->
                     cfg.setNestingMaximum((Integer) v));
 
             parser.on("-O", "--optimize", "=on|off", ON_OFF, Boolean.class,
@@ -749,10 +753,13 @@ public final class Indexer {
                     cfg.setWebappLAF((String) stylePath));
 
             parser.on("-T", "--threads", "=number", Integer.class,
-                    "The number of threads to use for index generation. By default the number",
-                    "of threads will be set to the number of available CPUs. This influences the number",
-                    "of spawned ctags processes as well.").execute(threadCount ->
-                    cfg.setIndexingParallelism((Integer) threadCount));
+                    "The number of threads to use for index generation and repository scan.",
+                    "By default the number of threads will be set to the number of available",
+                    "CPUs. This influences the number of spawned ctags processes as well.").
+                    execute(threadCount -> {
+                        cfg.setIndexingParallelism((Integer) threadCount);
+                        cfg.setRepositorySearchParallelism((Integer) threadCount);
+                    });
 
             parser.on("-t", "--tabSize", "=number", Integer.class,
                 "Default tab size to use (number of spaces per tab character).")

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -756,10 +756,7 @@ public final class Indexer {
                     "The number of threads to use for index generation and repository scan.",
                     "By default the number of threads will be set to the number of available",
                     "CPUs. This influences the number of spawned ctags processes as well.").
-                    execute(threadCount -> {
-                        cfg.setIndexingParallelism((Integer) threadCount);
-                        cfg.setRepositorySearchParallelism((Integer) threadCount);
-                    });
+                    execute(threadCount -> cfg.setIndexingParallelism((Integer) threadCount));
 
             parser.on("-t", "--tabSize", "=number", Integer.class,
                 "Default tab size to use (number of spaces per tab character).")

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
@@ -62,7 +62,6 @@ public class IndexerParallelizer implements AutoCloseable {
     private LazilyInstantiate<ExecutorService> lzHistoryExecutor;
     private LazilyInstantiate<ExecutorService> lzHistoryRenamedExecutor;
     private LazilyInstantiate<ExecutorService> lzCtagsWatcherExecutor;
-    private LazilyInstantiate<ExecutorService> lzRepositorySearchExecutor;
 
     /**
      * Initializes a new instance using settings from the specified environment
@@ -86,7 +85,6 @@ public class IndexerParallelizer implements AutoCloseable {
         createLazyHistoryExecutor();
         createLazyHistoryRenamedExecutor();
         createLazyCtagsWatcherExecutor();
-        createLazyRepositorySearchExecutor();
     }
 
     /**
@@ -132,13 +130,6 @@ public class IndexerParallelizer implements AutoCloseable {
     }
 
     /**
-     * @return the ExecutorService used for repository scan
-     */
-    public ExecutorService getRepositorySearchExecutor() {
-        return lzRepositorySearchExecutor.get();
-    }
-
-    /**
      * Calls {@link #bounce()}, which prepares for -- but does not start -- new
      * pools.
      */
@@ -170,7 +161,6 @@ public class IndexerParallelizer implements AutoCloseable {
         bounceHistoryExecutor();
         bounceHistoryRenamedExecutor();
         bounceCtagsWatcherExecutor();
-        bounceRepositorySearchExecutor();
     }
 
     private void bounceForkJoinPool() {
@@ -221,18 +211,6 @@ public class IndexerParallelizer implements AutoCloseable {
         }
     }
 
-    /**
-     * Shutdown the executor used for repository search.
-     * @see #bounce()
-     */
-    public void bounceRepositorySearchExecutor() {
-        if (lzRepositorySearchExecutor.isActive()) {
-            ExecutorService formerRepositorySearchExecutor = lzRepositorySearchExecutor.get();
-            createLazyRepositorySearchExecutor();
-            formerRepositorySearchExecutor.shutdown();
-        }
-    }
-
     private void createLazyForkJoinPool() {
         lzForkJoinPool = LazilyInstantiate.using(() ->
                 new ForkJoinPool(indexingParallelism));
@@ -266,11 +244,6 @@ public class IndexerParallelizer implements AutoCloseable {
     private void createLazyHistoryRenamedExecutor() {
         lzHistoryRenamedExecutor = LazilyInstantiate.using(() ->
                 Executors.newFixedThreadPool(env.getHistoryRenamedParallelism()));
-    }
-
-    private void createLazyRepositorySearchExecutor() {
-        lzRepositorySearchExecutor = LazilyInstantiate.using(() ->
-                Executors.newFixedThreadPool(env.getRepositorySearchParallelism()));
     }
 
     private class CtagsObjectFactory implements ObjectFactory<Ctags> {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/GroupsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/GroupsTest.java
@@ -55,19 +55,19 @@ public class GroupsTest {
         Set<Group> groups = cfg.getGroups();
 
         invokeMethod("deleteGroup",
-                new Class[]{Set.class, String.class},
+                new Class<?>[]{Set.class, String.class},
                 new Object[]{groups, "random not existing group"});
 
         Assert.assertEquals(6, cfg.getGroups().size());
 
         invokeMethod("deleteGroup",
-                new Class[]{Set.class, String.class},
+                new Class<?>[]{Set.class, String.class},
                 new Object[]{groups, "apache"});
 
         Assert.assertEquals(5, cfg.getGroups().size());
 
         invokeMethod("deleteGroup",
-                new Class[]{Set.class, String.class},
+                new Class<?>[]{Set.class, String.class},
                 new Object[]{groups, "ctags"});
 
         Assert.assertEquals(1, cfg.getGroups().size());
@@ -80,7 +80,7 @@ public class GroupsTest {
         Assert.assertNull(grp);
 
         invokeMethod("modifyGroup",
-                new Class[]{Set.class, String.class, String.class, String.class},
+                new Class<?>[]{Set.class, String.class, String.class, String.class},
                 new Object[]{groups, "new fantastic group", "some pattern", null});
 
         Assert.assertEquals(7, groups.size());
@@ -101,7 +101,7 @@ public class GroupsTest {
         Assert.assertNull(grp);
 
         invokeMethod("modifyGroup",
-                new Class[]{Set.class, String.class, String.class, String.class},
+                new Class<?>[]{Set.class, String.class, String.class, String.class},
                 new Object[]{groups, "new fantastic group", "some pattern", "apache"});
 
         Assert.assertEquals(7, groups.size());
@@ -127,7 +127,7 @@ public class GroupsTest {
         Assert.assertEquals(grp.getPattern(), "apache-.*");
 
         invokeMethod("modifyGroup",
-                new Class[]{Set.class, String.class, String.class, String.class},
+                new Class<?>[]{Set.class, String.class, String.class, String.class},
                 new Object[]{groups, "apache", "different pattern", null});
 
         grp = findGroup(groups, "apache");
@@ -159,7 +159,7 @@ public class GroupsTest {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         PrintStream out = new PrintStream(os);
         invokeMethod("matchGroups",
-                new Class[]{PrintStream.class, Set.class, String.class},
+                new Class<?>[]{PrintStream.class, Set.class, String.class},
                 new Object[]{out, groups, match});
 
         String output = os.toString();


### PR DESCRIPTION
For the past week or so I have been trying to determine the cause of slowly running reindex from scratch which made me to run it over and over with different settings/versions. Watching the behavior of the initial phase of such indexing made me to address the speed of repository scanning. This change adds parallelism on the level of source root sub-directories. The original behavior should be preserved.