### PR TITLE
assert xml attributes in correct order for python 3.8

### DIFF
--- a/opengrok-tools/src/test/python/web.xml
+++ b/opengrok-tools/src/test/python/web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         version="3.1"
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
-         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
-         version="3.1">
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
     <display-name>OpenGrok</display-name>
     <description>A wicked fast source browser</description>


### PR DESCRIPTION
fixes #3297

Seems this should be enough to make it work under python 3.8.