### PR TITLE
support OPTIONAL control flag in authorization framework

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthControlFlag.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthControlFlag.java
@@ -55,6 +55,7 @@ public enum AuthControlFlag {
      */
     SUFFICIENT("sufficient"),
     /**
+     * A success of a optional plugin is ignored and processing of the stack continues unaffected.
      * The failure is returned only if stack traversal finished and
      * there was no prior result recorded.
      */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthControlFlag.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthControlFlag.java
@@ -48,13 +48,17 @@ public enum AuthControlFlag {
      */
     REQUISITE("requisite"),
     /**
-     * If such a plugin succeeds and no prior required plugin has failed the
-     * authorization framework returns success to the application immediately
-     * without calling any further plugins in the stack. A failure of a
-     * sufficient plugin is ignored and processing of the plugin list continues
-     * unaffected.
+     * If such a plugin succeeds and no prior required plugin has failed,
+     * the authorization framework returns success immediately
+     * without calling any further plugins in the stack.
+     * A failure of a sufficient plugin is ignored and processing of the stack continues unaffected.
      */
-    SUFFICIENT("sufficient");
+    SUFFICIENT("sufficient"),
+    /**
+     * The failure is returned only if stack traversal finished and
+     * there was no prior result recorded.
+     */
+    OPTIONAL("optional");
 
     private final String flag;
 
@@ -77,6 +81,10 @@ public enum AuthControlFlag {
 
     public boolean isSufficient() {
         return SUFFICIENT.equals(this);
+    }
+
+    public boolean isOptional() {
+        return OPTIONAL.equals(this);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthControlFlag.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthControlFlag.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.authorization;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationEntity.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationEntity.java
@@ -524,6 +524,15 @@ public abstract class AuthorizationEntity implements Nameable, Serializable, Clo
     }
 
     /**
+     * Check if this plugin is marked as optional.
+     *
+     * @return true if is optional; false otherwise
+     */
+    public boolean isOptional() {
+        return getFlag().isOptional();
+    }
+
+    /**
      * Print the entity hierarchy.
      *
      * @return the string containing this entity representation

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkTest.java
@@ -705,6 +705,21 @@ public class AuthorizationFrameworkTest {
                     NewTest(true, createAllowedProject()),
                     NewTest(true, createAllowedGroup()))
             },
+            {
+                new StackSetup(
+                    NewStack(AuthControlFlag.REQUIRED,
+                            new AuthorizationPlugin(AuthControlFlag.OPTIONAL, createAllowedPrefixPlugin()),
+                            new AuthorizationPlugin(AuthControlFlag.OPTIONAL, createNotAllowedPrefixPlugin())
+                    ),
+                    // optional plugin1 returns false
+                    // optional plugin2 returns true => true
+                    NewTest(true, createUnallowedProject()),
+                    NewTest(true, createUnallowedGroup()),
+                    // optional plugin1 returns true
+                    // optional plugin2 returns false
+                    NewTest(true, createAllowedProject()),
+                    NewTest(true, createAllowedGroup()))
+            },
         };
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkTest.java
@@ -720,6 +720,21 @@ public class AuthorizationFrameworkTest {
                     NewTest(true, createAllowedProject()),
                     NewTest(true, createAllowedGroup()))
             },
+            {
+                new StackSetup(
+                    NewStack(AuthControlFlag.REQUIRED,
+                            new AuthorizationPlugin(AuthControlFlag.OPTIONAL, createAllowedPrefixPlugin()),
+                            new AuthorizationPlugin(AuthControlFlag.SUFFICIENT, createNotAllowedPrefixPlugin())
+                    ),
+                    // optional plugin returns false
+                    // sufficient plugin returns true => true
+                    NewTest(true, createUnallowedProject()),
+                    NewTest(true, createUnallowedGroup()),
+                    // optional plugin returns true
+                    // sufficient plugin returns false => true
+                    NewTest(true, createAllowedProject()),
+                    NewTest(true, createAllowedGroup()))
+            },
         };
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkTest.java
@@ -654,6 +654,57 @@ public class AuthorizationFrameworkTest {
                 NewTest(false, createAllowedProject()),
                 NewTest(false, createAllowedGroup()))
             },
+            {
+                new StackSetup(
+                    NewStack(AuthControlFlag.REQUIRED,
+                        new AuthorizationPlugin(AuthControlFlag.OPTIONAL, createTestFailingPlugin()),
+                        new AuthorizationPlugin(AuthControlFlag.REQUIRED, createAllowedPrefixPlugin())),
+                    // optional plugin returns false
+                    // required plugin returns false => false
+                    NewTest(false, createUnallowedProject()),
+                    NewTest(false, createUnallowedGroup()),
+                    // optional plugin returns false
+                    // required plugin returns true => true
+                    NewTest(true, createAllowedProject()),
+                    NewTest(true, createAllowedGroup()))
+            },
+            {
+                new StackSetup(
+                    NewStack(AuthControlFlag.REQUIRED,
+                            new AuthorizationPlugin(AuthControlFlag.OPTIONAL, createAllowedPrefixPlugin()),
+                            new AuthorizationPlugin(AuthControlFlag.REQUIRED, createNotAllowedPrefixPlugin())),
+                    // optional plugin returns false
+                    // required plugin returns true => true
+                    NewTest(true, createUnallowedProject()),
+                    NewTest(true, createUnallowedGroup()),
+                    // optional plugin returns true
+                    // required plugin returns false => false
+                    NewTest(false, createAllowedProject()),
+                    NewTest(false, createAllowedGroup()))
+            },
+            {
+                new StackSetup(
+                    NewStack(AuthControlFlag.REQUIRED,
+                            new AuthorizationPlugin(AuthControlFlag.OPTIONAL, createTestFailingPlugin())
+                            ),
+                    // optional plugin returns false => false
+                    NewTest(false, createUnallowedProject()),
+                    NewTest(false, createUnallowedGroup()),
+                    NewTest(false, createAllowedProject()),
+                    NewTest(false, createAllowedGroup()))
+            },
+            {
+                new StackSetup(
+                    NewStack(AuthControlFlag.REQUIRED,
+                            new AuthorizationPlugin(AuthControlFlag.OPTIONAL, createAllowedPrefixPlugin())
+                    ),
+                    // optional plugin returns false => false
+                    NewTest(false, createUnallowedProject()),
+                    NewTest(false, createUnallowedGroup()),
+                    // optional plugin returns true => true
+                    NewTest(true, createAllowedProject()),
+                    NewTest(true, createAllowedGroup()))
+            },
         };
     }
 
@@ -668,11 +719,13 @@ public class AuthorizationFrameworkTest {
         for (TestCase innerSetup : setup.setup) {
             String entityName = (innerSetup.entity == null ? "null" : innerSetup.entity.getName());
             try {
+                // group test
                 actual = framework.isAllowed(innerSetup.request, (Group) innerSetup.entity);
                 Assert.assertEquals(String.format(format, setup.toString(), innerSetup.expected, actual, entityName),
                         innerSetup.expected,
                         actual);
             } catch (ClassCastException ex) {
+                // project test
                 actual = framework.isAllowed(innerSetup.request, (Project) innerSetup.entity);
                 Assert.assertEquals(String.format(format, setup.toString(), innerSetup.expected, actual, entityName),
                         innerSetup.expected,

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/authorization/AuthorizationFrameworkTest.java
@@ -716,7 +716,7 @@ public class AuthorizationFrameworkTest {
                     NewTest(true, createUnallowedProject()),
                     NewTest(true, createUnallowedGroup()),
                     // optional plugin1 returns true
-                    // optional plugin2 returns false
+                    // optional plugin2 returns false => true
                     NewTest(true, createAllowedProject()),
                     NewTest(true, createAllowedGroup()))
             },


### PR DESCRIPTION
This introduces the `OPTIONAL` authorization control flag.

Tested with stack that contained this at the top level:
```
LdapUserPlugin (OPTIONAL)
  - substack (REQUIRED)
    UserWhiteListPlugin (SUFFICIENT)
    LdapFilterPlugin (REQUIRED)
```
Works fine except when `LdapUserPlugin` fails the check because the user does not exist in LDAP it will cause a LDAP query each time the user sends a request as there is no negative caching.