### PR TITLE
Allow users to specify custom mirroring and sync command

### DIFF
--- a/opengrok-tools/src/main/python/opengrok_tools/scm/cvs.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/cvs.py
@@ -18,7 +18,8 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
 from shutil import which

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/cvs.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/cvs.py
@@ -21,20 +21,17 @@
 # Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 
-from ..utils.command import Command
-from .repository import Repository, RepositoryException
 from shutil import which
+
+from .repository import Repository, RepositoryException
+from ..utils.command import Command
 
 
 class CVSRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
-
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        if command:
-            self.command = command
-        else:
-            self.command = which("cvs")
+        self.command = self._repository_command(command, default=lambda: which('cvs'))
 
         if not self.command:
             raise RepositoryException("Cannot get cvs command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/cvs.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/cvs.py
@@ -31,7 +31,10 @@ class CVSRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(command, default=lambda: which('cvs'))
+        self.command = self._repository_command(
+            command,
+            default=lambda: which('cvs')
+        )
 
         if not self.command:
             raise RepositoryException("Cannot get cvs command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/cvs.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/cvs.py
@@ -31,10 +31,7 @@ class CVSRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(
-            command,
-            default=lambda: which('cvs')
-        )
+        self.command = self._repository_command(command, default=lambda: which('cvs'))
 
         if not self.command:
             raise RepositoryException("Cannot get cvs command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/cvs.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/cvs.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
@@ -31,7 +31,10 @@ class GitRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(command, default=lambda: which('git'))
+        self.command = self._repository_command(
+            command,
+            default=lambda: which('git')
+        )
 
         if not self.command:
             raise RepositoryException("Cannot get git command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
@@ -18,7 +18,8 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
 from shutil import which

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
@@ -31,10 +31,7 @@ class GitRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(
-            command,
-            default=lambda: which('git')
-        )
+        self.command = self._repository_command(command, default=lambda: which('git'))
 
         if not self.command:
             raise RepositoryException("Cannot get git command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
@@ -47,30 +47,7 @@ class GitRepository(Repository):
             cmd.log_error("failed to configure git pull.ff")
 
     def reposync(self):
-        git_command = [self.command, "pull", "--ff-only"]
-        cmd = self.getCommand(git_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
-        cmd.execute()
-        self.logger.info("output of {}:".format(git_command))
-        self.logger.info(cmd.getoutputstr())
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
-            cmd.log_error("failed to perform pull")
-            return 1
-
-        return 0
+        return self._run_custom_sync_command([self.command, 'pull', '--ff-only'])
 
     def incoming_check(self):
-        git_command = [self.command, "pull", "--dry-run"]
-        cmd = self.getCommand(git_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
-        cmd.execute()
-        self.logger.info("output of {}:".format(git_command))
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
-            cmd.log_error("failed to perform pull")
-            raise RepositoryException('failed to check for incoming in '
-                                      'repository {}'.format(self))
-
-        if len(cmd.getoutput()) == 0:
-            return False
-        else:
-            return True
+        return self._run_custom_incoming_command([self.command, 'pull', '--dry-run'])

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
@@ -21,20 +21,17 @@
 # Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 
-from ..utils.command import Command
-from .repository import Repository, RepositoryException
 from shutil import which
+
+from .repository import Repository, RepositoryException
+from ..utils.command import Command
 
 
 class GitRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
-
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        if command:
-            self.command = command
-        else:
-            self.command = which("git")
+        self.command = self._repository_command(command, default=lambda: which('git'))
 
         if not self.command:
             raise RepositoryException("Cannot get git command")
@@ -61,7 +58,7 @@ class GitRepository(Repository):
 
         return 0
 
-    def incoming(self):
+    def incoming_check(self):
         git_command = [self.command, "pull", "--dry-run"]
         cmd = self.getCommand(git_command, work_dir=self.path,
                               env_vars=self.env, logger=self.logger)

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/git.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -31,10 +31,7 @@ class MercurialRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(
-            command,
-            default=lambda: which('hg')
-        )
+        self.command = self._repository_command(command, default=lambda: which('hg'))
 
         if not self.command:
             raise RepositoryException("Cannot get hg command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -21,20 +21,17 @@
 # Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 
-from ..utils.command import Command
-from .repository import Repository, RepositoryException
 from shutil import which
+
+from .repository import Repository, RepositoryException
+from ..utils.command import Command
 
 
 class MercurialRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
-
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        if command:
-            self.command = command
-        else:
-            self.command = which("hg")
+        self.command = self._repository_command(command, default=lambda: which('hg'))
 
         if not self.command:
             raise RepositoryException("Cannot get hg command")
@@ -95,7 +92,7 @@ class MercurialRepository(Repository):
 
         return 0
 
-    def incoming(self):
+    def incoming_check(self):
         branch = self.get_branch()
         if not branch:
             # Error logged already in get_branch().

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -31,7 +31,10 @@ class MercurialRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(command, default=lambda: which('hg'))
+        self.command = self._repository_command(
+            command,
+            default=lambda: which('hg')
+        )
 
         if not self.command:
             raise RepositoryException("Cannot get hg command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -18,7 +18,8 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
 from shutil import which

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
@@ -18,9 +18,10 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
-#
+# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright 2020 Robert Williams
+# Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
+#
 
 from shutil import which
 

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
@@ -26,7 +26,6 @@
 from shutil import which
 
 from .repository import Repository, RepositoryException
-from ..utils.command import Command
 
 
 class PerforceRepository(Repository):
@@ -39,13 +38,4 @@ class PerforceRepository(Repository):
             raise RepositoryException("Cannot get perforce command")
 
     def reposync(self):
-        perforce_command = [self.command, "sync"]
-        cmd = self.getCommand(perforce_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
-        cmd.execute()
-        self.logger.info("output of {}:".format(perforce_command))
-        self.logger.info(cmd.getoutputstr())
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
-            cmd.log_error("failed to perform sync")
-            return 1
-        return 0
+        return self._run_custom_sync_command([self.command, 'sync'])

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
@@ -32,10 +32,7 @@ class PerforceRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(
-            command,
-            default=lambda: which('p4')
-        )
+        self.command = self._repository_command(command, default=lambda: which('p4'))
 
         if not self.command:
             raise RepositoryException("Cannot get perforce command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
@@ -32,7 +32,10 @@ class PerforceRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(command, default=lambda: which('p4'))
+        self.command = self._repository_command(
+            command,
+            default=lambda: which('p4')
+        )
 
         if not self.command:
             raise RepositoryException("Cannot get perforce command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright 2020 Robert Williams
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/perforce.py
@@ -22,20 +22,17 @@
 #
 # Portions Copyright 2020 Robert Williams
 
-from ..utils.command import Command
-from .repository import Repository, RepositoryException
 from shutil import which
+
+from .repository import Repository, RepositoryException
+from ..utils.command import Command
 
 
 class PerforceRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
-
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        if command:
-            self.command = command
-        else:
-            self.command = which("p4")
+        self.command = self._repository_command(command, default=lambda: which('p4'))
 
         if not self.command:
             raise RepositoryException("Cannot get perforce command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
@@ -21,20 +21,17 @@
 # Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 
-from ..utils.command import Command
-from .repository import Repository, RepositoryException
 from shutil import which
+
+from .repository import Repository, RepositoryException
+from ..utils.command import Command
 
 
 class RepoRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
-
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        if command:
-            self.command = command
-        else:
-            self.command = which("repo")
+        self.command = self._repository_command(command, default=lambda: which('repo'))
 
         if not self.command:
             raise RepositoryException("Cannot get repo command")
@@ -52,7 +49,7 @@ class RepoRepository(Repository):
 
         return 0
 
-    def incoming(self):
+    def incoming_check(self):
         repo_command = [self.command, "sync", "-n"]
         cmd = self.getCommand(repo_command, work_dir=self.path,
                               env_vars=self.env, logger=self.logger)

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
@@ -18,7 +18,8 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
 from shutil import which

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
@@ -25,7 +25,6 @@
 from shutil import which
 
 from .repository import Repository, RepositoryException
-from ..utils.command import Command
 
 
 class RepoRepository(Repository):
@@ -38,31 +37,7 @@ class RepoRepository(Repository):
             raise RepositoryException("Cannot get repo command")
 
     def reposync(self):
-        repo_command = [self.command, "sync", "-cf"]
-        cmd = self.getCommand(repo_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
-        cmd.execute()
-        self.logger.info("output of {}:".format(cmd))
-        self.logger.info(cmd.getoutputstr())
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
-            cmd.log_error("failed to perform sync")
-            return 1
-
-        return 0
+        return self._run_custom_sync_command([self.command, 'sync', '-cf'])
 
     def incoming_check(self):
-        repo_command = [self.command, "sync", "-n"]
-        cmd = self.getCommand(repo_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
-        cmd.execute()
-        self.logger.info("output of {}:".format(cmd))
-        self.logger.info(cmd.getoutputstr())
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
-            cmd.log_error("failed to perform sync")
-            raise RepositoryException('failed to check for incoming in '
-                                      'repository {}'.format(self))
-
-        if len(cmd.getoutput()) == 0:
-            return False
-        else:
-            return True
+        return self._run_custom_incoming_command([self.command, 'sync', '-n'])

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
@@ -31,10 +31,7 @@ class RepoRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(
-            command,
-            default=lambda: which('repo')
-        )
+        self.command = self._repository_command(command, default=lambda: which('repo'))
 
         if not self.command:
             raise RepositoryException("Cannot get repo command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
@@ -31,7 +31,10 @@ class RepoRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(command, default=lambda: which('repo'))
+        self.command = self._repository_command(
+            command,
+            default=lambda: which('repo')
+        )
 
         if not self.command:
             raise RepositoryException("Cannot get repo command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repo.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
@@ -41,6 +41,9 @@ class Repository:
 
     __metaclass__ = abc.ABCMeta
 
+    SYNC_COMMAND_SECTION = 'sync'
+    INCOMING_COMMAND_SECTION = 'incoming'
+
     def __init__(self, logger, path, project, configured_commands, env, hooks,
                  timeout):
         self.logger = logger
@@ -62,9 +65,9 @@ class Repository:
 
     def sync(self):
         # Eventually, there might be per-repository hooks added here.
-        if self.is_command_overridden(self.configured_commands, 'sync'):
+        if self.is_command_overridden(self.configured_commands, self.SYNC_COMMAND_SECTION):
             return self._run_custom_sync_command(
-                self.listify(self.configured_commands['sync'])
+                self.listify(self.configured_commands[self.SYNC_COMMAND_SECTION])
             )
         return self.reposync()
 
@@ -84,9 +87,9 @@ class Repository:
 
         Return True if so, False otherwise.
         """
-        if self.is_command_overridden(self.configured_commands, 'incoming'):
+        if self.is_command_overridden(self.configured_commands, self.INCOMING_COMMAND_SECTION):
             return self._run_custom_incoming_command(
-                self.listify(self.configured_commands['incoming'])
+                self.listify(self.configured_commands[self.INCOMING_COMMAND_SECTION])
             )
         return self.incoming_check()
 

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
@@ -18,7 +18,8 @@
 #
 
 #
-# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
 import abc

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
@@ -125,9 +125,7 @@ class Repository:
         if status != 0:
             self.logger.error("output of '{}':".format(command))
             self.logger.error(output)
-            raise RepositoryException(
-                'failed to check for incoming in repository {}'.format(self)
-            )
+            raise RepositoryException('failed to check for incoming in repository {}'.format(self))
         return len(output.strip()) > 0
 
     def _run_command(self, command):

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
@@ -180,7 +180,7 @@ class Repository:
     @staticmethod
     def is_command_overridden(config, command):
         """
-        Determine if command is overridden in the configuration.
+        Determine if command key is overridden in the configuration.
 
         :param config: configuration
         :param command: the command

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
@@ -186,4 +186,4 @@ class Repository:
         :param command: the command
         :return: true if overridden, false otherwise
         """
-        return isinstance(config, dict) and config.get(command)
+        return isinstance(config, dict) and config.get(command) is not None

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
@@ -22,6 +22,7 @@
 #
 
 import abc
+
 from ..utils.command import Command
 
 
@@ -39,12 +40,13 @@ class Repository:
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, logger, path, project, command, env, hooks,
+    def __init__(self, logger, path, project, configured_commands, env, hooks,
                  timeout):
         self.logger = logger
         self.path = path
         self.project = project
         self.timeout = timeout
+        self.configured_commands = configured_commands
         if env:
             self.env = env
         else:
@@ -59,6 +61,8 @@ class Repository:
 
     def sync(self):
         # Eventually, there might be per-repository hooks added here.
+        if isinstance(self.configured_commands, dict) and self.configured_commands.get('sync'):
+            return self._run_command(self.listify(self.configured_commands['sync']))
         return self.reposync()
 
     @abc.abstractmethod
@@ -77,4 +81,56 @@ class Repository:
 
         Return True if so, False otherwise.
         """
+        if isinstance(self.configured_commands, dict) and self.configured_commands.get('incoming'):
+            return self._run_command(self.listify(self.configured_commands['incoming'])) != 0
+        return self.incoming_check()
+
+    def incoming_check(self):
+        """
+        Check if there are any incoming changes.
+
+        Return True if so, False otherwise.
+        """
         return True
+
+    def _run_command(self, command):
+        """
+        Execute the command.
+
+        :param command: the command
+        :return: 0 on success execution, 1 otherwise
+        """
+        cmd = self.getCommand(command, work_dir=self.path, env_vars=self.env, logger=self.logger)
+        cmd.execute()
+        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
+            self.logger.debug("output of '{}':".format(cmd))
+            if cmd.getoutputstr():
+                self.logger.debug(cmd.getoutputstr())
+            if cmd.geterroutputstr():
+                self.logger.debug(cmd.geterroutputstr())
+            cmd.log_error("failed to perform command")
+            return 1
+        if cmd.getoutputstr():
+            self.logger.debug("output of '{}':".format(cmd))
+            self.logger.debug(cmd.getoutputstr())
+        return 0
+
+    @staticmethod
+    def _repository_command(configured_commands, default=lambda: None):
+        """
+        Get the repository command, or use default supplier.
+
+        :param configured_commands: commands section from configuration for this repository type
+        :param default: the supplier of default command
+        :return: the repository command
+        """
+        if isinstance(configured_commands, str):
+            return configured_commands
+        elif isinstance(configured_commands, dict) and configured_commands.get('command'):
+            return configured_commands['command']
+
+        return default()
+
+    @staticmethod
+    def listify(object):
+        return object if isinstance(object, list) or isinstance(object, tuple) else [object]

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/repository.py
@@ -61,8 +61,7 @@ class Repository:
 
     def sync(self):
         # Eventually, there might be per-repository hooks added here.
-        if isinstance(self.configured_commands, dict) and \
-                self.configured_commands.get('sync'):
+        if self.is_command_overridden(self.configured_commands, 'sync'):
             return self._run_custom_sync_command(
                 self.listify(self.configured_commands['sync'])
             )
@@ -84,8 +83,7 @@ class Repository:
 
         Return True if so, False otherwise.
         """
-        if isinstance(self.configured_commands, dict) and \
-                self.configured_commands.get('incoming'):
+        if self.is_command_overridden(self.configured_commands, 'incoming'):
             return self._run_custom_incoming_command(
                 self.listify(self.configured_commands['incoming'])
             )
@@ -174,3 +172,14 @@ class Repository:
         if isinstance(object, list) or isinstance(object, tuple):
             return object
         return [object]
+
+    @staticmethod
+    def is_command_overridden(config, command):
+        """
+        Determine if command is overridden in the configuration.
+
+        :param config: configuration
+        :param command: the command
+        :return: true if overridden, false otherwise
+        """
+        return isinstance(config, dict) and config.get(command)

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
@@ -18,7 +18,8 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
 from shutil import which

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
@@ -21,20 +21,17 @@
 # Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 
-from ..utils.command import Command
-from .repository import Repository, RepositoryException
 from shutil import which
+
+from .repository import Repository, RepositoryException
+from ..utils.command import Command
 
 
 class SubversionRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
-
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        if command:
-            self.command = command
-        else:
-            self.command = which("svn")
+        self.command = self._repository_command(command, default=lambda: which('svn'))
 
         if not self.command:
             raise RepositoryException("Cannot get svn command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
@@ -31,7 +31,10 @@ class SubversionRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(command, default=lambda: which('svn'))
+        self.command = self._repository_command(
+            command,
+            default=lambda: which('svn')
+        )
 
         if not self.command:
             raise RepositoryException("Cannot get svn command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
@@ -31,10 +31,7 @@ class SubversionRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
-        self.command = self._repository_command(
-            command,
-            default=lambda: which('svn')
-        )
+        self.command = self._repository_command(command, default=lambda: which('svn'))
 
         if not self.command:
             raise RepositoryException("Cannot get svn command")

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
@@ -25,7 +25,6 @@
 from shutil import which
 
 from .repository import Repository, RepositoryException
-from ..utils.command import Command
 
 
 class SubversionRepository(Repository):
@@ -64,13 +63,4 @@ class SubversionRepository(Repository):
                                no_proxy)
 
         svn_command.append("update")
-        cmd = self.getCommand(svn_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
-        cmd.execute()
-        self.logger.info("output of {}:".format(cmd))
-        self.logger.info(cmd.getoutputstr())
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
-            cmd.log_error("failed to perform update")
-            return 1
-
-        return 0
+        return self._run_custom_sync_command(svn_command)

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/svn.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/teamware.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/teamware.py
@@ -18,7 +18,8 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
 import os

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/teamware.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/teamware.py
@@ -25,7 +25,6 @@
 import os
 
 from .repository import Repository, RepositoryException
-from ..utils.command import Command
 
 
 class TeamwareRepository(Repository):
@@ -67,14 +66,4 @@ class TeamwareRepository(Repository):
                               format(self.path))
             return 0
 
-        bringover_command = ["bringover"]
-        cmd = self.getCommand(bringover_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
-        cmd.execute()
-        self.logger.info("output of {}:".format(cmd))
-        self.logger.info(cmd.getoutputstr())
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
-            cmd.log_error("failed to perform bringover")
-            return 1
-
-        return 0
+        return self._run_custom_sync_command(['bringover'])

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/teamware.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/teamware.py
@@ -21,14 +21,14 @@
 # Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 
-from ..utils.command import Command
-from .repository import Repository, RepositoryException
 import os
+
+from .repository import Repository, RepositoryException
+from ..utils.command import Command
 
 
 class TeamwareRepository(Repository):
     def __init__(self, logger, path, project, command, env, hooks, timeout):
-
         super().__init__(logger, path, project, command, env, hooks, timeout)
 
         #
@@ -39,6 +39,7 @@ class TeamwareRepository(Repository):
         # argument contains the path to the directory that contains
         # the binaries.
         #
+        command = self._repository_command(command)
         if command:
             if not os.path.isdir(command):
                 raise RepositoryException("Cannot construct Teamware "

--- a/opengrok-tools/src/main/python/opengrok_tools/scm/teamware.py
+++ b/opengrok-tools/src/main/python/opengrok_tools/scm/teamware.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -402,12 +402,15 @@ def test_get_repos_for_project(monkeypatch):
             assert len(repos) == 0
 
 
+DEFAULT_COMMAND = 'default-command'
+
+
 @pytest.mark.parametrize(['expected_command', 'config'], [
-    ('default-command', None),
+    (DEFAULT_COMMAND, None),
     ('/usr/bin/git', '/usr/bin/git'),
-    ('default-command', {}),
-    ('default-command', {'incoming': '/bin/false'}),
-    ('default-command', []),
+    (DEFAULT_COMMAND, {}),
+    (DEFAULT_COMMAND, {'incoming': '/bin/false'}),
+    (DEFAULT_COMMAND, []),
     ('/usr/local/bin/git', {'command': '/usr/local/bin/git'}),
     (
             '/usr/local/bin/git',
@@ -415,7 +418,7 @@ def test_get_repos_for_project(monkeypatch):
     )
 ])
 def test_mirroring_custom_repository_command(expected_command, config):
-    assert expected_command == Repository._repository_command(config, lambda: 'default-command')
+    assert expected_command == Repository._repository_command(config, lambda: DEFAULT_COMMAND)
 
 
 @pytest.mark.parametrize(

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -120,9 +120,10 @@ def test_invalid_config_option():
 
 
 def test_valid_config():
-    assert check_configuration({PROJECTS_PROPERTY:
-                                    {"foo": {PROXY_PROPERTY: True}},
-                                PROXY_PROPERTY: "proxy"})
+    assert check_configuration({
+        PROJECTS_PROPERTY: {"foo": {PROXY_PROPERTY: True}},
+        PROXY_PROPERTY: "proxy"
+    })
 
 
 @pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")
@@ -196,11 +197,16 @@ def test_disabled_command_api():
     with patch(opengrok_tools.utils.mirror.call_rest_api,
                lambda a, b, c: mock(spec=requests.Response)):
         project_name = "foo"
-        config = {DISABLED_CMD_PROPERTY:
-                      {COMMAND_PROPERTY:
-                           ["http://localhost:8080/source/api/v1/foo",
-                            "POST", "data"]},
-                  PROJECTS_PROPERTY: {project_name: {DISABLED_PROPERTY: True}}}
+        config = {
+            DISABLED_CMD_PROPERTY: {
+                COMMAND_PROPERTY: [
+                    "http://localhost:8080/source/api/v1/foo",
+                    "POST", "data"]
+            },
+            PROJECTS_PROPERTY: {
+                project_name: {DISABLED_PROPERTY: True}
+            }
+        }
 
         assert mirror_project(config, project_name, False,
                               None, None) == CONTINUE_EXITVAL
@@ -237,14 +243,19 @@ def test_disabled_command_api_text_append(monkeypatch):
         data = {'messageLevel': 'info', 'duration': 'PT5M',
                 'tags': ['%PROJECT%'],
                 'text': 'disabled project'}
-        config = {DISABLED_CMD_PROPERTY:
-                      {COMMAND_PROPERTY:
-                           ["http://localhost:8080/source/api/v1/foo",
-                            "POST", data]},
-                  PROJECTS_PROPERTY: {project_name:
-                                          {DISABLED_REASON_PROPERTY:
-                                               text_to_append,
-                                           DISABLED_PROPERTY: True}}}
+        config = {
+            DISABLED_CMD_PROPERTY: {
+                COMMAND_PROPERTY: [
+                    "http://localhost:8080/source/api/v1/foo",
+                    "POST", data]
+            },
+            PROJECTS_PROPERTY: {
+                project_name: {
+                    DISABLED_REASON_PROPERTY: text_to_append,
+                    DISABLED_PROPERTY: True
+                }
+            }
+        }
 
         mirror_project(config, project_name, False, None, None)
 
@@ -255,9 +266,14 @@ def test_disabled_command_run():
     """
     spy2(opengrok_tools.utils.mirror.run_command)
     project_name = "foo"
-    config = {DISABLED_CMD_PROPERTY:
-                  {COMMAND_PROPERTY: ["cat"]},
-              PROJECTS_PROPERTY: {project_name: {DISABLED_PROPERTY: True}}}
+    config = {
+        DISABLED_CMD_PROPERTY: {
+            COMMAND_PROPERTY: ["cat"]
+        },
+        PROJECTS_PROPERTY: {
+            project_name: {DISABLED_PROPERTY: True}
+        }
+    }
 
     assert mirror_project(config, project_name, False,
                           None, None) == CONTINUE_EXITVAL
@@ -319,15 +335,21 @@ def test_mirror_project_timeout(monkeypatch):
 
         project_name = "foo"
         # override testing
-        global_config_1 = {PROJECTS_PROPERTY:
-                               {project_name:
-                                    {CMD_TIMEOUT_PROPERTY: cmd_timeout,
-                                     HOOK_TIMEOUT_PROPERTY: hook_timeout}},
-                           CMD_TIMEOUT_PROPERTY: cmd_timeout * 2,
-                           HOOK_TIMEOUT_PROPERTY: hook_timeout * 2}
+        global_config_1 = {
+            PROJECTS_PROPERTY: {
+                project_name: {
+                    CMD_TIMEOUT_PROPERTY: cmd_timeout,
+                    HOOK_TIMEOUT_PROPERTY: hook_timeout
+                }
+            },
+            CMD_TIMEOUT_PROPERTY: cmd_timeout * 2,
+            HOOK_TIMEOUT_PROPERTY: hook_timeout * 2
+        }
         # inheritance testing
-        global_config_2 = {CMD_TIMEOUT_PROPERTY: cmd_timeout,
-                           HOOK_TIMEOUT_PROPERTY: hook_timeout}
+        global_config_2 = {
+            CMD_TIMEOUT_PROPERTY: cmd_timeout,
+            HOOK_TIMEOUT_PROPERTY: hook_timeout
+        }
 
         test_mirror_project(global_config_1)
         test_mirror_project(global_config_2)
@@ -385,10 +407,16 @@ def test_get_repos_for_project(monkeypatch):
     ({'incoming': '/bin/false'}, 'default-command'),
     ([], 'default-command'),
     ({'command': '/usr/local/bin/git'}, '/usr/local/bin/git'),
-    ({'command': '/usr/local/bin/git', 'incoming': '/bin/false'}, '/usr/local/bin/git')
+    (
+            {'command': '/usr/local/bin/git', 'incoming': '/bin/false'},
+            '/usr/local/bin/git'
+    )
 ])
 def test_mirroring_custom_repository_command(config, expected_command):
-    assert expected_command == Repository._repository_command(config, lambda: 'default-command')
+    assert expected_command == Repository._repository_command(
+        config,
+        lambda: 'default-command'
+    )
 
 
 @pytest.mark.parametrize(
@@ -408,7 +436,7 @@ def test_mirroring_custom_incoming_invoke_command(touch_binary):
         repository = GitRepository(mock(), repository_root, 'test-1', {
             'incoming': [touch_binary, 'incoming.txt']
         }, None, None, None)
-        assert repository.incoming() == False
+        assert repository.incoming() is False
         assert 'incoming.txt' in os.listdir(repository_root)
 
 
@@ -429,7 +457,7 @@ def test_mirroring_custom_incoming_changes(echo_binary):
         repository = GitRepository(mock(), repository_root, 'test-1', {
             'incoming': [echo_binary, 'new incoming changes!']
         }, None, None, None)
-        assert True == repository.incoming()
+        assert repository.incoming() is True
 
 
 @pytest.mark.parametrize(
@@ -449,7 +477,7 @@ def test_mirroring_custom_incoming_no_changes(true_binary):
         repository = GitRepository(mock(), repository_root, 'test-1', {
             'incoming': true_binary
         }, None, None, None)
-        assert False == repository.incoming()
+        assert repository.incoming() is False
 
 
 @pytest.mark.parametrize(
@@ -475,7 +503,8 @@ def test_mirroring_custom_incoming_error(false_binary):
 
 def test_mirroring_incoming_invoke_original_command():
     with tempfile.TemporaryDirectory() as repository_root:
-        repository = GitRepository(mock(), repository_root, 'test-1', None, None, None, None)
+        repository = GitRepository(mock(), repository_root, 'test-1',
+                                   None, None, None, None)
         with when(repository).incoming_check().thenReturn(0):
             repository.incoming()
             verify(repository).incoming_check()
@@ -498,7 +527,7 @@ def test_mirroring_custom_sync_invoke_command(touch_binary):
         repository = GitRepository(mock(), repository_root, 'test-1', {
             'sync': [touch_binary, 'sync.txt']
         }, None, None, None)
-        assert False == repository.sync()
+        assert repository.sync() == 0
         assert 'sync.txt' in os.listdir(repository_root)
 
 
@@ -544,7 +573,8 @@ def test_mirroring_custom_sync_error(false_binary):
 
 def test_mirroring_sync_invoke_original_command():
     with tempfile.TemporaryDirectory() as repository_root:
-        repository = GitRepository(mock(), repository_root, 'test-1', None, None, None, None)
+        repository = GitRepository(mock(), repository_root, 'test-1',
+                                   None, None, None, None)
         with when(repository).reposync().thenReturn(0):
             repository.sync()
             verify(repository).reposync()

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -21,7 +21,9 @@
 
 #
 # Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+# Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
+
 import os
 import stat
 import sys

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -415,10 +415,7 @@ def test_get_repos_for_project(monkeypatch):
     )
 ])
 def test_mirroring_custom_repository_command(config, expected_command):
-    assert expected_command == Repository._repository_command(
-        config,
-        lambda: 'default-command'
-    )
+    assert expected_command == Repository._repository_command(config, lambda: 'default-command')
 
 
 @pytest.mark.parametrize(

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -432,12 +432,13 @@ def test_mirroring_custom_repository_command(config, expected_command):
     ]
 )
 def test_mirroring_custom_incoming_invoke_command(touch_binary):
+    checking_file = 'incoming.txt'
     with tempfile.TemporaryDirectory() as repository_root:
         repository = GitRepository(mock(), repository_root, 'test-1', {
-            'incoming': [touch_binary, 'incoming.txt']
+            'incoming': [touch_binary, checking_file]
         }, None, None, None)
         assert repository.incoming() is False
-        assert 'incoming.txt' in os.listdir(repository_root)
+        assert checking_file in os.listdir(repository_root)
 
 
 @pytest.mark.parametrize(
@@ -523,12 +524,13 @@ def test_mirroring_incoming_invoke_original_command():
     ]
 )
 def test_mirroring_custom_sync_invoke_command(touch_binary):
+    checking_file = 'sync.txt'
     with tempfile.TemporaryDirectory() as repository_root:
         repository = GitRepository(mock(), repository_root, 'test-1', {
-            'sync': [touch_binary, 'sync.txt']
+            'sync': [touch_binary, checking_file]
         }, None, None, None)
         assert repository.sync() == 0
-        assert 'sync.txt' in os.listdir(repository_root)
+        assert checking_file in os.listdir(repository_root)
 
 
 @pytest.mark.parametrize(

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -402,19 +402,19 @@ def test_get_repos_for_project(monkeypatch):
             assert len(repos) == 0
 
 
-@pytest.mark.parametrize(['config', 'expected_command'], [
-    (None, 'default-command'),
+@pytest.mark.parametrize(['expected_command', 'config'], [
+    ('default-command', None),
     ('/usr/bin/git', '/usr/bin/git'),
-    ({}, 'default-command'),
-    ({'incoming': '/bin/false'}, 'default-command'),
-    ([], 'default-command'),
-    ({'command': '/usr/local/bin/git'}, '/usr/local/bin/git'),
+    ('default-command', {}),
+    ('default-command', {'incoming': '/bin/false'}),
+    ('default-command', []),
+    ('/usr/local/bin/git', {'command': '/usr/local/bin/git'}),
     (
-            {'command': '/usr/local/bin/git', 'incoming': '/bin/false'},
-            '/usr/local/bin/git'
+            '/usr/local/bin/git',
+            {'command': '/usr/local/bin/git', 'incoming': '/bin/false'}
     )
 ])
-def test_mirroring_custom_repository_command(config, expected_command):
+def test_mirroring_custom_repository_command(expected_command, config):
     assert expected_command == Repository._repository_command(config, lambda: 'default-command')
 
 


### PR DESCRIPTION
Of course the change is compatible with the current setup:

mirror.conf:
```
commands:
  git: /usr/bin/git
```

The syntax is extended to support custom commands as follows:

```
commands:
  git:
    command: /usr/local/bin/git
    incoming: ['git', 'pull', '--dry-run']
    # for sync the default procedure will be used with the overriden command /usr/local/bin/git
```

```
commands:
  git:
    command: /usr/local/bin/git
    sync: ['git', 'pull', '--ff-only']
    # for mirroring the default procedure will be used with the overriden command /usr/local/bin/git
```

```
commands:
  git:
    command: /usr/local/bin/git
    incoming: ['git', 'pull', '--dry-run']
    sync: ['git', 'pull', '--ff-only']
```


This pull request is to allow user to overcome problems from #2583 and #2432 before an universal solution exists in opengrok.