### PR TITLE
Suggester rebuild terminate on undeploy

### DIFF
--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -217,6 +217,10 @@ public final class Suggester implements Closeable {
     private Runnable getInitRunnable(final NamedIndexDir indexDir) {
         return () -> {
             try {
+                if (terminating) {
+                    return;
+                }
+
                 Instant start = Instant.now();
                 LOGGER.log(Level.FINE, "Initializing {0}", indexDir);
 
@@ -334,6 +338,10 @@ public final class Suggester implements Closeable {
     private Runnable getRebuildRunnable(final SuggesterProjectData data) {
         return () -> {
             try {
+                if (terminating) {
+                    return;
+                }
+
                 Instant start = Instant.now();
                 LOGGER.log(Level.FINE, "Rebuilding {0}", data);
                 data.rebuild();

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -173,16 +173,16 @@ public final class Suggester implements Closeable {
         }
 
         synchronized (lock) {
-            if (terminating) {
-                return;
-            }
-
             Instant start = Instant.now();
             LOGGER.log(Level.INFO, "Initializing suggester");
 
             ExecutorService executor = Executors.newWorkStealingPool(rebuildParallelismLevel);
 
             for (NamedIndexDir indexDir : luceneIndexes) {
+                if (terminating) {
+                    LOGGER.log(Level.INFO, "Terminating suggester initialization");
+                    return;
+                }
                 submitInitIfIndexExists(executor, indexDir);
             }
 

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -173,6 +173,10 @@ public final class Suggester implements Closeable {
         }
 
         synchronized (lock) {
+            if (terminating) {
+                return;
+            }
+
             Instant start = Instant.now();
             LOGGER.log(Level.INFO, "Initializing suggester");
 
@@ -181,6 +185,7 @@ public final class Suggester implements Closeable {
             for (NamedIndexDir indexDir : luceneIndexes) {
                 if (terminating) {
                     LOGGER.log(Level.INFO, "Terminating suggester initialization");
+                    shutdownAndAwaitTermination(executor);
                     return;
                 }
                 submitInitIfIndexExists(executor, indexDir);
@@ -251,17 +256,26 @@ public final class Suggester implements Closeable {
         }
     }
 
+    private void shutdownAndAwaitTermination(final ExecutorService executorService) {
+        shutdownAndAwaitTermination(executorService, null, null, null);
+    }
+
     private void shutdownAndAwaitTermination(final ExecutorService executorService, Instant start,
                                              Timer timer,
                                              final String logMessageOnSuccess) {
         executorService.shutdown();
         try {
             executorService.awaitTermination(awaitTerminationTime.toMillis(), TimeUnit.MILLISECONDS);
-            Duration duration = Duration.between(start, Instant.now());
-            timer.record(duration);
-            LOGGER.log(Level.INFO, "{0} (took {1})", new Object[]{logMessageOnSuccess,
-                    DurationFormatUtils.formatDurationWords(duration.toMillis(),
-                            true, true)});
+            Duration duration = null;
+            if (timer != null) {
+                duration = Duration.between(start, Instant.now());
+                timer.record(duration);
+            }
+            if (duration != null && logMessageOnSuccess != null) {
+                LOGGER.log(Level.INFO, "{0} (took {1})", new Object[]{logMessageOnSuccess,
+                        DurationFormatUtils.formatDurationWords(duration.toMillis(),
+                                true, true)});
+            }
         } catch (InterruptedException e) {
             LOGGER.log(Level.SEVERE, "Interrupted while building suggesters", e);
             Thread.currentThread().interrupt();
@@ -293,6 +307,12 @@ public final class Suggester implements Closeable {
             ExecutorService executor = Executors.newWorkStealingPool(rebuildParallelismLevel);
 
             for (NamedIndexDir indexDir : indexDirs) {
+                if (terminating) {
+                    LOGGER.log(Level.INFO, "Terminating suggester rebuild");
+                    shutdownAndAwaitTermination(executor);
+                    return;
+                }
+
                 SuggesterProjectData data = this.projectData.get(indexDir.name);
                 if (data != null) {
                     executor.submit(getRebuildRunnable(data));

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -173,6 +173,10 @@ public final class Suggester implements Closeable {
         }
 
         synchronized (lock) {
+            if (terminating) {
+                return;
+            }
+
             Instant start = Instant.now();
             LOGGER.log(Level.INFO, "Initializing suggester");
 


### PR DESCRIPTION
This should take care of the long wait on undeploy when there is a number of outstanding suggester rebuild jobs.

It does so by setting a flag so if there is a long running rebuild in progress already it will still wait for that. That would be the case also when shutting down an executor (interrupting the threads by shutting the executor down immediately would not be a good practice).