### PR TITLE
Extract and reuse pytest parameters

### DIFF
--- a/opengrok-tools/src/test/python/conftest.py
+++ b/opengrok-tools/src/test/python/conftest.py
@@ -32,6 +32,7 @@ def system_binary(name):
     """
     Creates an argument of {name}_binary which automatically
     skips the test execution when the binary is not available on the system.
+    The full path to the binary on the system is then available as an argument {name}_binary.
 
     :param name: the binary name (the command)
     """
@@ -39,8 +40,14 @@ def system_binary(name):
     def decorator(fn):
         return pytest.mark.parametrize(
             ('{}_binary'.format(name)), [
-                pytest.param('/bin/{}'.format(name), marks=pytest.mark.skipif(not os.path.exists('/bin/{}'.format(name)), reason="requires /bin binaries")),
-                pytest.param('/usr/bin/{}'.format(name), marks=pytest.mark.skipif(not os.path.exists('/usr/bin/{}'.format(name)), reason="requires /usr/bin binaries")),
+                pytest.param('/bin/{}'.format(name), marks=pytest.mark.skipif(
+                    not os.path.exists('/bin/{}'.format(name)),
+                    reason="requires /bin binaries"
+                )),
+                pytest.param('/usr/bin/{}'.format(name), marks=pytest.mark.skipif(
+                    not os.path.exists('/usr/bin/{}'.format(name)),
+                    reason="requires /usr/bin binaries"
+                )),
             ])(fn)
 
     return decorator

--- a/opengrok-tools/src/test/python/conftest.py
+++ b/opengrok-tools/src/test/python/conftest.py
@@ -1,42 +1,18 @@
 import os
+
 import pytest
 
 
-@pytest.fixture(
-    params=[
-        pytest.param('/bin/true', marks=pytest.mark.skipif(not os.path.exists('/bin/true'), reason="requires /bin binaries")),
-        pytest.param('/usr/bin/true', marks=pytest.mark.skipif(not os.path.exists('/usr/bin/true'), reason="requires /usr/bin binaries"))
-    ]
-)
-def true_binary(request):
-    return request.param
+def system_binary(name):
+    def decorator(fn):
+        return pytest.mark.parametrize(
+            ('{}_binary'.format(name)), [
+                pytest.param('/bin/{}'.format(name), marks=pytest.mark.skipif(not os.path.exists('/bin/{}'.format(name)), reason="requires /bin binaries")),
+                pytest.param('/usr/bin/{}'.format(name), marks=pytest.mark.skipif(not os.path.exists('/usr/bin/{}'.format(name)), reason="requires /usr/bin binaries")),
+            ])(fn)
+
+    return decorator
 
 
-@pytest.fixture(
-    params=[
-        pytest.param('/bin/false', marks=pytest.mark.skipif(not os.path.exists('/bin/false'), reason="requires /bin binaries")),
-        pytest.param('/usr/bin/false', marks=pytest.mark.skipif(not os.path.exists('/usr/bin/false'), reason="requires /usr/bin binaries"))
-    ]
-)
-def false_binary(request):
-    return request.param
-
-
-@pytest.fixture(
-    params=[
-        pytest.param('/bin/touch', marks=pytest.mark.skipif(not os.path.exists('/bin/touch'), reason="requires /bin binaries")),
-        pytest.param('/usr/bin/touch', marks=pytest.mark.skipif(not os.path.exists('/usr/bin/touch'), reason="requires /usr/bin binaries"))
-    ]
-)
-def touch_binary(request):
-    return request.param
-
-
-@pytest.fixture(
-    params=[
-        pytest.param('/bin/echo', marks=pytest.mark.skipif(not os.path.exists('/bin/echo'), reason="requires /bin binaries")),
-        pytest.param('/usr/bin/echo', marks=pytest.mark.skipif(not os.path.exists('/usr/bin/echo'), reason="requires /usr/bin binaries"))
-    ]
-)
-def echo_binary(request):
-    return request.param
+def posix_only(fn):
+    return pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")(fn)

