### PR TITLE
another suggester.rebuild() to become async

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.controller;
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
@@ -34,6 +34,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 
 @Path("/system")
 public class SystemController {
@@ -48,7 +49,7 @@ public class SystemController {
     @Consumes(MediaType.TEXT_PLAIN)
     public void refresh(final String project) {
         env.maybeRefreshIndexSearchers(Collections.singleton(project));
-        suggester.rebuild(project);
+        CompletableFuture.runAsync(() -> suggester.rebuild(project));
     }
 
     @PUT


### PR DESCRIPTION
Forgot make one of the `suggester.rebuild()` calls async when working on #3349. Noticed this in Grafana as it skews the overall request max latency graphs.