### PR TITLE
control thread pool size in invalidateRepositories()

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -42,7 +42,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -816,16 +815,12 @@ public final class HistoryGuru {
          * run in parallel to speed up the process.
          */
         final CountDownLatch latch = new CountDownLatch(repos.size());
-        final ExecutorService executor = Executors.newFixedThreadPool(
-            Runtime.getRuntime().availableProcessors(),
-            new ThreadFactory() {
-                @Override
-                public Thread newThread(Runnable runnable) {
+        final ExecutorService executor = Executors.newFixedThreadPool(env.getIndexingParallelism(),
+                runnable -> {
                     Thread thread = Executors.defaultThreadFactory().newThread(runnable);
                     thread.setName("invalidate-repos-" + thread.getId());
                     return thread;
-                }
-        });
+                });
 
         for (RepositoryInfo rinfo : repos) {
             executor.submit(new Runnable() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -757,7 +757,8 @@ public final class Indexer {
                     cfg.setWebappLAF((String) stylePath));
 
             parser.on("-T", "--threads", "=number", Integer.class,
-                    "The number of threads to use for index generation and repository scan.",
+                    "The number of threads to use for index generation, repository scan",
+                    "and repository invalidation.",
                     "By default the number of threads will be set to the number of available",
                     "CPUs. This influences the number of spawned ctags processes as well.").
                     execute(threadCount -> cfg.setIndexingParallelism((Integer) threadCount));


### PR DESCRIPTION
This change allows to set thread pool size in `HistoryGuru#invalidateRepositories()` via `-T` indexer option.