### PR TITLE
run the build once a week

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - README.md
+    - '**/*.md'
+  pull_request:
+  schedule:
+  - cron: "0 0 * * 0"
 
 jobs:
   build:


### PR DESCRIPTION
also adds some ignore paths to the `push` event.