### PR TITLE
Fix for #3307: Make GitRepository#isWorking synchronized to avoid read/write proble…

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -117,7 +117,7 @@ public abstract class Repository extends RepositoryInfo {
 
     /**
      * Gets the instance's repository command, primarily for testing purposes.
-     * @return null if not {@link isWorking}, or otherwise a defined command
+     * @return null if not {@link #isWorking()}, or otherwise a defined command
      */
     public String getRepoCommand() {
         isWorking();
@@ -548,6 +548,17 @@ public abstract class Repository extends RepositoryInfo {
         return exec.exec(false) == 0;
     }
 
+    protected static String getCommand(Class<? extends Repository> repoClass, String propertyKey, String fallbackCommand) {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        String className = repoClass.getCanonicalName();
+        String command = env.getRepoCmd(className);
+        if (command == null) {
+            command = System.getProperty(propertyKey, fallbackCommand);
+            env.setRepoCmd(className, command);
+        }
+        return command;
+    }
+
     /**
      * Set the name of the external client command that should be used to access
      * the repository wrt. the given parameters. Does nothing, if this
@@ -561,18 +572,10 @@ public abstract class Repository extends RepositoryInfo {
      * @see #RepoCommand
      */
     protected String ensureCommand(String propertyKey, String fallbackCommand) {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        
-        if (RepoCommand != null) {
-            return RepoCommand;
-        }
-        
-        RepoCommand = env.getRepoCmd(this.getClass().getCanonicalName());
         if (RepoCommand == null) {
-            RepoCommand = System.getProperty(propertyKey, fallbackCommand);
-            env.setRepoCmd(this.getClass().getCanonicalName(), RepoCommand);
+            RepoCommand = getCommand(this.getClass(), propertyKey, fallbackCommand);
         }
-        
+
         return RepoCommand;
     }
 


### PR DESCRIPTION
…ms with mutable working field. Check whether git is working once per JVM run and don't recheck every time.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
