### PR TITLE
Update junit to 5.7.0

### DIFF
--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/LangMapTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/LangMapTest.java
@@ -23,11 +23,10 @@
 package org.opengrok.indexer.analysis;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.List;
 import java.util.Map;
@@ -37,9 +36,6 @@ import java.util.Set;
  * Represents a container for tests of {@link LangMap}.
  */
 public class LangMapTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testEmptyMap() {
@@ -168,8 +164,7 @@ public class LangMapTest {
     public void testBadExtensionFileSpec() {
         LangMap map = new LangTreeMap();
 
-        thrown.expect(IllegalArgumentException.class);
-        map.add(".c.in", "foo");
+        assertThrows(IllegalArgumentException.class, () -> map.add(".c.in", "foo"));
     }
 
     @Test
@@ -177,8 +172,7 @@ public class LangMapTest {
         LangMap map = new LangTreeMap();
         LangMap map2 = map.unmodifiable();
 
-        thrown.expect(UnsupportedOperationException.class);
-        map2.add(".FOO", "foo");
+        assertThrows(UnsupportedOperationException.class, () -> map2.add(".FOO", "foo"));
     }
 
     @Test
@@ -186,8 +180,7 @@ public class LangMapTest {
         LangMap map = new LangTreeMap();
         LangMap map2 = map.unmodifiable();
 
-        thrown.expect(UnsupportedOperationException.class);
-        map2.exclude(".FOO");
+        assertThrows(UnsupportedOperationException.class, () -> map2.exclude(".FOO"));
     }
 
     @Test
@@ -195,8 +188,7 @@ public class LangMapTest {
         LangMap map = new LangTreeMap();
         Map<String, String> additions = map.getAdditions();
 
-        thrown.expect(UnsupportedOperationException.class);
-        additions.clear();
+        assertThrows(UnsupportedOperationException.class, additions::clear);
     }
 
     @Test
@@ -204,7 +196,6 @@ public class LangMapTest {
         LangMap map = new LangTreeMap();
         Set<String> exclusions = map.getExclusions();
 
-        thrown.expect(UnsupportedOperationException.class);
-        exclusions.clear();
+        assertThrows(UnsupportedOperationException.class, exclusions::clear);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzerFactoryTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.clojure;
@@ -42,7 +42,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzerFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzerFactoryTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.pascal;
@@ -32,8 +32,9 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import static org.hamcrest.CoreMatchers.is;
 import org.junit.AfterClass;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.BeforeClass;
@@ -129,7 +130,6 @@ public class PascalAnalyzerFactoryTest {
         assertThat(type[0], is("function"));
         assertTrue(definitions.hasDefinitionAt("TSample.GetUser", 63, type));
         assertThat(type[0], is("function"));
-        
     }
 
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BitKeeperRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BitKeeperRepositoryTest.java
@@ -24,10 +24,10 @@ package org.opengrok.indexer.history;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/BooleanUtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/BooleanUtilTest.java
@@ -20,13 +20,9 @@
 package org.opengrok.indexer.util;
 
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class BooleanUtilTest {
-
-  @Rule public final ExpectedException thrown = ExpectedException.none();
 
   // Test written by Diffblue Cover.
   @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -43,11 +43,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opengrok.indexer.util.PlatformUtils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         https://eclipse-ee4j.github.io/jersey.github.io/release-notes/2.30.1.html
         reads that Jersey 2.30.1 did "adopt Jackson 2.10.1." -->
         <jackson.version>2.10.1</jackson.version>
-        <junit.version>5.4.2</junit.version>
+        <junit.version>5.7.0</junit.version>
         <maven-surefire.version>2.22.2</maven-surefire.version>
         <apache-commons-lang3.version>3.9</apache-commons-lang3.version>
         <micrometer.version>1.5.4</micrometer.version>

--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterUtilsTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterUtilsTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest;
 
@@ -34,11 +34,11 @@ import org.opengrok.suggest.query.SuggesterPrefixQuery;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 
 public class SuggesterUtilsTest {
 

--- a/suggester/src/test/java/org/opengrok/suggest/popular/impl/ChronicleMapAdapterTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/popular/impl/ChronicleMapAdapterTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest.popular.impl;
 
@@ -35,9 +35,9 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map.Entry;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class ChronicleMapAdapterTest {
 

--- a/suggester/src/test/java/org/opengrok/suggest/query/customized/CustomSloppyPhraseScorerTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/query/customized/CustomSloppyPhraseScorerTest.java
@@ -47,8 +47,8 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.Assert.assertThat;
 
 public class CustomSloppyPhraseScorerTest {
 


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

While trying to make https://github.com/oracle/opengrok/pull/3336 work I've tried to update the junit and had to fix a few files.

`assertThat` and `ExpectedException.none()` became deprecated in junit 4.13.

Thanks.