--- a/opengrok-tools/src/test/python/conftest.py
+++ b/opengrok-tools/src/test/python/conftest.py
@@ -1,9 +1,41 @@
+#!/usr/bin/env python3
+
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
+#
 import os
 
 import pytest
 
 
 def system_binary(name):
+    """
+    Creates an argument of {name}_binary which automatically
+    skips the test execution when the binary is not available on the system.
+
+    :param name: the binary name (the command)
+    """
+
     def decorator(fn):
         return pytest.mark.parametrize(
             ('{}_binary'.format(name)), [
@@ -15,4 +47,7 @@ def system_binary(name):
 
 
 def posix_only(fn):
+    """
+    Automatically skips the test execution when the current system is not in posix family.
+    """
     return pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")(fn)

--- a/opengrok-tools/src/test/python/conftest.py
+++ b/opengrok-tools/src/test/python/conftest.py
@@ -1,0 +1,42 @@
+import os
+import pytest
+
+
+@pytest.fixture(
+    params=[
+        pytest.param('/bin/true', marks=pytest.mark.skipif(not os.path.exists('/bin/true'), reason="requires /bin binaries")),
+        pytest.param('/usr/bin/true', marks=pytest.mark.skipif(not os.path.exists('/usr/bin/true'), reason="requires /usr/bin binaries"))
+    ]
+)
+def true_binary(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        pytest.param('/bin/false', marks=pytest.mark.skipif(not os.path.exists('/bin/false'), reason="requires /bin binaries")),
+        pytest.param('/usr/bin/false', marks=pytest.mark.skipif(not os.path.exists('/usr/bin/false'), reason="requires /usr/bin binaries"))
+    ]
+)
+def false_binary(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        pytest.param('/bin/touch', marks=pytest.mark.skipif(not os.path.exists('/bin/touch'), reason="requires /bin binaries")),
+        pytest.param('/usr/bin/touch', marks=pytest.mark.skipif(not os.path.exists('/usr/bin/touch'), reason="requires /usr/bin binaries"))
+    ]
+)
+def touch_binary(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        pytest.param('/bin/echo', marks=pytest.mark.skipif(not os.path.exists('/bin/echo'), reason="requires /bin binaries")),
+        pytest.param('/usr/bin/echo', marks=pytest.mark.skipif(not os.path.exists('/usr/bin/echo'), reason="requires /usr/bin binaries"))
+    ]
+)
+def echo_binary(request):
+    return request.param

--- a/opengrok-tools/src/test/python/test_command.py
+++ b/opengrok-tools/src/test/python/test_command.py
@@ -93,11 +93,9 @@ def test_work_dir():
     assert os.getcwd() == orig_cwd
 
 
-@pytest.mark.skipif(not os.path.exists('/usr/bin/env'),
-                    reason="requires posix")
-def test_env():
-    cmd = Command(['/usr/bin/env'],
-                  env_vars={'FOO': 'BAR', 'A': 'B'})
+@system_binary('env')
+def test_env(env_binary):
+    cmd = Command([env_binary], env_vars={'FOO': 'BAR', 'A': 'B'})
     cmd.execute()
     assert "FOO=BAR\n" in cmd.getoutput()
 
@@ -121,11 +119,10 @@ def test_command_to_str():
     assert str(cmd) == "foo bar"
 
 
-@pytest.mark.skipif(not os.path.exists('/bin/sleep'),
-                    reason="requires /bin/sleep")
-def test_command_timeout():
+@system_binary('sleep')
+def test_command_timeout(sleep_binary):
     timeout = 30
-    cmd = Command(["/bin/sleep", str(timeout)], timeout=3)
+    cmd = Command([sleep_binary, str(timeout)], timeout=3)
     start_time = time.time()
     cmd.execute()
     # Check the process is no longer around.
@@ -138,11 +135,10 @@ def test_command_timeout():
     assert cmd.getretcode() is None
 
 
