### PR TITLE
Use annotations instead of declarations in web.xml

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -39,6 +39,7 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletRequestEvent;
 import javax.servlet.ServletRequestListener;
+import javax.servlet.annotation.WebListener;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
@@ -51,6 +52,7 @@ import java.util.logging.Logger;
  *
  * @author Trond Norbye
  */
+@WebListener
 public final class WebappListener
         implements ServletContextListener, ServletRequestListener {
 

--- a/opengrok-web/src/main/java/org/opengrok/web/filter/AuthorizationFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/filter/AuthorizationFilter.java
@@ -21,7 +21,7 @@
  * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
-package org.opengrok.web;
+package org.opengrok.web.filter;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -32,14 +32,17 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.web.Laundromat;
+import org.opengrok.web.PageConfig;
 import org.opengrok.web.api.v1.RestApp;
 
+@WebFilter(urlPatterns = "/*")
 public class AuthorizationFilter implements Filter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationFilter.class);

--- a/opengrok-web/src/main/java/org/opengrok/web/filter/CookieFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/filter/CookieFilter.java
@@ -20,14 +20,17 @@
 /*
  * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  */
-package org.opengrok.web;
+package org.opengrok.web.filter;
 
+import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.annotation.WebInitParam;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.HttpHeaders;
 import java.io.IOException;
@@ -37,6 +40,14 @@ import java.util.Enumeration;
 /**
  * Makes sure that all cookies originating from the web application have the Same-site attribute set.
  */
