### PR TITLE
Move Message and related classes to web module

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -118,11 +118,6 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <version>${jersey.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>webjars-locator-core</artifactId>
-            <version>0.46</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
@@ -136,12 +131,6 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
             <version>2.0.0.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
-            <version>${jersey.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -242,7 +231,7 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
                     <includeOnlyProperties>
                         <includeOnlyProperty>^git.commit.id</includeOnlyProperty>
                     </includeOnlyProperties>
-		    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
                 </configuration>
                 <executions>
                     <execution>

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -102,11 +102,6 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
         </dependency>
-        <dependency> <!-- TODO: remove! (moving Messages to web module) -->
-            <groupId>org.glassfish.jersey.ext</groupId>
-            <artifactId>jersey-bean-validation</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
@@ -137,10 +132,10 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency> <!-- TODO: remove! (moving Messages to web module) -->
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>3.1.6</version>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+            <version>2.0.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -586,7 +586,7 @@ public final class Configuration {
     }
 
     /**
-     * @see org.opengrok.indexer.web.messages.MessagesContainer
+     * Returns maximum number of messages that can be kept in the system.
      *
      * @return int the current message limit
      */
@@ -595,7 +595,7 @@ public final class Configuration {
     }
 
     /**
-     * @see org.opengrok.indexer.web.messages.MessagesContainer
+     * Sets maximum number of messages that can be kept in the system.
      *
      * @param messageLimit the limit
      * @throws IllegalArgumentException when the limit is negative

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationChangedListener.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationChangedListener.java
@@ -23,7 +23,10 @@
 package org.opengrok.indexer.configuration;
 
 /**
- * Callback that is called when configuration is changed.
+ * Callback that is called when configuration is changed. Use {@link RuntimeEnvironment} to get the actual
+ * configuration values.
+ *
+ * @see Configuration
  */
 public interface ConfigurationChangedListener {
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationChangedListener.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationChangedListener.java
@@ -22,7 +22,10 @@
  */
 package org.opengrok.indexer.configuration;
 
-public interface OnConfigurationChangedListener {
+/**
+ * Callback that is called when configuration is changed.
+ */
+public interface ConfigurationChangedListener {
 
     void onConfigurationChanged();
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/OnConfigurationChangedListener.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/OnConfigurationChangedListener.java
@@ -1,0 +1,29 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.configuration;
+
+public interface OnConfigurationChangedListener {
+
+    void onConfigurationChanged();
+
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -120,7 +120,7 @@ public final class RuntimeEnvironment {
 
     public WatchDogService watchDog;
 
-    private final Set<OnConfigurationChangedListener> listeners = new CopyOnWriteArraySet<>();
+    private final Set<ConfigurationChangedListener> listeners = new CopyOnWriteArraySet<>();
 
     public List<String> getSubFiles() {
         return subFiles;
@@ -1676,7 +1676,7 @@ public final class RuntimeEnvironment {
         getAuthorizationFramework().setStack(getPluginStack());
         getAuthorizationFramework().reload();
 
-        for (OnConfigurationChangedListener l : listeners) {
+        for (ConfigurationChangedListener l : listeners) {
             l.onConfigurationChanged();
         }
     }
@@ -1882,7 +1882,7 @@ public final class RuntimeEnvironment {
         return syncReadConfiguration(Configuration::getMessageLimit);
     }
 
-    public void registerListener(OnConfigurationChangedListener listener) {
+    public void registerListener(ConfigurationChangedListener listener) {
         listeners.add(listener);
     }
 }

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -117,6 +117,11 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
+            <artifactId>webjars-locator-core</artifactId>
+            <version>0.46</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
             <version>3.5.1</version>
         </dependency>

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions copyright (c) 2011 Jens Elkner.
  * Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
  */
@@ -90,7 +90,8 @@ import org.opengrok.indexer.web.QueryParameters;
 import org.opengrok.indexer.web.SearchHelper;
 import org.opengrok.indexer.web.SortOrder;
 import org.opengrok.indexer.web.Util;
-import org.opengrok.indexer.web.messages.MessagesContainer.AcceptedMessage;
+import org.opengrok.web.messages.MessagesContainer;
+import org.opengrok.web.messages.MessagesContainer.AcceptedMessage;
 import org.suigeneris.jrcs.diff.Diff;
 import org.suigeneris.jrcs.diff.DifferentiationFailedException;
 
@@ -1608,13 +1609,12 @@ public final class PageConfig {
         return this.authFramework.isAllowed(this.req, g);
     }
 
-    
     public SortedSet<AcceptedMessage> getMessages() {
-        return env.getMessages();
+        return MessagesContainer.getInstance().getMessages();
     }
-    
+
     public SortedSet<AcceptedMessage> getMessages(String tag) {
-        return env.getMessages(tag);
+        return MessagesContainer.getInstance().getMessages(tag);
     }
 
     /**
@@ -1728,7 +1728,7 @@ public final class PageConfig {
      * </ol>
      *
      * @return the sorted set of messages according to the accept time
-     * @see org.opengrok.indexer.web.messages.MessagesContainer#MESSAGES_MAIN_PAGE_TAG
+     * @see MessagesContainer#MESSAGES_MAIN_PAGE_TAG
      */
     private SortedSet<AcceptedMessage> getProjectMessages() {
         SortedSet<AcceptedMessage> messages = getMessages();

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web;
@@ -33,6 +33,7 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.web.SearchHelper;
 import org.opengrok.web.api.v1.suggester.provider.service.SuggesterServiceFactory;
+import org.opengrok.web.messages.MessagesContainer;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
@@ -100,7 +101,7 @@ public final class WebappListener
             env.watchDog.start(new File(pluginDirectory));
         }
 
-        env.startExpirationTimer();
+        MessagesContainer.getInstance().startExpirationTimer();
         startupTimer.record(Duration.between(start, Instant.now()));
     }
 
@@ -112,7 +113,7 @@ public final class WebappListener
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.getIndexerParallelizer().bounce();
         env.watchDog.stop();
-        env.stopExpirationTimer();
+        MessagesContainer.getInstance().stopExpirationTimer();
         try {
             env.shutdownRevisionExecutor();
         } catch (InterruptedException e) {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/constraints/PositiveDuration.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/constraints/PositiveDuration.java
@@ -18,9 +18,9 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  */
-package org.opengrok.indexer.web.api.constraints;
+package org.opengrok.web.api.constraints;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PositiveDuration {
 
-    String message() default "{org.opengrok.indexer.web.api.constraints.PositiveDuration.message}";
+    String message() default "{org.opengrok.web.api.constraints.PositiveDuration.message}";
 
     Class<?>[] groups() default {};
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/constraints/PositiveDurationValidator.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/constraints/PositiveDurationValidator.java
@@ -18,9 +18,9 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  */
-package org.opengrok.indexer.web.api.constraints;
+package org.opengrok.web.api.constraints;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/HistoryController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/HistoryController.java
@@ -29,7 +29,7 @@ import org.opengrok.indexer.history.History;
 import org.opengrok.indexer.history.HistoryEntry;
 import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.history.HistoryGuru;
-import org.opengrok.indexer.web.messages.JSONable;
+import org.opengrok.web.messages.JSONable;
 import org.opengrok.web.api.v1.filter.CorsEnable;
 import org.opengrok.web.api.v1.filter.PathAuthorized;
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/MessagesController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/MessagesController.java
@@ -18,13 +18,13 @@
  */
 
 /*
- * Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.controller;
 
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
-import org.opengrok.indexer.web.messages.Message;
-import org.opengrok.indexer.web.messages.MessagesContainer.AcceptedMessage;
+import org.opengrok.web.messages.Message;
+import org.opengrok.web.messages.MessagesContainer;
+import org.opengrok.web.messages.MessagesContainer.AcceptedMessage;
 
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
@@ -43,12 +43,12 @@ import java.util.Set;
 @Path("/messages")
 public class MessagesController {
 
-    private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+    private final MessagesContainer container = MessagesContainer.getInstance();
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     public Response addMessage(@Valid final Message message) {
-        env.addMessage(message);
+        container.addMessage(message);
 
         return Response.status(Response.Status.CREATED).build();
     }
@@ -59,16 +59,16 @@ public class MessagesController {
         if (tag == null) {
             throw new WebApplicationException("Message tag has to be specified", Response.Status.BAD_REQUEST);
         }
-        env.removeAnyMessage(Collections.singleton(tag), text);
+        container.removeAnyMessage(Collections.singleton(tag), text);
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Set<AcceptedMessage> getMessages(@QueryParam("tag") final String tag) {
         if (tag != null) {
-            return env.getMessages(tag);
+            return container.getMessages(tag);
         } else {
-            return env.getAllMessages();
+            return container.getAllMessages();
         }
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/messages/JSONable.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/messages/JSONable.java
@@ -18,10 +18,10 @@
  */
 
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 
-package org.opengrok.indexer.web.messages;
+package org.opengrok.web.messages;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/opengrok-web/src/main/java/org/opengrok/web/messages/Message.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/messages/Message.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  */
-package org.opengrok.indexer.web.messages;
+package org.opengrok.web.messages;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import org.opengrok.indexer.web.Util;
-import org.opengrok.indexer.web.api.constraints.PositiveDuration;
+import org.opengrok.web.api.constraints.PositiveDuration;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -45,7 +45,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static org.opengrok.indexer.web.messages.MessagesContainer.MESSAGES_MAIN_PAGE_TAG;
+import static org.opengrok.web.messages.MessagesContainer.MESSAGES_MAIN_PAGE_TAG;
 
 public class Message implements Comparable<Message>, JSONable {
 

--- a/opengrok-web/src/main/java/org/opengrok/web/messages/MessagesContainer.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/messages/MessagesContainer.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import org.opengrok.indexer.configuration.OnConfigurationChangedListener;
+import org.opengrok.indexer.configuration.ConfigurationChangedListener;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 
@@ -53,13 +53,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-public class MessagesContainer implements OnConfigurationChangedListener {
+public class MessagesContainer implements ConfigurationChangedListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MessagesContainer.class);
 
     public static final String MESSAGES_MAIN_PAGE_TAG = "main";
-
-    private static final int DEFAULT_MESSAGE_LIMIT = 100;
 
     private static final MessagesContainer instance = new MessagesContainer();
 
@@ -67,7 +65,7 @@ public class MessagesContainer implements OnConfigurationChangedListener {
 
     private int messagesInTheSystem = 0;
 
-    private int messageLimit = DEFAULT_MESSAGE_LIMIT;
+    private int messageLimit = RuntimeEnvironment.getInstance().getMessageLimit();
 
     private Timer expirationTimer;
 
@@ -234,7 +232,6 @@ public class MessagesContainer implements OnConfigurationChangedListener {
     }
 
     public void startExpirationTimer() {
-        setMessageLimit(RuntimeEnvironment.getInstance().getMessageLimit());
         if (expirationTimer != null) {
             stopExpirationTimer();
         }

--- a/opengrok-web/src/main/java/org/opengrok/web/messages/MessagesUtils.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/messages/MessagesUtils.java
@@ -18,16 +18,15 @@
  */
 
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 
-package org.opengrok.indexer.web.messages;
+package org.opengrok.web.messages;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opengrok.indexer.configuration.Group;
 import org.opengrok.indexer.configuration.Project;
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.web.Util;
 
@@ -147,7 +146,7 @@ public final class MessagesUtils {
         Set<TaggedMessagesContainer> messages = new HashSet<>();
 
         for (String tag : tags) {
-            SortedSet<MessagesContainer.AcceptedMessage> messagesWithTag = RuntimeEnvironment.getInstance().getMessages(tag);
+            SortedSet<MessagesContainer.AcceptedMessage> messagesWithTag = MessagesContainer.getInstance().getMessages(tag);
             if (messagesWithTag.isEmpty()) {
                 continue;
             }
@@ -251,10 +250,9 @@ public final class MessagesUtils {
      */
     public static String getMessageLevel(String... tags) {
         Set<MessagesContainer.AcceptedMessage> messages;
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
         messages = Arrays.stream(tags).
-                map(env::getMessages).
+                map(MessagesContainer.getInstance()::getMessages).
                 flatMap(Collection::stream).
                 collect(Collectors.toSet());
 

--- a/opengrok-web/src/main/java/org/opengrok/web/search/Results.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/search/Results.java
@@ -18,14 +18,14 @@
  */
 
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2011 Jens Elkner.
  * Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
  */
 
-package org.opengrok.indexer.search;
+package org.opengrok.web.search;
 
-import static org.opengrok.indexer.web.messages.MessagesContainer.MESSAGES_MAIN_PAGE_TAG;
+import static org.opengrok.web.messages.MessagesContainer.MESSAGES_MAIN_PAGE_TAG;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -56,12 +56,13 @@ import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.IOUtils;
 import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.Prefix;
 import org.opengrok.indexer.web.SearchHelper;
 import org.opengrok.indexer.web.Util;
-import org.opengrok.indexer.web.messages.MessagesUtils;
+import org.opengrok.web.messages.MessagesUtils;
 
 /**
  * @author Chandan slightly rewritten by Lubos Kosco

--- a/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
+++ b/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
@@ -16,13 +16,13 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
 --%>
 <%@ tag import="org.apache.commons.lang3.ObjectUtils" %>
 <%@ tag import="org.opengrok.indexer.web.Prefix" %>
 <%@ tag import="org.opengrok.indexer.web.Util" %>
-<%@ tag import="org.opengrok.indexer.web.messages.MessagesUtils" %>
+<%@ tag import="org.opengrok.web.messages.MessagesUtils" %>
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>

--- a/opengrok-web/src/main/webapp/mast.jsp
+++ b/opengrok-web/src/main/webapp/mast.jsp
@@ -28,12 +28,12 @@ After include you are here: /body/div#page/div#content/
 
 --%>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@page import="org.opengrok.indexer.web.messages.MessagesContainer"%>
-<%@ page session="false" errorPage="error.jsp" import="
+<%@page import="org.opengrok.web.messages.MessagesContainer"%>
+<%@page session="false" errorPage="error.jsp" import="
 org.opengrok.web.PageConfig,
 org.opengrok.indexer.web.Prefix,
 org.opengrok.indexer.web.Util"%>
-<%@ page import="org.opengrok.indexer.web.messages.MessagesUtils" %>
+<%@page import="org.opengrok.web.messages.MessagesUtils" %>
 <%
 /* ---------------------- mast.jsp start --------------------- */
 {

--- a/opengrok-web/src/main/webapp/menu.jspf
+++ b/opengrok-web/src/main/webapp/menu.jspf
@@ -16,7 +16,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
 
@@ -35,7 +35,7 @@ org.opengrok.web.ProjectHelper,
 org.opengrok.indexer.web.QueryParameters,
 org.opengrok.indexer.web.SearchHelper,
 org.opengrok.indexer.web.Util,
-org.opengrok.indexer.web.messages.MessagesUtils"
+org.opengrok.web.messages.MessagesUtils"
 %>
 <%
 /* ---------------------- menu.jspf start --------------------- */

--- a/opengrok-web/src/main/webapp/repos.jspf
+++ b/opengrok-web/src/main/webapp/repos.jspf
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
 --%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="opengrok" %>
@@ -33,8 +33,8 @@ Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
 <%@page import="org.opengrok.indexer.history.RepositoryInfo"%>
 <%@page import="org.opengrok.web.PageConfig"%>
 <%@page import="org.opengrok.web.ProjectHelper"%>
-<%@ page import="static org.opengrok.indexer.web.messages.MessagesUtils.printMessages" %>
-<%@ page import="static org.opengrok.indexer.web.messages.MessagesUtils.messagesToJson" %>
+<%@page import="static org.opengrok.web.messages.MessagesUtils.printMessages" %>
+<%@page import="static org.opengrok.web.messages.MessagesUtils.messagesToJson" %>
 <%
 {
     PageConfig cfg = PageConfig.get(request);

--- a/opengrok-web/src/main/webapp/search.jsp
+++ b/opengrok-web/src/main/webapp/search.jsp
@@ -16,7 +16,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
 
@@ -25,7 +25,7 @@ Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
 <%@page import="javax.servlet.http.HttpServletResponse"%>
 <%@page session="false" errorPage="error.jsp" import="
 org.apache.lucene.queryparser.classic.QueryParser,
-org.opengrok.indexer.search.Results,
+org.opengrok.web.search.Results,
 org.opengrok.web.api.v1.suggester.provider.service.SuggesterServiceFactory,
 org.opengrok.indexer.web.QueryParameters,
 org.opengrok.indexer.web.SearchHelper,

--- a/opengrok-web/src/test/java/org/opengrok/web/api/constraints/PositiveDurationValidatorTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/constraints/PositiveDurationValidatorTest.java
@@ -18,9 +18,9 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  */
-package org.opengrok.indexer.web.api.constraints;
+package org.opengrok.web.api.constraints;
 
 import org.junit.Test;
 

--- a/opengrok-web/src/test/java/org/opengrok/web/messages/JSONUtils.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/messages/JSONUtils.java
@@ -18,10 +18,10 @@
  */
 
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 
-package org.opengrok.indexer.web.messages;
+package org.opengrok.web.messages;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;

--- a/opengrok-web/src/test/java/org/opengrok/web/messages/MessageTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/messages/MessageTest.java
@@ -18,9 +18,9 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  */
-package org.opengrok.indexer.web.messages;
+package org.opengrok.web.messages;
 
 import org.junit.Test;
 
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.HashSet;
 
 import static org.junit.Assert.assertEquals;
-import static org.opengrok.indexer.web.messages.JSONUtils.getTopLevelJSONFields;
+import static org.opengrok.web.messages.JSONUtils.getTopLevelJSONFields;
 
 public class MessageTest {
 

--- a/opengrok-web/src/test/java/org/opengrok/web/messages/MessagesContainerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/messages/MessagesContainerTest.java
@@ -18,15 +18,16 @@
  */
 
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
  */
-package org.opengrok.indexer.web.messages;
+package org.opengrok.web.messages;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -39,15 +40,17 @@ import java.util.concurrent.TimeUnit;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.opengrok.indexer.web.messages.JSONUtils.getTopLevelJSONFields;
+import static org.opengrok.web.messages.JSONUtils.getTopLevelJSONFields;
 
 public class MessagesContainerTest {
 
     private MessagesContainer container;
 
     @Before
-    public void setUp() {
-        container = new MessagesContainer();
+    public void setUp() throws Exception {
+        Constructor<MessagesContainer> constructor = MessagesContainer.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        container = constructor.newInstance();
         container.startExpirationTimer();
     }
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
I've noticed the `TODO` messages in indexer's `pom.xml` and since I was already moving some classes in #3269 I decided to give messages a go as well.

I made `MessagesContainer` a singleton (we basically had only one instance in `RuntimeEnvironment`) so I had to change the tests around it a bit.

`MessagesContainer` was depending on configuration change so I introduced `OnConfigurationChangedListener` as a callback for any configuration dependent classes to use.

Thanks.