### PR TITLE
handle some exceptions related to path descriptions

### DIFF
--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/EftarFileTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/EftarFileTest.java
@@ -53,9 +53,7 @@ public class EftarFileTest {
         tsv = File.createTempFile("paths", ".tsv");
         eftar = File.createTempFile("paths", ".eftar");
 
-        PrintWriter out = null;
-        try {
-            out = new PrintWriter(new FileWriter(tsv));
+        try (PrintWriter out = new PrintWriter(new FileWriter(tsv))) {
             StringBuilder sb = new StringBuilder();
             for (int ii = 0; ii < 100; ii++) {
                 sb.append(PATH_STRING);
@@ -65,11 +63,6 @@ public class EftarFileTest {
                 out.println(ii);
             }
             out.flush();
-        } finally {
-            try {
-                out.close();
-            } catch (Exception e) {
-            }
         }
 
         // Create eftar files.

--- a/opengrok-web/src/main/java/org/opengrok/web/DirectoryListing.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/DirectoryListing.java
@@ -34,11 +34,14 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.opengrok.indexer.configuration.PathAccepter;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.history.HistoryGuru;
+import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.search.DirectoryEntry;
 import org.opengrok.indexer.search.FileExtra;
 import org.opengrok.indexer.web.EftarFileReader;
@@ -48,6 +51,8 @@ import org.opengrok.indexer.web.Util;
  * Generates HTML listing of a Directory.
  */
 public class DirectoryListing {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DirectoryListing.class);
 
     protected static final String DIRECTORY_SIZE_PLACEHOLDER = "-";
     private final EftarFileReader desc;
@@ -135,14 +140,12 @@ public class DirectoryListing {
      * @throws HistoryException history exception
      * @throws IOException I/O exception
      */
-    public List<String> listTo(String contextPath, File dir, Writer out,
-        String path, List<String> files)
-            throws HistoryException, IOException {
+    public List<String> listTo(String contextPath, File dir, Writer out, String path, List<String> files)
+            throws IOException, HistoryException {
         List<DirectoryEntry> filesExtra = null;
         if (files != null) {
             filesExtra = files.stream().map(f ->
-                new DirectoryEntry(new File(dir, f), null)).collect(
-                Collectors.toList());
+                new DirectoryEntry(new File(dir, f), null)).collect(Collectors.toList());
         }
         return extraListTo(contextPath, dir, out, path, filesExtra);
     }
@@ -159,22 +162,21 @@ public class DirectoryListing {
      *  but filtered by {@link PathAccepter}.
      * @return a possible empty list of README files included in the written
      *  listing.
-     * @throws org.opengrok.indexer.history.HistoryException when we cannot
-     * get result from SCM
-     *
-     * @throws java.io.IOException when any I/O problem
-     * @throws NullPointerException if a parameter except <var>files</var>
-     *  is {@code null}
+     * @throws IOException when cannot write to the {@code out} parameter
+     * @throws HistoryException when failed to get last modified time for files in directory
      */
     public List<String> extraListTo(String contextPath, File dir, Writer out,
-        String path, List<DirectoryEntry> entries)
-            throws HistoryException, IOException {
+                                    String path, List<DirectoryEntry> entries) throws IOException, HistoryException {
         // TODO this belongs to a jsp, not here
         ArrayList<String> readMes = new ArrayList<>();
         int offset = -1;
         EftarFileReader.FNode parentFNode = null;
         if (desc != null) {
-            parentFNode = desc.getNode(path);
+            try {
+                parentFNode = desc.getNode(path);
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, String.format("cannot get Eftar node for path ''%s''", path), e);
+            }
             if (parentFNode != null) {
                 offset = parentFNode.getChildOffset();
             }

--- a/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
@@ -382,6 +382,6 @@ public class DirectoryListingTest {
         StringWriter mockWriter = spy(StringWriter.class);
         instance.extraListTo("ctx", directory, mockWriter, directory.getPath(),
                 Collections.singletonList(new DirectoryEntry(file)));
-        verify(mockWriter, atLeast(1)). write(anyString());
+        verify(mockWriter, atLeast(20)). write(anyString());
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
@@ -53,8 +53,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * JUnit test to test that the DirectoryListing produce the expected result.
@@ -380,7 +379,9 @@ public class DirectoryListingTest {
         when(mockReader.getNode(anyString())).thenThrow(IOException.class);
         DirectoryListing instance = new DirectoryListing(mockReader);
         File file = new File(directory, "foo");
-        instance.extraListTo("ctx", directory, new StringWriter(), directory.getPath(),
+        StringWriter mockWriter = spy(StringWriter.class);
+        instance.extraListTo("ctx", directory, mockWriter, directory.getPath(),
                 Collections.singletonList(new DirectoryEntry(file)));
+        verify(mockWriter, atLeast(1)). write(anyString());
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
@@ -26,10 +26,12 @@ package org.opengrok.web;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -37,7 +39,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.history.RepositoryFactory;
+import org.opengrok.indexer.search.DirectoryEntry;
+import org.opengrok.indexer.web.EftarFileReader;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -47,6 +52,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * JUnit test to test that the DirectoryListing produce the expected result.
@@ -364,5 +372,15 @@ public class DirectoryListingTest {
         for (int i = 2; i < len; ++i) {
             validateEntry((Element) nl.item(i));
         }
+    }
+
+    @Test
+    public void directoryListingWithEftarException() throws IOException, HistoryException {
+        EftarFileReader mockReader = mock(EftarFileReader.class);
+        when(mockReader.getNode(anyString())).thenThrow(IOException.class);
+        DirectoryListing instance = new DirectoryListing(mockReader);
+        File file = new File(directory, "foo");
+        instance.extraListTo("ctx", directory, new StringWriter(), directory.getPath(),
+                Collections.singletonList(new DirectoryEntry(file)));
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
@@ -382,6 +382,6 @@ public class DirectoryListingTest {
         StringWriter mockWriter = spy(StringWriter.class);
         instance.extraListTo("ctx", directory, mockWriter, directory.getPath(),
                 Collections.singletonList(new DirectoryEntry(file)));
-        verify(mockWriter, atLeast(20)). write(anyString());
+        verify(mockWriter, atLeast(20)).write(anyString());
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
@@ -53,7 +53,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /**
  * JUnit test to test that the DirectoryListing produce the expected result.


### PR DESCRIPTION
This change adds handling of `IOException` from `EftarFileReader#getNode()` to avoid UI disruption when the `dtags.eftar` file has unexpected contents.