### PR TITLE
LDAP server fixes

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -226,11 +226,11 @@ public class LdapServer implements Serializable {
      * @return true if it is working
      */
     public synchronized boolean isWorking() {
-        if (!isReachable()) {
-            return false;
-        }
-
         if (ctx == null) {
+            if (!isReachable()) {
+                return false;
+            }
+
             ctx = connect();
         }
         return ctx != null;

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -268,7 +268,6 @@ public class LdapServer implements Serializable {
 
             try {
                 ctx = new InitialLdapContext(env, null);
-                ctx.reconnect(null);
                 ctx.setRequestControls(null);
                 LOGGER.log(Level.INFO, "Connected to LDAP server {0}", this.toString());
                 errorTimestamp = 0;


### PR DESCRIPTION
This change fixes problems related to LDAP server connections. This will decrease the utilization of LDAP servers used by the LDAP authorization plugins.