### PR TITLE
Fix for #3306: Speed up HistoryGuru.getRepository(File) call for Open…

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -137,6 +137,12 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency> <!-- TODO: remove! (moving Messages to web module) -->
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
@@ -153,6 +159,12 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.28.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -407,8 +408,8 @@ public final class RuntimeEnvironment {
             throw new FileNotFoundException("sourceRoot is not defined");
         }
 
-        String maybeRelPath = PathUtils.getRelativeToCanonical(file.getPath(),
-                sourceRoot, getAllowedSymlinks(), getCanonicalRoots());
+        String maybeRelPath = PathUtils.getRelativeToCanonical(file.toPath(),
+                Paths.get(sourceRoot), getAllowedSymlinks(), getCanonicalRoots());
         File maybeRelFile = new File(maybeRelPath);
         if (!maybeRelFile.isAbsolute()) {
             /*

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -36,6 +35,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -90,6 +90,11 @@ public final class HistoryGuru {
     private final Map<String, String> repositoryRoots = new ConcurrentHashMap<>();
 
     /**
+     * Interface to perform repository lookup for a given file path and HistoryGuru state.
+     */
+    private final RepositoryLookup repositoryLookup;
+
+    /**
      * Creates a new instance of HistoryGuru, and try to set the default source
      * control system.
      */
@@ -110,6 +115,7 @@ public final class HistoryGuru {
             }
         }
         historyCache = cache;
