### PR TITLE
suppress raw type warning in IDEA

### DIFF
--- a/suggester/src/main/java/org/opengrok/suggest/popular/impl/chronicle/BytesRefSizedReader.java
+++ b/suggester/src/main/java/org/opengrok/suggest/popular/impl/chronicle/BytesRefSizedReader.java
@@ -46,6 +46,7 @@ public class BytesRefSizedReader implements SizedReader<BytesRef>, Marshallable,
 
     @NotNull
     @Override
+    @SuppressWarnings("rawtypes")
     public BytesRef read(Bytes in, long size, @Nullable BytesRef using) {
         if (size < 0L || size > (long) Integer.MAX_VALUE) {
             throw new IORuntimeException("byte[] size should be non-negative int, " +


### PR DESCRIPTION
When building with recent IDEA I am getting warnings for `missing type arguments for generic class` in `BytesRefSizedReader`. This change suppresses the warning - the class overrides a method from `net.openhft.chronicle.hash.serialization`.