### PR TITLE
add Indexer option to set API token

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -304,6 +304,7 @@ public final class Configuration {
     private Set<String> disabledRepositories;
 
     private Set<String> authenticationTokens; // for non-localhost API access
+    private String indexerAuthenticationToken;
 
     /*
      * types of handling history for remote SCM repositories:
@@ -1345,6 +1346,14 @@ public final class Configuration {
 
     public void setAuthenticationTokens(Set<String> tokens) {
         this.authenticationTokens = tokens;
+    }
+
+    public String getIndexerAuthenticationToken() {
+        return indexerAuthenticationToken;
+    }
+
+    public void setIndexerAuthenticationToken(String token) {
+        this.indexerAuthenticationToken = token;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -24,6 +24,7 @@
 package org.opengrok.indexer.configuration;
 
 import static org.opengrok.indexer.configuration.Configuration.makeXMLStringAsConfiguration;
+import static org.opengrok.indexer.index.IndexerUtil.getHeaders;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -1418,6 +1419,7 @@ public final class RuntimeEnvironment {
                 .path("configuration")
                 .queryParam("reindex", true)
                 .request()
+                .headers(getHeaders())
                 .put(Entity.xml(configXML));
 
         if (r.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
@@ -1444,6 +1446,7 @@ public final class RuntimeEnvironment {
                     .path("system")
                     .path("refresh")
                     .request()
+                    .headers(getHeaders())
                     .put(Entity.text(project));
 
             if (r.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
@@ -1946,6 +1949,14 @@ public final class RuntimeEnvironment {
 
     private int getMessageLimit() {
         return syncReadConfiguration(Configuration::getMessageLimit);
+    }
+
+    public String getIndexerAuthenticationToken() {
+        return syncReadConfiguration(Configuration::getIndexerAuthenticationToken);
+    }
+
+    public void setIndexerAuthenticationToken(String token) {
+        syncWriteConfiguration(token, Configuration::setIndexerAuthenticationToken);
     }
 
     public Set<String> getAuthenticationTokens() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -24,7 +24,7 @@
 package org.opengrok.indexer.configuration;
 
 import static org.opengrok.indexer.configuration.Configuration.makeXMLStringAsConfiguration;
-import static org.opengrok.indexer.index.IndexerUtil.getHeaders;
+import static org.opengrok.indexer.index.IndexerUtil.getWebAppHeaders;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -1419,7 +1419,7 @@ public final class RuntimeEnvironment {
                 .path("configuration")
                 .queryParam("reindex", true)
                 .request()
-                .headers(getHeaders())
+                .headers(getWebAppHeaders())
                 .put(Entity.xml(configXML));
 
         if (r.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
@@ -1446,7 +1446,7 @@ public final class RuntimeEnvironment {
                     .path("system")
                     .path("refresh")
                     .request()
-                    .headers(getHeaders())
+                    .headers(getWebAppHeaders())
                     .put(Entity.text(project));
 
             if (r.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -104,6 +104,8 @@ import org.opengrok.indexer.util.Statistics;
 import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.Util;
 
+import static org.opengrok.indexer.index.IndexerUtil.getHeaders;
+
 /**
  * This class is used to create / update the index databases. Currently we use
  * one index database per project.
@@ -376,6 +378,7 @@ public class IndexDatabase {
                     .path(Util.URIEncode(project.getName()))
                     .path("indexed")
                     .request()
+                    .headers(getHeaders())
                     .put(Entity.text(""));
         } catch (RuntimeException e) {
             LOGGER.log(Level.WARNING, String.format("Couldn''t notify the webapp that project %s was indexed",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -104,7 +104,7 @@ import org.opengrok.indexer.util.Statistics;
 import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.Util;
 
-import static org.opengrok.indexer.index.IndexerUtil.getHeaders;
+import static org.opengrok.indexer.index.IndexerUtil.getWebAppHeaders;
 
 /**
  * This class is used to create / update the index databases. Currently we use
@@ -378,7 +378,7 @@ public class IndexDatabase {
                     .path(Util.URIEncode(project.getName()))
                     .path("indexed")
                     .request()
-                    .headers(getHeaders())
+                    .headers(getWebAppHeaders())
                     .put(Entity.text(""));
         } catch (RuntimeException e) {
             LOGGER.log(Level.WARNING, String.format("Couldn''t notify the webapp that project %s was indexed",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -35,7 +35,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -756,6 +756,23 @@ public final class Indexer {
                     "stylesheet. The factory-setting is: \"default\".").execute(stylePath ->
                     cfg.setWebappLAF((String) stylePath));
 
+            parser.on("--token", "=string|@file_with_string",
+                    "Authorization bearer API token to use when making API calls",
+                    "to the web application").
+                    execute(optarg -> {
+                        String value = ((String) optarg).trim();
+                        if (value.startsWith("@")) {
+                            try {
+                                String token = new String(Files.readAllBytes(Path.of(value))).trim();
+                                cfg.setIndexerAuthenticationToken(token);
+                            } catch (IOException e) {
+                                die("Failed to read from " + value);
+                            }
+                        } else {
+                            cfg.setIndexerAuthenticationToken(value);
+                        }
+                    });
+
             parser.on("-T", "--threads", "=number", Integer.class,
                     "The number of threads to use for index generation, repository scan",
                     "and repository invalidation.",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -756,6 +756,17 @@ public final class Indexer {
                     "stylesheet. The factory-setting is: \"default\".").execute(stylePath ->
                     cfg.setWebappLAF((String) stylePath));
 
+            parser.on("-T", "--threads", "=number", Integer.class,
+                    "The number of threads to use for index generation, repository scan",
+                    "and repository invalidation.",
+                    "By default the number of threads will be set to the number of available",
+                    "CPUs. This influences the number of spawned ctags processes as well.").
+                    execute(threadCount -> cfg.setIndexingParallelism((Integer) threadCount));
+
+            parser.on("-t", "--tabSize", "=number", Integer.class,
+                "Default tab size to use (number of spaces per tab character).")
+                    .execute(tabSize -> cfg.setTabSize((Integer) tabSize));
+
             parser.on("--token", "=string|@file_with_string",
                     "Authorization bearer API token to use when making API calls",
                     "to the web application").
@@ -772,17 +783,6 @@ public final class Indexer {
                             cfg.setIndexerAuthenticationToken(value);
                         }
                     });
-
-            parser.on("-T", "--threads", "=number", Integer.class,
-                    "The number of threads to use for index generation, repository scan",
-                    "and repository invalidation.",
-                    "By default the number of threads will be set to the number of available",
-                    "CPUs. This influences the number of spawned ctags processes as well.").
-                    execute(threadCount -> cfg.setIndexingParallelism((Integer) threadCount));
-
-            parser.on("-t", "--tabSize", "=number", Integer.class,
-                "Default tab size to use (number of spaces per tab character).")
-                    .execute(tabSize -> cfg.setTabSize((Integer) tabSize));
 
             parser.on("-U", "--uri", "=SCHEME://webappURI:port/contextPath",
                 "Send the current configuration to the specified web application.").execute(webAddr -> {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -24,14 +24,18 @@
  */
 package org.opengrok.indexer.index;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -773,8 +777,9 @@ public final class Indexer {
                     execute(optarg -> {
                         String value = ((String) optarg).trim();
                         if (value.startsWith("@")) {
-                            try {
-                                String token = new String(Files.readAllBytes(Path.of(value))).trim();
+                            try (BufferedReader in = new BufferedReader(new InputStreamReader(
+                                    new FileInputStream(Path.of(value).toString().substring(1))))) {
+                                String token = in.readLine().trim();
                                 cfg.setIndexerAuthenticationToken(token);
                             } catch (IOException e) {
                                 die("Failed to read from " + value);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerUtil.java
@@ -43,7 +43,7 @@ public class IndexerUtil {
     /**
      * @return map of HTTP headers to use when making API requests to the web application
      */
-    public static MultivaluedMap<String, Object> getHeaders() {
+    public static MultivaluedMap<String, Object> getWebAppHeaders() {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         String token = null;
         if ((token = RuntimeEnvironment.getInstance().getIndexerAuthenticationToken()) != null) {
@@ -75,7 +75,7 @@ public class IndexerUtil {
                                                         .path("configuration")
                                                         .path("projectsEnabled")
                                                         .request()
-                                                        .headers(getHeaders());
+                                                        .headers(getWebAppHeaders());
         final String enabled = request.get(String.class);
         if (enabled == null || !Boolean.valueOf(enabled)) {
             final Response r = request.put(Entity.text(Boolean.TRUE.toString()));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerUtil.java
@@ -22,17 +22,35 @@
  */
 package org.opengrok.indexer.index;
 
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.ResponseProcessingException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
-class IndexerUtil {
+public class IndexerUtil {
 
     private IndexerUtil() {
+    }
+
+    /**
+     * @return map of HTTP headers to use when making API requests to the web application
+     */
+    public static MultivaluedMap<String, Object> getHeaders() {
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        String token = null;
+        if ((token = RuntimeEnvironment.getInstance().getIndexerAuthenticationToken()) != null) {
+            headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        }
+
+        return headers;
     }
 
     /**
@@ -56,7 +74,8 @@ class IndexerUtil {
                                                         .path("v1")
                                                         .path("configuration")
                                                         .path("projectsEnabled")
-                                                        .request();
+                                                        .request()
+                                                        .headers(getHeaders());
         final String enabled = request.get(String.class);
         if (enabled == null || !Boolean.valueOf(enabled)) {
             final Response r = request.put(Entity.text(Boolean.TRUE.toString()));


### PR DESCRIPTION
This change adds `--token` Indexer option to allow setting API tokens in the requests made to the web application.

Out of the occurrences where requests are made to the web app `plugins/src/main/java/opengrok/auth/plugin/util/RestfulClient.java#postIt()` was left untouched because it is effectively running in the web app context.

Tested with the `isSecure()` check commented out in the `IncomingFilter` and making sure the token matched.