### PR TITLE
log more info during init() in plugins using whitelist

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
@@ -110,8 +110,8 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
             throw new IllegalArgumentException(String.format("Unable to read the file \"%s\"", filePath), e);
         }
 
-        LOGGER.log(Level.FINE, "LdapAttrPlugin plugin loaded with attr={0}, whitelist={1}, instance={2}",
-                new Object[]{ldapAttr, filePath, ldapUserInstance});
+        LOGGER.log(Level.FINE, "LdapAttrPlugin plugin loaded with attr={0}, whitelist={1} ({2} entries), " +
+                        "instance={3}", new Object[]{ldapAttr, filePath, whitelist.size(), ldapUserInstance});
     }
 
     @Override

--- a/plugins/src/main/java/opengrok/auth/plugin/UserWhiteListPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/UserWhiteListPlugin.java
@@ -74,6 +74,9 @@ public class UserWhiteListPlugin implements IAuthorizationPlugin {
         } catch (IOException e) {
             throw new IllegalArgumentException(String.format("Unable to read the file \"%s\"", filePath), e);
         }
+
+        LOGGER.log(Level.FINE, "UserWhiteList plugin loaded with filePath={0} ({1} entries), fieldName={2}",
+                new Object[]{filePath, whitelist.size(), fieldName});
     }
 
     @Override


### PR DESCRIPTION
This change adds a bit more logging to the init()/load() functions of the plugins using whitelists.

Sample output:
```
03-Nov-2020 16:16:06.058 FINE [http-nio-8080-exec-29] opengrok.auth.plugin.UserWhiteListPlugin.load UserWhiteList plugin loaded with filePath=/opengrok/auth/config/whitelists/foo.txt (404 entries), fieldName=id
03-Nov-2020 16:16:07.770 FINE [http-nio-8080-exec-29] opengrok.auth.plugin.LdapAttrPlugin.init LdapAttrPlugin plugin loaded with attr=gidNumber, whitelist=/opengrok/auth/config/whitelists/bar.txt (2 entries), instance=33
```