-@pytest.mark.skipif(not os.path.exists('/bin/sleep'),
-                    reason="requires /bin/sleep")
-def test_command_notimeout():
+@system_binary('sleep')
+def test_command_notimeout(sleep_binary):
     cmd_timeout = 30
-    cmd = Command(["/bin/sleep", "3"], timeout=cmd_timeout)
+    cmd = Command([sleep_binary, "3"], timeout=cmd_timeout)
     cmd.execute()
     assert cmd.getstate() == Command.FINISHED
     assert cmd.getretcode() == 0

--- a/opengrok-tools/src/test/python/test_command.py
+++ b/opengrok-tools/src/test/python/test_command.py
@@ -101,20 +101,6 @@ def test_env():
     assert "FOO=BAR\n" in cmd.getoutput()
 
 
-@pytest.mark.parametrize(
-    ('true_binary', 'false_binary'), [
-        pytest.param('/bin/true', '/bin/false',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/bin/true') or
-                         not os.path.exists('/bin/false'),
-                         reason="requires /bin binaries")),
-        pytest.param('/usr/bin/true', '/usr/bin/false',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/usr/bin/true') or
-                         not os.path.exists('/usr/bin/false'),
-                         reason="requires /usr/bin binaries")),
-    ]
-)
 def test_retcode(true_binary, false_binary):
     cmd = Command([false_binary])
     cmd.execute()

--- a/opengrok-tools/src/test/python/test_command.py
+++ b/opengrok-tools/src/test/python/test_command.py
@@ -21,6 +21,7 @@
 
 #
 # Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+# Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
 import os

--- a/opengrok-tools/src/test/python/test_command.py
+++ b/opengrok-tools/src/test/python/test_command.py
@@ -24,12 +24,13 @@
 #
 
 import os
+import platform
 import tempfile
 import time
-import platform
 
 import pytest
 
+from conftest import posix_only, system_binary
 from opengrok_tools.utils.command import Command
 
 
@@ -74,14 +75,14 @@ def test_execute_nonexistent():
     assert cmd.getstate() == Command.ERRORED
 
 
-@pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")
+@posix_only
 def test_getoutput():
     cmd = Command(['/bin/ls', '/etc/passwd'])
     cmd.execute()
     assert cmd.getoutput() == ['/etc/passwd\n']
 
 
-@pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")
+@posix_only
 def test_work_dir():
     os.chdir("/")
     orig_cwd = os.getcwd()
@@ -101,6 +102,8 @@ def test_env():
     assert "FOO=BAR\n" in cmd.getoutput()
 
 
+@system_binary('true')
+@system_binary('false')
 def test_retcode(true_binary, false_binary):
     cmd = Command([false_binary])
     cmd.execute()
@@ -145,7 +148,7 @@ def test_command_notimeout():
     assert cmd.getretcode() == 0
 
 
-@pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")
+@posix_only
 def test_stderr():
     cmd = Command(["/bin/cat", "/foo/bar", "/etc/passwd"],
                   redirect_stderr=False)
@@ -160,7 +163,7 @@ def test_stderr():
 
 
 # This test needs the "/bin/cat" command, therefore it is Unix only.
-@pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")
+@posix_only
 def test_long_output():
     """
     Test that output thread in the Command class captures all of the output.
@@ -188,7 +191,7 @@ def test_long_output():
         assert len("".join(cmd.getoutput())) == num_bytes
 
 
-@pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")
+@posix_only
 def test_resource_limits():
     """
     Simple smoke test for setting resource limits.

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -359,18 +359,6 @@ def test_mirroring_custom_repository_command(expected_command, config):
     assert expected_command == Repository._repository_command(config, lambda: DEFAULT_COMMAND)
 
 
