### PR TITLE
disable the Coverity addon, causes TLS black hole

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,7 @@ cache:
   directories:
   - "$HOME/.m2"
   - "$HOME/.sonar/cache"
-env:
-  global:
-  # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
-  # via the "travis encrypt" command using the project repo's public key.
-  - secure: O_cda5pWDBAP-O3_0nG5RQ
 addons:
-  coverity_scan:
-    project:
-      name: OpenGrok/OpenGrok
-      description: Build submitted via Travis CI
-      branch_pattern: coverity_scan
-      build_command: ./mvnw -DskipTests=true -Dmaven.javadoc.skip=false -B -V compile
   sonarcloud:
     organization: opengrok
     token:


### PR DESCRIPTION
This should fix the macOS build with Xcode 10.1.