### PR TITLE
restrict checkout of gh-pages to the main repo

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -29,6 +29,7 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Checkout gh-pages branch
+      if: github.repository == 'oracle/opengrok'
       uses: actions/checkout@v2
       with:
         ref: gh-pages


### PR DESCRIPTION
This avoids failures when pushing to the `master` branch in forked repository. Not everyone has `gh-branch` in his forked repo.