### PR TITLE
close inactive servers in prepareServers()

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
@@ -197,12 +197,24 @@ public class LdapFacade extends AbstractLdapProvider {
      * Go through all servers in the pool and record the first working.
      */
     void prepareServers() {
+        LOGGER.log(Level.FINER, "checking servers for {0}", this);
         for (int i = 0; i < servers.size(); i++) {
             LdapServer server = servers.get(i);
             if (server.isWorking() && actualServer == -1) {
                 actualServer = i;
             }
         }
+
+        // Close the connections to the inactive servers.
+        LOGGER.log(Level.FINER, "closing unused servers");
+        for (int i = 0; i < servers.size(); i++) {
+            if (i != actualServer) {
+                servers.get(i).close();
+            }
+        }
+
+        LOGGER.log(Level.FINER, "server check done, chosen {0} as the current server",
+                servers.get(actualServer));
     }
 
     /**

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
@@ -213,8 +213,8 @@ public class LdapFacade extends AbstractLdapProvider {
             }
         }
 
-        LOGGER.log(Level.FINER, "server check done, chosen {0} as the current server",
-                servers.get(actualServer));
+        LOGGER.log(Level.FINER, String.format("server check done (current server: %s)",
+                actualServer != -1 ? servers.get(actualServer) : "N/A"));
     }
 
     /**

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
@@ -213,8 +213,10 @@ public class LdapFacade extends AbstractLdapProvider {
             }
         }
 
-        LOGGER.log(Level.FINER, String.format("server check done (current server: %s)",
-                actualServer != -1 ? servers.get(actualServer) : "N/A"));
+        if (LOGGER.isLoggable(Level.FINER)) {
+            LOGGER.log(Level.FINER, String.format("server check done (current server: %s)",
+                    actualServer != -1 ? servers.get(actualServer) : "N/A"));
+        }
     }
 
     /**


### PR DESCRIPTION
This change makes sure that inactive LDAP servers are closed in `LdapFacade#prepareServers()` after the working one is determined. The main goal is resource efficiency.

I had contemplated this change for a while. While it is nice to have connections/contexts established for these servers for quicker failover, it is not guaranteed that they will be in a working state by the time search request is made through them. Also, usually the 3-way TCP hadshake and LDAP bind operation do not take too long compared to LDAP query latency so the benefit of keeping them around is arguable.