### PR TITLE
make ProjectsController API calls using suggester async

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -206,7 +207,7 @@ public class ProjectsController {
         deleteHistoryCache(projectName);
 
         // Delete suggester data.
-        new Thread(() -> suggester.delete(projectName)).start();
+        CompletableFuture.runAsync(() -> suggester.delete(projectName));
     }
 
     @DELETE
@@ -273,7 +274,7 @@ public class ProjectsController {
             }
         }
 
-        new Thread(() -> suggester.rebuild(projectName)).start();
+        CompletableFuture.runAsync(() -> suggester.rebuild(projectName));
 
         // In case this project has just been incrementally indexed,
         // its IndexSearcher needs a poke.

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SuggesterController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SuggesterController.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SuggesterController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SuggesterController.java
@@ -69,6 +69,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -173,13 +174,13 @@ public final class SuggesterController {
     @PUT
     @Path("/rebuild")
     public void rebuild() {
-        new Thread(() -> suggester.rebuild()).start();
+        CompletableFuture.runAsync(() -> suggester.rebuild());
     }
 
     @PUT
     @Path("/rebuild/{project}")
     public void rebuild(@PathParam("project") final String project) {
-        new Thread(() -> suggester.rebuild(project)).start();
+        CompletableFuture.runAsync(() -> suggester.rebuild(project));
     }
 
     /**

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -22,7 +22,6 @@
  */
 package org.opengrok.suggest;
 
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.apache.commons.lang3.time.DurationFormatUtils;

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -100,7 +100,6 @@ public final class Suggester implements Closeable {
 
     private final CountDownLatch initDone = new CountDownLatch(1);
 
-    private final Counter suggesterRebuildCounter;
     private final Timer suggesterRebuildTimer;
     private final Timer suggesterInitTimer;
 
@@ -152,9 +151,6 @@ public final class Suggester implements Closeable {
         this.timeThreshold = timeThreshold;
         this.rebuildParallelismLevel = rebuildParallelismLevel;
 
-        suggesterRebuildCounter = Counter.builder("suggester.rebuild").
-                description("suggester rebuild count").
-                register(registry);
         suggesterRebuildTimer = Timer.builder("suggester.rebuild.latency").
                 description("suggester rebuild latency").
                 register(registry);
@@ -284,7 +280,6 @@ public final class Suggester implements Closeable {
 
         synchronized (lock) {
             Instant start = Instant.now();
-            suggesterRebuildCounter.increment();
             logger.log(Level.INFO, "Rebuilding the following suggesters: {0}", indexDirs);
 
             ExecutorService executor = Executors.newWorkStealingPool(rebuildParallelismLevel);


### PR DESCRIPTION
This change removes unnecessary Counter and making the API calls to spawn a thread when calling into suggester.

The change merely changes the behavior of the API calls. In terms of #3347 it actually makes the situation worse since there will be more threads created.