### PR TITLE
generate xref for non empty compressed files

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.net.ConnectException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.ConnectException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -354,27 +355,38 @@ public class IndexDatabase {
         // Successfully indexed the project. The message is sent even if
         // the project's isIndexed() is true because it triggers RepositoryInfo
         // refresh.
-        if (project != null) {
-            // Also need to store the correct value in configuration
-            // when indexer writes it to a file.
-            project.setIndexed(true);
+        if (project == null) {
+            return;
+        }
 
-            if (env.getConfigURI() != null) {
-                Response r = ClientBuilder.newClient()
-                        .target(env.getConfigURI())
-                        .path("api")
-                        .path("v1")
-                        .path("projects")
-                        .path(Util.URIEncode(project.getName()))
-                        .path("indexed")
-                        .request()
-                        .put(Entity.text(""));
+        // Also need to store the correct value in configuration
+        // when indexer writes it to a file.
+        project.setIndexed(true);
 
-                if (r.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
-                    LOGGER.log(Level.WARNING, "Couldn''t notify the webapp that project {0} was indexed: {1}",
-                            new Object[] {project, r});
-                }
-            }
+        if (env.getConfigURI() == null) {
+            return;
+        }
+
+        Response r;
+        try {
+            r = ClientBuilder.newClient()
+                    .target(env.getConfigURI())
+                    .path("api")
+                    .path("v1")
+                    .path("projects")
+                    .path(Util.URIEncode(project.getName()))
+                    .path("indexed")
+                    .request()
+                    .put(Entity.text(""));
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.WARNING, "Couldn''t notify the webapp that project {0} was indexed: {1}",
+                    new Object[] {project, e});
+            return;
+        }
+
+        if (r.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+            LOGGER.log(Level.WARNING, "Couldn''t notify the webapp that project {0} was indexed: {1}",
+                    new Object[] {project, r});
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -378,7 +378,7 @@ public class IndexDatabase {
                     .request()
                     .put(Entity.text(""));
         } catch (RuntimeException e) {
-            LOGGER.log(Level.WARNING, String.format("Couldn''t notify the webapp that project {0} was indexed",
+            LOGGER.log(Level.WARNING, String.format("Couldn''t notify the webapp that project %s was indexed",
                     project), e);
             return;
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -500,6 +500,8 @@ public class IndexDatabase {
                 }
             }
 
+            // The RuntimeException thrown from the block above can prevent the writing from completing.
+            // This is deliberate.
             try {
                 finishWriting();
             } catch (IOException e) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -83,6 +83,7 @@ import org.apache.lucene.store.NativeFSLockFactory;
 import org.apache.lucene.store.NoLockFactory;
 import org.apache.lucene.store.SimpleFSLockFactory;
 import org.apache.lucene.util.BytesRef;
+import org.jetbrains.annotations.NotNull;
 import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.opengrok.indexer.analysis.AnalyzerFactory;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
@@ -725,8 +726,28 @@ public class IndexDatabase {
         fa.setFoldingEnabled(env.isFoldingEnabled());
 
         Document doc = new Document();
-        try (Writer xrefOut = newXrefWriter(fa, path)) {
+        CountingWriter xrefOut = null;
+        try {
+            String xrefAbs = null;
+            File transientXref = null;
+            if (env.isGenerateHtml()) {
+                xrefAbs = getXrefPath(path);
+                transientXref = new File(TandemPath.join(xrefAbs,
+                        PendingFileCompleter.PENDING_EXTENSION));
+                xrefOut = newXrefWriter(path, transientXref, env.isCompressXref());
+            }
+
             analyzerGuru.populateDocument(doc, file, path, fa, xrefOut);
+
+            // Avoid producing empty xref files.
+            if (xrefOut != null && xrefOut.getCount() > 0) {
+                PendingFileRenaming ren = new PendingFileRenaming(xrefAbs,
+                        transientXref.getAbsolutePath());
+                completer.add(ren);
+            } else if (xrefOut != null) {
+                LOGGER.log(Level.FINER, "xref for {0} would be empty, removing", path);
+                transientXref.delete();
+            }
         } catch (InterruptedException e) {
             LOGGER.log(Level.WARNING, "File ''{0}'' interrupted--{1}",
                 new Object[]{path, e.getMessage()});
@@ -745,6 +766,9 @@ public class IndexDatabase {
             return;
         } finally {
             fa.setCtags(null);
+            if (xrefOut != null) {
+                xrefOut.close();
+            }
         }
 
         try {
@@ -1629,40 +1653,63 @@ public class IndexDatabase {
         return hash;
     }
 
+    private class CountingWriter extends Writer {
+        private long count;
+        private Writer out;
+
+        CountingWriter(Writer out) {
+            super(out);
+            this.out = out;
+            this.count = 0;
+        }
+
+        @Override
+        public void write(@NotNull char[] chars, int off, int len) throws IOException {
+            out.write(chars, off, len);
+            count += len;
+        }
+
+        @Override
+        public void flush() throws IOException {
+            out.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            out.close();
+        }
+
+        public long getCount() {
+            return count;
+        }
+    }
+
+    private String getXrefPath(String path) {
+        boolean compressed = RuntimeEnvironment.getInstance().isCompressXref();
+        File xrefFile = whatXrefFile(path, compressed);
+        File parentFile = xrefFile.getParentFile();
+
+        // If mkdirs() returns false, the failure is most likely
+        // because the file already exists. But to check for the
+        // file first and only add it if it doesn't exists would
+        // only increase the file IO...
+        if (!parentFile.mkdirs()) {
+            assert parentFile.exists();
+        }
+
+        // Write to a pending file for later renaming.
+        String xrefAbs = xrefFile.getAbsolutePath();
+        return xrefAbs;
+    }
+
     /**
      * Get a writer to which the xref can be written, or null if no xref
      * should be produced for files of this type.
      */
-    private Writer newXrefWriter(AbstractAnalyzer fa, String path) throws IOException {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (env.isGenerateHtml() && fa != null) {
-            boolean compressed = env.isCompressXref();
-            File xrefFile = whatXrefFile(path, compressed);
-            File parentFile = xrefFile.getParentFile();
-
-            // If mkdirs() returns false, the failure is most likely
-            // because the file already exists. But to check for the
-            // file first and only add it if it doesn't exists would
-            // only increase the file IO...
-            if (!parentFile.mkdirs()) {
-                assert parentFile.exists();
-            }
-
-            // Write to a pending file for later renaming.
-            String xrefAbs = xrefFile.getAbsolutePath();
-            File transientXref = new File(TandemPath.join(xrefAbs,
-                PendingFileCompleter.PENDING_EXTENSION));
-            PendingFileRenaming ren = new PendingFileRenaming(xrefAbs,
-                transientXref.getAbsolutePath());
-            completer.add(ren);
-
-            return new BufferedWriter(new OutputStreamWriter(compressed ?
-                new GZIPOutputStream(new FileOutputStream(transientXref)) :
-                new FileOutputStream(transientXref)));
-        }
-
-        // no Xref for this analyzer
-        return null;
+    private CountingWriter newXrefWriter(String path, File transientXref, boolean compressed) throws IOException {
+        return new CountingWriter(new BufferedWriter(new OutputStreamWriter(compressed ?
+            new GZIPOutputStream(new FileOutputStream(transientXref)) :
+            new FileOutputStream(transientXref))));
     }
 
     LockFactory pickLockFactory(RuntimeEnvironment env) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1666,14 +1666,13 @@ public class IndexDatabase {
         return hash;
     }
 
-    private class CountingWriter extends Writer {
+    private static class CountingWriter extends Writer {
         private long count;
-        private Writer out;
+        private final Writer out;
 
         CountingWriter(Writer out) {
             super(out);
             this.out = out;
-            this.count = 0;
         }
 
         @Override
@@ -1721,8 +1720,8 @@ public class IndexDatabase {
      */
     private CountingWriter newXrefWriter(String path, File transientXref, boolean compressed) throws IOException {
         return new CountingWriter(new BufferedWriter(new OutputStreamWriter(compressed ?
-            new GZIPOutputStream(new FileOutputStream(transientXref)) :
-            new FileOutputStream(transientXref))));
+                new GZIPOutputStream(new FileOutputStream(transientXref)) :
+                new FileOutputStream(transientXref))));
     }
 
     LockFactory pickLockFactory(RuntimeEnvironment env) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -725,7 +725,7 @@ public class IndexDatabase {
         fa.setFoldingEnabled(env.isFoldingEnabled());
 
         Document doc = new Document();
-        try (Writer xrefOut = newXrefWriter(path)) {
+        try (Writer xrefOut = newXrefWriter(fa, path)) {
             analyzerGuru.populateDocument(doc, file, path, fa, xrefOut);
         } catch (InterruptedException e) {
             LOGGER.log(Level.WARNING, "File ''{0}'' interrupted--{1}",
@@ -1633,9 +1633,9 @@ public class IndexDatabase {
      * Get a writer to which the xref can be written, or null if no xref
      * should be produced for files of this type.
      */
-    private Writer newXrefWriter(String path) throws IOException {
+    private Writer newXrefWriter(AbstractAnalyzer fa, String path) throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (env.isGenerateHtml()) {
+        if (env.isGenerateHtml() && fa != null) {
             boolean compressed = env.isCompressXref();
             File xrefFile = whatXrefFile(path, compressed);
             File parentFile = xrefFile.getParentFile();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -487,17 +487,17 @@ public class IndexDatabase {
                     reader.close();
                 }
             }
-
-            try {
-                finishWriting();
-            } catch (IOException e) {
-                finishingException = e;
-            }
         } catch (RuntimeException ex) {
             LOGGER.log(Level.SEVERE,
                 "Failed with unexpected RuntimeException", ex);
             throw ex;
         } finally {
+            try {
+                finishWriting();
+            } catch (IOException e) {
+                finishingException = e;
+            }
+
             completer = null;
             try {
                 if (writer != null) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -725,7 +725,7 @@ public class IndexDatabase {
         fa.setFoldingEnabled(env.isFoldingEnabled());
 
         Document doc = new Document();
-        try (Writer xrefOut = newXrefWriter(fa, path)) {
+        try (Writer xrefOut = newXrefWriter(path)) {
             analyzerGuru.populateDocument(doc, file, path, fa, xrefOut);
         } catch (InterruptedException e) {
             LOGGER.log(Level.WARNING, "File ''{0}'' interrupted--{1}",
@@ -1629,19 +1629,13 @@ public class IndexDatabase {
         return hash;
     }
 
-    private boolean isXrefWriter(AbstractAnalyzer fa) {
-        AbstractAnalyzer.Genre g = fa.getFactory().getGenre();
-        return (g == AbstractAnalyzer.Genre.PLAIN || g == AbstractAnalyzer.Genre.XREFABLE);
-    }
-
     /**
      * Get a writer to which the xref can be written, or null if no xref
      * should be produced for files of this type.
      */
-    private Writer newXrefWriter(AbstractAnalyzer fa, String path)
-            throws IOException {
+    private Writer newXrefWriter(String path) throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (env.isGenerateHtml() && isXrefWriter(fa)) {
+        if (env.isGenerateHtml()) {
             boolean compressed = env.isCompressXref();
             File xrefFile = whatXrefFile(path, compressed);
             File parentFile = xrefFile.getParentFile();
@@ -1721,7 +1715,7 @@ public class IndexDatabase {
                                   String path) throws IOException {
 
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        boolean outIsXrefWriter = false;
+        boolean outIsXrefWriter = false; // potential xref writer
         int reqTabSize = project != null && project.hasTabSizeSetting() ?
             project.getTabSize() : 0;
         Integer actTabSize = settings.getTabSize();
@@ -1799,7 +1793,7 @@ public class IndexDatabase {
             }
 
             if (fa != null) {
-                outIsXrefWriter = isXrefWriter(fa);
+                outIsXrefWriter = true;
             }
 
             // The versions checks have passed.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -378,8 +378,8 @@ public class IndexDatabase {
                     .request()
                     .put(Entity.text(""));
         } catch (RuntimeException e) {
-            LOGGER.log(Level.WARNING, "Couldn''t notify the webapp that project {0} was indexed: {1}",
-                    new Object[] {project, e});
+            LOGGER.log(Level.WARNING, String.format("Couldn''t notify the webapp that project {0} was indexed",
+                    project), e);
             return;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -487,17 +487,17 @@ public class IndexDatabase {
                     reader.close();
                 }
             }
-        } catch (RuntimeException ex) {
-            LOGGER.log(Level.SEVERE,
-                "Failed with unexpected RuntimeException", ex);
-            throw ex;
-        } finally {
+
             try {
                 finishWriting();
             } catch (IOException e) {
                 finishingException = e;
             }
-
+        } catch (RuntimeException ex) {
+            LOGGER.log(Level.SEVERE,
+                "Failed with unexpected RuntimeException", ex);
+            throw ex;
+        } finally {
             completer = null;
             try {
                 if (writer != null) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -758,8 +758,8 @@ public class IndexDatabase {
                         transientXref.getAbsolutePath());
                 completer.add(ren);
             } else if (xrefOut != null) {
-                LOGGER.log(Level.FINER, "xref for {0} would be empty, removing", path);
-                transientXref.delete();
+                LOGGER.log(Level.FINER, "xref for {0} would be empty, will remove", path);
+                completer.add(new PendingFileDeletion(transientXref.toString()));
             }
         } catch (InterruptedException e) {
             LOGGER.log(Level.WARNING, "File ''{0}'' interrupted--{1}",


### PR DESCRIPTION
This change makes it possible to produce xref's for compressed files. The most complex part is trying to make sure that empty xref files are not lying around.