-@pytest.mark.parametrize(
-    ('touch_binary'), [
-        pytest.param('/bin/touch',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/bin/touch'),
-                         reason="requires /bin binaries")),
-        pytest.param('/usr/bin/touch',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/usr/bin/touch'),
-                         reason="requires /usr/bin binaries")),
-    ]
-)
 def test_mirroring_custom_incoming_invoke_command(touch_binary):
     checking_file = 'incoming.txt'
     with tempfile.TemporaryDirectory() as repository_root:
@@ -381,18 +369,6 @@ def test_mirroring_custom_incoming_invoke_command(touch_binary):
         assert checking_file in os.listdir(repository_root)
 
 
-@pytest.mark.parametrize(
-    ('echo_binary'), [
-        pytest.param('/bin/echo',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/bin/echo'),
-                         reason="requires /bin binaries")),
-        pytest.param('/usr/bin/echo',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/usr/bin/echo'),
-                         reason="requires /usr/bin binaries")),
-    ]
-)
 def test_mirroring_custom_incoming_changes(echo_binary):
     with tempfile.TemporaryDirectory() as repository_root:
         repository = GitRepository(mock(), repository_root, 'test-1', {
@@ -401,18 +377,6 @@ def test_mirroring_custom_incoming_changes(echo_binary):
         assert repository.incoming() is True
 
 
-@pytest.mark.parametrize(
-    ('true_binary'), [
-        pytest.param('/bin/true',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/bin/true'),
-                         reason="requires /bin binaries")),
-        pytest.param('/usr/bin/true',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/usr/bin/true'),
-                         reason="requires /usr/bin binaries")),
-    ]
-)
 def test_mirroring_custom_incoming_no_changes(true_binary):
     with tempfile.TemporaryDirectory() as repository_root:
         repository = GitRepository(mock(), repository_root, 'test-1', {
@@ -421,18 +385,6 @@ def test_mirroring_custom_incoming_no_changes(true_binary):
         assert repository.incoming() is False
 
 
-@pytest.mark.parametrize(
-    ('false_binary'), [
-        pytest.param('/bin/false',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/bin/false'),
-                         reason="requires /bin binaries")),
-        pytest.param('/usr/bin/false',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/usr/bin/false'),
-                         reason="requires /usr/bin binaries")),
-    ]
-)
 def test_mirroring_custom_incoming_error(false_binary):
     with pytest.raises(RepositoryException):
         with tempfile.TemporaryDirectory() as repository_root:
@@ -451,18 +403,6 @@ def test_mirroring_incoming_invoke_original_command():
             verify(repository).incoming_check()
 
 
-@pytest.mark.parametrize(
-    ('touch_binary'), [
-        pytest.param('/bin/touch',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/bin/touch'),
-                         reason="requires /bin binaries")),
-        pytest.param('/usr/bin/touch',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/usr/bin/touch'),
-                         reason="requires /usr/bin binaries")),
-    ]
-)
 def test_mirroring_custom_sync_invoke_command(touch_binary):
     checking_file = 'sync.txt'
     with tempfile.TemporaryDirectory() as repository_root:
@@ -473,18 +413,6 @@ def test_mirroring_custom_sync_invoke_command(touch_binary):
         assert checking_file in os.listdir(repository_root)
 
 
