### PR TITLE
change default path to dtags.eftar

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -1223,7 +1223,7 @@ public final class Configuration {
      * @return path to the file holding compiled path descriptions for the web application
      */
     public Path getDtagsEftarPath() {
-        return Paths.get(getDataRoot(), "index", EFTAR_DTAGS_NAME);
+        return Paths.get(getDataRoot(), EFTAR_DTAGS_NAME);
     }
 
     public String getCTagsExtraOptionsFile() {


### PR DESCRIPTION
Keeping the `dtags.eftar` file underneath the `index` directory does not make sense to me. After all it does not hold index data. Also, when upgrading OpenGrok from scratch, I tend to clone the directory structure (yes, via ZFS) and recreate the subdirectories (er, datasets) such as `index,historycache,...`. With this procedure the file is lost.