### PR TITLE
add Graphite support

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -215,6 +215,11 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <artifactId>micrometer-registry-statsd</artifactId>
             <version>${micrometer.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-graphite</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -154,6 +154,7 @@ public final class Metrics {
                 }
                 break;
             case NONE:
+                activeRegistry = null;
                 break;
             default:
                 throw new IllegalArgumentException("unsupported registry type");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -149,6 +149,8 @@ public final class Metrics {
                     activeRegistry = new StatsdMeterRegistry(getStatsdConfig(), Clock.SYSTEM);
                 }
                 break;
+            case NONE:
+                break;
             default:
                 throw new IllegalArgumentException("unsupported registry type");
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -30,11 +30,15 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.graphite.GraphiteProtocol;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.graphite.GraphiteConfig;
+import io.micrometer.graphite.GraphiteMeterRegistry;
 import io.micrometer.statsd.StatsdConfig;
 import io.micrometer.statsd.StatsdMeterRegistry;
 import io.micrometer.statsd.StatsdFlavor;
+import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.index.Indexer;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -53,90 +57,136 @@ public final class Metrics {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Metrics.class);
 
-    private static final StatsdConfig statsdConfig = new StatsdConfig() {
-        @Override
-        public String get(String k) {
-            return null;
-        }
+    private StatsdConfig getStatsdConfig() {
+        return new StatsdConfig() {
+            @Override
+            public String get(String k) {
+                return null;
+            }
 
-        @Override
-        public StatsdFlavor flavor() {
-            return RuntimeEnvironment.getInstance().getStatsdConfig().getFlavor();
-        }
+            @Override
+            public StatsdFlavor flavor() {
+                return RuntimeEnvironment.getInstance().getStatsdConfig().getFlavor();
+            }
 
-        @Override
-        public int port() {
-            return RuntimeEnvironment.getInstance().getStatsdConfig().getPort();
-        }
+            @Override
+            public int port() {
+                return RuntimeEnvironment.getInstance().getStatsdConfig().getPort();
+            }
 
-        @Override
-        public String host() {
-            return RuntimeEnvironment.getInstance().getStatsdConfig().getHost();
-        }
+            @Override
+            public String host() {
+                return RuntimeEnvironment.getInstance().getStatsdConfig().getHost();
+            }
 
-        @Override
-        public boolean buffered() {
-            return true;
-        }
-    };
-
-    private static PrometheusMeterRegistry prometheusRegistry;
-    private static StatsdMeterRegistry statsdRegistry;
-
-    static {
-        MeterRegistry registry = null;
-
-        if (RuntimeEnvironment.getInstance().getStatsdConfig().isEnabled()) {
-            LOGGER.log(Level.INFO, "configuring StatsdRegistry");
-            statsdRegistry = new StatsdMeterRegistry(statsdConfig, Clock.SYSTEM);
-            registry = statsdRegistry;
-        } else if (!RuntimeEnvironment.getInstance().isIndexer()) {
-            LOGGER.log(Level.INFO, "configuring PrometheusRegistry");
-            prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-            registry = prometheusRegistry;
-        }
-
-        if (registry != null) {
-            new ClassLoaderMetrics().bindTo(registry);
-            new JvmMemoryMetrics().bindTo(registry);
-            new JvmGcMetrics().bindTo(registry);
-            new ProcessorMetrics().bindTo(registry);
-            new JvmThreadMetrics().bindTo(registry);
-        }
+            @Override
+            public boolean buffered() {
+                return true;
+            }
+        };
     }
+
+    private GraphiteConfig getGraphiteConfig() {
+        return new GraphiteConfig() {
+            @Override
+            public String get(String k) {
+                return null;
+            }
+
+            @Override
+            public int port() {
+                return RuntimeEnvironment.getInstance().getGraphiteConfig().getPort();
+            }
+
+            @Override
+            public String host() {
+                return RuntimeEnvironment.getInstance().getGraphiteConfig().getHost();
+            }
+
+            @Override
+            public GraphiteProtocol protocol() {
+                return RuntimeEnvironment.getInstance().getGraphiteConfig().getProtocol();
+            }
+        };
+    }
+
+    private PrometheusMeterRegistry prometheusRegistry;
+
+    private MeterRegistry activeRegistry;
+
+    private static final Metrics instance = new Metrics();
 
     private Metrics() {
     }
 
-    public static void updateSubFiles(List<String> subFiles) {
+    /**
+     * @return the only instance of Metrics
+     */
+    public static Metrics getInstance() {
+        return instance;
+    }
+
+    /**
+     * Configure meter registry.
+     * @param type type of meter registry
+     */
+    public void configure(Configuration.MeterRegistryType type) {
+        switch (type) {
+            case PROMETHEUS:
+                LOGGER.log(Level.INFO, "configuring Prometheus registry");
+                prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+                activeRegistry = prometheusRegistry;
+                break;
+            case GRAPHITE:
+                if (RuntimeEnvironment.getInstance().getGraphiteConfig().isEnabled()) {
+                    LOGGER.log(Level.INFO, "configuring Graphite registry");
+                    activeRegistry = new GraphiteMeterRegistry(getGraphiteConfig(), Clock.SYSTEM);
+                }
+                break;
+            case STATSD:
+                if (RuntimeEnvironment.getInstance().getStatsdConfig().isEnabled()) {
+                    LOGGER.log(Level.INFO, "configuring Statsd registry");
+                    activeRegistry = new StatsdMeterRegistry(getStatsdConfig(), Clock.SYSTEM);
+                }
+                break;
+            default:
+                throw new IllegalArgumentException("unsupported registry type");
+        }
+
+        if (activeRegistry != null) {
+            new ClassLoaderMetrics().bindTo(activeRegistry);
+            new JvmMemoryMetrics().bindTo(activeRegistry);
+            new JvmGcMetrics().bindTo(activeRegistry);
+            new ProcessorMetrics().bindTo(activeRegistry);
+            new JvmThreadMetrics().bindTo(activeRegistry);
+        }
+    }
+
+    /**
+     * Set common tag according to list of files.
+     * @param subFiles list of files
+     */
+    public void updateSubFiles(List<String> subFiles) {
         // Add tag for per-project reindex.
-        if (statsdRegistry != null && !subFiles.isEmpty()) {
+        if (activeRegistry != null && !subFiles.isEmpty()) {
             String projects = subFiles.stream().
                     map(s -> s.startsWith(Indexer.PATH_SEPARATOR_STRING) ? s.substring(1) : s).
                     collect(Collectors.joining(","));
             Tag commonTag = Tag.of("projects", projects);
-            LOGGER.log(Level.FINE, "updating statsdRegistry with common tag: {}", commonTag);
-            statsdRegistry.config().commonTags(Collections.singleton(commonTag));
+            LOGGER.log(Level.FINE, "updating active registry with common tag: {}", commonTag);
+            activeRegistry.config().commonTags(Collections.singleton(commonTag));
         }
     }
 
-    public static PrometheusMeterRegistry getPrometheusRegistry() {
+    public PrometheusMeterRegistry getPrometheusRegistry() {
         return prometheusRegistry;
-    }
-
-    private static StatsdMeterRegistry getStatsdRegistry() {
-        return statsdRegistry;
     }
 
     /**
      * Get registry based on running context.
      * @return MeterRegistry instance
      */
-    public static MeterRegistry getRegistry() {
-        if (RuntimeEnvironment.getInstance().isIndexer()) {
-            return getStatsdRegistry();
-        } else {
-            return getPrometheusRegistry();
-        }
+    public MeterRegistry getRegistry() {
+        return activeRegistry;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -40,7 +40,7 @@ import io.micrometer.statsd.StatsdMeterRegistry;
 import io.micrometer.statsd.StatsdFlavor;
 import org.opengrok.indexer.configuration.BaseGraphiteConfig;
 import org.opengrok.indexer.configuration.BaseStatsdConfig;
-import org.opengrok.indexer.configuration.Configuration;
+import org.opengrok.indexer.configuration.MeterRegistryType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.index.Indexer;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -132,7 +132,7 @@ public final class Metrics {
      * Configure meter registry.
      * @param type type of meter registry
      */
-    public void configure(Configuration.MeterRegistryType type) {
+    public void configure(MeterRegistryType type) {
         switch (type) {
             case PROMETHEUS:
                 LOGGER.log(Level.INFO, "configuring Prometheus registry with default config");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -171,17 +171,21 @@ public final class Metrics {
     /**
      * Set common tag according to list of files.
      * @param subFiles list of files
+     * @return Tag object or null
      */
-    public void updateSubFiles(List<String> subFiles) {
+    public Tag updateSubFiles(List<String> subFiles) {
         // Add tag for per-project reindex.
+        Tag commonTag = null;
         if (activeRegistry != null && !subFiles.isEmpty()) {
             String projects = subFiles.stream().
                     map(s -> s.startsWith(Indexer.PATH_SEPARATOR_STRING) ? s.substring(1) : s).
                     collect(Collectors.joining(","));
-            Tag commonTag = Tag.of("projects", projects);
+            commonTag = Tag.of("projects", projects);
             LOGGER.log(Level.FINE, "updating active registry with common tag: {}", commonTag);
             activeRegistry.config().commonTags(Collections.singleton(commonTag));
         }
+
+        return commonTag;
     }
 
     public PrometheusMeterRegistry getPrometheusRegistry() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseGraphiteConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseGraphiteConfig.java
@@ -25,7 +25,7 @@ package org.opengrok.indexer.configuration;
 
 import io.micrometer.graphite.GraphiteProtocol;
 
-public class GraphiteConfig {
+public class BaseGraphiteConfig {
     private int port;
     private String host;
     private boolean enabled;
@@ -59,12 +59,17 @@ public class GraphiteConfig {
         return protocol;
     }
 
+    @Override
+    public String toString() {
+        return String.format("%s:%d (%s)", getHost(), getPort(), getProtocol());
+    }
+
     /**
      * Gets an instance version suitable for helper documentation by shifting
      * most default properties slightly.
      */
-    static GraphiteConfig getForHelp() {
-        GraphiteConfig res = new GraphiteConfig();
+    static BaseGraphiteConfig getForHelp() {
+        BaseGraphiteConfig res = new BaseGraphiteConfig();
         res.setHost("foo.bar");
         res.setPort(2004);
         return res;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseGraphiteConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseGraphiteConfig.java
@@ -31,6 +31,15 @@ public class BaseGraphiteConfig {
     private boolean enabled;
     private GraphiteProtocol protocol;
 
+    public BaseGraphiteConfig() {
+    }
+
+    public BaseGraphiteConfig(String host, int port, GraphiteProtocol protocol) {
+        this.host = host;
+        this.port = port;
+        this.protocol = protocol;
+    }
+
     public String getHost() {
         return host;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseGraphiteConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseGraphiteConfig.java
@@ -80,6 +80,7 @@ public class BaseGraphiteConfig {
         BaseGraphiteConfig res = new BaseGraphiteConfig();
         res.setHost("foo.bar");
         res.setPort(2004);
+        res.setProtocol(GraphiteProtocol.UDP);
         return res;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseGraphiteConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseGraphiteConfig.java
@@ -28,7 +28,6 @@ import io.micrometer.graphite.GraphiteProtocol;
 public class BaseGraphiteConfig {
     private int port;
     private String host;
-    private boolean enabled;
     private GraphiteProtocol protocol;
 
     public BaseGraphiteConfig() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseStatsdConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseStatsdConfig.java
@@ -34,6 +34,15 @@ public class BaseStatsdConfig {
     private boolean enabled;
     private StatsdFlavor flavor;
 
+    public BaseStatsdConfig() {
+    }
+
+    public BaseStatsdConfig(String host, int port, StatsdFlavor flavor) {
+        this.host = host;
+        this.port = port;
+        this.flavor = flavor;
+    }
+
     public String getHost() {
         return host;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseStatsdConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseStatsdConfig.java
@@ -28,7 +28,7 @@ import io.micrometer.statsd.StatsdFlavor;
 /**
  * Configuration for Statsd metrics emitted by the Indexer via {@link org.opengrok.indexer.util.Statistics}.
  */
-public class StatsdConfig {
+public class BaseStatsdConfig {
     private int port;
     private String host;
     private boolean enabled;
@@ -62,12 +62,17 @@ public class StatsdConfig {
         return port != 0 && host != null && !host.isEmpty() && flavor != null;
     }
 
+    @Override
+    public String toString() {
+        return String.format("%s:%d (%s)", getHost(), getPort(), getFlavor());
+    }
+
     /**
      * Gets an instance version suitable for helper documentation by shifting
      * most default properties slightly.
      */
-    static StatsdConfig getForHelp() {
-        StatsdConfig res = new StatsdConfig();
+    static BaseStatsdConfig getForHelp() {
+        BaseStatsdConfig res = new BaseStatsdConfig();
         res.setHost("foo.bar");
         res.setPort(8125);
         res.setFlavor(StatsdFlavor.ETSY);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseStatsdConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/BaseStatsdConfig.java
@@ -31,7 +31,6 @@ import io.micrometer.statsd.StatsdFlavor;
 public class BaseStatsdConfig {
     private int port;
     private String host;
-    private boolean enabled;
     private StatsdFlavor flavor;
 
     public BaseStatsdConfig() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -317,6 +317,7 @@ public final class Configuration {
     }
 
     public enum MeterRegistryType {
+        NONE,
         PROMETHEUS,
         GRAPHITE,
         STATSD
@@ -575,7 +576,7 @@ public final class Configuration {
         setWebappLAF("default");
         // webappCtags is default(boolean)
         setWebAppMeterRegistryType(MeterRegistryType.PROMETHEUS);
-        setIndexerMeterRegistryType(MeterRegistryType.STATSD);
+        setIndexerMeterRegistryType(MeterRegistryType.NONE);
     }
 
     public String getRepoCmd(String clazzName) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -316,13 +316,6 @@ public final class Configuration {
         ON, OFF, DIRBASED, UIONLY
     }
 
-    public enum MeterRegistryType {
-        NONE,
-        PROMETHEUS,
-        GRAPHITE,
-        STATSD
-    };
-
     private MeterRegistryType webAppMeterRegistryType;
     private MeterRegistryType indexerMeterRegistryType;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -299,8 +299,8 @@ public final class Configuration {
 
     private SuggesterConfig suggesterConfig = new SuggesterConfig();
 
-    private StatsdConfig statsdConfig = new StatsdConfig();
-    private GraphiteConfig graphiteConfig = new GraphiteConfig();
+    private BaseStatsdConfig statsdConfig = new BaseStatsdConfig();
+    private BaseGraphiteConfig graphiteConfig = new BaseGraphiteConfig();
 
     private Set<String> disabledRepositories;
 
@@ -1330,24 +1330,24 @@ public final class Configuration {
         this.suggesterConfig = config;
     }
 
-    public StatsdConfig getStatsdConfig() {
+    public BaseStatsdConfig getStatsdConfig() {
         return statsdConfig;
     }
 
-    public void setStatsdConfig(final StatsdConfig config) {
+    public void setStatsdConfig(final BaseStatsdConfig config) {
         if (config == null) {
             throw new IllegalArgumentException("Cannot set Statsd configuration to null");
         }
         this.statsdConfig = config;
     }
 
-    public GraphiteConfig getGraphiteConfig() {
+    public BaseGraphiteConfig getGraphiteConfig() {
         return graphiteConfig;
     }
 
-    public void setGraphiteConfig(GraphiteConfig config) {
+    public void setGraphiteConfig(BaseGraphiteConfig config) {
         if (config == null) {
-            throw new IllegalArgumentException("Cannot set Statsd configuration to null");
+            throw new IllegalArgumentException("Cannot set Graphite configuration to null");
         }
         this.graphiteConfig = config;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -300,6 +300,7 @@ public final class Configuration {
     private SuggesterConfig suggesterConfig = new SuggesterConfig();
 
     private StatsdConfig statsdConfig = new StatsdConfig();
+    private GraphiteConfig graphiteConfig = new GraphiteConfig();
 
     private Set<String> disabledRepositories;
 
@@ -314,6 +315,15 @@ public final class Configuration {
     public enum RemoteSCM {
         ON, OFF, DIRBASED, UIONLY
     }
+
+    public enum MeterRegistryType {
+        PROMETHEUS,
+        GRAPHITE,
+        STATSD
+    };
+
+    private MeterRegistryType webAppMeterRegistryType;
+    private MeterRegistryType indexerMeterRegistryType;
 
     /**
      * Get the default tab size (number of space characters per tab character)
@@ -564,6 +574,8 @@ public final class Configuration {
         setUserPageSuffix("");
         setWebappLAF("default");
         // webappCtags is default(boolean)
+        setWebAppMeterRegistryType(MeterRegistryType.PROMETHEUS);
+        setIndexerMeterRegistryType(MeterRegistryType.STATSD);
     }
 
     public String getRepoCmd(String clazzName) {
@@ -1326,6 +1338,36 @@ public final class Configuration {
             throw new IllegalArgumentException("Cannot set Statsd configuration to null");
         }
         this.statsdConfig = config;
+    }
+
+    public GraphiteConfig getGraphiteConfig() {
+        return graphiteConfig;
+    }
+
+    public void setGraphiteConfig(GraphiteConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("Cannot set Statsd configuration to null");
+        }
+        this.graphiteConfig = config;
+    }
+
+    public MeterRegistryType getWebAppMeterRegistryType() {
+        return webAppMeterRegistryType;
+    }
+
+    public void setWebAppMeterRegistryType(MeterRegistryType registryType) {
+        this.webAppMeterRegistryType = registryType;
+    }
+
+    public MeterRegistryType getIndexerMeterRegistryType() {
+        return indexerMeterRegistryType;
+    }
+
+    public void setIndexerMeterRegistryType(MeterRegistryType registryType) {
+        if (registryType == MeterRegistryType.PROMETHEUS) {
+            throw new IllegalArgumentException("unsupported registry type");
+        }
+        this.indexerMeterRegistryType = registryType;
     }
 
     public Set<String> getDisabledRepositories() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationHelp.java
@@ -88,8 +88,7 @@ public class ConfigurationHelp {
             try {
                 mthd.invoke(conf, sampleValue);
             } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-                throw new RuntimeException("error setting sample value for " +
-                    mthd);
+                throw new RuntimeException("error setting sample value " + sampleValue + " for " + mthd);
             }
 
             sample = conf.getXMLRepresentationAsString();
@@ -174,6 +173,8 @@ public class ConfigurationHelp {
             inm.add("f:user-specified-value");
             inm.add("d:user-specified-value");
             return inm;
+        } else if (paramType == Configuration.MeterRegistryType.class) {
+            return Configuration.MeterRegistryType.GRAPHITE;
         } else if (paramType.isEnum()) {
             for (Object value : paramType.getEnumConstants()) {
                 if (!value.equals(defaultValue)) {
@@ -185,6 +186,8 @@ public class ConfigurationHelp {
             return SuggesterConfig.getForHelp();
         } else if (paramType == StatsdConfig.class) {
             return StatsdConfig.getForHelp();
+        } else if (paramType == GraphiteConfig.class) {
+            return GraphiteConfig.getForHelp();
         } else {
             throw new UnsupportedOperationException("getSampleValue() for " +
                 paramType + ", " + genType);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationHelp.java
@@ -184,10 +184,10 @@ public class ConfigurationHelp {
             return null;
         } else if (paramType == SuggesterConfig.class) {
             return SuggesterConfig.getForHelp();
-        } else if (paramType == StatsdConfig.class) {
-            return StatsdConfig.getForHelp();
-        } else if (paramType == GraphiteConfig.class) {
-            return GraphiteConfig.getForHelp();
+        } else if (paramType == BaseStatsdConfig.class) {
+            return BaseStatsdConfig.getForHelp();
+        } else if (paramType == BaseGraphiteConfig.class) {
+            return BaseGraphiteConfig.getForHelp();
         } else {
             throw new UnsupportedOperationException("getSampleValue() for " +
                 paramType + ", " + genType);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationHelp.java
@@ -173,8 +173,8 @@ public class ConfigurationHelp {
             inm.add("f:user-specified-value");
             inm.add("d:user-specified-value");
             return inm;
-        } else if (paramType == Configuration.MeterRegistryType.class) {
-            return Configuration.MeterRegistryType.GRAPHITE;
+        } else if (paramType == MeterRegistryType.class) {
+            return MeterRegistryType.GRAPHITE;
         } else if (paramType.isEnum()) {
             for (Object value : paramType.getEnumConstants()) {
                 if (!value.equals(defaultValue)) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/GraphiteConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/GraphiteConfig.java
@@ -1,0 +1,72 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.configuration;
+
+import io.micrometer.graphite.GraphiteProtocol;
+
+public class GraphiteConfig {
+    private int port;
+    private String host;
+    private boolean enabled;
+    private GraphiteProtocol protocol;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public boolean isEnabled() {
+        return port != 0 && host != null && !host.isEmpty();
+    }
+
+    public void setProtocol(GraphiteProtocol protocol) {
+        this.protocol = protocol;
+    }
+
+    public GraphiteProtocol getProtocol() {
+        return protocol;
+    }
+
+    /**
+     * Gets an instance version suitable for helper documentation by shifting
+     * most default properties slightly.
+     */
+    static GraphiteConfig getForHelp() {
+        GraphiteConfig res = new GraphiteConfig();
+        res.setHost("foo.bar");
+        res.setPort(2004);
+        return res;
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/MeterRegistryType.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/MeterRegistryType.java
@@ -1,0 +1,31 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.configuration;
+
+public enum MeterRegistryType {
+    NONE,
+    PROMETHEUS,
+    GRAPHITE,
+    STATSD
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1882,20 +1882,20 @@ public final class RuntimeEnvironment {
         syncWriteConfiguration(suggesterConfig, Configuration::setSuggesterConfig);
     }
 
-    public StatsdConfig getStatsdConfig() {
+    public BaseStatsdConfig getBaseStatsdConfig() {
         return syncReadConfiguration(Configuration::getStatsdConfig);
     }
 
-    public void setStatsdConfig(StatsdConfig statsdConfig) {
-        syncWriteConfiguration(statsdConfig, Configuration::setStatsdConfig);
+    public void setBaseStatsdConfig(BaseStatsdConfig baseStatsdConfig) {
+        syncWriteConfiguration(baseStatsdConfig, Configuration::setStatsdConfig);
     }
 
-    public GraphiteConfig getGraphiteConfig() {
+    public BaseGraphiteConfig getBaseGraphiteConfig() {
         return syncReadConfiguration(Configuration::getGraphiteConfig);
     }
 
-    public void setGraphiteConfig(GraphiteConfig graphiteConfig) {
-        syncWriteConfiguration(graphiteConfig, Configuration::setGraphiteConfig);
+    public void setBaseGraphiteConfig(BaseGraphiteConfig baseGraphiteConfig) {
+        syncWriteConfiguration(baseGraphiteConfig, Configuration::setGraphiteConfig);
     }
 
     public Configuration.MeterRegistryType getWebAppMeterRegistryType() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -147,16 +147,6 @@ public final class RuntimeEnvironment {
     private AuthorizationFramework authFramework;
     private final Object authFrameworkLock = new Object();
 
-    private boolean indexer;
-
-    public boolean isIndexer() {
-        return indexer;
-    }
-
-    public void setIndexer(boolean indexer) {
-        this.indexer = indexer;
-    }
-
     /** Gets the thread pool used for multi-project searches. */
     public ExecutorService getSearchExecutor() {
         return lzSearchExecutor.get();
@@ -1898,6 +1888,30 @@ public final class RuntimeEnvironment {
 
     public void setStatsdConfig(StatsdConfig statsdConfig) {
         syncWriteConfiguration(statsdConfig, Configuration::setStatsdConfig);
+    }
+
+    public GraphiteConfig getGraphiteConfig() {
+        return syncReadConfiguration(Configuration::getGraphiteConfig);
+    }
+
+    public void setGraphiteConfig(GraphiteConfig graphiteConfig) {
+        syncWriteConfiguration(graphiteConfig, Configuration::setGraphiteConfig);
+    }
+
+    public Configuration.MeterRegistryType getWebAppMeterRegistryType() {
+        return syncReadConfiguration(Configuration::getWebAppMeterRegistryType);
+    }
+
+    public void setWebAppMeterRegistryType(Configuration.MeterRegistryType registryType) {
+        syncWriteConfiguration(registryType, Configuration::setWebAppMeterRegistryType);
+    }
+
+    public Configuration.MeterRegistryType getIndexerMeterRegistryType() {
+        return syncReadConfiguration(Configuration::getIndexerMeterRegistryType);
+    }
+
+    public void setIndexerAppMeterRegistryType(Configuration.MeterRegistryType registryType) {
+        syncWriteConfiguration(registryType, Configuration::setIndexerMeterRegistryType);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1898,19 +1898,19 @@ public final class RuntimeEnvironment {
         syncWriteConfiguration(baseGraphiteConfig, Configuration::setGraphiteConfig);
     }
 
-    public Configuration.MeterRegistryType getWebAppMeterRegistryType() {
+    public MeterRegistryType getWebAppMeterRegistryType() {
         return syncReadConfiguration(Configuration::getWebAppMeterRegistryType);
     }
 
-    public void setWebAppMeterRegistryType(Configuration.MeterRegistryType registryType) {
+    public void setWebAppMeterRegistryType(MeterRegistryType registryType) {
         syncWriteConfiguration(registryType, Configuration::setWebAppMeterRegistryType);
     }
 
-    public Configuration.MeterRegistryType getIndexerMeterRegistryType() {
+    public MeterRegistryType getIndexerMeterRegistryType() {
         return syncReadConfiguration(Configuration::getIndexerMeterRegistryType);
     }
 
-    public void setIndexerAppMeterRegistryType(Configuration.MeterRegistryType registryType) {
+    public void setIndexerAppMeterRegistryType(MeterRegistryType registryType) {
         syncWriteConfiguration(registryType, Configuration::setIndexerMeterRegistryType);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -179,7 +179,6 @@ public final class Indexer {
             }
 
             env = RuntimeEnvironment.getInstance();
-            env.setIndexer(true);
 
             // Complete the configuration of repository types.
             List<Class<? extends Repository>> repositoryClasses
@@ -246,6 +245,7 @@ public final class Indexer {
 
             // Set updated configuration in RuntimeEnvironment.
             env.setConfiguration(cfg, subFilesList, CommandTimeoutType.INDEXER);
+            Metrics.getInstance().configure(env.getIndexerMeterRegistryType());
 
             // Check version of index(es) versus current Lucene version and exit
             // with return code upon failure.
@@ -319,7 +319,7 @@ public final class Indexer {
                 System.exit(1);
             }
 
-            Metrics.updateSubFiles(subFiles);
+            Metrics.getInstance().updateSubFiles(subFiles);
 
             // If the webapp is running with a config that does not contain
             // 'projectsEnabled' property (case of upgrade or transition

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
@@ -67,7 +67,7 @@ public class Statistics {
 
         logIt(logger, logLevel, msg, duration);
 
-        MeterRegistry registry = Metrics.getRegistry();
+        MeterRegistry registry = Metrics.getInstance().getRegistry();
         if (registry != null) {
             Timer.builder(meterName).
                     register(registry).

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkReloadTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkReloadTest.java
@@ -32,9 +32,12 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import javax.servlet.http.HttpSession;
+
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengrok.indexer.Metrics;
 import org.opengrok.indexer.configuration.Project;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.web.DummyHttpServletRequest;
 
 /**
@@ -46,6 +49,11 @@ public class AuthorizationFrameworkReloadTest {
 
     private final File pluginDirectory;
     volatile boolean runThread;
+
+    @BeforeClass
+    public static void testInit() {
+        Metrics.getInstance().configure(RuntimeEnvironment.getInstance().getWebAppMeterRegistryType());
+    }
 
     public AuthorizationFrameworkReloadTest() throws URISyntaxException {
         pluginDirectory = Paths.get(getClass().getResource("/authorization/plugins/testplugins.jar").toURI()).toFile().getParentFile();
@@ -146,7 +154,7 @@ public class AuthorizationFrameworkReloadTest {
         }
 
         // Double check that at least one reload() was done.
-        long reloads = (long) Metrics.getRegistry().counter("authorization.stack.reload").count();
+        long reloads = (long) Metrics.getInstance().getRegistry().counter("authorization.stack.reload").count();
         assertTrue(reloads > 0);
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkTest.java
@@ -32,13 +32,16 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.opengrok.indexer.Metrics;
 import org.opengrok.indexer.condition.DeliberateRuntimeException;
 import org.opengrok.indexer.configuration.Group;
 import org.opengrok.indexer.configuration.Nameable;
 import org.opengrok.indexer.configuration.Project;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.web.DummyHttpServletRequest;
 
 @RunWith(Parameterized.class)
@@ -47,6 +50,11 @@ public class AuthorizationFrameworkTest {
     private static final Random RANDOM = new Random();
 
     private final StackSetup setup;
+
+    @BeforeClass
+    public static void testInit() {
+        Metrics.getInstance().configure(RuntimeEnvironment.getInstance().getWebAppMeterRegistryType());
+    }
 
     public AuthorizationFrameworkTest(StackSetup setup) {
         this.setup = setup;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/BaseGraphiteConfigTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/BaseGraphiteConfigTest.java
@@ -23,22 +23,22 @@
 
 package org.opengrok.indexer.configuration;
 
-import io.micrometer.statsd.StatsdFlavor;
+import io.micrometer.graphite.GraphiteProtocol;
 import org.junit.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class StatsdConfigTest {
+public class BaseGraphiteConfigTest {
     @Test
     public void testIsEnabled() {
-        StatsdConfig config = new StatsdConfig();
+        BaseGraphiteConfig config = new BaseGraphiteConfig();
         assertFalse(config.isEnabled());
-        config.setPort(3141);
+        config.setPort(2222);
         assertFalse(config.isEnabled());
         config.setHost("foo");
-        assertFalse(config.isEnabled());
-        config.setFlavor(StatsdFlavor.ETSY);
+        assertTrue(config.isEnabled());
+        config.setProtocol(GraphiteProtocol.UDP);
         assertTrue(config.isEnabled());
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/BaseStatsdConfigTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/BaseStatsdConfigTest.java
@@ -1,0 +1,44 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.configuration;
+
+import io.micrometer.statsd.StatsdFlavor;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BaseStatsdConfigTest {
+    @Test
+    public void testIsEnabled() {
+        BaseStatsdConfig config = new BaseStatsdConfig();
+        assertFalse(config.isEnabled());
+        config.setPort(3141);
+        assertFalse(config.isEnabled());
+        config.setHost("foo");
+        assertFalse(config.isEnabled());
+        config.setFlavor(StatsdFlavor.ETSY);
+        assertTrue(config.isEnabled());
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ConfigurationHelpTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ConfigurationHelpTest.java
@@ -23,6 +23,7 @@
 
 package org.opengrok.indexer.configuration;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ public class ConfigurationHelpTest {
     @Test
     public void shouldCreateReadableUsage() {
         String samples = ConfigurationHelp.getSamples();
-        assertTrue("samples are not empty", !samples.isEmpty());
+        assertFalse("samples are not empty", samples.isEmpty());
         assertTrue("samples contains \"<?\"", samples.contains("<?"));
         assertTrue("samples contains \"user-defined\"",
             samples.contains("user-defined"));

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsCommonTagTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsCommonTagTest.java
@@ -42,7 +42,7 @@ public class MetricsCommonTagTest {
         assertNull(metrics.updateSubFiles(Collections.emptyList()));
 
         List<String> subFiles = Arrays.asList("/foo", "/bar");
-        metrics.configure(Configuration.MeterRegistryType.PROMETHEUS);
+        metrics.configure(MeterRegistryType.PROMETHEUS);
         Tag tag = metrics.updateSubFiles(subFiles);
         assertEquals(Tag.of("projects", subFiles.stream().map(s -> s.substring(1)).
                 collect(Collectors.joining(","))), tag);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsCommonTagTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsCommonTagTest.java
@@ -1,0 +1,50 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.configuration;
+
+import io.micrometer.core.instrument.Tag;
+import org.junit.Test;
+import org.opengrok.indexer.Metrics;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class MetricsCommonTagTest {
+    @Test
+    public void testCommonTag() {
+        Metrics metrics = Metrics.getInstance();
+        assertNull(metrics.updateSubFiles(Collections.emptyList()));
+
+        List<String> subFiles = Arrays.asList("/foo", "/bar");
+        metrics.configure(Configuration.MeterRegistryType.PROMETHEUS);
+        Tag tag = metrics.updateSubFiles(subFiles);
+        assertEquals(Tag.of("projects", subFiles.stream().map(s -> s.substring(1)).
+                collect(Collectors.joining(","))), tag);
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
@@ -37,5 +37,8 @@ public class MetricsConfigureTest {
         metrics.configure(Configuration.MeterRegistryType.PROMETHEUS);
         assertNotNull(metrics.getRegistry());
         assertNotNull(metrics.getPrometheusRegistry());
+
+        metrics.configure(Configuration.MeterRegistryType.NONE);
+        assertNull(metrics.getRegistry());
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
@@ -1,0 +1,40 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.configuration;
+
+import org.junit.Test;
+import org.opengrok.indexer.Metrics;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MetricsConfigureTest {
+    @Test
+    public void testConfigure() {
+        Metrics metrics = Metrics.getInstance();
+        assertNull(metrics.getRegistry());
+
+        metrics.configure(Configuration.MeterRegistryType.PROMETHEUS);
+        assertNotNull(metrics.getRegistry());
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
@@ -39,21 +39,21 @@ public class MetricsConfigureTest {
         Metrics metrics = Metrics.getInstance();
         assertNull(metrics.getRegistry());
 
-        metrics.configure(Configuration.MeterRegistryType.PROMETHEUS);
+        metrics.configure(MeterRegistryType.PROMETHEUS);
         assertNotNull(metrics.getRegistry());
         assertNotNull(metrics.getPrometheusRegistry());
 
-        metrics.configure(Configuration.MeterRegistryType.NONE);
+        metrics.configure(MeterRegistryType.NONE);
         assertNull(metrics.getRegistry());
 
         env.setBaseGraphiteConfig(new BaseGraphiteConfig("localhost", 2222, GraphiteProtocol.PLAINTEXT));
-        metrics.configure(Configuration.MeterRegistryType.GRAPHITE);
+        metrics.configure(MeterRegistryType.GRAPHITE);
         assertNotNull(metrics.getRegistry());
-        metrics.configure(Configuration.MeterRegistryType.NONE);
+        metrics.configure(MeterRegistryType.NONE);
 
         env.setBaseStatsdConfig(new BaseStatsdConfig("loalhost", 8126, StatsdFlavor.DATADOG));
-        metrics.configure(Configuration.MeterRegistryType.STATSD);
+        metrics.configure(MeterRegistryType.STATSD);
         assertNotNull(metrics.getRegistry());
-        metrics.configure(Configuration.MeterRegistryType.NONE);
+        metrics.configure(MeterRegistryType.NONE);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
@@ -28,7 +28,8 @@ import io.micrometer.statsd.StatsdFlavor;
 import org.junit.Test;
 import org.opengrok.indexer.Metrics;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class MetricsConfigureTest {
     @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
@@ -23,6 +23,8 @@
 
 package org.opengrok.indexer.configuration;
 
+import io.micrometer.graphite.GraphiteProtocol;
+import io.micrometer.statsd.StatsdFlavor;
 import org.junit.Test;
 import org.opengrok.indexer.Metrics;
 
@@ -31,6 +33,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MetricsConfigureTest {
     @Test
     public void testConfigure() {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
         Metrics metrics = Metrics.getInstance();
         assertNull(metrics.getRegistry());
 
@@ -40,5 +44,15 @@ public class MetricsConfigureTest {
 
         metrics.configure(Configuration.MeterRegistryType.NONE);
         assertNull(metrics.getRegistry());
+
+        env.setBaseGraphiteConfig(new BaseGraphiteConfig("localhost", 2222, GraphiteProtocol.PLAINTEXT));
+        metrics.configure(Configuration.MeterRegistryType.GRAPHITE);
+        assertNotNull(metrics.getRegistry());
+        metrics.configure(Configuration.MeterRegistryType.NONE);
+
+        env.setBaseStatsdConfig(new BaseStatsdConfig("loalhost", 8126, StatsdFlavor.DATADOG));
+        metrics.configure(Configuration.MeterRegistryType.STATSD);
+        assertNotNull(metrics.getRegistry());
+        metrics.configure(Configuration.MeterRegistryType.NONE);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/MetricsConfigureTest.java
@@ -36,5 +36,6 @@ public class MetricsConfigureTest {
 
         metrics.configure(Configuration.MeterRegistryType.PROMETHEUS);
         assertNotNull(metrics.getRegistry());
+        assertNotNull(metrics.getPrometheusRegistry());
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -41,6 +41,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.opengrok.indexer.Metrics;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.PlatformUtils;
 
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
@@ -59,6 +61,7 @@ public class UtilTest {
         // Set locale to en_US for these tests.
         savedLocale = Locale.getDefault();
         Locale.setDefault(Locale.US);
+        Metrics.getInstance().configure(RuntimeEnvironment.getInstance().getWebAppMeterRegistryType());
     }
 
     @AfterClass

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -43,14 +43,14 @@ public class StatisticsFilter implements Filter {
 
     static final String REQUESTS_METRIC = "requests";
 
-    private final DistributionSummary requests = Metrics.getPrometheusRegistry().summary(REQUESTS_METRIC);
+    private final DistributionSummary requests = Metrics.getInstance().getRegistry().summary(REQUESTS_METRIC);
 
     private final Timer emptySearch = Timer.builder("search.latency").
             tags("outcome", "empty").
-            register(Metrics.getPrometheusRegistry());
+            register(Metrics.getInstance().getRegistry());
     private final Timer successfulSearch = Timer.builder("search.latency").
             tags("outcome", "success").
-            register(Metrics.getPrometheusRegistry());
+            register(Metrics.getInstance().getRegistry());
 
     @Override
     public void init(FilterConfig fc) throws ServletException {
@@ -89,7 +89,7 @@ public class StatisticsFilter implements Filter {
 
         Timer categoryTimer = Timer.builder("requests.latency").
                 tags("category", category, "code", String.valueOf(httpResponse.getStatus())).
-                register(Metrics.getPrometheusRegistry());
+                register(Metrics.getInstance().getRegistry());
         categoryTimer.record(duration);
 
         SearchHelper helper = (SearchHelper) config.getRequestAttribute(SearchHelper.REQUEST_ATTR);

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -55,9 +55,6 @@ public final class WebappListener
         implements ServletContextListener, ServletRequestListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WebappListener.class);
-    private Timer startupTimer = Timer.builder("webapp.startup.latency").
-                description("web application startup latency").
-                register(Metrics.getPrometheusRegistry());
 
     /**
      * {@inheritDoc}
@@ -83,6 +80,8 @@ public final class WebappListener
             }
         }
 
+        Metrics.getInstance().configure(env.getWebAppMeterRegistryType());
+
         /*
          * Create a new instance of authorization framework. If the code above
          * (reading the configuration) failed then the plugin directory is
@@ -101,7 +100,10 @@ public final class WebappListener
         }
 
         env.startExpirationTimer();
-        startupTimer.record(Duration.between(start, Instant.now()));
+        Timer.builder("webapp.startup.latency").
+                description("web application startup latency").
+                register(Metrics.getInstance().getRegistry()).
+                record(Duration.between(start, Instant.now()));
     }
 
     /**

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -318,7 +318,7 @@ public class SuggesterServiceImpl implements SuggesterService {
                 suggesterConfig.getAllowedFields(),
                 suggesterConfig.getTimeThreshold(),
                 rebuildParalleismLevel,
-                Metrics.getRegistry());
+                Metrics.getInstance().getRegistry());
 
         new Thread(() -> {
             suggester.init(getAllProjectIndexDirs());

--- a/opengrok-web/src/main/java/org/opengrok/web/servlet/MetricsServlet.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/servlet/MetricsServlet.java
@@ -39,7 +39,7 @@ public class MetricsServlet extends HttpServlet {
     @Override
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
         try (PrintWriter pw = resp.getWriter()) {
-            pw.print(Metrics.getPrometheusRegistry().scrape());
+            pw.print(Metrics.getInstance().getPrometheusRegistry().scrape());
         }
     }
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/servlet/MetricsServlet.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/servlet/MetricsServlet.java
@@ -22,6 +22,7 @@
  */
 package org.opengrok.web.servlet;
 
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import org.opengrok.indexer.Metrics;
 
 import javax.servlet.annotation.WebServlet;
@@ -38,8 +39,13 @@ public class MetricsServlet extends HttpServlet {
 
     @Override
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
-        try (PrintWriter pw = resp.getWriter()) {
-            pw.print(Metrics.getInstance().getPrometheusRegistry().scrape());
+        PrometheusMeterRegistry registry = Metrics.getInstance().getPrometheusRegistry();
+        if (registry != null) {
+            try (PrintWriter pw = resp.getWriter()) {
+                pw.print(registry.scrape());
+            }
+        } else {
+            resp.sendError(HttpServletResponse.SC_NOT_IMPLEMENTED);
         }
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ConfigurationControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ConfigurationControllerTest.java
@@ -46,7 +46,7 @@ import org.opengrok.web.api.v1.suggester.provider.service.SuggesterService;
 
 public class ConfigurationControllerTest extends OGKJerseyTest {
 
-    private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+    private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
     @Mock
     private SuggesterService suggesterService;


### PR DESCRIPTION
This change introduces support for Graphite metering repository. Also it allows to mix and match metering repositories for the indexer and the webapp (the only exception is Prometheus registry for the indexer). There is always at most one repository for each.

The default is StatsD for the indexer and Prometheus for the web app.

Sample configuration:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<java version="11.0.4" class="java.beans.XMLDecoder">
 <object class="org.opengrok.indexer.configuration.Configuration" id="Configuration0">

  <void property="webAppMeterRegistryType">
     <object class="java.lang.Enum" method="valueOf">
       <class>org.opengrok.indexer.configuration.MeterRegistryType</class>
       <string>GRAPHITE</string>
     </object>
  </void>

  <void property="indexerMeterRegistryType">
     <object class="java.lang.Enum" method="valueOf">
       <class>org.opengrok.indexer.configuration.MeterRegistryType</class>
       <string>STATSD</string>
     </object>
  </void>

  <void property="graphiteConfig">
     <void property="port">
       <int>2005</int>
     </void>
     <void property="host">
       <string>localhost</string>
     </void>
    <void property="protocol">
       <object class="java.lang.Enum" method="valueOf">
         <class>io.micrometer.graphite.GraphiteProtocol</class>
         <string>UDP</string>
       </object>
    </void>
  </void>

  <void property="statsdConfig">
     <void property="port">
       <int>8125</int>
     </void>
     <void property="host">
       <string>localhost</string>
     </void>
     <void property="flavor">
       <object class="java.lang.Enum" method="valueOf">
         <class>io.micrometer.statsd.StatsdFlavor</class>
         <string>ETSY</string>
       </object>
    </void>
  </void>

 </object>
</java>
```