### PR TITLE
compute suggester rebuild duration correctly

### DIFF
--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -186,9 +186,7 @@ public final class Suggester implements Closeable {
                 submitInitIfIndexExists(executor, indexDir);
             }
 
-            Duration duration = Duration.between(start, Instant.now());
-            suggesterInitTimer.record(duration);
-            shutdownAndAwaitTermination(executor, duration, "Suggester successfully initialized");
+            shutdownAndAwaitTermination(executor, start, "Suggester successfully initialized");
             initDone.countDown();
         }
     }
@@ -252,10 +250,13 @@ public final class Suggester implements Closeable {
         }
     }
 
-    private void shutdownAndAwaitTermination(final ExecutorService executorService, Duration duration, final String logMessageOnSuccess) {
+    private void shutdownAndAwaitTermination(final ExecutorService executorService, Instant start,
+                                             final String logMessageOnSuccess) {
         executorService.shutdown();
         try {
             executorService.awaitTermination(awaitTerminationTime.toMillis(), TimeUnit.MILLISECONDS);
+            Duration duration = Duration.between(start, Instant.now());
+            suggesterInitTimer.record(duration);
             logger.log(Level.INFO, "{0} (took {1})", new Object[]{logMessageOnSuccess,
                     DurationFormatUtils.formatDurationWords(duration.toMillis(),
                             true, true)});
@@ -295,9 +296,8 @@ public final class Suggester implements Closeable {
                 }
             }
 
-            Duration duration = Duration.between(start, Instant.now());
-            suggesterRebuildTimer.record(duration);
-            shutdownAndAwaitTermination(executor, duration, "Suggesters for " + indexDirs + " were successfully rebuilt");
+            shutdownAndAwaitTermination(executor, start,
+                    "Suggesters for " + indexDirs + " were successfully rebuilt");
         }
 
         rebuildLock.lock();


### PR DESCRIPTION
This change fixes a regression in suggester rebuild metrics computation.

Checked by hand that positive duration is output to the log:
```
30-Oct-2020 09:05:15.518 INFO [Thread-102] org.opengrok.suggest.Suggester.rebuild Rebuilding the following suggesters: [grizzly, new, opengrok, foo, opengrok-1.0, bar, sics, sudo-1.8.9p5, sudo-1.8.15, symlink, sudo, universal-ctags]
30-Oct-2020 09:05:20.380 INFO [Thread-102] org.opengrok.suggest.Suggester.shutdownAndAwaitTermination Suggesters for [grizzly, new, opengrok, foo, opengrok-1.0, bar, sics, sudo-1.8.9p5, sudo-1.8.15, symlink, sudo, universal-ctags] were successfully rebuilt (took 4 seconds)
```