### PR TITLE
do not hardcode exact versions in requirements.txt

### DIFF
--- a/opengrok-tools/README.md
+++ b/opengrok-tools/README.md
@@ -39,12 +39,6 @@ python3 -m venv env
 . env/bin/activate
 ```
 
-Install development dependencies
-
-```bash
-python -m pip install -r requirements.txt
-```
-
 ## Developing
 
 When you start developing, install the package in a development mode.

--- a/opengrok-tools/requirements.txt
+++ b/opengrok-tools/requirements.txt
@@ -1,14 +1,3 @@
-certifi==2018.8.24
-chardet==3.0.4
-filelock==3.0.10
-idna==2.7
-JsonForm==0.0.2
-jsonschema==2.6.0
-JsonSir==0.0.2
-Python-EasyConfig==0.1.7
-PyYAML==3.13
-requests==2.20.0
-Resource==0.2.1
-six==1.11.0
-urllib3==1.23
-GitPython==3.0.6
+# installs dependencies from ./setup.py, and the package itself,
+# in editable mode
+-e .

--- a/opengrok-tools/requirements.txt
+++ b/opengrok-tools/requirements.txt
@@ -1,3 +1,0 @@
-# installs dependencies from ./setup.py, and the package itself,
-# in editable mode
--e .


### PR DESCRIPTION
I don't think capturing the exact developer environment via `requirements.txt` for the Python tools is necessary. This change will make `pip install -r requirements.txt` to install whatever is in the package dependencies in `setup.py`.