+@WebFilter(
+        urlPatterns = "/*",
+        initParams = {
+                @WebInitParam(name = "SameSite", value = "Strict"),
+                @WebInitParam(name = "Secure", value = "")
+        },
+        dispatcherTypes = DispatcherType.REQUEST
+)
 public class CookieFilter implements Filter {
     private FilterConfig fc;
 

--- a/opengrok-web/src/main/java/org/opengrok/web/filter/ExpiresHalfHourFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/filter/ExpiresHalfHourFilter.java
@@ -1,0 +1,43 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.filter;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.annotation.WebInitParam;
+
+@WebFilter(
+        initParams = @WebInitParam(name = "Cache-Control", value = "max-age=1800"),
+        urlPatterns = {
+            "/history/*",
+            "/raw/*",
+            "/download/*",
+            "/rss/*",
+            "/error",
+            "/enoent",
+            "/eforbidden"
+        },
+        dispatcherTypes = DispatcherType.REQUEST
+)
+public class ExpiresHalfHourFilter extends ResponseHeaderFilter {
+}

--- a/opengrok-web/src/main/java/org/opengrok/web/filter/ExpiresOneDayFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/filter/ExpiresOneDayFilter.java
@@ -1,0 +1,39 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.filter;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.annotation.WebInitParam;
+
+@WebFilter(
+        initParams = @WebInitParam(name = "Cache-Control", value = "max-age=86400"),
+        urlPatterns = {
+                "/default/*",
+                "/js/*",
+                "/webjars/*"
+        },
+        dispatcherTypes = DispatcherType.REQUEST
+)
+public class ExpiresOneDayFilter extends ResponseHeaderFilter {
+}

--- a/opengrok-web/src/main/java/org/opengrok/web/filter/ResponseHeaderFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/filter/ResponseHeaderFilter.java
@@ -8,7 +8,7 @@
  * Copyright © 2017, Chris Fraire <cfraire@me.com>.
  */
 
-package org.opengrok.web;
+package org.opengrok.web.filter;
 
 import java.io.IOException;
 import java.util.Enumeration;

--- a/opengrok-web/src/main/java/org/opengrok/web/filter/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/filter/StatisticsFilter.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  */
-package org.opengrok.web;
+package org.opengrok.web.filter;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -31,6 +31,7 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -38,7 +39,9 @@ import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Timer;
 import org.opengrok.indexer.Metrics;
 import org.opengrok.indexer.web.SearchHelper;
+import org.opengrok.web.PageConfig;
 
+@WebFilter(urlPatterns = "/*")
 public class StatisticsFilter implements Filter {
 
     static final String REQUESTS_METRIC = "requests";

--- a/opengrok-web/src/main/java/org/opengrok/web/servlet/GetFile.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/servlet/GetFile.java
@@ -22,7 +22,7 @@
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2011, Jens Elkner.
  */
-package org.opengrok.web;
+package org.opengrok.web.servlet;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -32,11 +32,14 @@ import java.io.OutputStream;
 
 import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.web.Prefix;
+import org.opengrok.web.PageConfig;
 
+import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+@WebServlet(urlPatterns = {"/raw/*", "/download/*"})
 public class GetFile extends HttpServlet {
 
     public static final long serialVersionUID = -1;

--- a/opengrok-web/src/main/webapp/WEB-INF/web.xml
+++ b/opengrok-web/src/main/webapp/WEB-INF/web.xml
@@ -12,76 +12,6 @@
         <param-name>CONFIGURATION</param-name>
         <param-value>/var/opengrok/etc/configuration.xml</param-value>
     </context-param>
-    <listener>
-        <listener-class>org.opengrok.web.WebappListener</listener-class>
-    </listener>
-    <filter>
-        <filter-name>StatisticsFilter</filter-name>
-        <filter-class>org.opengrok.web.StatisticsFilter</filter-class>
-    </filter>
-    <filter-mapping>
-        <filter-name>StatisticsFilter</filter-name>
-        <url-pattern>/*</url-pattern>
-    </filter-mapping>
-    <filter>
-        <filter-name>AuthorizationFilter</filter-name>
-        <filter-class>org.opengrok.web.AuthorizationFilter</filter-class>
-    </filter>
-    <filter-mapping>
-        <filter-name>AuthorizationFilter</filter-name>
-        <url-pattern>/*</url-pattern>
-    </filter-mapping>
-    <filter>
-        <filter-name>ExpiresHalfHourFilter</filter-name>
-        <filter-class>org.opengrok.web.ResponseHeaderFilter</filter-class>
-        <init-param>
-            <param-name>Cache-Control</param-name>
-            <param-value>max-age=1800</param-value>
-        </init-param>
-    </filter>
-    <filter>
-        <filter-name>ExpiresOneDayFilter</filter-name>
-        <filter-class>org.opengrok.web.ResponseHeaderFilter</filter-class>
-        <init-param>
-            <param-name>Cache-Control</param-name>
-            <param-value>max-age=86400</param-value>
-        </init-param>
-    </filter>
-    <filter-mapping>
-        <filter-name>ExpiresOneDayFilter</filter-name>
-        <url-pattern>/default/*</url-pattern>
-        <url-pattern>/js/*</url-pattern>
-        <url-pattern>/webjars/*</url-pattern>
-        <dispatcher>REQUEST</dispatcher>
-    </filter-mapping>
-    <filter-mapping>
-        <filter-name>ExpiresHalfHourFilter</filter-name>
-        <url-pattern>/history/*</url-pattern>
-        <url-pattern>/raw/*</url-pattern>
-        <url-pattern>/download/*</url-pattern>
-        <url-pattern>/rss/*</url-pattern>
-        <url-pattern>/error</url-pattern>
-        <url-pattern>/enoent</url-pattern>
-        <url-pattern>/eforbidden</url-pattern>
-        <dispatcher>REQUEST</dispatcher>
-    </filter-mapping>
-    <filter>
-        <filter-name>CookieFilter</filter-name>
-        <filter-class>org.opengrok.web.CookieFilter</filter-class>
-        <init-param>
-            <param-name>SameSite</param-name>
-            <param-value>Strict</param-value>
-        </init-param>
-        <init-param>
-            <param-name>Secure</param-name>
-            <param-value></param-value>
-        </init-param>
-    </filter>
-    <filter-mapping>
-        <filter-name>CookieFilter</filter-name>
-        <url-pattern>/*</url-pattern>
-        <dispatcher>REQUEST</dispatcher>
-    </filter-mapping>
     <servlet>
         <display-name>Source Finder</display-name>
         <servlet-name>search</servlet-name>
@@ -142,24 +72,6 @@
         </init-param>
     </servlet>
     <servlet>
-        <display-name>Raw Source lister</display-name>
-        <servlet-name>raw</servlet-name>
-        <servlet-class>org.opengrok.web.GetFile</servlet-class>
-        <init-param>
-            <param-name>keepgenerated</param-name>
-            <param-value>true</param-value>
-        </init-param>
-    </servlet>
-    <servlet>
-        <display-name>Download source</display-name>
-        <servlet-name>download</servlet-name>
-        <servlet-class>org.opengrok.web.GetFile</servlet-class>
-        <init-param>
-            <param-name>keepgenerated</param-name>
-            <param-value>true</param-value>
-        </init-param>
-    </servlet>
-    <servlet>
         <display-name>Error Handler</display-name>
         <servlet-name>error</servlet-name>
         <jsp-file>/error.jsp</jsp-file>
@@ -205,16 +117,6 @@
         <servlet-name>lister</servlet-name>
         <url-pattern>/xref/*</url-pattern>
         <!-- XREF_P -->
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>raw</servlet-name>
-        <url-pattern>/raw/*</url-pattern>
-        <!-- RAW_P -->
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>download</servlet-name>
-        <url-pattern>/download/*</url-pattern>
-        <!-- DOWNLOAD_P -->
     </servlet-mapping>
     <servlet-mapping>
         <servlet-name>search</servlet-name>

--- a/opengrok-web/src/test/java/org/opengrok/web/filter/CookieFilterTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/filter/CookieFilterTest.java
@@ -20,7 +20,7 @@
 /*
  * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  */
-package org.opengrok.web;
+package org.opengrok.web.filter;
 
 import org.junit.Test;
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
Using annotations is much more popular nowadays than declaring things in xml files. Therefore, I thought that this might be a good step forward.

I do not know how to deal with the jsp servlets properly so I left them be for the time being.

If you do not like this approach, then feel free to close :)

Thanks.