### PR TITLE
use statsd for indexer monitoring

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -210,6 +210,11 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <artifactId>micrometer-registry-prometheus</artifactId>
             <version>${micrometer.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-statsd</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -107,11 +107,10 @@ public final class Metrics {
             // Add tag for per-project reindex.
             List<String> subFiles = RuntimeEnvironment.getInstance().getSubFiles();
             if (!subFiles.isEmpty()) {
-                List<String> sList = subFiles.stream().
+                String projects = subFiles.stream().
                         map(s -> s.startsWith(Indexer.PATH_SEPARATOR_STRING) ? s.substring(1) : s).
-                        collect(Collectors.toList());
-                statsdRegistry.config().commonTags(Collections.singleton(Tag.of("projects",
-                        String.join(",", sList))));
+                        collect(Collectors.joining(","));
+                statsdRegistry.config().commonTags(Collections.singleton(Tag.of("projects", projects)));
             }
 
             registry = statsdRegistry;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -114,7 +114,7 @@ public final class Metrics {
             }
 
             registry = statsdRegistry;
-        } else {
+        } else if (!RuntimeEnvironment.getInstance().isIndexer()) {
             LOGGER.log(Level.INFO, "configuring PrometheusRegistry");
             prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
             registry = prometheusRegistry;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -106,7 +106,7 @@ public final class Metrics {
 
             // Add tag for per-project reindex.
             ArrayList<String> subFiles = RuntimeEnvironment.getInstance().getSubFiles();
-            if (subFiles.size() > 0) {
+            if (!subFiles.isEmpty()) {
                 List<String> sList = subFiles.stream().
                         map(s -> s.startsWith(Indexer.PATH_SEPARATOR_STRING) ? s.substring(1) : s).
                         collect(Collectors.toList());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -39,7 +39,6 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.index.Indexer;
 import org.opengrok.indexer.logger.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -97,7 +97,7 @@ public final class Metrics {
     private static StatsdMeterRegistry statsdRegistry;
 
     static {
-        MeterRegistry registry;
+        MeterRegistry registry = null;
 
         if (RuntimeEnvironment.getInstance().getStatsdConfig().isEnabled()) {
             LOGGER.log(Level.INFO, "configuring StatsdRegistry");
@@ -120,11 +120,13 @@ public final class Metrics {
             registry = prometheusRegistry;
         }
 
-        new ClassLoaderMetrics().bindTo(registry);
-        new JvmMemoryMetrics().bindTo(registry);
-        new JvmGcMetrics().bindTo(registry);
-        new ProcessorMetrics().bindTo(registry);
-        new JvmThreadMetrics().bindTo(registry);
+        if (registry != null) {
+            new ClassLoaderMetrics().bindTo(registry);
+            new JvmMemoryMetrics().bindTo(registry);
+            new JvmGcMetrics().bindTo(registry);
+            new ProcessorMetrics().bindTo(registry);
+            new JvmThreadMetrics().bindTo(registry);
+        }
     }
 
     private Metrics() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -145,9 +145,9 @@ public final class Metrics {
      */
     public static MeterRegistry getRegistry() {
         if (RuntimeEnvironment.getInstance().isIndexer()) {
-            return Metrics.getStatsdRegistry();
+            return getStatsdRegistry();
         } else {
-            return Metrics.getPrometheusRegistry();
+            return getPrometheusRegistry();
         }
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -110,8 +110,7 @@ public final class Metrics {
 
     public static void updateSubFiles(List<String> subFiles) {
         // Add tag for per-project reindex.
-        if (statsdRegistry != null &&
-                RuntimeEnvironment.getInstance().getStatsdConfig().isEnabled() && !subFiles.isEmpty()) {
+        if (statsdRegistry != null && !subFiles.isEmpty()) {
             String projects = subFiles.stream().
                     map(s -> s.startsWith(Indexer.PATH_SEPARATOR_STRING) ? s.substring(1) : s).
                     collect(Collectors.joining(","));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -105,7 +105,7 @@ public final class Metrics {
             statsdRegistry = new StatsdMeterRegistry(statsdConfig, Clock.SYSTEM);
 
             // Add tag for per-project reindex.
-            ArrayList<String> subFiles = RuntimeEnvironment.getInstance().getSubFiles();
+            List<String> subFiles = RuntimeEnvironment.getInstance().getSubFiles();
             if (!subFiles.isEmpty()) {
                 List<String> sList = subFiles.stream().
                         map(s -> s.startsWith(Indexer.PATH_SEPARATOR_STRING) ? s.substring(1) : s).

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -62,19 +62,7 @@ public final class Metrics {
 
         @Override
         public StatsdFlavor flavor() {
-            String flavor = RuntimeEnvironment.getInstance().getStatsdConfig().getFlavor().toLowerCase();
-            switch (flavor) {
-                case "etsy":
-                    return StatsdFlavor.ETSY;
-                case "datadog":
-                    return StatsdFlavor.DATADOG;
-                case "sysdig":
-                    return StatsdFlavor.SYSDIG;
-                case "telegraf":
-                    return StatsdFlavor.TELEGRAF;
-            }
-
-            return null;
+            return RuntimeEnvironment.getInstance().getStatsdConfig().getFlavor();
         }
 
         @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -299,6 +299,8 @@ public final class Configuration {
 
     private SuggesterConfig suggesterConfig = new SuggesterConfig();
 
+    private StatsdConfig statsdConfig = new StatsdConfig();
+
     private Set<String> disabledRepositories;
 
     /*
@@ -1313,6 +1315,17 @@ public final class Configuration {
             throw new IllegalArgumentException("Cannot set Suggester configuration to null");
         }
         this.suggesterConfig = config;
+    }
+
+    public StatsdConfig getStatsdConfig() {
+        return statsdConfig;
+    }
+
+    public void setStatsdConfig(final StatsdConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("Cannot set Statsd configuration to null");
+        }
+        this.statsdConfig = config;
     }
 
     public Set<String> getDisabledRepositories() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationHelp.java
@@ -183,6 +183,8 @@ public class ConfigurationHelp {
             return null;
         } else if (paramType == SuggesterConfig.class) {
             return SuggesterConfig.getForHelp();
+        } else if (paramType == StatsdConfig.class) {
+            return StatsdConfig.getForHelp();
         } else {
             throw new UnsupportedOperationException("getSampleValue() for " +
                 paramType + ", " + genType);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -123,6 +123,12 @@ public final class RuntimeEnvironment {
 
     public WatchDogService watchDog;
 
+    public ArrayList<String> getSubFiles() {
+        return subFiles;
+    }
+
+    private ArrayList<String> subFiles = new ArrayList<>();
+
     /**
      * Creates a new instance of RuntimeEnvironment. Private to ensure a
      * singleton anti-pattern.
@@ -140,6 +146,16 @@ public final class RuntimeEnvironment {
     // Instance of authorization framework and its lock.
     private AuthorizationFramework authFramework;
     private final Object authFrameworkLock = new Object();
+
+    private boolean indexer;
+
+    public boolean isIndexer() {
+        return indexer;
+    }
+
+    public void setIndexer(boolean indexer) {
+        this.indexer = indexer;
+    }
 
     /** Gets the thread pool used for multi-project searches. */
     public ExecutorService getSearchExecutor() {
@@ -1874,6 +1890,14 @@ public final class RuntimeEnvironment {
 
     public void setSuggesterConfig(SuggesterConfig suggesterConfig) {
         syncWriteConfiguration(suggesterConfig, Configuration::setSuggesterConfig);
+    }
+
+    public StatsdConfig getStatsdConfig() {
+        return syncReadConfiguration(Configuration::getStatsdConfig);
+    }
+
+    public void setStatsdConfig(StatsdConfig statsdConfig) {
+        syncWriteConfiguration(statsdConfig, Configuration::setStatsdConfig);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -123,7 +123,7 @@ public final class RuntimeEnvironment {
 
     public WatchDogService watchDog;
 
-    public ArrayList<String> getSubFiles() {
+    public List<String> getSubFiles() {
         return subFiles;
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -127,7 +127,7 @@ public final class RuntimeEnvironment {
         return subFiles;
     }
 
-    private ArrayList<String> subFiles = new ArrayList<>();
+    private List<String> subFiles = new ArrayList<>();
 
     /**
      * Creates a new instance of RuntimeEnvironment. Private to ensure a

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/StatsdConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/StatsdConfig.java
@@ -1,0 +1,74 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.configuration;
+
+/**
+ * Configuration for Statsd metrics emitted by the Indexer via {@link org.opengrok.indexer.util.Statistics}.
+ */
+public class StatsdConfig {
+    private int port;
+    private String host;
+    private boolean enabled;
+    private String flavor;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getFlavor() {
+        return flavor;
+    }
+
+    public void setFlavor(String flavor) {
+        this.flavor = flavor;
+    }
+
+    public boolean isEnabled() {
+        return port != 0 && !host.isEmpty() && !flavor.isEmpty();
+    }
+
+    /**
+     * Gets an instance version suitable for helper documentation by shifting
+     * most default properties slightly.
+     */
+    static StatsdConfig getForHelp() {
+        StatsdConfig res = new StatsdConfig();
+        res.setHost("foo.bar");
+        res.setPort(8125);
+        res.setFlavor("etsy");
+        return res;
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/StatsdConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/StatsdConfig.java
@@ -57,7 +57,7 @@ public class StatsdConfig {
     }
 
     public boolean isEnabled() {
-        return port != 0 && host != null && !host.isEmpty() && !flavor.isEmpty();
+        return port != 0 && host != null && !host.isEmpty() && flavor != null && !flavor.isEmpty();
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/StatsdConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/StatsdConfig.java
@@ -23,6 +23,8 @@
 
 package org.opengrok.indexer.configuration;
 
+import io.micrometer.statsd.StatsdFlavor;
+
 /**
  * Configuration for Statsd metrics emitted by the Indexer via {@link org.opengrok.indexer.util.Statistics}.
  */
@@ -30,7 +32,7 @@ public class StatsdConfig {
     private int port;
     private String host;
     private boolean enabled;
-    private String flavor;
+    private StatsdFlavor flavor;
 
     public String getHost() {
         return host;
@@ -48,16 +50,16 @@ public class StatsdConfig {
         this.port = port;
     }
 
-    public String getFlavor() {
+    public StatsdFlavor getFlavor() {
         return flavor;
     }
 
-    public void setFlavor(String flavor) {
+    public void setFlavor(StatsdFlavor flavor) {
         this.flavor = flavor;
     }
 
     public boolean isEnabled() {
-        return port != 0 && host != null && !host.isEmpty() && flavor != null && !flavor.isEmpty();
+        return port != 0 && host != null && !host.isEmpty() && flavor != null;
     }
 
     /**
@@ -68,7 +70,7 @@ public class StatsdConfig {
         StatsdConfig res = new StatsdConfig();
         res.setHost("foo.bar");
         res.setPort(8125);
-        res.setFlavor("etsy");
+        res.setFlavor(StatsdFlavor.ETSY);
         return res;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/StatsdConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/StatsdConfig.java
@@ -57,7 +57,7 @@ public class StatsdConfig {
     }
 
     public boolean isEnabled() {
-        return port != 0 && !host.isEmpty() && !flavor.isEmpty();
+        return port != 0 && host != null && !host.isEmpty() && !flavor.isEmpty();
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -618,7 +618,7 @@ public final class HistoryGuru {
             LOGGER.log(Level.WARNING,
                     "Failed optimizing the history cache database", he);
         }
-        elapsed.report(LOGGER, "Done historycache for all repositories");
+        elapsed.report(LOGGER, "Done history cache for all repositories", "indexer.history.cache");
         historyCache.setHistoryIndexDone();
     }
 
@@ -884,7 +884,8 @@ public final class HistoryGuru {
         repositories.clear();
         newrepos.forEach((_key, repo) -> putRepository(repo));
 
-        elapsed.report(LOGGER, String.format("done invalidating %d repositories", newrepos.size()));
+        elapsed.report(LOGGER, String.format("done invalidating %d repositories", newrepos.size()),
+                "history.repositories.invalidate");
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
 import org.opengrok.indexer.Info;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.analysis.AnalyzerGuruHelp;
@@ -148,7 +149,7 @@ public final class Indexer {
         boolean update = true;
 
         Executor.registerErrorHandler();
-        ArrayList<String> subFiles = new ArrayList<>();
+        ArrayList<String> subFiles = RuntimeEnvironment.getInstance().getSubFiles();
         ArrayList<String> subFilesList = new ArrayList<>();
 
         boolean createDict = false;
@@ -177,6 +178,7 @@ public final class Indexer {
             }
 
             env = RuntimeEnvironment.getInstance();
+            env.setIndexer(true);
 
             // Complete the configuration of repository types.
             List<Class<? extends Repository>> repositoryClasses
@@ -385,7 +387,7 @@ public final class Indexer {
             System.err.println("Exception: " + e.getLocalizedMessage());
             System.exit(1);
         } finally {
-            stats.report(LOGGER);
+            stats.report(LOGGER, "Indexer finished", "indexer.total");
         }
     }
 
@@ -990,7 +992,7 @@ public final class Indexer {
             Statistics stats = new Statistics();
             env.setRepositories(searchPaths.toArray(new String[0]));
             stats.report(LOGGER, String.format("Done scanning for repositories, found %d repositories",
-                    env.getRepositories().size()));
+                    env.getRepositories().size()), "indexer.repository.scan");
         }
 
         if (createHistoryCache) {
@@ -1102,7 +1104,7 @@ public final class Indexer {
             LOGGER.log(Level.WARNING, "Received interrupt while waiting" +
                     " for executor to finish", exp);
         }
-        elapsed.report(LOGGER, "Done indexing data of all repositories");
+        elapsed.report(LOGGER, "Done indexing data of all repositories", "indexer.repository.indexing");
 
         CtagsUtil.deleteTempFiles();
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -52,6 +52,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.opengrok.indexer.Info;
+import org.opengrok.indexer.Metrics;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.analysis.AnalyzerGuruHelp;
 import org.opengrok.indexer.analysis.Ctags;
@@ -317,6 +318,8 @@ public final class Indexer {
                 System.err.println("None of the paths were added, exiting");
                 System.exit(1);
             }
+
+            Metrics.updateSubFiles(subFiles);
 
             // If the webapp is running with a config that does not contain
             // 'projectsEnabled' property (case of upgrade or transition

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -149,7 +149,7 @@ public final class Indexer {
         boolean update = true;
 
         Executor.registerErrorHandler();
-        ArrayList<String> subFiles = RuntimeEnvironment.getInstance().getSubFiles();
+        List<String> subFiles = RuntimeEnvironment.getInstance().getSubFiles();
         ArrayList<String> subFilesList = new ArrayList<>();
 
         boolean createDict = false;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -232,8 +232,9 @@ public class Executor {
 
             ret = process.waitFor();
 
-            stat.report(LOGGER, Level.FINE, String.format("Finished command [%s] in directory %s with exit code %d",
-                    cmd_str, dir_str, ret));
+            stat.report(LOGGER, Level.FINE,
+                    String.format("Finished command [%s] in directory %s with exit code %d", cmd_str, dir_str, ret),
+                    "executor.latency");
             LOGGER.log(Level.FINE,
                 "Finished command [{0}] in directory {1} with exit code {2}",
                 new Object[] {cmd_str, dir_str, ret});

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
@@ -18,16 +18,19 @@
  */
 
 /*
- * Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  */
 
 package org.opengrok.indexer.util;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.opengrok.indexer.Metrics;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import static org.opengrok.indexer.util.StringUtils.getReadableTime;
 
 public class Statistics {
 
@@ -37,15 +40,50 @@ public class Statistics {
       startTime = Instant.now();
   }
 
+    private void logIt(Logger logger, Level logLevel, String msg, Duration duration) {
+        String timeStr = StringUtils.getReadableTime(duration.toMillis());
+        logger.log(logLevel, msg + " (took {0})", timeStr);
+    }
+
     /**
-     * log a message along with how much time it took since the constructor was called.
+     * Log a message along with how much time it took since the constructor was called.
      * @param logger logger instance
      * @param logLevel log level
      * @param msg message string
      */
     public void report(Logger logger, Level logLevel, String msg) {
-        String timeStr = StringUtils.getReadableTime(Duration.between(startTime, Instant.now()).toMillis());
-        logger.log(logLevel, msg + " (took {0})", timeStr);
+        logIt(logger, logLevel, msg, Duration.between(startTime, Instant.now()));
+    }
+
+    /**
+     * Log a message and trigger statsd message along with how much time it took since the constructor was called.
+     * @param logger logger instance
+     * @param logLevel log level
+     * @param msg message string
+     * @param meterName name of the meter
+     */
+    public void report(Logger logger, Level logLevel, String msg, String meterName) {
+        Duration duration = Duration.between(startTime, Instant.now());
+
+        logIt(logger, logLevel, msg, duration);
+
+        MeterRegistry registry = Metrics.getRegistry();
+        if (registry != null) {
+            Timer.builder(meterName).
+                    register(registry).
+                    record(duration);
+        }
+    }
+
+    /**
+     * log a message along with how much time it took since the constructor was called.
+     * The log level is {@code INFO}.
+     * @param logger logger instance
+     * @param msg message string
+     * @param meterName name of the meter
+     */
+    public void report(Logger logger, String msg, String meterName) {
+        report(logger, Level.INFO, msg, meterName);
     }
 
     /**
@@ -56,21 +94,5 @@ public class Statistics {
      */
     public void report(Logger logger, String msg) {
         report(logger, Level.INFO, msg);
-    }
-
-    /**
-     * log a message along with how much time and memory it took since the constructor was called.
-     * The message will be logged with the {@code INFO} level.
-     * @param logger logger instance
-     */
-    public void report(Logger logger) {
-        logger.log(Level.INFO, "Total time: {0}",
-                getReadableTime(Duration.between(startTime, Instant.now()).toMillis()));
-
-        System.gc();
-        Runtime r = Runtime.getRuntime();
-        long mb = 1024L * 1024;
-        logger.log(Level.INFO, "Final Memory: {0}M/{1}M",
-                new Object[]{(r.totalMemory() - r.freeMemory()) / mb, r.totalMemory() / mb});
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/StatsdConfigTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/StatsdConfigTest.java
@@ -1,0 +1,44 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.configuration;
+
+import io.micrometer.statsd.StatsdFlavor;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StatsdConfigTest {
+    @Test
+    public void testIsEnabled() {
+        StatsdConfig config = new StatsdConfig();
+        assertFalse(config.isEnabled());
+        config.setPort(3141);
+        assertFalse(config.isEnabled());
+        config.setHost("foo");
+        assertFalse(config.isEnabled());
+        config.setFlavor(StatsdFlavor.ETSY);
+        assertTrue(config.isEnabled());
+    }
+}

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -43,14 +43,14 @@ public class StatisticsFilter implements Filter {
 
     static final String REQUESTS_METRIC = "requests";
 
-    private final DistributionSummary requests = Metrics.getRegistry().summary(REQUESTS_METRIC);
+    private final DistributionSummary requests = Metrics.getPrometheusRegistry().summary(REQUESTS_METRIC);
 
     private final Timer emptySearch = Timer.builder("search.latency").
             tags("outcome", "empty").
-            register(Metrics.getRegistry());
+            register(Metrics.getPrometheusRegistry());
     private final Timer successfulSearch = Timer.builder("search.latency").
             tags("outcome", "success").
-            register(Metrics.getRegistry());
+            register(Metrics.getPrometheusRegistry());
 
     @Override
     public void init(FilterConfig fc) throws ServletException {
@@ -89,7 +89,7 @@ public class StatisticsFilter implements Filter {
 
         Timer categoryTimer = Timer.builder("requests.latency").
                 tags("category", category, "code", String.valueOf(httpResponse.getStatus())).
-                register(Metrics.getRegistry());
+                register(Metrics.getPrometheusRegistry());
         categoryTimer.record(duration);
 
         SearchHelper helper = (SearchHelper) config.getRequestAttribute(SearchHelper.REQUEST_ATTR);

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -57,7 +57,7 @@ public final class WebappListener
     private static final Logger LOGGER = LoggerFactory.getLogger(WebappListener.class);
     private Timer startupTimer = Timer.builder("webapp.startup.latency").
                 description("web application startup latency").
-                register(Metrics.getRegistry());
+                register(Metrics.getPrometheusRegistry());
 
     /**
      * {@inheritDoc}

--- a/opengrok-web/src/main/java/org/opengrok/web/servlet/MetricsServlet.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/servlet/MetricsServlet.java
@@ -39,7 +39,7 @@ public class MetricsServlet extends HttpServlet {
     @Override
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
         try (PrintWriter pw = resp.getWriter()) {
-            pw.print(Metrics.getRegistry().scrape());
+            pw.print(Metrics.getPrometheusRegistry().scrape());
         }
     }
 }


### PR DESCRIPTION
This change introduces remote monitoring of indexer via statsd registry in Micrometer. I wanted to use statsd for indexer because it does not require scraping and therefore the need for a web server. This would either conflict with already running web server on the same machine (assuming the indexer is usually run on the same machine as the web application) or would involve poking holes into firewall to allow the scraping to pass through to distinct TCP port.

Example read-only configuration:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<java version="11.0.4" class="java.beans.XMLDecoder">
 <object class="org.opengrok.indexer.configuration.Configuration" id="Configuration0">

  <void property="statsdConfig">
     <void property="port">
       <int>8125</int>
     </void>
     <void property="host">
       <string>localhost</string>
     </void>
     <void property="flavor">
       <string>etsy</string>
     </void>
  </void>

 </object>
</java>
```

This was used to generate the graphs in https://github.com/oracle/opengrok/pull/3248#issuecomment-706603506 (I used statsd-exporter for Prometheus and Grafana)

The metrics are not tagged unless the indexer is run per project.

During testing I noticed that some of the metrics recorded in the final stages of indexing are not sent out even with buffering set to false and big delay at the end of the Indexer#main. This is not such a big deal given that statsd traffic is usually not reliable anyway (assuming UDP by default). I will definitely investigate.

Once this is merged in I will update https://github.com/oracle/opengrok/wiki/Monitoring with example rig configuration.