### PR TITLE
Fix for #3308: Allow @path syntax for both search paths and repositor…

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -425,6 +425,10 @@ public final class HistoryGuru {
                     continue;
                 }
                 if (repository == null) {
+                    if (depth > env.getScanningDepth()) {
+                        // we reached our search max depth, skip looking through the children
+                        continue;
+                    }
                     // Not a repository, search its sub-dirs.
                     if (pathAccepter.accept(file)) {
                         File[] subFiles = file.listFiles();
@@ -433,7 +437,8 @@ public final class HistoryGuru {
                                     "Failed to get sub directories for ''{0}'', " +
                                     "check access permissions.",
                                     file.getAbsolutePath());
-                        } else if (depth <= env.getScanningDepth()) {
+                        } else {
+                            // Recursive call to scan next depth
                             repoList.addAll(addRepositories(subFiles,
                                     allowedNesting, depth + 1, isNested));
                         }


### PR DESCRIPTION
…y paths to be able to load values from a given file.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
