### PR TITLE
Build mvn modules in parallel fashion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,4 +74,4 @@ jobs:
     - name: Install Universal ctags
       run: choco install universal-ctags
     - name: Build
-      run: mvn -B -V verify
+      run: mvn -T 1C -B -V verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Before build actions
       run: ./dev/before
     - name: Build
-      run: ./mvnw -DskipTests=true -Dmaven.javadoc.skip=false -B -V package
+      run: ./mvnw -T 1C -DskipTests=true -Dmaven.javadoc.skip=false -B -V package
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,13 @@ RUN mkdir -p /mvn/opengrok-web/src/main/webapp
 RUN mkdir -p /mvn/opengrok-web/src/main/webapp/WEB-INF/ && touch /mvn/opengrok-web/src/main/webapp/WEB-INF/web.xml
 
 # dummy build to cache the dependencies
-RUN mvn -DskipTests -Dcheckstyle.skip -Dmaven.antrun.skip package
+RUN mvn -T 1C -DskipTests -Dcheckstyle.skip -Dmaven.antrun.skip package
 
 # build the project
 COPY ./ /opengrok-source
 WORKDIR /opengrok-source
 
-RUN mvn -DskipTests=true -Dmaven.javadoc.skip=true -B -V package
+RUN mvn -T 1C -DskipTests=true -Dmaven.javadoc.skip=true -B -V package
 RUN cp `ls -t distribution/target/*.tar.gz | head -1` /opengrok.tar.gz
 
 FROM tomcat:9-jdk11

--- a/dev/javadoc.sh
+++ b/dev/javadoc.sh
@@ -17,7 +17,7 @@ fi
 BRANCH="gh-pages"
 echo -e "Publishing javadoc to $BRANCH...\n"
 
-./mvnw -DskipTests=true site
+./mvnw -T 1C -DskipTests=true site
 
 git config --global user.email "noreply@github.com"
 git config --global user.name "Foo Bar"

--- a/dev/main
+++ b/dev/main
@@ -24,4 +24,4 @@ if [[ "x$OPENGROK_REPO_SLUG" == "xoracle/opengrok" && "x$OPENGROK_BRANCH" == "xm
 	fi
 fi
 
-./mvnw -B -V verify $extra_args
+./mvnw -T 1C -B -V verify $extra_args


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

I was inspired by `--parallel` option in Gradle. This should create a DAG from modules and build indexer, tools, and suggester modules in a parallel fashion which could save 1-2 minutes from the build times. Paid GitHub actions use 2 core VMs but I was not able to find the specs for free ones -> hopefully it's the same.

`1C` option means that one thread will be created for each core available.

The drawback is that it might be more difficult to find the failure in the logs.

What do you think?

Thanks.