### PR TITLE
macOS Xcode 10 vs. Python setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,10 @@ jobs:
     before_install: dev/before_install
     before_script: dev/before
   - stage: test
-    name: macOS + Oracle JDK 8
+    name: macOS + Oracle JDK 11
     os: osx
-    osx_image: xcode8.3
+    osx_image: xcode10.1
+    jdk: oraclejdk11
     install: true
     script: dev/main
     before_install: dev/before_install

--- a/opengrok-tools/pom.xml
+++ b/opengrok-tools/pom.xml
@@ -213,8 +213,39 @@ Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
                                 <argument>--upgrade</argument>
                                 <argument>pip</argument>
                                 <argument>setuptools</argument>
-                                <argument>certifi</argument>
                                 <argument>wheel</argument>
+                            </arguments>
+                        </configuration>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>Install requirements via pip</id>
+                        <configuration>
+                            <executable>${python.environment}/pip</executable>
+                            <workingDirectory>${project.build.directory}</workingDirectory>
+                            <arguments>
+                                <argument>install</argument>
+                                <argument>-r</argument>
+                                <argument>${project.basedir}/requirements.txt</argument>
+                            </arguments>
+                        </configuration>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>Install test modules via pip</id>
+                        <configuration>
+                            <executable>${python.environment}/pip</executable>
+                            <workingDirectory>${project.build.directory}</workingDirectory>
+                            <arguments>
+                                <argument>install</argument>
+                                <argument>-r</argument>
+                                <argument>${project.basedir}/tests.txt</argument>
                             </arguments>
                         </configuration>
                         <phase>test</phase>

--- a/opengrok-tools/tests.txt
+++ b/opengrok-tools/tests.txt
@@ -1,0 +1,5 @@
+pytest
+GitPython
+pytest-xdist
+mockito
+pytest-mockito


### PR DESCRIPTION
workaround for #2528 - in order to prevent setuptools from reaching out to PyPi, the needed packages are installed first via pip. This is done so that it is possible to merge #3098.