-@pytest.mark.parametrize(
-    ('true_binary'), [
-        pytest.param('/bin/true',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/bin/true'),
-                         reason="requires /bin binaries")),
-        pytest.param('/usr/bin/true',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/usr/bin/true'),
-                         reason="requires /usr/bin binaries")),
-    ]
-)
 def test_mirroring_custom_sync_success(true_binary):
     with tempfile.TemporaryDirectory() as repository_root:
         repository = GitRepository(mock(), repository_root, 'test-1', {
@@ -493,18 +421,6 @@ def test_mirroring_custom_sync_success(true_binary):
         assert 0 == repository.sync()
 
 
-@pytest.mark.parametrize(
-    ('false_binary'), [
-        pytest.param('/bin/false',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/bin/false'),
-                         reason="requires /bin binaries")),
-        pytest.param('/usr/bin/false',
-                     marks=pytest.mark.skipif(
-                         not os.path.exists('/usr/bin/false'),
-                         reason="requires /usr/bin binaries")),
-    ]
-)
 def test_mirroring_custom_sync_error(false_binary):
     with tempfile.TemporaryDirectory() as repository_root:
         repository = GitRepository(mock(), repository_root, 'test-1', {

--- a/opengrok-tools/src/test/python/test_mirror.py
+++ b/opengrok-tools/src/test/python/test_mirror.py
@@ -33,6 +33,7 @@ import requests
 from mockito import verify, patch, spy2, mock, ANY, when
 
 import opengrok_tools.mirror
+from conftest import posix_only, system_binary
 from opengrok_tools.scm import Repository
 from opengrok_tools.scm.git import GitRepository
 from opengrok_tools.scm.repository import RepositoryException
@@ -94,7 +95,7 @@ def test_invalid_project_config_hooknames():
         assert not check_project_configuration(config, hookdir=tmpdir)
 
 
-@pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")
+@posix_only
 def test_invalid_project_config_nonexec_hook():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "foo.sh"), 'w+') as tmpfile:
@@ -103,7 +104,7 @@ def test_invalid_project_config_nonexec_hook():
             assert not check_project_configuration(config, hookdir=tmpdir)
 
 
-@pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")
+@posix_only
 def test_valid_project_config_hook():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "foo.sh"), 'w+') as tmpfile:
@@ -359,6 +360,7 @@ def test_mirroring_custom_repository_command(expected_command, config):
     assert expected_command == Repository._repository_command(config, lambda: DEFAULT_COMMAND)
 
 
+@system_binary('touch')
 def test_mirroring_custom_incoming_invoke_command(touch_binary):
     checking_file = 'incoming.txt'
     with tempfile.TemporaryDirectory() as repository_root:
@@ -369,6 +371,7 @@ def test_mirroring_custom_incoming_invoke_command(touch_binary):
         assert checking_file in os.listdir(repository_root)
 
 
+@system_binary('echo')
 def test_mirroring_custom_incoming_changes(echo_binary):
     with tempfile.TemporaryDirectory() as repository_root:
         repository = GitRepository(mock(), repository_root, 'test-1', {
@@ -377,6 +380,7 @@ def test_mirroring_custom_incoming_changes(echo_binary):
         assert repository.incoming() is True
 
 
+@system_binary('true')
 def test_mirroring_custom_incoming_no_changes(true_binary):
     with tempfile.TemporaryDirectory() as repository_root:
         repository = GitRepository(mock(), repository_root, 'test-1', {
@@ -385,6 +389,7 @@ def test_mirroring_custom_incoming_no_changes(true_binary):
         assert repository.incoming() is False
 
 
+@system_binary('false')
 def test_mirroring_custom_incoming_error(false_binary):
     with pytest.raises(RepositoryException):
         with tempfile.TemporaryDirectory() as repository_root:
@@ -403,6 +408,7 @@ def test_mirroring_incoming_invoke_original_command():
             verify(repository).incoming_check()
 
 
+@system_binary('touch')
 def test_mirroring_custom_sync_invoke_command(touch_binary):
     checking_file = 'sync.txt'
     with tempfile.TemporaryDirectory() as repository_root:
@@ -413,6 +419,7 @@ def test_mirroring_custom_sync_invoke_command(touch_binary):
         assert checking_file in os.listdir(repository_root)
 
 
+@system_binary('true')
 def test_mirroring_custom_sync_success(true_binary):
     with tempfile.TemporaryDirectory() as repository_root:
         repository = GitRepository(mock(), repository_root, 'test-1', {
@@ -421,6 +428,7 @@ def test_mirroring_custom_sync_success(true_binary):
         assert 0 == repository.sync()
 
 
+@system_binary('false')
 def test_mirroring_custom_sync_error(false_binary):
     with tempfile.TemporaryDirectory() as repository_root:
         repository = GitRepository(mock(), repository_root, 'test-1', {


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
