### PR TITLE
Catch all IOExceptions thrown by toRealPath and fallback to normalize…

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/PathUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/PathUtils.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Deque;
@@ -96,8 +95,6 @@ public class PathUtils {
      * the explicit validation against {@code allowedSymlinks}.
      * @return a relative path determined as described above -- or {@code path}
      * if no canonical relativity is found
-     * @throws IOException if an error occurs determining canonical paths
-     * for portions of {@code path}
      * @throws ForbiddenSymlinkException if symbolic-link checking is active
      * and it encounters an ineligible link
      * @throws InvalidPathException if path cannot be decoded
@@ -133,7 +130,7 @@ public class PathUtils {
             Path iterCanon;
             try {
                 iterCanon = iterPath.toRealPath();
-            } catch (NoSuchFileException e) {
+            } catch (IOException e) {
                 iterCanon = iterPath.normalize().toAbsolutePath();
             }
 


### PR DESCRIPTION
…().toAbsolutePath()

This is necessary, because getRelativeToCanonical is called for paths that are not real paths
(e.g. in the case of reading git history and resolving historical paths relative to current)

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
