### PR TITLE
WIP: Refactor for History enumeration and ObjectStreamHandler

### DIFF
--- a/dev/checkstyle/suppressions.xml
+++ b/dev/checkstyle/suppressions.xml
@@ -49,6 +49,8 @@ Portions Copyright (c) 2018-2020, Chris Fraire <cfraire@me.com>.
 
     <suppress checks="LineLength" files="CustomSloppyPhraseScorer\.java" />
 
+    <suppress checks="AnonInnerLength" files="Executor\.java" />
+
     <suppress checks="EmptyBlock" files="JFlexNonXref\.java|JavaClassAnalyzer\.java|JFlexXref\.java|Util\.java|
         |ClearCaseRepository\.java" />
 

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -210,7 +210,25 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <artifactId>micrometer-registry-prometheus</artifactId>
             <version>${micrometer.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.oath.halodb</groupId>
+            <artifactId>halodb</artifactId>
+            <version>0.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>1.7.26</version>
+        </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>yahoo-bintray</id>
+            <name>yahoo-bintray</name>
+            <url>https://yahoo.bintray.com/maven</url>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AccuRevHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AccuRevHistoryParser.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -49,9 +50,8 @@ public class AccuRevHistoryParser implements Executor.StreamHandler {
      * @param file the file to parse history for
      * @param repos Pointer to the {@code AccuRevRepository}
      * @return object representing the file's history
-     * @throws HistoryException if a problem occurs while executing p4 command
      */
-    History parse(File file, Repository repos) throws HistoryException {
+    History parse(File file, Repository repos) {
 
         repository = (AccuRevRepository) repos;
 
@@ -68,7 +68,7 @@ public class AccuRevHistoryParser implements Executor.StreamHandler {
         
         if (relPath.equals(rootRelativePath)) {
 
-            List<HistoryEntry> entries = new ArrayList<HistoryEntry>();
+            List<HistoryEntry> entries = new ArrayList<>();
 
             entries.add(new HistoryEntry(
                     "", new Date(), "OpenGrok", null, "Workspace Root", true));
@@ -76,18 +76,11 @@ public class AccuRevHistoryParser implements Executor.StreamHandler {
             history = new History(entries);
 
         } else {
-            try {
-                /*
-                 * Errors will be logged, so not bothering to add to the output.
-                 */
-                Executor executor = repository.getHistoryLogExecutor(file);
-                executor.exec(true, this);
-
-            } catch (IOException e) {
-                throw new HistoryException(
-                        "Failed to get history for: \""
-                        + file.getAbsolutePath() + "\"" + e);
-            }
+            /*
+             * Errors will be logged, so not bothering to add to the output.
+             */
+            Executor executor = repository.getHistoryLogExecutor(file);
+            executor.exec(true, this);
         }
 
         return history;
@@ -96,7 +89,7 @@ public class AccuRevHistoryParser implements Executor.StreamHandler {
     public void processStream(InputStream input) throws IOException {
 
         BufferedReader in = new BufferedReader(new InputStreamReader(input));
-        List<HistoryEntry> entries = new ArrayList<HistoryEntry>();
+        List<HistoryEntry> entries = new ArrayList<>();
         String line;
         String user;
         Date date;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AccuRevRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AccuRevRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -108,7 +108,7 @@ public class AccuRevRepository extends Repository {
     }
 
     @Override
-    public Annotation annotate(File file, String rev) throws IOException {
+    public Annotation annotate(File file, String rev) {
 
         ArrayList<String> cmd = new ArrayList<>();
 
@@ -141,7 +141,7 @@ public class AccuRevRepository extends Repository {
      * @param file file for which history is to be retrieved.
      * @return An Executor ready to be started
      */
-    Executor getHistoryLogExecutor(File file) throws IOException {
+    Executor getHistoryLogExecutor(File file) {
 
         // Do not use absolute paths because symbolic links will cause havoc.
         String path = getDepotRelativePath( file );
@@ -455,12 +455,12 @@ public class AccuRevRepository extends Repository {
     }
 
     @Override
-    History getHistory(File file) throws HistoryException {
-        return new AccuRevHistoryParser().parse(file, this);
+    HistoryEnumeration getHistory(File file) throws HistoryException {
+        return new SingleHistory(new AccuRevHistoryParser().parse(file, this));
     }
 
     @Override
-    String determineParent(CommandTimeoutType cmdType) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) {
         getAccuRevInfo(new File(getDirectoryName()), cmdType);
         return parentInfo;
     }
@@ -471,7 +471,7 @@ public class AccuRevRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarHistoryParser.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -50,8 +50,8 @@ class BazaarHistoryParser implements Executor.StreamHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(BazaarHistoryParser.class);
 
     private String myDir;
-    private List<HistoryEntry> entries = new ArrayList<>(); //NOPMD
-    private BazaarRepository repository = new BazaarRepository(); //NOPMD
+    private final List<HistoryEntry> entries = new ArrayList<>(); //NOPMD
+    private final BazaarRepository repository;
 
     BazaarHistoryParser(BazaarRepository repository) {
         this.repository = repository;
@@ -93,12 +93,11 @@ class BazaarHistoryParser implements Executor.StreamHandler {
     @Override
     public void processStream(InputStream input) throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-
         BufferedReader in = new BufferedReader(new InputStreamReader(input));
-        String s;
-
         HistoryEntry entry = null;
         int state = 0;
+
+        String s;
         while ((s = in.readLine()) != null) {
             if ("------------------------------------------------------------".equals(s)) {
                 if (entry != null && state > 2) {
@@ -169,8 +168,8 @@ class BazaarHistoryParser implements Executor.StreamHandler {
 
                         File f = new File(myDir, s);
                         try {
-                            String name = env.getPathRelativeToSourceRoot(f);
-                            entry.addFile(name.intern());
+                            String path = env.getPathRelativeToSourceRoot(f);
+                            entry.addFile(path);
                         } catch (ForbiddenSymlinkException e) {
                             LOGGER.log(Level.FINER, e.getMessage());
                             // ignored

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -77,7 +77,7 @@ public class BazaarRepository extends Repository {
             throws IOException {
         String filename = getRepoRelativePath(file);
 
-        List<String> cmd = new ArrayList<String>();
+        List<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         cmd.add(RepoCommand);
         cmd.add("log");
@@ -202,7 +202,7 @@ public class BazaarRepository extends Repository {
     }
 
     @Override
-    History getHistory(File file, String sinceRevision) throws HistoryException {
+    HistoryEnumeration getHistory(File file, String sinceRevision) throws HistoryException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         History result = new BazaarHistoryParser(this).parse(file, sinceRevision);
         // Assign tags to changesets they represent
@@ -210,11 +210,11 @@ public class BazaarRepository extends Repository {
         if (env.isTagsEnabled()) {
             assignTagsInHistory(result);
         }
-        return result;
+        return new SingleHistory(result);
     }
 
     @Override
-    History getHistory(File file) throws HistoryException {
+    HistoryEnumeration getHistory(File file) throws HistoryException {
         return getHistory(file, null);
     }
 
@@ -271,7 +271,7 @@ public class BazaarRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BitKeeperRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BitKeeperRepository.java
@@ -20,7 +20,7 @@
 /*
  * Author: James Service <jas2701@googlemail.com>
  * Portions by: Oracle and/or its affiliates.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.history;
@@ -168,7 +168,7 @@ public class BitKeeperRepository extends Repository {
      * @return null
      */
     @Override
-    String determineBranch(CommandTimeoutType cmdType) throws IOException {
+    String determineBranch(CommandTimeoutType cmdType) {
         return null;
     }
 
@@ -181,7 +181,7 @@ public class BitKeeperRepository extends Repository {
     String determineParent(CommandTimeoutType cmdType) throws IOException {
         final File directory = new File(getDirectoryName());
 
-        final ArrayList<String> argv = new ArrayList<String>();
+        final ArrayList<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         argv.add(RepoCommand);
         argv.add("parent");
@@ -232,7 +232,7 @@ public class BitKeeperRepository extends Repository {
         final File directory = absolute.getParentFile();
         final String basename = absolute.getName();
 
-        final ArrayList<String> argv = new ArrayList<String>();
+        final ArrayList<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         argv.add(RepoCommand);
         argv.add("files");
@@ -251,10 +251,10 @@ public class BitKeeperRepository extends Repository {
      * Construct a History for a file in this repository.
      *
      * @param file a file in the repository
-     * @return history a history object
+     * @return history a history sequence
      */
     @Override
-    History getHistory(File file) throws HistoryException {
+    HistoryEnumeration getHistory(File file) throws HistoryException {
         return getHistory(file, null);
     }
 
@@ -263,15 +263,15 @@ public class BitKeeperRepository extends Repository {
      *
      * @param file a file in the repository
      * @param sinceRevision omit history from before, and including, this revision
-     * @return history a history object
+     * @return history a history sequence
      */
     @Override
-    History getHistory(File file, String sinceRevision) throws HistoryException {
+    HistoryEnumeration getHistory(File file, String sinceRevision) throws HistoryException {
         final File absolute = file.getAbsoluteFile();
         final File directory = absolute.getParentFile();
         final String basename = absolute.getName();
 
-        final ArrayList<String> argv = new ArrayList<String>();
+        final ArrayList<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         argv.add(RepoCommand);
         argv.add("log");
@@ -297,7 +297,7 @@ public class BitKeeperRepository extends Repository {
             assignTagsInHistory(history);
         }
 
-        return history;
+        return new SingleHistory(history);
     }
 
     @Override
@@ -305,7 +305,7 @@ public class BitKeeperRepository extends Repository {
             BufferSink sink, String parent, String basename, String revision) {
 
         final File directory = new File(parent).getAbsoluteFile();
-        final ArrayList<String> argv = new ArrayList<String>();
+        final ArrayList<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         argv.add(RepoCommand);
         argv.add("get");
@@ -436,7 +436,7 @@ public class BitKeeperRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -144,7 +144,7 @@ public class CVSRepository extends RCSRepository {
     }
 
     @Override
-    String determineBranch(CommandTimeoutType cmdType) throws IOException {
+    String determineBranch(CommandTimeoutType cmdType) {
         String branch = null;
 
         File tagFile = new File(getDirectoryName(), "CVS/Tag");
@@ -250,12 +250,12 @@ public class CVSRepository extends RCSRepository {
     }
 
     @Override
-    History getHistory(File file) throws HistoryException {
-        return new CVSHistoryParser().parse(file, this);
+    HistoryEnumeration getHistory(File file) throws HistoryException {
+        return new SingleHistory(new CVSHistoryParser().parse(file, this));
     }
 
     @Override
-    Annotation annotate(File file, String revision) throws IOException {
+    Annotation annotate(File file, String revision) {
         ArrayList<String> cmd = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         cmd.add(RepoCommand);
@@ -284,7 +284,7 @@ public class CVSRepository extends RCSRepository {
     }
 
     @Override
-    String determineParent(CommandTimeoutType cmdType) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) {
         File rootFile = new File(getDirectoryName() + File.separator + "CVS"
                 + File.separator + "Root");
         String parent = null;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/ClearCaseRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/ClearCaseRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -143,10 +143,9 @@ public class ClearCaseRepository extends Repository {
      * @param file file to annotate
      * @param revision revision to annotate
      * @return file annotation
-     * @throws java.io.IOException if I/O exception occurred
      */
     @Override
-    public Annotation annotate(File file, String revision) throws IOException {
+    public Annotation annotate(File file, String revision) {
         ArrayList<String> argv = new ArrayList<>();
 
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
@@ -223,7 +222,7 @@ public class ClearCaseRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) {
         return null;
     }
 
@@ -269,12 +268,12 @@ public class ClearCaseRepository extends Repository {
     }
 
     @Override
-    History getHistory(File file) throws HistoryException {
-        return new ClearCaseHistoryParser().parse(file, this);
+    HistoryEnumeration getHistory(File file) throws HistoryException {
+        return new SingleHistory(new ClearCaseHistoryParser().parse(file, this));
     }
 
     @Override
-    String determineParent(CommandTimeoutType cmdType) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) {
         return null;
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryTemp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryTemp.java
@@ -1,0 +1,351 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.history;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.primitives.Longs;
+import com.oath.halodb.HaloDB;
+import com.oath.halodb.HaloDBException;
+import com.oath.halodb.HaloDBOptions;
+import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.IOUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Represents a logger of batches of file {@link HistoryEntry} arrays for
+ * transient storage to be pieced together later file by file.
+ */
+class FileHistoryTemp implements Closeable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileHistoryTemp.class);
+
+    private static final ObjectMapper MAPPER;
+    private static final TypeReference<HistoryEntryFixed[]> TYPE_H_E_F_ARRAY;
+
+    private final AtomicLong counter = new AtomicLong(0);
+    private Path tempDir;
+    private Map<String, PointedMeta> batchPointers;
+    private HaloDB batchDb;
+
+    static {
+        MAPPER = new ObjectMapper();
+        MAPPER.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+
+        TYPE_H_E_F_ARRAY = new TypeReference<HistoryEntryFixed[]>() { };
+    }
+
+    /**
+     * Gets the number of appended files. (Not thread safe.)
+     * @return a non-negative number
+     */
+    int fileCount() {
+        return batchDb == null ? 0 : batchPointers.size();
+    }
+
+    /**
+     * Creates a temporary directory, and opens a HashDb for temporary storage
+     * of history. (Not thread safe.)
+     */
+    public void open() throws IOException {
+        if (tempDir != null) {
+            throw new IllegalStateException("already open");
+        }
+
+        tempDir = Files.createTempDirectory("org_opengrok-file_history_log");
+        Path batchDbPath = tempDir.resolve("batch.db");
+
+        HaloDBOptions options = new HaloDBOptions();
+        options.setMaxFileSize(64 * 1024 * 1024); // 64 MB
+        options.setFlushDataSizeBytes(8 * 1024 * 1024); // 8 MB
+        options.setCompactionThresholdPerFile(1.0);
+        options.setCompactionJobRate(64 * 1024 * 1024); // 64 MB
+        options.setNumberOfRecords(10_000_000);
+        options.setCleanUpTombstonesDuringOpen(false);
+        options.setCleanUpInMemoryIndexOnClose(true);
+        options.setUseMemoryPool(true);
+        options.setMemoryPoolChunkSize(2 * 1024 * 1024); // 2 MB
+        options.setFixedKeySize(Longs.BYTES);
+
+        try {
+            batchDb = HaloDB.open(batchDbPath.toString(), options);
+        } catch (HaloDBException e) {
+            throw new IOException("opening temp db", e);
+        }
+
+        counter.set(0);
+        batchPointers = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Cleans up temporary directory. (Not thread safe.)
+     */
+    @Override
+    public void close() throws IOException {
+        if (batchPointers != null) {
+            batchPointers.clear();
+        }
+
+        try {
+            if (batchDb != null) {
+                batchDb.close();
+            }
+        } catch (HaloDBException e) {
+            throw new IOException("closing temp db", e);
+        } finally {
+            batchDb = null;
+            if (tempDir != null) {
+                IOUtils.removeRecursive(tempDir);
+            }
+        }
+    }
+
+    /**
+     * Sets the specified {@code entries} as the list of entries for
+     * {@code file}, which will indicate a full overwrite later. (Thread safe
+     * but not guaranteeing batch order for simultaneous calls for the same
+     * {@code file}.)
+     * @throws IOException if an I/O error occurs writing to temp
+     */
+    public void set(String file, List<HistoryEntry> entries) throws IOException {
+        incorporate(file, entries, true);
+    }
+
+    /**
+     * Appends the specified batch of {@code entries} to the previous list of
+     * entries for {@code file}. (Thread safe but not guaranteeing batch order
+     * for simultaneous calls for the same {@code file}.)
+     * @throws IOException if an I/O error occurs writing to temp
+     */
+    public void append(String file, List<HistoryEntry> entries) throws IOException {
+        incorporate(file, entries, false);
+    }
+
+    private void incorporate(String file, List<HistoryEntry> entries, boolean forceOverwrite)
+            throws IOException {
+
+        if (batchDb == null) {
+            throw new IllegalStateException("not open");
+        }
+
+        HistoryEntryFixed[] fixedEntries = fix(entries);
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        MAPPER.writeValue(bytesOut, fixedEntries);
+        byte[] serialized = bytesOut.toByteArray();
+        byte[] packed = BinPacker.pack(serialized);
+
+        long i = counter.incrementAndGet();
+        try {
+            batchDb.put(Longs.toByteArray(i), packed);
+        } catch (HaloDBException e) {
+            throw new IOException("writing temp db", e);
+        }
+
+        final PointedMeta pointed;
+        if (forceOverwrite) {
+            pointed = new PointedMeta(true);
+            batchPointers.put(file, pointed);
+        } else {
+            pointed = batchPointers.computeIfAbsent(file, k -> new PointedMeta(false));
+        }
+
+        synchronized (pointed.lock) {
+            pointed.counters.add(i);
+        }
+    }
+
+    /**
+     * Gets an enumerator to recompose batches of entries by file into
+     * {@link KeyedHistory} instances. (Not thread safe.)
+     * @return a defined enumeration
+     */
+    Enumeration<KeyedHistory> getEnumerator() {
+
+        if (batchDb == null) {
+            throw new IllegalStateException("not open");
+        }
+
+        final Iterator<String> iterator = batchPointers.keySet().iterator();
+
+        return new Enumeration<KeyedHistory>() {
+            @Override
+            public boolean hasMoreElements() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public KeyedHistory nextElement() {
+                String file = iterator.next();
+                PointedMeta pointed = batchPointers.get(file);
+                List<HistoryEntry> entries;
+                try {
+                    entries = readEntries(pointed.counters);
+                } catch (IOException e) {
+                    throw new RuntimeException("readEntries()", e);
+                }
+                return new KeyHistoryImpl(file, entries, pointed.forceOverwrite);
+            }
+        };
+    }
+
+    private List<HistoryEntry> readEntries(List<Long> pointers) throws IOException {
+
+        List<HistoryEntry> res = new ArrayList<>();
+        for (long nextCounter : pointers) {
+            byte[] packed;
+            try {
+                packed = batchDb.get(Longs.toByteArray(nextCounter));
+            } catch (HaloDBException e) {
+                throw new IOException("reading temp db", e);
+            }
+            byte[] serialized = BinPacker.unpack(packed);
+            Object obj = MAPPER.readValue(serialized, TYPE_H_E_F_ARRAY);
+
+            if (obj == null) {
+                LOGGER.log(Level.SEVERE, "Unexpected null");
+            } else if (obj instanceof HistoryEntryFixed[]) {
+                for (HistoryEntryFixed element : (HistoryEntryFixed[]) obj) {
+                    res.add(element.toEntry());
+                }
+            } else {
+                LOGGER.log(Level.SEVERE, "Unexpected serialized type, {0}", obj.getClass());
+            }
+        }
+        return res;
+    }
+
+    private static HistoryEntryFixed[] fix(List<HistoryEntry> entries) {
+        HistoryEntryFixed[] res = new HistoryEntryFixed[entries.size()];
+
+        int i = 0;
+        for (HistoryEntry entry : entries) {
+            res[i++] = new HistoryEntryFixed(entry);
+        }
+        return res;
+    }
+
+    private static class PointedMeta {
+        final Object lock = new Object();
+        final List<Long> counters = new ArrayList<>();
+        final boolean forceOverwrite;
+
+        PointedMeta(boolean forceOverwrite) {
+            this.forceOverwrite = forceOverwrite;
+        }
+    }
+
+    private static class KeyHistoryImpl implements KeyedHistory {
+        private final String file;
+        private final List<HistoryEntry> entries;
+        private final boolean forceOverwrite;
+
+        KeyHistoryImpl(String file, List<HistoryEntry> entries, boolean forceOverwrite) {
+            this.file = file;
+            this.entries = entries;
+            this.forceOverwrite = forceOverwrite;
+        }
+
+        @Override
+        public String getFile() {
+            return file;
+        }
+
+        @Override
+        public List<HistoryEntry> getEntries() {
+            return Collections.unmodifiableList(entries);
+        }
+
+        @Override
+        public boolean isForceOverwrite() {
+            return forceOverwrite;
+        }
+    }
+
+    private static class BinPacker {
+        static final int MINIMUM_LENGTH_TO_COMPRESS = 100;
+
+        static byte[] pack(byte[] value) {
+            if (value.length < MINIMUM_LENGTH_TO_COMPRESS) {
+                final byte[] packed = new byte[value.length + 1];
+                packed[0] = 0; // Set 0 to indicate uncompressed.
+                System.arraycopy(value, 0, packed, 1, value.length);
+                return packed;
+            } else {
+                ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+                bytesOut.write(1); // Set 1 to indicate compressed.
+
+                try (GZIPOutputStream gz = new GZIPOutputStream(bytesOut)) {
+                    gz.write(value);
+                } catch (IOException e) {
+                    // Not expected to happen
+                    throw new RuntimeException(e);
+                }
+                return bytesOut.toByteArray();
+            }
+        }
+
+        static byte[] unpack(byte[] packed) {
+            if (packed[0] == 0) {
+                byte[] res = new byte[packed.length - 1];
+                System.arraycopy(packed, 1, res, 0, packed.length - 1);
+                return res;
+            } else {
+                ByteArrayInputStream bytesIn = new ByteArrayInputStream(packed);
+                //noinspection ResultOfMethodCallIgnored
+                bytesIn.read();
+
+                ByteArrayOutputStream res = new ByteArrayOutputStream();
+                try (GZIPInputStream gz = new GZIPInputStream(bytesIn)) {
+                    int b;
+                    while ((b = gz.read()) != -1) {
+                        res.write(b);
+                    }
+                } catch (IOException e) {
+                    // Not expected to happen
+                    throw new RuntimeException(e);
+                }
+                return res.toByteArray();
+            }
+        }
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FilteredHistoryEnumeration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FilteredHistoryEnumeration.java
@@ -1,0 +1,126 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.history;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Represents a filtering of a history sequence up to but not including a
+ * specified revision identifier. For {@link Repository} implementations that
+ * do not yet support a partial history, then a simple, but expensive,
+ * filtering of the full history is done.
+ * <p>N.b. the underlying sequence is fully exhausted during the filtering.
+ */
+class FilteredHistoryEnumeration implements HistoryEnumeration {
+
+    private final HistoryEnumeration underlying;
+    private final String sinceRevision;
+    private boolean didMatchRevision;
+
+    /**
+     * Initializes an instance from the specified sequence.
+     * @param historySequence a defined sequence ordered from most recent to
+     * earlier between each element and within each element
+     * @param sinceRevision the revision at which to stop (non-inclusive)
+     * returning data, or {@code null} to return the full sequence
+     */
+    FilteredHistoryEnumeration(HistoryEnumeration historySequence, String sinceRevision) {
+        this.underlying = historySequence;
+        this.sinceRevision = sinceRevision;
+    }
+
+    @Override
+    public void close() throws IOException {
+        underlying.close();
+    }
+
+    /**
+     * Tests if this enumeration contains more elements.
+     * @return {@code true} if and only if a defined {@code sinceRevision} has
+     * not yet matched and if the underlying sequence contains at least one
+     * more element to provide; {@code false} otherwise.
+     */
+    @Override
+    public boolean hasMoreElements() {
+        if (didMatchRevision) {
+            return false;
+        } else {
+            return underlying.hasMoreElements();
+        }
+    }
+
+    /**
+     * Returns the next element of this enumeration if a defined
+     * {@code sinceRevision} has not yet matched and if the underlying sequence
+     * has at least one more element to provide.
+     * @return the next element of this enumeration.
+     * @throws NoSuchElementException if a defined {@code sinceRevision} has
+     * matched or if no more elements exist.
+     */
+    @Override
+    public History nextElement() {
+        if (didMatchRevision) {
+            throw new NoSuchElementException();
+        }
+
+        History next = underlying.nextElement();
+
+        if (sinceRevision != null) {
+            // Iterate to try to match sinceRevision within the element.
+            int i = 0;
+            for (; i < next.count(); ++i) {
+                HistoryEntry historyEntry = next.getHistoryEntry(i);
+                if (sinceRevision.equals(historyEntry.getRevision())) {
+                    break;
+                }
+            }
+
+            if (i < next.count()) {
+                didMatchRevision = true;
+
+                // non-intuitive order BTW
+                List<HistoryEntry> filtered = new ArrayList<>(next.getHistoryEntries(i, 0));
+                next = new History(filtered, next.getRenamedFiles());
+
+                // Exhaust the underlying sequence
+                while (underlying.hasMoreElements()) {
+                    underlying.nextElement();
+                }
+            }
+        }
+
+        return next;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int exitValue() {
+        return underlying.exitValue();
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitHistoryParser.java
@@ -24,17 +24,18 @@
 package org.opengrok.indexer.history;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
+import java.io.StringReader;
 import java.nio.file.InvalidPathException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -42,28 +43,41 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
+import org.opengrok.indexer.util.ObjectCloseableEnumeration;
+import org.opengrok.indexer.util.ObjectStreamHandler;
 import org.opengrok.indexer.util.StringUtils;
 
 /**
  * Parse a stream of Git log comments.
  */
-class GitHistoryParser implements Executor.StreamHandler {
+class GitHistoryParser implements Executor.StreamHandler, ObjectStreamHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GitHistoryParser.class);
 
-    private enum ParseState {
+    private static final int HISTORY_ENTRY_BATCH_SIZE = 512;
 
+    private enum ParseState {
         HEADER, MESSAGE, FILES
     }
+
+    private final boolean handleRenamedFiles;
+    private final RuntimeEnvironment env;
+
     private String myDir;
     private GitRepository repository = new GitRepository();
     private List<HistoryEntry> entries = new ArrayList<>();
     private History history;
 
-    private final boolean handleRenamedFiles;
-    
-    GitHistoryParser(boolean flag) {
-        handleRenamedFiles = flag;
+    private BufferedReader reader;
+    private String savedLine;
+
+    /**
+     * Initializes an instance, with the user specifying whether renamed-files
+     * handling should be done.
+     */
+    GitHistoryParser(boolean handleRenamedFiles) {
+        this.handleRenamedFiles = handleRenamedFiles;
+        this.env = RuntimeEnvironment.getInstance();
     }
 
     /**
@@ -84,21 +98,59 @@ class GitHistoryParser implements Executor.StreamHandler {
     @Override
     public void processStream(InputStream input) throws IOException {
         try (BufferedReader in = new BufferedReader(GitRepository.newLogReader(input))) {
-            process(in);
+            processStream(in);
         }
         history = new History(entries);
     }
-    
-    private void process(BufferedReader in) throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        entries = new ArrayList<>();
+
+    /**
+     * Process the output from the log command and insert the HistoryEntries
+     * into the {@link #getHistory()} property.
+     *
+     * @param input The output from the process
+     * @throws java.io.IOException If an error occurs while reading the stream
+     */
+    public void processStream(BufferedReader input) throws IOException {
+        process(input);
+        history = new History(entries);
+    }
+
+    /**
+     * Initializes the handler to read from the specified input.
+     */
+    public void initializeObjectStream(InputStream in) {
+        reader = null;
+        reader = new BufferedReader(GitRepository.newLogReader(in));
+    }
+
+    /**
+     * Reads a {@link HistoryEntry} from the initialized input unless the
+     * stream has been exhausted.
+     * @return a defined instance or {@code null} if the stream has been
+     * exhausted
+     */
+    public Object readObject() throws IOException {
         HistoryEntry entry = null;
         ParseState state = ParseState.HEADER;
-        String s = in.readLine();
+
+        String s;
+        if (savedLine == null) {
+            s = reader.readLine();
+        } else {
+            s = savedLine;
+            savedLine = null;
+        }
+
         while (s != null) {
             if (state == ParseState.HEADER) {
 
                 if (s.startsWith("commit")) {
+                    if (entry != null) {
+                        savedLine = s;
+                        return entry;
+                    }
+                    entry = new HistoryEntry();
+                    entry.setActive(true);
                     String commit = s.substring("commit".length()).trim();
 
                     /*
@@ -113,25 +165,6 @@ class GitHistoryParser implements Executor.StreamHandler {
                         commit = commit.substring(0, offset);
                     }
 
-                    if (entry != null) {
-                        /*
-                         * With -m, a commit hash repeats for each merged head.
-                         * For OpenGrok's purposes, the same HistoryEntry would
-                         * get reused for each head. If the commit hash differs,
-                         * then add the entry to the list, and prepare to start
-                         * a new entry.
-                         */
-                        if (commit.equals(entry.getRevision())) {
-                            entry.setMessage(""); // Avoid message repetition.
-                        } else {
-                            entries.add(entry);
-                            entry = null;
-                        }
-                    }
-                    if (entry == null) {
-                        entry = new HistoryEntry();
-                    }
-                    entry.setActive(true);
                     entry.setRevision(commit);
                 } else if (s.startsWith("Author:") && entry != null) {
                     entry.setAuthor(s.substring("Author:".length()).trim());
@@ -147,12 +180,15 @@ class GitHistoryParser implements Executor.StreamHandler {
                         //
                         throw new IOException("Failed to parse author date: " + s, pe);
                     }
+                } else //noinspection StatementWithEmptyBody
+                    if (s.startsWith("Merge:") && entry != null) {
+                    ; // ignore for now
                 } else if (StringUtils.isOnlyWhitespace(s)) {
                     // We are done reading the heading, start to read the message
                     state = ParseState.MESSAGE;
 
                     // The current line is empty - the message starts on the next line (to be parsed below).
-                    s = in.readLine();
+                    s = reader.readLine();
                 }
 
             }
@@ -175,7 +211,7 @@ class GitHistoryParser implements Executor.StreamHandler {
                     try {
                         File f = new File(myDir, s);
                         String path = env.getPathRelativeToSourceRoot(f);
-                        entry.addFile(path.intern());
+                        entry.addFile(path);
                     } catch (ForbiddenSymlinkException e) {
                         LOGGER.log(Level.FINER, e.getMessage());
                         // ignore
@@ -187,41 +223,45 @@ class GitHistoryParser implements Executor.StreamHandler {
                     }
                 }
             }
-            s = in.readLine();
+            s = reader.readLine();
         }
 
-        if (entry != null) {
+        return entry;
+    }
+
+    private void process(BufferedReader in) throws IOException {
+        entries = new ArrayList<>();
+        reader = in;
+
+        HistoryEntry entry;
+        while ((entry = (HistoryEntry) readObject()) != null) {
             entries.add(entry);
         }
     }
 
     /**
-     * Parse the history for the specified file.
+     * Starts a parse of history for the specified file.
      *
      * @param file the file to parse history for
-     * @param repos Pointer to the GitRepository
+     * @param repo a defined instance
      * @param sinceRevision the oldest changeset to return from the executor, or
      *                      {@code null} if all changesets should be returned
-     * @return object representing the file's history
+     * @param tagger an optional function to tag changesets
+     * @return a defined sequence representing the file's history
      */
-    History parse(File file, Repository repos, String sinceRevision) throws HistoryException {
-        myDir = repos.getDirectoryName() + File.separator;
-        repository = (GitRepository) repos;
+    HistoryEnumeration startParse(File file, GitRepository repo, String sinceRevision,
+            Consumer<History> tagger) throws HistoryException {
+
+        myDir = repo.getDirectoryName() + File.separator;
+        repository = repo;
         RenamedFilesParser parser = new RenamedFilesParser();
         try {
-            Executor executor = repository.getHistoryLogExecutor(file, sinceRevision);
-            int status = executor.exec(true, this);
+            Executor executor;
 
-            if (status != 0) {
-                throw new HistoryException(
-                        String.format("Failed to get history for: \"%s\" Exit code: %d",
-                                file.getAbsolutePath(),
-                                status));
-            }
-
+            // Process renames first so they are on the first in sequence.
             if (handleRenamedFiles) {
-                executor = repository.getRenamedFilesExecutor(file, sinceRevision);
-                status = executor.exec(true, parser);
+                executor = repo.getRenamedFilesExecutor(file, sinceRevision);
+                int status = executor.exec(true, parser);
 
                 if (status != 0) {
                     throw new HistoryException(
@@ -230,13 +270,16 @@ class GitHistoryParser implements Executor.StreamHandler {
                                     status));
                 }
             }
+
+            executor = repo.getHistoryLogExecutor(file, sinceRevision);
+            ObjectCloseableEnumeration entriesSequence = executor.startExec(true, this);
+            List<String> renamedFiles = parser.getRenamedFiles();
+            return newHistoryEnumeration(entriesSequence, renamedFiles, tagger);
         } catch (IOException e) {
             throw new HistoryException(
                     String.format("Failed to get history for: \"%s\"", file.getAbsolutePath()),
                     e);
         }
-
-        return new History(entries, parser.getRenamedFiles());
     }
 
     /**
@@ -247,9 +290,96 @@ class GitHistoryParser implements Executor.StreamHandler {
      * @throws IOException if we fail to parse the buffer
      */
     History parse(String buffer) throws IOException {
-        myDir = RuntimeEnvironment.getInstance().getSourceRootPath();
-        processStream(new ByteArrayInputStream(buffer.getBytes(StandardCharsets.UTF_8)));
-        return new History(entries);
+        myDir = env.getSourceRootPath();
+        processStream(new BufferedReader(new StringReader(buffer)));
+        return history;
+    }
+
+    /**
+     * Transforms a specified sequence of {@link HistoryEntry} instances into a
+     * batching sequence of {@link History} instances.
+     * @return a defined, wrapping sequence
+     */
+    private static HistoryEnumeration newHistoryEnumeration(
+            final ObjectCloseableEnumeration entriesSequence,
+            final List<String> renamedFiles,
+            final Consumer<History> tagger) {
+
+        // Renamed files are published on the first element.
+        History firstHistory = nextHistory(entriesSequence, renamedFiles, tagger);
+
+        return new HistoryEnumeration() {
+            History nextHistory = firstHistory;
+
+            @Override
+            public void close() throws IOException {
+                nextHistory = null;
+                entriesSequence.close();
+            }
+
+            @Override
+            public boolean hasMoreElements() {
+                return nextHistory != null;
+            }
+
+            @Override
+            public History nextElement() {
+                if (nextHistory == null) {
+                    throw new NoSuchElementException();
+                }
+                History res = nextHistory;
+                nextHistory = null;
+                // Renamed files are only published on the first element.
+                nextHistory = nextHistory(entriesSequence, null, tagger);
+                return res;
+            }
+
+            @Override
+            public int exitValue() {
+                return entriesSequence.exitValue();
+            }
+        };
+    }
+
+    /**
+     * Reads a next batch if available.
+     * @return a defined instance or {@code null} if the sequence is exhausted
+     */
+    private static History nextHistory(
+            final ObjectCloseableEnumeration entriesSequence,
+            final List<String> renamedFiles,
+            final Consumer<History> tagger) {
+
+        List<HistoryEntry> entries = null;
+        while (entriesSequence.hasMoreElements()) {
+            HistoryEntry entry = (HistoryEntry) entriesSequence.nextElement();
+            if (entries == null) {
+                entries = new ArrayList<>();
+            }
+            entries.add(entry);
+            if (entries.size() >= HISTORY_ENTRY_BATCH_SIZE) {
+                break;
+            }
+        }
+
+        if (entries == null && renamedFiles == null ) {
+            return null;
+        }
+
+        History res;
+        if (renamedFiles != null) {
+            if (entries == null) {
+                entries = new ArrayList<>();
+            }
+            res = new History(entries, renamedFiles);
+        } else {
+            res = new History(entries);
+        }
+
+        if (tagger != null) {
+            tagger.accept(res);
+        }
+        return res;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
@@ -24,35 +24,59 @@
 
 package org.opengrok.indexer.history;
 
+import java.beans.Encoder;
+import java.beans.Expression;
+import java.beans.PersistenceDelegate;
+import java.beans.XMLDecoder;
+import java.beans.XMLEncoder;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 /**
  * Class representing the history of a file.
  */
 public class History {
     /** Entries in the log. The first entry is the most recent one. */
-    private List<HistoryEntry> entries;
+    private final ArrayList<HistoryEntry> entries;
     /** 
      * track renamed files so they can be treated in special way (for some
      * SCMs) during cache creation.
      * These are relative to repository root.
      */
-    private List<String> renamedFiles = new ArrayList<String>();
+    private final ArrayList<String> renamedFiles;
     
     public History() {
-        this(new ArrayList<HistoryEntry>());
+        this(new ArrayList<>());
     }
 
     History(List<HistoryEntry> entries) {
-        this.entries = entries;
+        this.entries = new ArrayList<>(entries);
+        this.renamedFiles = new ArrayList<>();
     }
 
     History(List<HistoryEntry> entries, List<String> renamed) {
-        this.entries = entries;
-        this.renamedFiles = renamed;
+        this.entries = new ArrayList<>(entries);
+        this.renamedFiles = new ArrayList<>(renamed);
     }
-    
+
+    /**
+     * Gets the number of history entries.
+     * @return a non-negative number
+     */
+    public int count() {
+        return entries == null ? 0 : entries.size();
+    }
+
     /**
      * Set the list of log entries for the file. The first entry is the most
      * recent one.
@@ -60,7 +84,12 @@ public class History {
      * @param entries The entries to add to the list
      */
     public void setHistoryEntries(List<HistoryEntry> entries) {
-        this.entries = entries;
+        if (entries == null) {
+            this.entries.clear();
+        } else if (this.entries != entries) {
+            this.entries.clear();
+            this.entries.addAll(entries);
+        }
     }
 
     /**
@@ -73,6 +102,28 @@ public class History {
     }
 
     /**
+     * Returns the entry at the specified position.
+     * @param index index of the entry to return
+     * @return the element at the specified position
+     * @throws IndexOutOfBoundsException if the index is out of range
+     * ({@code index < 0 || index >= size()})
+     */
+    HistoryEntry getHistoryEntry(int index) {
+        return entries.get(index);
+    }
+
+    /**
+     * Removes the entry at the specified position.
+     * @param index the index of the entry to be removed
+     * @return the entry previously at the specified position
+     * @throws IndexOutOfBoundsException if the index is out of range
+     * ({@code index < 0 || index > count()})
+     */
+    HistoryEntry removeHistoryEntry(int index) {
+        return entries.remove(index);
+    }
+
+    /**
      * Get the list of log entries, most recent first.
      * With parameters
      * @param limit max number of entries
@@ -82,7 +133,7 @@ public class History {
      */
     public List<HistoryEntry> getHistoryEntries(int limit, int offset) {
         offset = offset < 0 ? 0 : offset;
-        limit = offset + limit > entries.size() ? limit = entries.size() - offset : limit;
+        limit = offset + limit > entries.size() ? entries.size() - offset : limit;
         return entries.subList(offset, offset + limit);
     }    
     
@@ -121,11 +172,60 @@ public class History {
      * Gets a value indicating if {@code file} is in the list of renamed files.
      * TODO: Warning -- this does a slow {@link List} search.
      */
-    public boolean isRenamed(String file) {
+    public boolean isRenamedBySlowLookup(String file) {
         return renamedFiles.contains(file);
     }
 
     public List<String> getRenamedFiles() {
         return renamedFiles;
+    }
+
+    /**
+     * Reads a GZIP file to decode a {@link History} instance.
+     * @param file the source file
+     * @return a defined instance
+     * @throws IOException if an I/O error occurs
+     */
+    static History readGZIP(File file) throws IOException {
+        try (FileInputStream in = new FileInputStream(file);
+             BufferedInputStream bufIn = new BufferedInputStream(in);
+             GZIPInputStream gzIn = new GZIPInputStream(bufIn)) {
+            return decodeObject(gzIn);
+        }
+    }
+
+    static History decodeObject(InputStream in) {
+        try (XMLDecoder d = new XMLDecoder(in)) {
+            return (History) d.readObject();
+        }
+    }
+
+    /**
+     * Writes the current instance to a file with GZIP compression.
+     * @param file the target file
+     * @throws IOException if an I/O error occurs
+     */
+    void writeGZIP(File file) throws IOException {
+        try (FileOutputStream out = new FileOutputStream(file);
+             BufferedOutputStream bufOut = new BufferedOutputStream(out);
+             GZIPOutputStream gzOut = new GZIPOutputStream(bufOut)) {
+            encodeObject(gzOut);
+        }
+    }
+
+    void encodeObject(OutputStream out) {
+        try (XMLEncoder e = new XMLEncoder(out)) {
+            e.setPersistenceDelegate(File.class, new FilePersistenceDelegate());
+            e.writeObject(this);
+        }
+    }
+
+    static class FilePersistenceDelegate extends PersistenceDelegate {
+        @Override
+        protected Expression instantiate(Object oldInstance, Encoder out) {
+            File f = (File) oldInstance;
+            return new Expression(oldInstance, f.getClass(), "new",
+                    new Object[] {f.toString()});
+        }
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
@@ -19,11 +19,13 @@
 
 /*
  * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
 import java.io.File;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.Map;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
 
@@ -65,14 +67,17 @@ interface HistoryCache {
             throws HistoryException, ForbiddenSymlinkException;
 
     /**
-     * Store the history for a repository.
-     *
-     * @param history The history to store
+     * Stores the history enumeration for a repository, where
+     * {@code historyElements} must be ordered from most recent to earlier
+     * between each element and within each element.
+     * @param historySequence The history series to store
      * @param repository The repository whose history to store
+     * @param forceOverwrite a value indicating whether to overwrite existing
+     * stored history for the files in {@code historySequence}
      * @throws HistoryException if the history cannot be stored
      */
-    void store(History history, Repository repository)
-            throws HistoryException;
+    void store(Enumeration<History> historySequence, Repository repository,
+            boolean forceOverwrite) throws HistoryException;
 
     /**
      * Optimize how the history is stored on disk. This method is typically
@@ -85,6 +90,12 @@ interface HistoryCache {
      * @throws HistoryException if an error happens during optimization
      */
     void optimize() throws HistoryException;
+
+    /**
+     * Closes the history cache, releasing any resources. {@link #initialize()}
+     * must be called before accessing the cache again.
+     */
+    void close() throws HistoryException;
 
     /**
      * Check if the specified directory is present in the cache.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntryFixed.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntryFixed.java
@@ -1,0 +1,140 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2006 Trond Norbye.  All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+package org.opengrok.indexer.history;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+
+/**
+ * Represents an immutable (i.e. "fixed") version of {@link HistoryEntry} for
+ * serialization.
+ * @author Trond Norbye
+ */
+public class HistoryEntryFixed {
+
+    private final String revision;
+    private final Long date; // Date Instant toEpochMilli()
+    private final String author;
+    private final String tags;
+    private final String message;
+    private final boolean active;
+    private final String[] files;
+
+    /**
+     * Copy constructor to fix the specified {@link HistoryEntry} fully.
+     */
+    HistoryEntryFixed(HistoryEntry that) {
+        this(that, false);
+    }
+
+    /**
+     * Copy constructor to fix the specified {@link HistoryEntry} with a
+     * parameter indicating whether to trim files from the entry.
+     */
+    HistoryEntryFixed(HistoryEntry that, boolean trim) {
+        this.revision = that.getRevision();
+
+        Date thatDate = that.getDate();
+        this.date = thatDate == null ? null : thatDate.toInstant().toEpochMilli();
+
+        this.author = that.getAuthor();
+        this.tags = that.getTags();
+        this.message = that.getMessage();
+        this.active = that.isActive();
+        this.files = trim ? new String[0] : that.getFiles().toArray(new String[0]);
+    }
+
+    @JsonCreator
+    public HistoryEntryFixed(@JsonProperty("revision") String revision,
+            @JsonProperty("date") Long date,
+            @JsonProperty("author") String author,
+            @JsonProperty("tags") String tags,
+            @JsonProperty("message") String message,
+            @JsonProperty("active") boolean active,
+            @JsonProperty("files") String[] files) {
+
+        this.revision = revision;
+        this.date = date;
+        this.author = author;
+        this.tags = tags;
+        this.message = message;
+        this.active = active;
+        this.files = files;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public Long getDate() {
+        return date;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getRevision() {
+        return revision;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public String[] getFiles() {
+        return Arrays.copyOf(files, files.length);
+    }
+
+    HistoryEntry toEntry() {
+        HistoryEntry res = new HistoryEntry();
+
+        res.setRevision(this.revision);
+
+        if (this.date != null) {
+            res.setDate(Date.from(Instant.ofEpochMilli(this.date)));
+        }
+
+        res.setAuthor(this.author);
+        res.setTags(this.tags);
+        res.appendMessage(this.message);
+        res.setActive(this.active);
+
+        if (this.files != null) {
+            for (String file : this.files) {
+                res.addFile(file);
+            }
+        }
+        return res;
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEnumeration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEnumeration.java
@@ -18,26 +18,27 @@
  */
 
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
+
 package org.opengrok.indexer.history;
 
+import java.io.Closeable;
+import java.util.Enumeration;
+
 /**
- * Bazaar specific tag class with ability to compare itself with generic
- * HistoryEntry.
- *
- * @author Stanislav Kozina
+ * Represents an API for a sequence of {@link History} instances where the
+ * sequence is {@link Closeable} to release resources.
  */
-public class BazaarTagEntry extends TagEntry {
+public interface HistoryEnumeration extends Enumeration<History>, Closeable {
 
-    public BazaarTagEntry(int revision, String tag) {
-        super(revision, tag);
-    }
-
-    @Override
-    public int compareTo(HistoryEntry that) {
-        assert this.revision != NOREV : "BazaarTagEntry created without tag specified.specified";
-        return Integer.compare(this.revision, Integer.parseInt(that.getRevision()));
-    }
+    /**
+     * Returns the exit value for the subprocess.
+     *
+     * @return the exit value of the subprocess represented by this instance.
+     * By convention, the value {@code 0} indicates normal termination.
+     * @throws IllegalThreadStateException if the subprocess represented by
+     * this instance has not yet terminated
+     */
+    int exitValue();
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryUtil.java
@@ -1,0 +1,69 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.history;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a container for {@link History}-related utility methods.
+ */
+public class HistoryUtil {
+
+    /**
+     * Initialize an instance as the union of a sequence and closes the
+     * sequence to affirm a zero exit value.
+     * @param sequence a defined sequence
+     * @throws HistoryException if the sequence fails to enumerate or the
+     * subprocess returns non-zero
+     */
+    public static History union(HistoryEnumeration sequence) throws HistoryException {
+
+        List<HistoryEntry> entries = new ArrayList<>();
+        List<String> renamedFiles = new ArrayList<>();
+
+        while (sequence.hasMoreElements()) {
+            History that = sequence.nextElement();
+            entries.addAll(that.getHistoryEntries());
+            renamedFiles.addAll(that.getRenamedFiles());
+        }
+
+        try {
+            sequence.close();
+        } catch (IOException e) {
+            throw new HistoryException("Error closing sequence", e);
+        }
+
+        if (sequence.exitValue() != 0) {
+            throw new HistoryException("HistoryEnumeration exit value=" + sequence.exitValue());
+        }
+
+        return new History(entries, renamedFiles);
+    }
+
+    /* private to enforce static */
+    private HistoryUtil() {
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/KeyedHistory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/KeyedHistory.java
@@ -18,26 +18,19 @@
  */
 
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
+
 package org.opengrok.indexer.history;
 
+import java.util.List;
+
 /**
- * Bazaar specific tag class with ability to compare itself with generic
- * HistoryEntry.
- *
- * @author Stanislav Kozina
+ * Represents an API for a file name and its associated {@link HistoryEntry}
+ * collection.
  */
-public class BazaarTagEntry extends TagEntry {
-
-    public BazaarTagEntry(int revision, String tag) {
-        super(revision, tag);
-    }
-
-    @Override
-    public int compareTo(HistoryEntry that) {
-        assert this.revision != NOREV : "BazaarTagEntry created without tag specified.specified";
-        return Integer.compare(this.revision, Integer.parseInt(that.getRevision()));
-    }
+interface KeyedHistory {
+    String getFile();
+    List<HistoryEntry> getEntries();
+    boolean isForceOverwrite();
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -111,9 +111,10 @@ class MercurialHistoryParser implements Executor.StreamHandler {
     public void processStream(InputStream input) throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         BufferedReader in = new BufferedReader(new InputStreamReader(input));
-        entries = new ArrayList<HistoryEntry>();
-        String s;
+        entries = new ArrayList<>();
         HistoryEntry entry = null;
+
+        String s;
         while ((s = in.readLine()) != null) {
             if (s.startsWith(MercurialRepository.CHANGESET)) {
                 entry = new HistoryEntry();
@@ -141,7 +142,7 @@ class MercurialHistoryParser implements Executor.StreamHandler {
                         File f = new File(mydir, strings[ii]);
                         try {
                             String path = env.getPathRelativeToSourceRoot(f);
-                            entry.addFile(path.intern());
+                            entry.addFile(path);
                         } catch (ForbiddenSymlinkException e) {
                             LOGGER.log(Level.FINER, e.getMessage());
                             // ignore

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialTagEntry.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialTagEntry.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -39,6 +40,6 @@ public class MercurialTagEntry extends TagEntry {
         assert this.revision != NOREV : "Mercurial TagEntry created without revision specified";
         String[] revs = that.getRevision().split(":");
         assert revs.length == 2 : "Unable to parse revision format";
-        return ((Integer) this.revision).compareTo(Integer.parseInt(revs[0]));
+        return Integer.compare(this.revision, Integer.parseInt(revs[0]));
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MonotoneHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MonotoneHistoryParser.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -98,10 +98,10 @@ class MonotoneHistoryParser implements Executor.StreamHandler {
     public void processStream(InputStream input) throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         BufferedReader in = new BufferedReader(new InputStreamReader(input));
-        String s;
-
         HistoryEntry entry = null;
         int state = 0;
+
+        String s;
         while ((s = in.readLine()) != null) {
             s = s.trim();
             // Later versions of monotone (such as 1.0) output even more dashes so lets require
@@ -164,9 +164,8 @@ class MonotoneHistoryParser implements Executor.StreamHandler {
                         for (String f : files) {
                             File file = new File(mydir, f);
                             try {
-                                String path = env.getPathRelativeToSourceRoot(
-                                    file);
-                                entry.addFile(path.intern());
+                                String path = env.getPathRelativeToSourceRoot(file);
+                                entry.addFile(path);
                             } catch (ForbiddenSymlinkException e) {
                                 LOGGER.log(Level.FINER, e.getMessage());
                                 // ignore

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MonotoneRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MonotoneRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -184,14 +184,14 @@ public class MonotoneRepository extends Repository {
     }
 
     @Override
-    History getHistory(File file) throws HistoryException {
+    HistoryEnumeration getHistory(File file) throws HistoryException {
         return getHistory(file, null);
     }
 
     @Override
-    History getHistory(File file, String sinceRevision)
+    HistoryEnumeration getHistory(File file, String sinceRevision)
             throws HistoryException {
-        return new MonotoneHistoryParser(this).parse(file, sinceRevision);
+        return new SingleHistory(new MonotoneHistoryParser(this).parse(file, sinceRevision));
     }
 
     private String getQuietOption() {
@@ -202,7 +202,7 @@ public class MonotoneRepository extends Repository {
         }
     }
 
-    public static final String DEPRECATED_KEY
+    private static final String DEPRECATED_KEY
             = "org.opengrok.indexer.history.monotone.deprecated";
 
     private boolean useDeprecated() {
@@ -248,7 +248,7 @@ public class MonotoneRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2019, Chris Ross <cross@distal.com>.
  */
 package org.opengrok.indexer.history;
@@ -216,15 +216,15 @@ public class PerforceRepository extends Repository {
     }
 
     @Override
-    History getHistory(File file) throws HistoryException {
+    HistoryEnumeration getHistory(File file) throws HistoryException {
         PerforceHistoryParser parser = new PerforceHistoryParser(this);
-        return parser.parse(file);
+        return new SingleHistory(parser.parse(file));
     }
 
     @Override
-    History getHistory(File file, String sinceRevision) throws HistoryException {
+    HistoryEnumeration getHistory(File file, String sinceRevision) throws HistoryException {
         PerforceHistoryParser parser = new PerforceHistoryParser(this);
-        return parser.parse(file, sinceRevision);
+        return new SingleHistory(parser.parse(file, sinceRevision));
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RCSRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RCSRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.history;
@@ -93,7 +93,7 @@ public class RCSRepository extends Repository {
     }
 
     @Override
-    Annotation annotate(File file, String revision) throws IOException {
+    Annotation annotate(File file, String revision) {
         List<String> argv = new ArrayList<>();
         ensureCommand(CMD_BLAME_PROPERTY_KEY, CMD_BLAME_FALLBACK);
 
@@ -118,9 +118,7 @@ public class RCSRepository extends Repository {
      */
     static IOException wrapInIOException(String message, Throwable t) {
         // IOException's constructor takes a Throwable, but only in JDK 6
-        IOException ioe = new IOException(message + ": " + t.getMessage());
-        ioe.initCause(t);
-        return ioe;
+        return new IOException(message + ": " + t.getMessage(), t);
     }
 
     @Override
@@ -166,22 +164,22 @@ public class RCSRepository extends Repository {
     }
 
     @Override
-    History getHistory(File file) throws HistoryException {
-        return new RCSHistoryParser().parse(file, this);
+    HistoryEnumeration getHistory(File file) throws HistoryException {
+        return new SingleHistory(new RCSHistoryParser().parse(file, this));
     }
 
     @Override
-    String determineParent(CommandTimeoutType cmdType) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) {
         return null;
     }
 
     @Override
-    String determineBranch(CommandTimeoutType cmdType) throws IOException {
+    String determineBranch(CommandTimeoutType cmdType) {
         return null;
     }
 
     @Override
-    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RazorRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RazorRepository.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright 2008 Peter Bray
- * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -164,31 +164,6 @@ public class RazorRepository extends Repository {
                 = directory.getParentFile().getAbsolutePath();
         razorGroupBaseDirectoryPath
                 = new File(directory, RAZOR_DIR).getAbsolutePath();
-    }
-
-    public String getOpengrokSourceRootDirectoryPath() {
-        return opengrokSourceRootDirectoryPath;
-    }
-
-    public void setOpengrokSourceRootDirectoryPath(String opengrokSourceRootDirectoryPath) {
-        this.opengrokSourceRootDirectoryPath = opengrokSourceRootDirectoryPath;
-    }
-
-    public String getRazorGroupBaseDirectoryPath() {
-        return razorGroupBaseDirectoryPath;
-    }
-
-    public void setRazorGroupBaseDirectoryPath(String razorGroupBaseDirectoryPath) {
-        this.razorGroupBaseDirectoryPath = razorGroupBaseDirectoryPath;
-    }
-
-    String getOpenGrokFileNameFor(File file) {
-        return file.getAbsolutePath()
-                .substring(opengrokSourceRootDirectoryPath.length());
-    }
-
-    File getSourceNameForOpenGrokName(String path) {
-        return new File(opengrokSourceRootDirectoryPath + path);
     }
 
     File getRazorHistoryFileFor(File file) throws IOException {
@@ -344,12 +319,12 @@ public class RazorRepository extends Repository {
     }
 
     @Override
-    History getHistory(File file) throws HistoryException {
-        return new RazorHistoryParser().parse(file, this);
+    HistoryEnumeration getHistory(File file) throws HistoryException {
+        return new SingleHistory(new RazorHistoryParser().parse(file, this));
     }
 
     @Override
-    String determineParent(CommandTimeoutType cmdType) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) {
         return null;
     }
 
@@ -359,7 +334,7 @@ public class RazorRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepoRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepoRepository.java
@@ -20,12 +20,11 @@
 /*
  * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2010, Trond Norbye <trond.norbye@gmail.com>. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.util.BufferSink;
@@ -86,7 +85,7 @@ public class RepoRepository extends Repository {
     }
 
     @Override
-    History getHistory(File file) {
+    HistoryEnumeration getHistory(File file) {
         throw new UnsupportedOperationException("Should never be called!");
     }
 
@@ -107,7 +106,7 @@ public class RepoRepository extends Repository {
     }
 
     @Override
-    String determineParent(CommandTimeoutType cmdType) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) {
         return null;
     }
 
@@ -117,7 +116,7 @@ public class RepoRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -184,8 +184,8 @@ public class SCCSRepository extends Repository {
     }
 
     @Override
-    History getHistory(File file) throws HistoryException {
-        return new SCCSHistoryParser(this).parse(file);
+    HistoryEnumeration getHistory(File file) throws HistoryException {
+        return new SingleHistory(new SCCSHistoryParser(this).parse(file));
     }
 
     @Override
@@ -224,7 +224,7 @@ public class SCCSRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SSCMHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SSCMHistoryParser.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -146,17 +147,12 @@ public class SSCMHistoryParser implements Executor.StreamHandler {
     }
 
     History parse(File file, String sinceRevision) throws HistoryException {
-        try {
-            Executor executor = repository.getHistoryLogExecutor(file, sinceRevision);
-            int status = executor.exec(true, this);
+        Executor executor = repository.getHistoryLogExecutor(file, sinceRevision);
+        int status = executor.exec(true, this);
 
-            if (status != 0) {
-                throw new HistoryException("Failed to get history for: \""
-                        + file.getAbsolutePath() + "\" Exit code: " + status);
-            }
-        } catch (IOException e) {
+        if (status != 0) {
             throw new HistoryException("Failed to get history for: \""
-                    + file.getAbsolutePath() + "\"", e);
+                    + file.getAbsolutePath() + "\" Exit code: " + status);
         }
 
         return history;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SSCMRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SSCMRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -129,7 +129,7 @@ public class SSCMRepository extends Repository {
      *                  {@code null} if all changesets should be returned
      * @return An Executor ready to be started
      */
-    Executor getHistoryLogExecutor(final File file, String sinceRevision) throws IOException {
+    Executor getHistoryLogExecutor(final File file, String sinceRevision) {
 
         List<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
@@ -159,14 +159,14 @@ public class SSCMRepository extends Repository {
     }
 
     @Override
-    History getHistory(File file) throws HistoryException {
+    HistoryEnumeration getHistory(File file) throws HistoryException {
         return getHistory(file, null);
     }
 
     @Override
-    History getHistory(File file, String sinceRevision)
+    HistoryEnumeration getHistory(File file, String sinceRevision)
             throws HistoryException {
-        return new SSCMHistoryParser(this).parse(file, sinceRevision);
+        return new SingleHistory(new SSCMHistoryParser(this).parse(file, sinceRevision));
     }
 
     @Override
@@ -306,7 +306,7 @@ public class SSCMRepository extends Repository {
         return parseAnnotation(exec.getOutputReader(), file.getName());
     }
 
-    protected Annotation parseAnnotation(Reader input, String fileName)
+    private Annotation parseAnnotation(Reader input, String fileName)
             throws IOException {
         BufferedReader in = new BufferedReader(input);
         Annotation ret = new Annotation(fileName);
@@ -345,7 +345,7 @@ public class SSCMRepository extends Repository {
     }
 
     @Override
-    String determineParent(CommandTimeoutType cmdType) throws IOException {
+    String determineParent(CommandTimeoutType cmdType) {
         return null;
     }
 
@@ -355,7 +355,7 @@ public class SSCMRepository extends Repository {
     }
 
     @Override
-    String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+    String determineCurrentVersion(CommandTimeoutType cmdType) {
         return null;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SingleHistory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SingleHistory.java
@@ -1,0 +1,72 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.history;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Represents a history sequence for a single item. This is used for older
+ * repository implementations that read all history at once with no
+ * sequencing.
+ */
+class SingleHistory implements HistoryEnumeration {
+    private final History element;
+    private boolean didYield;
+
+    SingleHistory(History element) {
+        if (element == null) {
+            throw new IllegalArgumentException("element is null");
+        }
+        this.element = element;
+    }
+
+    /**
+     * Does nothing.
+     */
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public boolean hasMoreElements() {
+        return !didYield;
+    }
+
+    @Override
+    public History nextElement() {
+        if (didYield) {
+            throw new NoSuchElementException();
+        }
+        didYield = true;
+        return element;
+    }
+
+    /**
+     * @return 0 to indicate success
+     */
+    @Override
+    public int exitValue() {
+        return 0;
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -71,7 +71,7 @@ public class SubversionRepository extends Repository {
 
     private static final String URLattr = "url";
 
-    protected String reposPath;
+    String reposPath;
 
     public SubversionRepository() {
         type = "Subversion";
@@ -275,13 +275,13 @@ public class SubversionRepository extends Repository {
     }
 
     @Override
-    History getHistory(File file) throws HistoryException {
-        return getHistory(file, null, 0, CommandTimeoutType.INDEXER);
+    HistoryEnumeration getHistory(File file) throws HistoryException {
+        return new SingleHistory(getHistory(file, null, 0, CommandTimeoutType.INDEXER));
     }
 
     @Override
-    History getHistory(File file, String sinceRevision) throws HistoryException {
-        return getHistory(file, sinceRevision, 0, CommandTimeoutType.INDEXER);
+    HistoryEnumeration getHistory(File file, String sinceRevision) throws HistoryException {
+        return new SingleHistory(getHistory(file, sinceRevision, 0, CommandTimeoutType.INDEXER));
     }
 
     private History getHistory(File file, String sinceRevision, int numEntries,
@@ -386,7 +386,7 @@ public class SubversionRepository extends Repository {
     }
 
     @Override
-    String determineBranch(CommandTimeoutType cmdType) throws IOException {
+    String determineBranch(CommandTimeoutType cmdType) {
         String branch = null;
         Document document = getInfoDocument();
 
@@ -403,7 +403,7 @@ public class SubversionRepository extends Repository {
     }
 
     @Override
-    public String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+    public String determineCurrentVersion(CommandTimeoutType cmdType) {
         String curVersion = null;
 
         try {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/TagEntry.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/TagEntry.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019-2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1703,8 +1703,7 @@ public class IndexDatabase {
             if (hasPendingCommit) {
                 writer.rollback();
             }
-            LOGGER.log(Level.WARNING,
-                "An error occurred while finishing writer and completer", e);
+            LOGGER.log(Level.WARNING, "Error while finishing writer and completer", e);
             throw e;
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -809,7 +809,8 @@ public final class Indexer {
         // so that options may be overwritten later.
         configure.parse(argv);
 
-        LOGGER.log(Level.INFO, "Indexer options: {0}", Arrays.toString(argv));
+        LOGGER.log(Level.INFO, "Indexer options {0}", Executor.escapeForShell(Arrays.asList(argv),
+                false, PlatformUtils.isWindows()));
 
         if (cfg == null) {
             cfg = new Configuration();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileCompleter.java
@@ -52,11 +52,11 @@ import org.opengrok.indexer.util.StringUtils;
 import org.opengrok.indexer.util.TandemPath;
 
 /**
- * Represents a tracker of pending file deletions and renamings that can later
- * be executed.
+ * Represents a tracker of pending file deletions, renamings, and linkages that
+ * can later be executed.
  * <p>
  * {@link PendingFileCompleter} is not generally thread-safe, as only
- * {@link #add(org.opengrok.indexer.index.PendingFileRenaming)} is expected
+ * {@link #add(PendingFileRenaming)} is expected
  * to be run in parallel; that method is thread-safe -- but only among other
  * callers of the same method.
  * <p>
@@ -65,13 +65,13 @@ import org.opengrok.indexer.util.TandemPath;
  * additions of {@link PendingSymlinkage}s, {@link PendingFileDeletion}s, and
  * {@link PendingFileRenaming}s are indicated.
  * <p>
- * {@link #add(org.opengrok.indexer.index.PendingSymlinkage)} should only
+ * {@link #add(PendingSymlinkage)} should only
  * be called in serial from a single thread in an isolated stage.
  * <p>
- * {@link #add(org.opengrok.indexer.index.PendingFileDeletion)} should only
+ * {@link #add(PendingFileDeletion)} should only
  * be called in serial from a single thread in an isolated stage.
  * <p>
- * {@link #add(org.opengrok.indexer.index.PendingFileRenaming)}, as noted,
+ * {@link #add(PendingFileRenaming)}, as noted,
  * can be called in parallel in an isolated stage.
  */
 class PendingFileCompleter {
@@ -81,7 +81,7 @@ class PendingFileCompleter {
      * {@link PendingFileRenaming} actions.
      * <p>Value is {@code ".org_opengrok"}.
      */
-    public static final String PENDING_EXTENSION = ".org_opengrok";
+    static final String PENDING_EXTENSION = ".org_opengrok";
 
     private static final Logger LOGGER =
         LoggerFactory.getLogger(PendingFileCompleter.class);
@@ -622,8 +622,8 @@ class PendingFileCompleter {
      * deleted for cleanliness.
      */
     private static class SkeletonDirs {
-        boolean ineligible; // a flag used during recursion
         final Set<File> childDirs = new TreeSet<>(DESC_PATHLEN_COMPARATOR);
+        boolean ineligible; // a flag used during recursion
 
         void reset() {
             ineligible = false;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileDeletion.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileDeletion.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.index;
@@ -26,10 +26,10 @@ package org.opengrok.indexer.index;
 /**
  * Represents the metadata for a pending file deletion.
  */
-public final class PendingFileDeletion {
+final class PendingFileDeletion {
     private final String absolutePath;
 
-    public PendingFileDeletion(String absolutePath) {
+    PendingFileDeletion(String absolutePath) {
         this.absolutePath = absolutePath;
     }
 
@@ -55,6 +55,9 @@ public final class PendingFileDeletion {
         return this.absolutePath.equals(other.absolutePath);
     }
 
+    /**
+     * Gets the hash code of the absolute path.
+     */
     @Override
     public int hashCode() {
         return this.absolutePath.hashCode();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileRenaming.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingFileRenaming.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 
 package org.opengrok.indexer.index;
@@ -26,11 +26,11 @@ package org.opengrok.indexer.index;
 /**
  * Represents the metadata for a pending file renaming.
  */
-public final class PendingFileRenaming {
+final class PendingFileRenaming {
     private final String absolutePath;
     private final String transientPath;
 
-    public PendingFileRenaming(String absolutePath, String transientPath) {
+    PendingFileRenaming(String absolutePath, String transientPath) {
         this.absolutePath = absolutePath;
         this.transientPath = transientPath;
     }
@@ -45,7 +45,7 @@ public final class PendingFileRenaming {
     /**
      * @return the transient, absolute path
      */
-    public String getTransientPath() {
+    String getTransientPath() {
         return transientPath;
     }
 
@@ -64,6 +64,9 @@ public final class PendingFileRenaming {
         return this.absolutePath.equals(other.absolutePath);
     }
 
+    /**
+     * Gets the hash code of the final, absolute path.
+     */
     @Override
     public int hashCode() {
         return this.absolutePath.hashCode();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingSymlinkage.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/PendingSymlinkage.java
@@ -18,18 +18,18 @@
  */
 
 /*
- * Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2017-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
 
 /**
  * Represents the metadata for a pending symbolic linkage.
  */
-public final class PendingSymlinkage {
+final class PendingSymlinkage {
     private final String sourcePath;
     private final String targetRelPath;
 
-    public PendingSymlinkage(String sourcePath, String targetRelPath) {
+    PendingSymlinkage(String sourcePath, String targetRelPath) {
         this.sourcePath = sourcePath;
         this.targetRelPath = targetRelPath;
     }
@@ -37,14 +37,14 @@ public final class PendingSymlinkage {
     /**
      * @return the source, absolute path
      */
-    public String getSourcePath() {
+    String getSourcePath() {
         return sourcePath;
     }
 
     /**
      * @return the target, relative path
      */
-    public String getTargetRelPath() {
+    String getTargetRelPath() {
         return targetRelPath;
     }
 
@@ -63,6 +63,9 @@ public final class PendingSymlinkage {
         return this.sourcePath.equals(other.sourcePath);
     }
 
+    /**
+     * Gets the hash code of the source, absolute path.
+     */
     @Override
     public int hashCode() {
         return this.sourcePath.hashCode();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/ObjectCloseableEnumeration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/ObjectCloseableEnumeration.java
@@ -18,26 +18,27 @@
  */
 
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
-package org.opengrok.indexer.history;
+
+package org.opengrok.indexer.util;
+
+import java.io.Closeable;
+import java.util.Enumeration;
 
 /**
- * Bazaar specific tag class with ability to compare itself with generic
- * HistoryEntry.
- *
- * @author Stanislav Kozina
+ * Represents an API for a sequence of {@link Object} instances where
+ * the sequence is {@link Closeable} to release resources.
  */
-public class BazaarTagEntry extends TagEntry {
+public interface ObjectCloseableEnumeration extends Enumeration<Object>, Closeable {
 
-    public BazaarTagEntry(int revision, String tag) {
-        super(revision, tag);
-    }
-
-    @Override
-    public int compareTo(HistoryEntry that) {
-        assert this.revision != NOREV : "BazaarTagEntry created without tag specified.specified";
-        return Integer.compare(this.revision, Integer.parseInt(that.getRevision()));
-    }
+    /**
+     * Returns the exit value for the subprocess.
+     *
+     * @return the exit value of the subprocess represented by this instance.
+     * By convention, the value {@code 0} indicates normal termination.
+     * @throws IllegalThreadStateException if the subprocess represented by
+     * this instance has not yet terminated
+     */
+    int exitValue();
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/ObjectStreamHandler.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/ObjectStreamHandler.java
@@ -18,26 +18,29 @@
  */
 
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
-package org.opengrok.indexer.history;
+
+package org.opengrok.indexer.util;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
- * Bazaar specific tag class with ability to compare itself with generic
- * HistoryEntry.
- *
- * @author Stanislav Kozina
+ * Represents an API for parsing objects from a stream.
  */
-public class BazaarTagEntry extends TagEntry {
+public interface ObjectStreamHandler {
 
-    public BazaarTagEntry(int revision, String tag) {
-        super(revision, tag);
-    }
+    /**
+     * Initializes the handler to read from the specified input.
+     */
+    void initializeObjectStream(InputStream in);
 
-    @Override
-    public int compareTo(HistoryEntry that) {
-        assert this.revision != NOREV : "BazaarTagEntry created without tag specified.specified";
-        return Integer.compare(this.revision, Integer.parseInt(that.getRevision()));
-    }
+    /**
+     * Reads an object from the initialized input unless the stream has been
+     * exhausted.
+     * @return a defined instance or {@code null} if the stream has been
+     * exhausted
+     */
+    Object readObject() throws IOException;
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BazaarHistoryParserTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BazaarHistoryParserTest.java
@@ -24,20 +24,18 @@
 
 package org.opengrok.indexer.history;
 
-import java.nio.file.Paths;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.HashSet;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.PlatformUtils;
-import org.opengrok.indexer.web.Util;
-
-import static org.junit.Assert.*;
 
 /**
  *
@@ -47,17 +45,6 @@ public class BazaarHistoryParserTest {
 
     private BazaarHistoryParser instance;
     
-    public BazaarHistoryParserTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
     @Before
     public void setUp() {
         if (RuntimeEnvironment.getInstance().getSourceRootPath() == null) {
@@ -206,5 +193,4 @@ public class BazaarHistoryParserTest {
         assertEquals(author1, e1.getAuthor());
         assertEquals(new HashSet<>(Arrays.asList(files)), e1.getFiles());
     }
-    
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BitKeeperRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BitKeeperRepositoryTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -95,7 +96,7 @@ public class BitKeeperRepositoryTest {
         bkFiles = null;
     }
 
-    static private void validateHistory(History history) throws Exception {
+    static private void validateHistory(History history) {
         final List<HistoryEntry> entries = history.getHistoryEntries();
         final List<String> renames = history.getRenamedFiles();
 
@@ -113,12 +114,12 @@ public class BitKeeperRepositoryTest {
 
         // Validate that the renamed files list corresponds
         // to all the file names we know of for this file.
-        final TreeSet<String> fileNames = new TreeSet<String>();
+        final TreeSet<String> fileNames = new TreeSet<>();
         for (final HistoryEntry entry : entries) {
             fileNames.addAll(entry.getFiles());
         }
         final String currentName = entries.get(0).getFiles().first();
-        final TreeSet<String> pastNames = new TreeSet<String>(renames);
+        final TreeSet<String> pastNames = new TreeSet<>(renames);
         pastNames.add(currentName);
         assertEquals("File history has incorrect rename list.", fileNames, pastNames);
     }
@@ -129,8 +130,8 @@ public class BitKeeperRepositoryTest {
 
         for (final String bkFile : bkFiles) {
             final File file = new File(bkRepo.getDirectoryName(), bkFile);
-            final History fullHistory = bkRepo.getHistory(file);
-            final History partHistory = bkRepo.getHistory(file, "1.2");
+            final History fullHistory = HistoryUtil.union(bkRepo.getHistory(file));
+            final History partHistory = HistoryUtil.union(bkRepo.getHistory(file, "1.2"));
             // I made sure that each file had a 1.2
 
             validateHistory(fullHistory);
@@ -144,14 +145,14 @@ public class BitKeeperRepositoryTest {
     }
 
     @Test
-    public void testGetHistoryInvalid() throws Exception {
+    public void testGetHistoryInvalid() {
         assertNotNull("Couldn't read bitkeeper test repository.", bkRepo);
 
         final File file = new File(bkRepo.getDirectoryName(), "fakename.cpp");
 
         boolean caughtFull = false;
         try {
-            final History fullHistory = bkRepo.getHistory(file);
+            HistoryUtil.union(bkRepo.getHistory(file));
         } catch (final HistoryException e) {
             caughtFull = true;
         }
@@ -159,20 +160,20 @@ public class BitKeeperRepositoryTest {
 
         boolean caughtPart = false;
         try {
-            final History partHistory = bkRepo.getHistory(file, "1.2");
+            HistoryUtil.union(bkRepo.getHistory(file, "1.2"));
         } catch (final HistoryException e) {
             caughtPart = true;
         }
         assertTrue("No exception thrown by getHistory with fake file", caughtPart);
     }
 
-    static private String readStream(InputStream stream) throws IOException {
+    static private String readStream(InputStream stream) {
         final Scanner scanner = new Scanner(stream).useDelimiter("\\A");
         return scanner.hasNext() ? scanner.next() : "";
     }
 
     @Test
-    public void testGetHistoryGet() throws Exception {
+    public void testGetHistoryGet() {
         assertNotNull("Couldn't read bitkeeper test repository.", bkRepo);
 
         for (final String bkFile : bkFiles) {
@@ -186,7 +187,7 @@ public class BitKeeperRepositoryTest {
     }
 
     @Test
-    public void testGetHistoryGetInvalid() throws Exception {
+    public void testGetHistoryGetInvalid() {
         assertNotNull("Couldn't read bitkeeper test repository.", bkRepo);
 
         assertNull("Something returned by getHistoryGet with fake file",
@@ -207,19 +208,19 @@ public class BitKeeperRepositoryTest {
             assertEquals("Wrong file returned by annotate.", currentVersion.getFilename(), file.getName());
             assertEquals("Wrong file returned by annotate.", firstVersion.getFilename(), file.getName());
             assertTrue("Incorrect revisions returned by annotate.", currentVersion.getRevisions().size() > 1);
-            assertTrue("Incorrect revisions returned by annotate.", firstVersion.getRevisions().size() == 1);
+            assertEquals("Incorrect revisions returned by annotate.", 1, firstVersion.getRevisions().size());
         }
     }
 
     @Test
-    public void testAnnotationInvalid() throws Exception {
+    public void testAnnotationInvalid() {
         assertNotNull("Couldn't read bitkeeper test repository.", bkRepo);
 
         final File file = new File(bkRepo.getDirectoryName(), "fakename.cpp");
 
         boolean caughtCurrent = false;
         try {
-            final Annotation currentVersion = bkRepo.annotate(file, "+");
+            bkRepo.annotate(file, "+");
         } catch (final IOException e) {
             caughtCurrent = true;
         }
@@ -227,7 +228,7 @@ public class BitKeeperRepositoryTest {
 
         boolean caughtFirst = false;
         try {
-            final Annotation firstVersion = bkRepo.annotate(file, "1.1");
+            bkRepo.annotate(file, "1.1");
         } catch (final IOException e) {
             caughtFirst = true;
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSRepositoryTest.java
@@ -28,14 +28,14 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.Before;
@@ -106,9 +106,7 @@ public class CVSRepositoryTest {
         List<String> cmdargs = new ArrayList<>();
         CVSRepository repo = new CVSRepository();
         cmdargs.add(repo.getRepoCommand());
-        for (String arg: args) {
-            cmdargs.add(arg);
-        }
+        Collections.addAll(cmdargs, args);
         Executor exec = new Executor(cmdargs, reposRoot);
         int exitCode = exec.exec();
         if (exitCode != 0) {
@@ -122,7 +120,6 @@ public class CVSRepositoryTest {
     /**
      * Get the CVS repository, test that getBranch() returns null if there is
      * no branch.
-     * @throws Exception
      */
     @Test
     public void testGetBranchNoBranch() throws Exception {
@@ -130,7 +127,7 @@ public class CVSRepositoryTest {
         File root = new File(repository.getSourceRoot(), "cvs_test/cvsrepo");
         CVSRepository cvsrepo
                 = (CVSRepository) RepositoryFactory.getRepository(root);
-        assertEquals(null, cvsrepo.getBranch());
+        assertNull("getBranch()", cvsrepo.getBranch());
     }
 
     /**
@@ -139,7 +136,6 @@ public class CVSRepositoryTest {
      * with branch revision numbers.
      * Last, check that history entries of the file follow through before the
      * branch was created.
-     * @throws Exception
      */
     @Test
     public void testNewBranch() throws Exception {
@@ -172,7 +168,7 @@ public class CVSRepositoryTest {
         Annotation annotation = cvsrepo.annotate(mainC, null);
         assertEquals("1.2.2.1", annotation.getRevision(1));
 
-        History mainCHistory = cvsrepo.getHistory(mainC);
+        History mainCHistory = HistoryUtil.union(cvsrepo.getHistory(mainC));
         assertEquals(3, mainCHistory.getHistoryEntries().size());
         assertEquals("1.2.2.1", mainCHistory.getHistoryEntries().get(0).getRevision());
         assertEquals("1.2", mainCHistory.getHistoryEntries().get(1).getRevision());
@@ -199,7 +195,6 @@ public class CVSRepositoryTest {
 
     /**
      * Test of parseAnnotation method, of class CVSRepository.
-     * @throws java.lang.Exception
      */
     @Test
     public void testParseAnnotation() throws Exception {
@@ -222,7 +217,7 @@ public class CVSRepositoryTest {
         assertNotNull(result);
         assertEquals(3, result.size());
         for (int i = 1; i <= 3; i++) {
-            assertEquals(true, result.isEnabled(i));
+            assertTrue("isEnabled()", result.isEnabled(i));
         }
         assertEquals(revId1, result.getRevision(1));
         assertEquals(revId2, result.getRevision(2));

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheOctopusTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheOctopusTest.java
@@ -54,7 +54,6 @@ public class FileHistoryCacheOctopusTest {
     public void setUp() throws Exception {
         repositories = new TestRepository();
         repositories.create(getClass().getResourceAsStream("/history/git-octopus.zip"));
-
         cache = new FileHistoryCache();
         cache.initialize();
     }
@@ -72,9 +71,10 @@ public class FileHistoryCacheOctopusTest {
     public void testStoreAndGet() throws Exception {
         File reposRoot = new File(repositories.getSourceRoot(), "git-octopus");
         Repository repo = RepositoryFactory.getRepository(reposRoot);
-        History historyToStore = repo.getHistory(reposRoot);
+        HistoryEnumeration historyToStore = repo.getHistory(reposRoot);
 
         cache.store(historyToStore, repo);
+        historyToStore.close();
 
         assertEquals("latest git-octopus commit", "206f862b",
                 cache.getLatestCachedRevision(repo));

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitHistoryParserTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitHistoryParserTest.java
@@ -42,7 +42,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengrok.indexer.util.TestRepository;
 import org.opengrok.indexer.web.Util;
-
 /**
  * @author austvik
  */
@@ -107,11 +106,18 @@ public class GitHistoryParserTest {
         History gitHistory = instance.getHistory();
         assertNotNull("should parse git-log-merged-file.txt", gitHistory);
         List<HistoryEntry> entries = gitHistory.getHistoryEntries();
-        assertEquals("git-log-merged-file.txt entries", 1, entries.size());
+        assertEquals("git-log-merged-file.txt entries", 2, entries.size());
 
         final String MERGE_REV = "4c3d5e8e";
+        HistoryEntry e1 = entries.get(1);
+        assertEquals("entries[1] revision", MERGE_REV, e1.getRevision());
+
         HistoryEntry e0 = entries.get(0);
         assertEquals("entries[0] revision", MERGE_REV, e0.getRevision());
+
+        SortedSet<String> f1 = e1.getFiles();
+        assertEquals("e[1] files size", 1, f1.size());
+        assertEquals("e[1] files[0]", "/contrib/serf/STATUS", f1.first());
 
         SortedSet<String> f0 = e0.getFiles();
         assertEquals("e[0] files size", 1, f0.size());

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryOctopusTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryOctopusTest.java
@@ -167,16 +167,17 @@ public class GitRepositoryOctopusTest {
         File root = new File(repository.getSourceRoot(), "git-octopus");
         GitRepository gitRepo = (GitRepository) RepositoryFactory.getRepository(root);
 
-        History history = gitRepo.getHistory(root);
+        History history = HistoryUtil.union(gitRepo.getHistory(root));
         assertNotNull("git-octopus getHistory()", history);
 
         List<HistoryEntry> entries = history.getHistoryEntries();
         assertNotNull("git-octopus getHistoryEntries()", entries);
 
         /*
-         * git-octopus has four-way merge, but GitHistoryParser condenses.
+         * git-octopus has four-way merge, so there are three more history
+         * entries with `git log -m`
          */
-        assertEquals("git-octopus log entries", 4, entries.size());
+        assertEquals("git-octopus log entries", 7, entries.size());
 
         SortedSet<String> allFiles = new TreeSet<>();
         for (HistoryEntry entry : entries) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
@@ -202,7 +202,6 @@ public class GitRepositoryTest {
                 = (GitRepository) RepositoryFactory.getRepository(root);
         gitrepo.setHandleRenamedFiles(true);
 
-        int i = 0;
         for (String[] test : tests) {
             String file = Paths.get(root.getCanonicalPath(), test[0]).toString();
             String changeset = test[1];
@@ -213,7 +212,6 @@ public class GitRepositoryTest {
             } catch (IOException ex) {
                 Assert.fail(String.format("Looking for original name of %s in %s shouldn't fail", file, changeset));
             }
-            i++;
         }
     }
 
@@ -440,7 +438,7 @@ public class GitRepositoryTest {
         GitRepository gitrepo
                 = (GitRepository) RepositoryFactory.getRepository(root);
 
-        History history = gitrepo.getHistory(root);
+        History history = HistoryUtil.union(gitrepo.getHistory(root));
         Assert.assertNotNull(history);
         Assert.assertNotNull(history.getHistoryEntries());
         Assert.assertEquals(8, history.getHistoryEntries().size());
@@ -448,11 +446,11 @@ public class GitRepositoryTest {
         Assert.assertNotNull(history.getRenamedFiles());
         Assert.assertEquals(3, history.getRenamedFiles().size());
 
-        Assert.assertTrue(history.isRenamed("moved/renamed2.c"));
-        Assert.assertTrue(history.isRenamed("moved2/renamed2.c"));
-        Assert.assertTrue(history.isRenamed("moved/renamed.c"));
-        Assert.assertFalse(history.isRenamed("non-existent.c"));
-        Assert.assertFalse(history.isRenamed("renamed.c"));
+        Assert.assertTrue(history.isRenamedBySlowLookup("moved/renamed2.c"));
+        Assert.assertTrue(history.isRenamedBySlowLookup("moved2/renamed2.c"));
+        Assert.assertTrue(history.isRenamedBySlowLookup("moved/renamed.c"));
+        Assert.assertFalse(history.isRenamedBySlowLookup("non-existent.c"));
+        Assert.assertFalse(history.isRenamedBySlowLookup("renamed.c"));
 
         Assert.assertEquals("84599b3c", history.getHistoryEntries().get(0).getRevision());
         Assert.assertEquals("67dfbe26", history.getHistoryEntries().get(1).getRevision());
@@ -471,7 +469,7 @@ public class GitRepositoryTest {
         GitRepository gitrepo
                 = (GitRepository) RepositoryFactory.getRepository(root);
 
-        History history = gitrepo.getHistory(new File(root.getAbsolutePath(), "moved2/renamed2.c"));
+        History history = HistoryUtil.union(gitrepo.getHistory(new File(root.getAbsolutePath(), "moved2/renamed2.c")));
         Assert.assertNotNull(history);
         Assert.assertNotNull(history.getHistoryEntries());
         Assert.assertEquals(5, history.getHistoryEntries().size());
@@ -479,11 +477,11 @@ public class GitRepositoryTest {
         Assert.assertNotNull(history.getRenamedFiles());
         Assert.assertEquals(3, history.getRenamedFiles().size());
 
-        Assert.assertTrue(history.isRenamed("moved/renamed2.c"));
-        Assert.assertTrue(history.isRenamed("moved2/renamed2.c"));
-        Assert.assertTrue(history.isRenamed("moved/renamed.c"));
-        Assert.assertFalse(history.isRenamed("non-existent.c"));
-        Assert.assertFalse(history.isRenamed("renamed.c"));
+        Assert.assertTrue(history.isRenamedBySlowLookup("moved/renamed2.c"));
+        Assert.assertTrue(history.isRenamedBySlowLookup("moved2/renamed2.c"));
+        Assert.assertTrue(history.isRenamedBySlowLookup("moved/renamed.c"));
+        Assert.assertFalse(history.isRenamedBySlowLookup("non-existent.c"));
+        Assert.assertFalse(history.isRenamedBySlowLookup("renamed.c"));
 
         Assert.assertEquals("84599b3c", history.getHistoryEntries().get(0).getRevision());
         Assert.assertEquals("67dfbe26", history.getHistoryEntries().get(1).getRevision());

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryEntryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryEntryTest.java
@@ -19,21 +19,24 @@
 
 /*
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.SortedSet;
 import java.util.TreeSet;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
- *
  * @author austvik
  */
 public class HistoryEntryTest {
@@ -44,25 +47,10 @@ public class HistoryEntryTest {
     private String historyAuthor = "test author";
     private String historyMessage = "history entry message";
  
-    public HistoryEntryTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
     @Before
     public void setUp() {
         instance = new HistoryEntry(historyRevision, historyDate,
             historyAuthor, null, historyMessage, true);
-    }
-
-    @After
-    public void tearDown() {
     }
 
     /**
@@ -256,4 +244,44 @@ public class HistoryEntryTest {
         assertEquals(null, instance.getTags());
     }
 
+    @Test
+    public void shouldMergeSimplest() {
+        HistoryEntry a = new HistoryEntry();
+        HistoryEntry b = new HistoryEntry();
+
+        a.merge(b);
+        assertEquals("a getFiles() size",0, a.getFiles().size());
+        assertNull("a getTags()", a.getTags());
+    }
+
+    @Test
+    public void shouldMergeFiles() {
+        HistoryEntry a = new HistoryEntry();
+        a.setFiles(new TreeSet<>(Arrays.asList("a,b".split(","))));
+
+        HistoryEntry b = new HistoryEntry();
+        b.setFiles(new TreeSet<>(Arrays.asList("b,c".split(","))));
+
+        a.merge(b);
+        SortedSet<String> aFiles = a.getFiles();
+        assertEquals("a getFiles() size",3, aFiles.size());
+        assertTrue("contains 'a'", aFiles.contains("a"));
+        assertTrue("contains 'b'", aFiles.contains("b"));
+        assertTrue("contains 'c'", aFiles.contains("c"));
+
+        assertNull("a getTags()", a.getTags());
+    }
+
+    @Test
+    public void shouldMergeTags() {
+        HistoryEntry a = new HistoryEntry();
+        a.setTags("a, b");
+
+        HistoryEntry b = new HistoryEntry();
+        b.setTags("c, b");
+
+        a.merge(b);
+        assertEquals("a getFiles() size",0, a.getFiles().size());
+        assertEquals("a getTags()", "a, b, c", a.getTags());
+    }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
+ */
+
+package org.opengrok.indexer.history;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+
+/**
+ * Represents a container for tests of {@link History}.
+ */
+public class HistoryTest {
+
+    @Test
+    public void testEncode() {
+        final History hist = new History(
+                new ArrayList<>(Arrays.asList(
+                        new HistoryEntry(
+                                "2",
+                                new Date(1554648411000L),
+                                "fred",
+                                "b",
+                                "second commit",
+                                true),
+                        new HistoryEntry(
+                                "1",
+                                new Date(1554648401000L),
+                                "barney",
+                                "a, b",
+                                "first commit",
+                                true))),
+                new ArrayList<>(Arrays.asList("a/b", "b/c")));
+
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        hist.encodeObject(bytesOut);
+        String xml = new String(bytesOut.toByteArray());
+
+        assertNotNull("String from encodeObject()", xml);
+        assertTrue("has Date #2", xml.contains("<long>1554648411000</long>"));
+        assertTrue("has Date #1", xml.contains("<long>1554648401000</long>"));
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -104,7 +104,7 @@ public class MercurialRepositoryTest {
         File root = new File(repository.getSourceRoot(), "mercurial");
         MercurialRepository mr
                 = (MercurialRepository) RepositoryFactory.getRepository(root);
-        History hist = mr.getHistory(root);
+        History hist = HistoryUtil.union(mr.getHistory(root));
         List<HistoryEntry> entries = hist.getHistoryEntries();
         assertEquals(REVISIONS.length, entries.size());
         for (int i = 0; i < entries.size(); i++) {
@@ -128,7 +128,7 @@ public class MercurialRepositoryTest {
 
         MercurialRepository mr
                 = (MercurialRepository) RepositoryFactory.getRepository(root);
-        History hist = mr.getHistory(new File(root, "subdir"));
+        History hist = HistoryUtil.union(mr.getHistory(new File(root, "subdir")));
         List<HistoryEntry> entries = hist.getHistoryEntries();
         assertEquals(1, entries.size());
     }
@@ -136,8 +136,6 @@ public class MercurialRepositoryTest {
     /**
      * Test that subset of changesets can be extracted based on penultimate
      * revision number. This works for directories only.
-     *
-     * @throws Exception
      */
     @Test
     public void testGetHistoryPartial() throws Exception {
@@ -146,7 +144,7 @@ public class MercurialRepositoryTest {
         MercurialRepository mr
                 = (MercurialRepository) RepositoryFactory.getRepository(root);
         // Get all but the oldest revision.
-        History hist = mr.getHistory(root, REVISIONS[REVISIONS.length - 1]);
+        History hist = HistoryUtil.union(mr.getHistory(root, REVISIONS[REVISIONS.length - 1]));
         List<HistoryEntry> entries = hist.getHistoryEntries();
         assertEquals(REVISIONS.length - 1, entries.size());
         for (int i = 0; i < entries.size(); i++) {
@@ -185,8 +183,6 @@ public class MercurialRepositoryTest {
     /**
      * Test that history of branched repository contains changesets of the
      * default branch as well.
-     *
-     * @throws Exception
      */
     @Test
     public void testGetHistoryBranch() throws Exception {
@@ -205,13 +201,13 @@ public class MercurialRepositoryTest {
                 = (MercurialRepository) RepositoryFactory.getRepository(root);
 
         // Get all revisions.
-        History hist = mr.getHistory(root);
+        History hist = HistoryUtil.union(mr.getHistory(root));
         List<HistoryEntry> entries = hist.getHistoryEntries();
         List<String> both = new ArrayList<>(REVISIONS.length
                 + REVISIONS_extra_branch.length);
         Collections.addAll(both, REVISIONS_extra_branch);
         Collections.addAll(both, REVISIONS);
-        String revs[] = both.toArray(new String[both.size()]);
+        String[] revs = both.toArray(new String[0]);
         assertEquals(revs.length, entries.size());
         // Ideally we should check that the last revision is branched but
         // there is currently no provision for that in HistoryEntry object.
@@ -225,7 +221,7 @@ public class MercurialRepositoryTest {
         }
 
         // Get revisions starting with given changeset before the repo was branched.
-        hist = mr.getHistory(root, "8:6a8c423f5624");
+        hist = HistoryUtil.union(mr.getHistory(root, "8:6a8c423f5624"));
         entries = hist.getHistoryEntries();
         assertEquals(2, entries.size());
         assertEquals(REVISIONS_extra_branch[0], entries.get(0).getRevision());
@@ -234,8 +230,6 @@ public class MercurialRepositoryTest {
 
     /**
      * Test that contents of last revision of a text file match expected content.
-     *
-     * @throws java.lang.Exception
      */
     @Test
     public void testGetHistoryGet() throws Exception {
@@ -267,8 +261,6 @@ public class MercurialRepositoryTest {
 
     /**
      * Test that it is possible to get contents of multiple revisions of a file.
-     * 
-     * @throws java.lang.Exception
      */
     @Test
     public void testgetHistoryGetForAll() throws Exception {
@@ -287,8 +279,6 @@ public class MercurialRepositoryTest {
     /**
      * Test that {@code getHistoryGet()} returns historical contents of renamed
      * file.
-     *
-     * @throws java.lang.Exception
      */
     @Test
     public void testGetHistoryGetRenamed() throws Exception {
@@ -315,8 +305,6 @@ public class MercurialRepositoryTest {
     /**
      * Test that {@code getHistory()} throws an exception if the revision
      * argument doesn't match any of the revisions in the history.
-     *
-     * @throws java.lang.Exception
      */
     @Test
     public void testGetHistoryWithNoSuchRevision() throws Exception {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2017, 2019-2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2019, Chris Ross <cross@distal.com>.
  */
 package org.opengrok.indexer.history;
@@ -122,7 +122,7 @@ public class PerforceRepositoryTest {
 
         for (File f : files) {
             if (instance.fileHasHistory(f)) {
-                History history = instance.getHistory(f);
+                History history = HistoryUtil.union(instance.getHistory(f));
                 assertNotNull("Failed to get history for: " + f.getAbsolutePath(), history);
 
                 for (HistoryEntry entry : history.getHistoryEntries()) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RCSRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RCSRepositoryTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
@@ -93,7 +94,7 @@ public class RCSRepositoryTest {
     public void testGetHistory() throws Exception {
         File root = new File(repository.getSourceRoot(), "rcs_test");
         RCSRepository repo = (RCSRepository) RepositoryFactory.getRepository(root);
-        History hist = repo.getHistory(new File(root, "Makefile"));
+        History hist = HistoryUtil.union(repo.getHistory(new File(root, "Makefile")));
         List<HistoryEntry> entries = hist.getHistoryEntries();
         assertEquals(REVISIONS.length, entries.size());
         for (int i = 0; i < entries.size(); i++) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryTest.java
@@ -19,12 +19,11 @@
 
 /*
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2018-2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
 import java.io.File;
-import java.io.IOException;
 import java.text.ParseException;
 import java.util.Arrays;
 import org.junit.Assert;
@@ -154,7 +153,7 @@ public class RepositoryTest {
         }
 
         @Override
-        public History getHistory(File file) throws HistoryException {
+        public HistoryEnumeration getHistory(File file) {
             return null;
         }
 
@@ -170,7 +169,7 @@ public class RepositoryTest {
         }
 
         @Override
-        public Annotation annotate(File file, String revision) throws IOException {
+        public Annotation annotate(File file, String revision) {
             return null;
         }
 
@@ -180,17 +179,17 @@ public class RepositoryTest {
         }
 
         @Override
-        public String determineParent(CommandTimeoutType cmdType) throws IOException {
+        public String determineParent(CommandTimeoutType cmdType) {
             return "";
         }
 
         @Override
-        public String determineBranch(CommandTimeoutType cmdType) throws IOException {
+        public String determineBranch(CommandTimeoutType cmdType) {
             return "";
         }
 
         @Override
-        String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
+        String determineCurrentVersion(CommandTimeoutType cmdType) {
             return null;
         }
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -294,7 +294,7 @@ public class IndexerTest {
                 RuntimeEnvironment env = RuntimeEnvironment.getInstance();
                 File f = new File(env.getDataRootPath(),
                         TandemPath.join("historycache" + path, ".gz"));
-                Assert.assertTrue("history cache file should be preserved", f.exists());
+                Assert.assertTrue("historycache file should be preserved", f.exists());
             }
             removedFiles.add(path);
         }

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.26</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
@vladak , see:

* `HistoryEnumeration`
* `FileHistoryTemp` that uses HaloDB, and revising `FileHistoryCache`'s to use `FileHistoryTemp`
* `ObjectStreamHandler` and revising `Executor` to support it
* `GitHistoryParser` revised as an `ObjectStreamHandler`
* `SingleHistory` implementation for all other repositories which I did not convert to be  `ObjectStreamHandler`.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