+        repositoryLookup = RepositoryLookup.cached();
     }
 
     /**
@@ -728,38 +734,8 @@ public final class HistoryGuru {
         return repos;
     }
 
-    protected Repository getRepository(File path) {
-        File file = path;
-        Set<String> rootKeys = repositoryRoots.keySet();
-
-        while (file != null) {
-            String nextPath = file.getPath();
-            for (String rootKey : rootKeys) {
-                String rel;
-                try {
-                    rel = PathUtils.getRelativeToCanonical(nextPath, rootKey);
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING,
-                        "Failed to get relative to canonical for " + nextPath,
-                        e);
-                    return null;
-                }
-                Repository repo;
-                if (rel.equals(nextPath)) {
-                    repo = repositories.get(nextPath);
-                } else {
-                    String inRootPath = Paths.get(rootKey, rel).toString();
-                    repo = repositories.get(inRootPath);
-                }
-                if (repo != null) {
-                    return repo;
-                }
-            }
-
-            file = file.getParentFile();
-        }
-
-        return null;
+    protected Repository getRepository(File file) {
+        return repositoryLookup.getRepository(file.toPath(), repositoryRoots.keySet(), repositories, PathUtils::getRelativeToCanonical);
     }
 
     /**
@@ -769,10 +745,9 @@ public final class HistoryGuru {
      * @param repos repository paths
      */
     public void removeRepositories(Collection<String> repos) {
-        for (String repo : repos) {
-            repositories.remove(repo);
-        }
-
+        Set<Repository> removedRepos = repos.stream().map(repositories::remove)
+            .filter(Objects::nonNull).collect(Collectors.toSet());
+        repositoryLookup.repositoriesRemoved(removedRepos);
         // Re-map the repository roots.
         repositoryRoots.clear();
         List<Repository> ccopy = new ArrayList<>(repositories.values());
@@ -820,8 +795,7 @@ public final class HistoryGuru {
      */
     public void invalidateRepositories(Collection<? extends RepositoryInfo> repos, CommandTimeoutType cmdType) {
         if (repos == null || repos.isEmpty()) {
-            repositoryRoots.clear();
-            repositories.clear();
+            clear();
             return;
         }
 
@@ -880,12 +854,17 @@ public final class HistoryGuru {
         }
         executor.shutdown();
 
-        repositoryRoots.clear();
-        repositories.clear();
+        clear();
         newrepos.forEach((_key, repo) -> putRepository(repo));
 
         elapsed.report(LOGGER, String.format("done invalidating %d repositories", newrepos.size()),
                 "history.repositories.invalidate");
+    }
+
+    private void clear() {
+        repositoryRoots.clear();
+        repositories.clear();
+        repositoryLookup.clear();
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -169,7 +169,7 @@ public class RepositoryInfo implements Serializable {
         String path;
         String originalPath = dir.getPath();
         try {
-            path = PathUtils.getRelativeToCanonical(originalPath, rootPath);
+            path = PathUtils.getRelativeToCanonical(dir.toPath(), Paths.get(rootPath));
             // OpenGrok has a weird convention that directoryNameRelative must start with a path separator,
             // as it is elsewhere directly appended to env.getSourceRootPath() and also stored as such.
             if (!path.equals(originalPath)) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryLookup.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryLookup.java
@@ -1,0 +1,83 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Anatoly Akkerman <akkerman@gmail.com>, <anatoly.akkerman@twosigma.com>.
+ */
+package org.opengrok.indexer.history;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Interface for finding enclosing Repository for a given Path, used by HistoryGuru.
+ * <p>
+ * Two implementations exists
+ * - uncached, (legacy behavior) extracted from HistoryGuru into a stand-alone impl
+ * - cached, new implementation, which reduces number of expensive canonicalization calls
+ * <p>
+ * We preserve both cached and uncached implementations in order to verify correctness of the cached impl.
+ */
+public interface RepositoryLookup {
+
+    static RepositoryLookupCached cached() {
+        return new RepositoryLookupCached();
+    }
+
+    static RepositoryLookupUncached uncached() {
+        return new RepositoryLookupUncached();
+    }
+
+    /**
+     * This interface allows intercepting PathUtils.getRelativeToCanonical in order to measure the impact of caching.
+     *
+     * In practice, PathUtils::getRelativeToCanonical is the implementation of this interface
+     */
+    @FunctionalInterface
+    interface PathCanonicalizer {
+        String resolve(Path path, Path relativeTo) throws IOException;
+    }
+
+    /**
+     * Find enclosing repository for a given path.
+     *
+     * @param path path to find encolsing repository for
+     * @param repoParentDirs Set of repository parent dirs (parents of repository roots)
+     * @param repositories Map of repository root to Repository
+     * @param canonicalizer PathCanonicalizer reference
+     * @return enclosing Repository or null if not found
+     */
+    Repository getRepository(Path path, Set<String> repoParentDirs, Map<String, Repository> repositories,
+        PathCanonicalizer canonicalizer);
+
+    /**
+     * Lifecycle method to clear internal cache (if any) when repositories are invalidated.
+     */
+    void clear();
+
+    /**
+     * Lifecycle method to invalidate any cache entries that point to given repositories that are being removed.
+     *
+     * @param removedRepos
+     */
+    void repositoriesRemoved(Collection<Repository> removedRepos);
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryLookupCached.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryLookupCached.java
@@ -1,0 +1,224 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Anatoly Akkerman <akkerman@gmail.com>, <anatoly.akkerman@twosigma.com>.
+ */
+package org.opengrok.indexer.history;
+
+import org.opengrok.indexer.logger.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class RepositoryLookupCached implements RepositoryLookup {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryLookupCached.class);
+
+    /**
+     * Cache of directories to their enclosing repositories.
+     *
+     * This cache will contain Optional.empty() for any directory that has so far not been mapped to a repo.
+     * See findRepository for more information.
+     */
+    private final ConcurrentMap<String, Optional<Repository>> dirToRepoCache = new ConcurrentHashMap<>();
+
+    /**
+     * Find enclosing Repository for a given file, limiting canonicalization operations
+     * to a given set of Repository parent dirs.
+     * Search results are cached in an internal cache to speed up subsequent lookups for all directories
+     * between path and the root path of the enclosing Repository (if found). Negative results are also
+     * cached as empty Optional values in the cache. However, negative results are not treated as definitive.
+     * <p>
+     * The cache is only invalidated on Repository invalidation or removal
+     * which means that if the filesystem changes under HistoryGuru, it may return stale results
+     *
+     * @param filePath      path to find enclosing repository for
+     * @param repoRoots     set of Repository parent dirs
+     * @param repositories  map of repository roots to repositories
+     * @param canonicalizer path canonicalizer implementation to use
+     * @return Optional Repository (empty if not found)
+     */
+    private Optional<Repository> findRepository(final Path filePath, final Set<String> repoRoots,
+        Map<String, Repository> repositories, PathCanonicalizer canonicalizer) {
+        Path path = filePath;
+        FileSystem fileSystem = filePath.getFileSystem();
+        Optional<Repository> maybeRepo = Optional.empty();
+
+        // If we find repo mapping, we backfill the cache with these entries as well
+        List<String> backfillPaths = new ArrayList<>();
+        // Walk up the file's path until we find a matching enclosing Repository
+        while (!maybeRepo.isPresent() && path != null) {
+            String nextPath = path.toString();
+            boolean isDirectory = Files.isDirectory(path);
+            if (isDirectory) {
+                /*
+                 * Only store (and lookup) directory entries in the cache to avoid cache explosion
+                 * This may fail to find a Repository (e.g. nextPath is inside a root), so this will
+                 * insert an Optional.empty() into the map. However, as we walk up, we may eventually
+                 * find a Repo, in which case we need to backfill these placeholder Optional.empty() entries
+                 * with the final answer
+                 */
+                maybeRepo = dirToRepoCache
+                    .computeIfAbsent(nextPath, p -> repoForPath(p, repoRoots, repositories, fileSystem, canonicalizer));
+            } else {
+                maybeRepo = repoForPath(nextPath, repoRoots, repositories, fileSystem, canonicalizer);
+            }
+            /*
+             * Given that this class has to be thread-safe, Optional.empty() value cannot be assumed to be a definitive
+             * answer that a given directory is not inside a repo, because of backfilling.
+             * E.g.
+             * During lookup of repository /a/b/c/d in repository /a, the following happens:
+             * - /a/b/c/d: no entry in the cache, insert empty
+             * - /a/b/c: no entry in the cache, insert empty
+             * - /a/b: no entry in the cache, insert empty
+             * - /a: found Repo(a), insert it into cache
+             *
+             * Now, the code needs to replace (backfill) entries for /a/b/c/d, /a/b/c and /a/b
+             * However, before that happens, a concurrent findRepository() call can come in and find empty mappings
+             * for /a/b/c/d, /a/b/c and /a/b, before they were backfilled. So, instead of returning an incorrect
+             * cached result, we continue confirming negative result fully. This is a reasonable choice because
+             * most lookups will be made for files that do live inside repositories, so non-empty cached values will
+             * be the dominant cache hits.
+             *
+             * An alternative to provide definitive negative cache result would be to use a special sentinel
+             * Repository object that represents NO_REPOSITORY as a definitive negative cached value, while Optional.empty
+             * would represent a tentative negative value.
+             */
+            if (!maybeRepo.isPresent()) {
+                if (isDirectory) {
+                    backfillPaths.add(nextPath);
+                }
+                path = path.getParent();
+            }
+        }
+        /*
+         * If the lookup was for /a/b/c/d and we found the repo at /a, then
+         *   - /a -> Repo(/a) is done by the computeIfAbsent call
+         * And backfill fills in:
+         *   - /a/b -> Repo(/a)
+         *   - /a/b/c-> Repo(/a)
+         */
+        maybeRepo.ifPresent(repo ->
+            // Replace empty values with newly found Repository
+            backfillPaths.forEach(backfillPath -> dirToRepoCache.replace(backfillPath, Optional.empty(), Optional.of(repo))));
+
+        return maybeRepo;
+    }
+
+    /**
+     * Try to find path's enclosing repository by attempting to canonicalize it relative to
+     * a given set of repository roots. This method can be pretty expensive, with complexity
+     * of O(N*M) where N is path's depth and M is number of repository parent dirs.
+     *
+     * @param path           path to find enclosing Repository for
+     * @param repoParentDirs limit canonicalization search only to these Repository parent dirs
+     * @param canonicalizer  path canonicalizer implementation to use
+     * @return Optional of matching Repository (empty if not found)
+     */
+    private Optional<Repository> repoForPath(String path, Set<String> repoParentDirs,
+        Map<String, Repository> repositories,
+        FileSystem fileSystem, PathCanonicalizer canonicalizer) {
+        Optional<Repository> repo = Optional.ofNullable(repositories.get(path));
+
+        if (repo.isPresent()) {
+            return repo;
+        }
+
+        for (String repoRoot : repoParentDirs) {
+            try {
+                String rel = canonicalizer.resolve(fileSystem.getPath(path), fileSystem.getPath(repoRoot));
+                if (!rel.equals(path)) {
+                    // Resolve the relative against root key and look it up
+                    String canonicalPath = Paths.get(repoRoot, rel).toString();
+                    repo = Optional.ofNullable(repositories.get(canonicalPath));
+                    if (repo.isPresent()) {
+                        return repo;
+                    }
+                }
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING,
+                    "Failed to get relative to canonical for " + path + " and " + repoRoot,
+                    e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Repository getRepository(Path path, Set<String> repoParentDirs, Map<String, Repository> repositories,
+        PathCanonicalizer canonicalizer) {
+        Comparator<String> stringComparator = String::compareTo;
+        Comparator<String> reversedComparator = stringComparator.reversed();
+        TreeSet<String> allRoots = new TreeSet<>(repoParentDirs);
+        String pathStr = path.toString();
+        // parentRepoDirs are canonicalized, so we need to filter them against canonical path representation
+        Path canonicalPath;
+        try {
+            canonicalPath = path.toRealPath();
+        } catch (IOException e) {
+            canonicalPath = path.normalize().toAbsolutePath();
+        }
+
+        if (!canonicalPath.equals(path)) {
+            pathStr = canonicalPath.toString();
+        }
+
+        /*
+         * Find all potential Repository parent dirs by matching their roots to file's prefix
+         * This is useful to limit the number of iterations in repoForPath call.
+         * Store matches in reverse-ordered TreeSet so that longest prefixes appear first
+         * (There may be multiple entries if we allow nested repositories)
+         */
+        TreeSet<String> filteredParentDirs = allRoots.stream().filter(pathStr::startsWith)
+            .collect(Collectors.toCollection(() -> new TreeSet<>(reversedComparator)));
+
+        return findRepository(path, filteredParentDirs, repositories, canonicalizer).orElse(null);
+    }
+
+    @Override
+    public void repositoriesRemoved(Collection<Repository> removedRepos) {
+        dirToRepoCache.entrySet().stream().filter(entry -> entry.getValue().filter(removedRepos::contains).isPresent())
+            .map(Map.Entry::getKey).forEach(dirToRepoCache::remove);
+    }
+
+    @Override
+    public void clear() {
+        dirToRepoCache.clear();
+    }
+
+    public int size() {
+        return dirToRepoCache.size();
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryLookupUncached.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryLookupUncached.java
@@ -1,0 +1,86 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Anatoly Akkerman <akkerman@gmail.com>, <anatoly.akkerman@twosigma.com>.
+ */
+package org.opengrok.indexer.history;
+
+import org.opengrok.indexer.logger.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * RepositoryLookup uncached implementation (original logic taken from HistoryGuru.getRepository).
+ */
+public class RepositoryLookupUncached implements RepositoryLookup {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryLookupUncached.class);
+
+    @Override
+    public Repository getRepository(final Path filePath, Set<String> repoParentDirs,
+        Map<String, Repository> repositories, PathCanonicalizer canonicalizer) {
+        Path path = filePath;
+
+        while (path != null) {
+            String nextPath = path.toString();
+            for (String rootKey : repoParentDirs) {
+                String rel;
+                try {
+                    rel = canonicalizer.resolve(path, path.getFileSystem().getPath(rootKey));
+                } catch (IOException e) {
+                    LOGGER.log(Level.WARNING,
+                        "Failed to get relative to canonical for " + nextPath,
+                        e);
+                    return null;
+                }
+                Repository repo;
+                if (rel.equals(nextPath)) {
+                    repo = repositories.get(nextPath);
+                } else {
+                    String inRootPath = Paths.get(rootKey, rel).toString();
+                    repo = repositories.get(inRootPath);
+                }
+                if (repo != null) {
+                    return repo;
+                }
+            }
+
+            path = path.getParent();
+        }
+
+        return null;
+    }
+
+    @Override
+    public void clear() {
+        // Do nothing
+    }
+
+    @Override
+    public void repositoriesRemoved(Collection<Repository> removedRepos) {
+        // Do nothings
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
@@ -81,7 +81,12 @@ public class HistoryContext {
             return false;
         }
         File f = new File(filename);
-        return getHistoryContext(HistoryGuru.getInstance().getHistory(f), path, null, hits, null);
+        History history = HistoryGuru.getInstance().getHistory(f);
+        if (history == null) {
+            LOGGER.log(Level.INFO, "Null history got for {0}", f);
+            return false;
+        }
+        return getHistoryContext(history, path, null, hits, null);
 
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/PathUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/PathUtils.java
@@ -22,18 +22,21 @@
  */
 package org.opengrok.indexer.util;
 
-import java.io.File;
+import org.opengrok.indexer.logger.LoggerFactory;
+
 import java.io.IOException;
+import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import org.opengrok.indexer.logger.LoggerFactory;
 
 /**
  * Represents a container for file system paths-related utility methods.
@@ -43,7 +46,7 @@ public class PathUtils {
         LoggerFactory.getLogger(PathUtils.class);
 
     /**
-     * Calls {@link #getRelativeToCanonical(String, String, Set, Set)}
+     * Calls {@link #getRelativeToCanonical(Path, Path, Set, Set)}
      * with {@code path}, {@code canonical}, {@code allowedSymlinks=null}, and
      * {@code canonicalRoots=null} (to disable validation of links).
      * @param path a non-canonical (or canonical) path to compare
@@ -53,13 +56,13 @@ public class PathUtils {
      * @throws IOException if an error occurs determining canonical paths
      * for portions of {@code path}
      */
-    public static String getRelativeToCanonical(String path, String canonical)
+    public static String getRelativeToCanonical(Path path, Path canonical)
         throws IOException {
         try {
             return getRelativeToCanonical(path, canonical, null, null);
         } catch (ForbiddenSymlinkException e) {
             // should not get here with allowedSymlinks==null
-            return path;
+            return path.toString();
         }
     }
 
@@ -99,7 +102,7 @@ public class PathUtils {
      * and it encounters an ineligible link
      * @throws InvalidPathException if path cannot be decoded
      */
-    public static String getRelativeToCanonical(String path, String canonical,
+    public static String getRelativeToCanonical(Path path, Path canonical,
             Set<String> allowedSymlinks, Set<String> canonicalRoots)
             throws IOException, ForbiddenSymlinkException, InvalidPathException {
 
@@ -114,24 +117,32 @@ public class PathUtils {
         // following fixup would not be needed, since File and Paths recognize
         // backslash as a delimiter. On Linux and macOS, any backslash needs to
         // be normalized.
-        path = path.replace('\\', File.separatorChar);
-        canonical = canonical.replace('\\', File.separatorChar);
-        String normCanonical = canonical.endsWith(File.separator) ?
-            canonical : canonical + File.separator;
+        final FileSystem fileSystem = path.getFileSystem();
+        final String separator = fileSystem.getSeparator();
+        String strPath = path.toString();
+        strPath = strPath.replace("\\", separator);
+
+        String strCanonical = canonical.toString();
+        strCanonical = strCanonical.replace("\\", separator);
+        String normCanonical = strCanonical.endsWith(separator) ?
+            strCanonical : strCanonical + separator;
         Deque<String> tail = null;
 
-        File iterPath = new File(path);
+        Path iterPath = fileSystem.getPath(strPath);
         while (iterPath != null) {
-            String iterCanon = iterPath.getCanonicalPath();
+            Path iterCanon;
+            try {
+                iterCanon = iterPath.toRealPath();
+            } catch (NoSuchFileException e) {
+                iterCanon = iterPath.normalize().toAbsolutePath();
+            }
 
             // optional symbolic-link check
             if (allowedSymlinks != null) {
-                String iterOriginal = iterPath.getPath();
-                if (Files.isSymbolicLink(Paths.get(iterOriginal)) &&
-                        !isWhitelisted(iterCanon, canonicalRoots) &&
-                        !isAllowedSymlink(iterCanon, allowedSymlinks)) {
-                    String format = String.format("%1$s is prohibited symlink",
-                        iterOriginal);
+                if (Files.isSymbolicLink(iterPath) &&
+                    !isWhitelisted(iterCanon.toString(), canonicalRoots) &&
+                    !isAllowedSymlink(iterCanon, allowedSymlinks)) {
+                    String format = String.format("%1$s is prohibited symlink", iterPath);
                     LOGGER.finest(format);
                     throw new ForbiddenSymlinkException(format);
                 }
@@ -139,8 +150,8 @@ public class PathUtils {
 
             String rel = null;
             if (iterCanon.startsWith(normCanonical)) {
-                rel = iterCanon.substring(normCanonical.length());
-            } else if (normCanonical.equals(iterCanon + File.separator)) {
+                rel = fileSystem.getPath(normCanonical).relativize(iterCanon).toString();
+            } else if (normCanonical.equals(iterCanon + separator)) {
                 rel = "";
             }
             if (rel != null) {
@@ -155,20 +166,22 @@ public class PathUtils {
             if (tail == null) {
                 tail = new LinkedList<>();
             }
-            tail.push(iterPath.getName());
-            iterPath = iterPath.getParentFile();
+            tail.push(Optional.ofNullable(iterPath.getFileName()).map(Path::toString).orElse(""));
+            iterPath = iterPath.getParent();
         }
 
         // `path' is not found to be relative to `canonical', so return as is.
-        return path;
+        return path.toString();
     }
 
-    private static boolean isAllowedSymlink(String canonicalFile,
+    private static boolean isAllowedSymlink(Path canonicalFile,
         Set<String> allowedSymlinks) {
+        final FileSystem fileSystem = canonicalFile.getFileSystem();
+        String canonicalFileStr = canonicalFile.toString();
         for (String allowedSymlink : allowedSymlinks) {
             String canonicalLink;
             try {
-                canonicalLink = new File(allowedSymlink).getCanonicalPath();
+                canonicalLink = fileSystem.getPath(allowedSymlink).toRealPath().toString();
             } catch (IOException e) {
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.fine(String.format("unresolvable symlink: %s",
@@ -176,8 +189,8 @@ public class PathUtils {
                 }
                 continue;
             }
-            if (canonicalFile.equals(canonicalLink) ||
-                    canonicalFile.startsWith(canonicalLink + File.separator)) {
+            if (canonicalFileStr.equals(canonicalLink) ||
+                canonicalFile.startsWith(canonicalLink + fileSystem.getSeparator())) {
                 return true;
             }
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -125,12 +125,13 @@ public class HistoryGuruTest {
     }
 
     @Test
+    @ConditionalRun(RepositoryInstalled.SubversionInstalled.class)
     public void testBug16465() throws HistoryException, IOException {
         HistoryGuru instance = HistoryGuru.getInstance();
         for (File f : FILES) {
             if (f.getName().equals("bugreport16465@")) {
-                assertNotNull(instance.getHistory(f));
-                assertNotNull(instance.annotate(f, null));
+                assertNotNull(f.getPath() + " must have history", instance.getHistory(f));
+                assertNotNull(f.getPath() + " must have annotations", instance.annotate(f, null));
             }
         }
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryLookupTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryLookupTest.java
@@ -1,0 +1,305 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2020, Anatoly Akkerman <akkerman@gmail.com>, <anatoly.akkerman@twosigma.com>.
+ */
+package org.opengrok.indexer.history;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.number.OrderingComparison;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opengrok.indexer.util.PathUtils;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+
+public class RepositoryLookupTest {
+    // Files to include into Repositories having short paths
+    private static final String[] SHORT_PATH_CONTENTS = {"foo/bar.txt", "foo/bla/barf.txt", "special/woops@",
+        "special/veryveryverylongfilename_just_for_fun"};
+    // Files to include into Repositories having longer paths
+    private static final String[] LONG_PATH_CONTENTS = {"foo/bla/1/2/3/4/bar.txt", "foo/bla/1/2/3/4/5/barf.txt"};
+    Map<String, Repository> repositories;
+    Set<String> repositoryRoots;
+    // TODO: Parametrize this to run against windows(), unix() and macos()
+    FileSystem fileSystem = Jimfs.newFileSystem(Configuration.unix());
+    // Pick first root to resolve paths relative to it.
+    // Windows Jimfs can only resolve absolute paths relative to a rootDir, not via fileSystem.get("/a/b/c")
+    Path rootDir = fileSystem.getRootDirectories().iterator().next();
+    private RepositoryLookup.PathCanonicalizer canonicalizerForUncached;
+    private RepositoryLookup.PathCanonicalizer canonicalizerForCached;
+    private RepositoryLookupUncached uncached;
+    private RepositoryLookupCached cached;
+
+    @BeforeEach
+    public void before() {
+        repositories = new HashMap<>();
+        repositoryRoots = new HashSet<>();
+        // Spy on two canonicalizers, because we are need to measure number of lookups and compare cached vs uncached
+        canonicalizerForUncached =
+            spyLambda(RepositoryLookup.PathCanonicalizer.class, PathUtils::getRelativeToCanonical);
+        canonicalizerForCached =
+            spyLambda(RepositoryLookup.PathCanonicalizer.class, PathUtils::getRelativeToCanonical);
+        uncached = RepositoryLookup.uncached();
+        cached = RepositoryLookup.cached();
+    }
+
+    public static <T> T spyLambda(final Class<T> labmdaType, final T lambda) {
+        return mock(labmdaType, delegatesTo(lambda));
+    }
+
+    @Test
+    public void testLookups() throws IOException {
+        List<TestRepository> testRepositories = Arrays.asList(
+            createRepo("src/5/4/3/2/1", Optional.empty(), LONG_PATH_CONTENTS),
+            createRepo("src/1/2/3/4/5", Optional.empty(), SHORT_PATH_CONTENTS),
+            // Nested inside previous
+            createRepo("src/1/2/3/4/5/z", Optional.empty(), SHORT_PATH_CONTENTS),
+            createRepo("var/w", Optional.of("src/1/2/3/4/5/linked"), SHORT_PATH_CONTENTS),
+            createRepo("src/a/b/c/d/e1/f/g", Optional.empty(), SHORT_PATH_CONTENTS),
+            createRepo("src/a/b/c/d/e2/f/g", Optional.empty(), SHORT_PATH_CONTENTS),
+            createRepo("src/a/x/y/w", Optional.empty(), SHORT_PATH_CONTENTS),
+            createRepo("src/a/x/y/z", Optional.empty(), SHORT_PATH_CONTENTS));
+
+        assertEquals(
+            repositories.keySet().stream().map(fileSystem::getPath).map(Path::getParent).distinct().count(),
+            repositoryRoots.size());
+
+        for (TestRepository repo : testRepositories) {
+            for (Path p : repo.contents) {
+                // Number of cached path canonicalization lookups should be strictly less than uncached ones
+                compareLookups(Optional.of(repo), p, OrderingComparison::lessThan);
+            }
+        }
+        for (Path p : Arrays.asList(
+            rootDir.resolve("some/unknown/path/1/2/3/4"),
+            rootDir.resolve("some/unknown/path/otherdir/1/2/3/4"))) {
+            // File must exist otherwise lookup, which actually looks at the filesystem will fail
+            createFile(p);
+            // Number of cached path canonicalization lookups should be strictly less than uncached ones
+            compareLookups(Optional.empty(), p, OrderingComparison::lessThan);
+        }
+    }
+
+    @Test
+    public void testLookupsOnEmpty() {
+        for (Path p : Arrays.asList(
+            rootDir.resolve("some/unknown/path/1/2/3/4"),
+            rootDir.resolve("some/unknown/path/otherdir/1/2/3/4"))) {
+            // File must exist otherwise lookup, which actually looks at the filesystem will fail
+            createFile(p);
+            // Number of cached path canonicalization lookups <= uncached ones (both should be zero here)
+            compareLookups(Optional.empty(), p, OrderingComparison::lessThanOrEqualTo);
+        }
+    }
+
+    @Test
+    public void testSizeInvariantsAndBackfill() throws IOException {
+        TestRepository testRepo = createRepo("src/5/4/3/2/1", Optional.empty(), LONG_PATH_CONTENTS);
+        String knownFileSubpath = LONG_PATH_CONTENTS[0];
+        List<String> subdirs = Arrays.asList(knownFileSubpath.split("/"));
+        assertThat(subdirs.size(), Matchers.greaterThan(0));
+        // Lookup one known file, this should populate the cache
+        Path knownFile = testRepo.path.resolve(knownFileSubpath);
+        assertEquals(testRepo.repository,
+            cached.getRepository(knownFile, repositoryRoots, repositories, canonicalizerForCached));
+        final int initialCacheSize = cached.size();
+        assertThat(initialCacheSize, Matchers.greaterThan(0));
+        int cachedInvocations = mockingDetails(canonicalizerForCached).getInvocations().size();
+        System.out.printf("Inital lookup took %d relativize calls%n", cachedInvocations);
+        assertThat(cachedInvocations, Matchers.greaterThan(2));
+
+        // Check that backfill works correctly by looking up files in all parents dirs of knownFile in the repo
+        Path knownPathInRepo = testRepo.path;
+        for (String subpath: subdirs) {
+            knownPathInRepo = knownPathInRepo.resolve(subpath);
+            Mockito.reset(canonicalizerForCached);
+            assertEquals(testRepo.repository,
+                cached.getRepository(knownPathInRepo, repositoryRoots, repositories, canonicalizerForCached));
+            assertEquals(initialCacheSize, cached.size(),
+                "Cache should not grow when file in a known dir is looked up");
+            cachedInvocations = mockingDetails(canonicalizerForCached).getInvocations().size();
+            System.out.printf("Cached lookups took %d relativize calls%n", cachedInvocations);
+            if (Files.isDirectory(knownPathInRepo)) {
+                // Dirs are cached during backfill, so no relativize calls are expected
+                assertEquals(0, cachedInvocations, "Dirs should be cached");
+            } else {
+                // Files require a single relativize call before we try its parent dir which is cached
+                // because files are not stored in the cache
+                assertEquals(1, cachedInvocations, "Files should not be cached");
+            }
+        }
+    }
+
+        @Test
+    public void testCachedRemovedAndClear() throws IOException {
+        List<TestRepository> testRepositories = Arrays.asList(
+            createRepo("src/5/4/3/2/1", Optional.empty(), LONG_PATH_CONTENTS),
+            createRepo("src/1/2/3/4/5", Optional.empty(), SHORT_PATH_CONTENTS));
+
+        for (TestRepository repo : testRepositories) {
+            for (Path p : repo.contents) {
+                assertEquals(repo.repository, cached.getRepository(p, repositoryRoots, repositories,
+                    canonicalizerForUncached));
+            }
+        }
+        // Remove one of the repos
+        TestRepository removed = testRepositories.get(1);
+        repositories.remove(removed.path.toString());
+        repositoryRoots.remove(removed.path.getParent().toString());
+        assertEquals(testRepositories.size() - 1, repositories.size());
+        assertEquals(testRepositories.size() - 1, repositoryRoots.size());
+        cached.repositoriesRemoved(Collections.singletonList(removed.repository));
+        // Verify that once repository is removed, it can no longer be found
+        for (TestRepository repo : testRepositories) {
+            for (Path p : repo.contents) {
+                Repository lookedUp = cached.getRepository(p, repositoryRoots, repositories, canonicalizerForUncached);
+                if (repo == removed) {
+                    assertNull(lookedUp);
+                } else {
+                    assertEquals(repo.repository, lookedUp);
+                }
+            }
+        }
+        // clear and make sure we can't find anything
+        cached.clear();
+        repositories.clear();
+        repositoryRoots.clear();
+        for (TestRepository repo : testRepositories) {
+            for (Path p : repo.contents) {
+                assertNull(cached.getRepository(p, repositoryRoots, repositories, canonicalizerForUncached));
+            }
+        }
+    }
+
+    private void compareLookups(
+        Optional<TestRepository> expectedRepo, Path lookupPath,
+        Function<Integer, Matcher<Integer>> invocationComparatorFactory) {
+        System.out.printf("Processing %s, %s%n", expectedRepo, lookupPath);
+        // Reset counts before we do lookups
+        Mockito.reset(canonicalizerForCached, canonicalizerForUncached);
+        Repository expected = expectedRepo.map(TestRepository::getRepository).orElse(null);
+        assertEquals(expected,
+            uncached.getRepository(lookupPath, repositoryRoots, repositories, canonicalizerForUncached));
+        assertEquals(expected, cached.getRepository(lookupPath, repositoryRoots, repositories, canonicalizerForCached));
+        int uncachedInvocations = mockingDetails(canonicalizerForUncached).getInvocations().size();
+        int cachedInvocations = mockingDetails(canonicalizerForCached).getInvocations().size();
+        System.out.printf("Lookup %s (expected %s): uncached calls %d, cached calls %d%n", lookupPath,
+            expectedRepo.map(TestRepository::getPath), uncachedInvocations, cachedInvocations);
+        Matcher<Integer> cachedInvocationComparator = invocationComparatorFactory.apply(uncachedInvocations);
+        assertThat(cachedInvocations, cachedInvocationComparator);
+    }
+
+    TestRepository createRepo(String physicalPath, Optional<String> linkPath, String... contents) throws IOException {
+        // Create mock repository contents
+        Path realRepoPath = rootDir.resolve(physicalPath);
+        Files.createDirectories(realRepoPath);
+        Arrays.stream(contents).map(realRepoPath::resolve).forEach(this::createFile);
+
+        // Construct symlink to the physical path, if necessary
+        Optional<Path> indexingPath = linkPath.map(rootDir::resolve);
+        indexingPath.ifPresent(symlink -> {
+            try {
+                Files.createDirectories(symlink.getParent());
+                Files.createSymbolicLink(symlink, realRepoPath);
+                System.out.printf("Symlink %s -> %s%n", symlink, realRepoPath);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        // If given symlink, it should be the repoPath, otherwise, it should be the same as physical path
+        Path repoPath = indexingPath.orElse(realRepoPath);
+
+        // Just like HistoryGuru, store repository's parent dir in repositoryRoots
+        repositoryRoots.add(repoPath.getParent().toString());
+        // Construct a mock Repository (we only need references to them)
+        Repository repo = mock(Repository.class);
+        // Just like HistoryGuru, store repository in a map keyed by its repoPath
+        repositories.put(repoPath.toString(), repo);
+        // Now resolve contents relative to the actual repo path
+        List<Path> contentPaths = Arrays.stream(contents).map(repoPath::resolve).collect(Collectors.toList());
+        contentPaths.forEach(p -> assertTrue(Files.exists(p), p + " must exist"));
+        return new TestRepository(repo, repoPath, Collections.unmodifiableList(contentPaths));
+    }
+
+    private void createFile(Path p) {
+        try {
+            Files.createDirectories(p.getParent());
+            Files.createFile(p);
+            System.out.printf("Created %s%n", p);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class TestRepository {
+        final Repository repository;
+        final Path path;
+        final List<Path> contents;
+
+        private TestRepository(Repository repository, Path path, List<Path> contents) {
+            this.repository = repository;
+            this.path = path;
+            this.contents = contents;
+        }
+
+        Repository getRepository() {
+            return repository;
+        }
+
+        Path getPath() {
+            return path;
+        }
+
+        @Override
+        public String toString() {
+            return "TestRepository{" +
+                "repository=" + repository +
+                ", path=" + path +
+                ", contents=" + contents +
+                '}';
+        }
+    }
+}

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -199,6 +199,12 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <artifactId>modelmapper</artifactId>
             <version>2.3.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         reads that Jersey 2.30.1 did "adopt Jackson 2.10.1." -->
         <jackson.version>2.10.1</jackson.version>
         <junit.version>5.7.0</junit.version>
+        <hamcrest.version>2.1</hamcrest.version>
         <maven-surefire.version>2.22.2</maven-surefire.version>
         <apache-commons-lang3.version>3.9</apache-commons-lang3.version>
         <micrometer.version>1.5.4</micrometer.version>
@@ -89,6 +90,12 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                 <groupId>org.junit.vintage</groupId>
                 <artifactId>junit-vintage-engine</artifactId>
                 <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>${hamcrest.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.bcel</groupId>


### PR DESCRIPTION
…grok installations with many Repositories

   and deep file trees by caching previous lookup results for dir -> Repository.
   Additional refactorings to make this new functionality testable against legacy implementation:
      - Introduce Jimfs for testing which will allow testing Windows, MacOS or UNIX filesystem on any machine
      - Refactor PathUtils to use Paths instead of Files (this is needed to use Jimfs)

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
