### PR TITLE
upgrade Maven PMD plugin to 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.8</version>
+                <version>3.13.0</version>
                 <reportSets>
                     <reportSet>
                         <reports>


### PR DESCRIPTION
Running Javadoc Github acitons workflow currently fails with:
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.3:site (default-site) on project opengrok-top: failed to get report for org.apache.maven.plugins:maven-pmd-plugin: org.apache.maven.reporting.MavenReportException: Unsupported targetJdk value '11'. -> [Help 1]
```
Currently the PMD plugin is on 3.8 which was released in 2017. The official docs claim that Java 11 is supported: https://maven.apache.org/plugins/maven-pmd-plugin/pmd-mojo.html#targetJdk