### PR TITLE
do not call createCache() unnecessarily

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -747,7 +747,8 @@ public final class HistoryGuru {
             return;
         }
 
-        if (historyCache.hasCacheForDirectory(file, repository)) {
+        if (!repository.hasHistoryForDirectories() ||
+                historyCache.hasCacheForDirectory(file, repository)) {
             return;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -730,9 +730,7 @@ public final class HistoryGuru {
 
     /**
      * Ensure that we have a directory in the cache. If it's not there, fetch
-     * its history and populate the cache. If it's already there, and the cache
-     * is able to tell how recent it is, attempt to update it to the most recent
-     * revision.
+     * its history and populate the cache.
      *
      * @param file the root path to test
      * @throws HistoryException if an error occurs while accessing the history
@@ -745,24 +743,15 @@ public final class HistoryGuru {
 
         Repository repository = getRepository(file);
         if (repository == null) {
-            // no repository -> no history :(
+            // no repository -> no history
             return;
         }
 
-        String sinceRevision = null;
-
         if (historyCache.hasCacheForDirectory(file, repository)) {
-            sinceRevision = historyCache.getLatestCachedRevision(repository);
-            if (sinceRevision == null) {
-                // Cache already exists, but we don't know how recent it is,
-                // so don't do anything.
-                return;
-            }
+            return;
         }
 
-        // Create cache from the beginning if it doesn't exist, or update it
-        // incrementally otherwise.
-        createCache(repository, sinceRevision);
+        createCache(repository, null);
     }
 
     protected Repository getRepository(File path) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -728,33 +728,6 @@ public final class HistoryGuru {
         return repos;
     }
 
-    /**
-     * Ensure that we have a directory in the cache. If it's not there, fetch
-     * its history and populate the cache.
-     *
-     * @param file the root path to test
-     * @throws HistoryException if an error occurs while accessing the history
-     * cache
-     */
-    public void ensureHistoryCacheExists(File file) throws HistoryException {
-        if (!useCache()) {
-            return;
-        }
-
-        Repository repository = getRepository(file);
-        if (repository == null) {
-            // no repository -> no history
-            return;
-        }
-
-        if (!repository.hasHistoryForDirectories() ||
-                historyCache.hasCacheForDirectory(file, repository)) {
-            return;
-        }
-
-        createCache(repository, null);
-    }
-
     protected Repository getRepository(File path) {
         File file = path;
         Set<String> rootKeys = repositoryRoots.keySet();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -91,7 +91,6 @@ import org.opengrok.indexer.analysis.Definitions;
 import org.opengrok.indexer.configuration.PathAccepter;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
-import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.history.Repository;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -425,19 +424,6 @@ public class IndexDatabase {
                     sourceRoot = env.getSourceRootFile();
                 } else {
                     sourceRoot = new File(env.getSourceRootFile(), dir);
-                }
-
-                if (env.isHistoryEnabled()) {
-                    try {
-                        HistoryGuru.getInstance().ensureHistoryCacheExists(
-                            sourceRoot);
-                    } catch (HistoryException ex) {
-                        String exmsg = String.format(
-                            "Failed to ensureHistoryCacheExists() for %s",
-                            sourceRoot);
-                        LOGGER.log(Level.SEVERE, exmsg, ex);
-                        continue;
-                    }
                 }
 
                 dir = Util.fixPathIfWindows(dir);


### PR DESCRIPTION
Looking at `ensureHistoryCacheExists()` to fix the double emitted log message during reindex, it seems that there is some unnecessary logic there. If the history cache was created for the repository in the 1st step of indexing (the existence of the history cache directory should be enough to tell), it should not be necessary to call `createCache()` again - only for complete failure to create the history cache.

`ensureHistoryCacheExists()` will probably disappear anyway with the fix for #747.