### PR TITLE
check indexes on webapp startup

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -135,9 +135,7 @@ public class IndexCheck {
         int segVersion;
 
         try (Directory indexDirectory = FSDirectory.open(dir.toPath(), lockFactory)) {
-           SegmentInfos segInfos;
-
-            segInfos = SegmentInfos.readLatestCommit(indexDirectory);
+            SegmentInfos segInfos = SegmentInfos.readLatestCommit(indexDirectory);
             segVersion = segInfos.getIndexCreatedVersionMajor();
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -72,7 +72,6 @@ import org.opengrok.indexer.history.RepositoriesHelp;
 import org.opengrok.indexer.history.Repository;
 import org.opengrok.indexer.history.RepositoryFactory;
 import org.opengrok.indexer.history.RepositoryInfo;
-import org.opengrok.indexer.index.IndexVersion.IndexVersionException;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.logger.LoggerUtil;
 import org.opengrok.indexer.util.CtagsUtil;
@@ -112,7 +111,7 @@ public final class Indexer {
 
     private static final Indexer index = new Indexer();
     private static Configuration cfg = null;
-    private static boolean checkIndexVersion = false;
+    private static boolean checkIndex = false;
     private static boolean runIndex = true;
     private static boolean optimizedChanged = false;
     private static boolean addProjects = false;
@@ -253,22 +252,19 @@ public final class Indexer {
 
             // Check version of index(es) versus current Lucene version and exit
             // with return code upon failure.
-            if (checkIndexVersion) {
+            if (checkIndex) {
                 if (cfg == null) {
-                    System.err.println("Need configuration to check index version (use -R)");
+                    System.err.println("Need configuration to check index (use -R)");
                     System.exit(1);
                 }
 
-                try {
-                    IndexVersion.check(subFilesList);
-                } catch (IndexVersionException e) {
-                    System.err.printf("Index version check failed: %s\n", e);
+                if (!IndexCheck.check(subFilesList)) {
+                    System.err.printf("Index check failed\n");
                     System.err.print("You might want to remove " +
                             (subFilesList.size() > 0 ?
                                     "data for projects " + String.join(",", subFilesList) : "all data") +
-                            " under the DATA_ROOT and to reindex\n");
-                    status = 1;
-                    System.exit(status);
+                            " under the data root and reindex\n");
+                    System.exit(1);
                 }
             }
 
@@ -505,9 +501,7 @@ public final class Indexer {
                 canonicalRoots.add(root);
             });
 
-            parser.on("--checkIndexVersion",
-                    "Check if current Lucene version matches index version.").execute(v ->
-                    checkIndexVersion = true);
+            parser.on("--checkIndex", "Check index.").execute(v -> checkIndex = true);
 
             parser.on("-d", "--dataRoot", "=/path/to/data/root",
                 "The directory where OpenGrok stores the generated data.").

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -36,6 +36,7 @@ import org.junit.After;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -47,10 +48,10 @@ import org.opengrok.indexer.util.IOUtils;
 import org.opengrok.indexer.util.TestRepository;
 
 /**
- * Verify index version check.
- * @author Vladimir Kotal
+ * Verify index check.
+ * @author Vladimír Kotal
  */
-public class IndexVersionTest {
+public class IndexCheckTest {
 
     private TestRepository repository;
     private RuntimeEnvironment env = RuntimeEnvironment.getInstance();
@@ -88,12 +89,12 @@ public class IndexVersionTest {
                 false, null, null);
         Indexer.getInstance().doIndexerExecution(true, null, null);
 
-        IndexVersion.check(subFiles);
+        IndexCheck.check(subFiles);
     }
 
     @Test
     public void testIndexVersionNoIndex() throws Exception {
-        IndexVersion.check(new ArrayList<>());
+        IndexCheck.check(new ArrayList<>());
     }
 
     @Test
@@ -111,20 +112,21 @@ public class IndexVersionTest {
         testIndexVersion(false, new ArrayList<>());
     }
 
-    @Test(expected = IndexVersion.IndexVersionException.class)
+    @Test(expected = IndexCheck.IndexVersionException.class)
     public void testIndexVersionOldIndex() throws Exception {
         oldIndexDataDir = Files.createTempDirectory("data");
         Path indexPath = oldIndexDataDir.resolve("index");
         Files.createDirectory(indexPath);
         File indexDir = new File(indexPath.toString());
         assertTrue("index directory check", indexDir.isDirectory());
-        URL oldindex = getClass().getResource("/index/oldindex.zip");
-        assertNotNull("resource needs to be non null", oldindex);
-        File archive = new File(oldindex.getPath());
+        URL oldIndex = getClass().getResource("/index/oldindex.zip");
+        assertNotNull("resource needs to be non null", oldIndex);
+        File archive = new File(oldIndex.getPath());
         assertTrue("archive exists", archive.isFile());
         FileUtilities.extractArchive(archive, indexDir);
         env.setDataRoot(oldIndexDataDir.toString());
         env.setProjectsEnabled(false);
-        IndexVersion.check(new ArrayList<>());
+        assertFalse(IndexCheck.check(new ArrayList<>()));
+        IndexCheck.checkDir(indexDir);
     }
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -104,7 +104,7 @@ public final class WebappListener
             env.watchDog.start(new File(pluginDirectory));
         }
 
-        // Check project index(es).
+        // Check index(es).
         if (env.isProjectsEnabled()) {
             LOGGER.log(Level.FINE, "Checking indexes for all projects");
             Map<String, Project> projects = env.getProjects();

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -121,6 +121,14 @@ public final class WebappListener
                 }
             }
             LOGGER.log(Level.FINE, "Index check for all projects done");
+        } else {
+            LOGGER.log(Level.FINE, "Checking index");
+            try {
+                IndexCheck.checkDir(new File(env.getDataRootPath(), IndexDatabase.INDEX_DIR));
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, "index check failed", e);
+            }
+            LOGGER.log(Level.FINE, "Index check done");
         }
 
         env.startExpirationTimer();

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -105,6 +105,18 @@ public final class WebappListener
         }
 
         // Check index(es).
+        check_index(env);
+
+        env.startExpirationTimer();
+        startupTimer.record(Duration.between(start, Instant.now()));
+    }
+
+    /**
+     * Checks the index(es). If projects are enabled then each project with invalid index
+     * is marked as not being indexed.
+     * @param env runtime environment
+     */
+    private void check_index(RuntimeEnvironment env) {
         if (env.isProjectsEnabled()) {
             LOGGER.log(Level.FINE, "Checking indexes for all projects");
             Map<String, Project> projects = env.getProjects();
@@ -130,9 +142,6 @@ public final class WebappListener
             }
             LOGGER.log(Level.FINE, "Index check done");
         }
-
-        env.startExpirationTimer();
-        startupTimer.record(Duration.between(start, Instant.now()));
     }
 
     /**


### PR DESCRIPTION
This change checks the project indexes during web app startup. If a project does not have valid index, it is marked as not indexed. This is to catch cases such as the one described in #3418.

In web app log this looks like this:
```
17-Feb-2021 10:36:54.452 WARNING [RMI TCP Connection(10)-127.0.0.1] org.opengrok.web.WebappListener.contextInitialized Project foo index check failed, marking as not indexed
	Directory /var/opengrok/data/index/foo has index version discrepancy: Lucene version = 8, index version = 7
		at org.opengrok.indexer.index.IndexCheck.checkDir(IndexCheck.java:146)
		at org.opengrok.web.WebappListener.contextInitialized(WebappListener.java:115)
		at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4699)
		at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5165)
		at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
		at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:743)
		at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:719)
		at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:705)
		at org.apache.catalina.startup.HostConfig.manageApp(HostConfig.java:1720)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:566)
		at org.apache.tomcat.util.modeler.BaseModelMBean.invoke(BaseModelMBean.java:287)
		at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:809)
		at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:801)
		at org.apache.catalina.mbeans.MBeanFactory.createStandardContext(MBeanFactory.java:479)
		at org.apache.catalina.mbeans.MBeanFactory.createStandardContext(MBeanFactory.java:428)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:566)
		at org.apache.tomcat.util.modeler.BaseModelMBean.invoke(BaseModelMBean.java:287)
		at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:809)
		at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:801)
		at java.management/com.sun.jmx.remote.security.MBeanServerAccessController.invoke(MBeanServerAccessController.java:468)
		at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.doOperation(RMIConnectionImpl.java:1466)
		at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl$PrivilegedOperation.run(RMIConnectionImpl.java:1307)
		at java.base/java.security.AccessController.doPrivileged(Native Method)
		at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.doPrivilegedOperation(RMIConnectionImpl.java:1406)
		at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.invoke(RMIConnectionImpl.java:827)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:566)
		at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:359)
		at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
		at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
		at java.base/java.security.AccessController.doPrivileged(Native Method)
		at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
		at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:562)
		at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:796)
		at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:677)
		at java.base/java.security.AccessController.doPrivileged(Native Method)
		at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:676)
		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
		at java.base/java.lang.Thread.run(Thread.java:834)
17-Feb-2021 10:36:54.458 WARNING [RMI TCP Connection(10)-127.0.0.1] org.opengrok.web.WebappListener.contextInitialized Project unix-v1 index check failed, marking as not indexed
	org.apache.lucene.index.CorruptIndexException: Unexpected file read error while reading index. (resource=BufferedChecksumIndexInput(MMapIndexInput(path="/var/opengrok/data/index/unix-v1/segments_3")))
		at org.apache.lucene.index.SegmentInfos.readCommit(SegmentInfos.java:293)
		at org.apache.lucene.index.SegmentInfos$1.doBody(SegmentInfos.java:461)
		at org.apache.lucene.index.SegmentInfos$1.doBody(SegmentInfos.java:458)
		at org.apache.lucene.index.SegmentInfos$FindSegmentsFile.run(SegmentInfos.java:720)
		at org.apache.lucene.index.SegmentInfos$FindSegmentsFile.run(SegmentInfos.java:672)
		at org.apache.lucene.index.SegmentInfos.readLatestCommit(SegmentInfos.java:463)
		at org.opengrok.indexer.index.IndexCheck.checkDir(IndexCheck.java:140)
		at org.opengrok.web.WebappListener.contextInitialized(WebappListener.java:115)
		at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4699)
		at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5165)
		at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
		at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:743)
		at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:719)
		at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:705)
		at org.apache.catalina.startup.HostConfig.manageApp(HostConfig.java:1720)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:566)
		at org.apache.tomcat.util.modeler.BaseModelMBean.invoke(BaseModelMBean.java:287)
		at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:809)
		at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:801)
		at org.apache.catalina.mbeans.MBeanFactory.createStandardContext(MBeanFactory.java:479)
		at org.apache.catalina.mbeans.MBeanFactory.createStandardContext(MBeanFactory.java:428)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:566)
		at org.apache.tomcat.util.modeler.BaseModelMBean.invoke(BaseModelMBean.java:287)
		at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:809)
		at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:801)
		at java.management/com.sun.jmx.remote.security.MBeanServerAccessController.invoke(MBeanServerAccessController.java:468)
		at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.doOperation(RMIConnectionImpl.java:1466)
		at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl$PrivilegedOperation.run(RMIConnectionImpl.java:1307)
		at java.base/java.security.AccessController.doPrivileged(Native Method)
		at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.doPrivilegedOperation(RMIConnectionImpl.java:1406)
		at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.invoke(RMIConnectionImpl.java:827)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:566)
		at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:359)
		at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
		at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
		at java.base/java.security.AccessController.doPrivileged(Native Method)
		at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
		at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:562)
		at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:796)
		at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:677)
		at java.base/java.security.AccessController.doPrivileged(Native Method)
		at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:676)
		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
		at java.base/java.lang.Thread.run(Thread.java:834)
	Caused by: java.nio.file.NoSuchFileException: /var/opengrok/data/index/unix-v1/_6.si
		at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
		at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
		at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
		at java.base/sun.nio.fs.UnixFileSystemProvider.newFileChannel(UnixFileSystemProvider.java:182)
		at java.base/java.nio.channels.FileChannel.open(FileChannel.java:292)
		at java.base/java.nio.channels.FileChannel.open(FileChannel.java:345)
		at org.apache.lucene.store.MMapDirectory.openInput(MMapDirectory.java:238)
		at org.apache.lucene.store.Directory.openChecksumInput(Directory.java:157)
		at org.apache.lucene.codecs.lucene86.Lucene86SegmentInfoFormat.read(Lucene86SegmentInfoFormat.java:91)
		at org.apache.lucene.index.SegmentInfos.readCommit(SegmentInfos.java:357)
		at org.apache.lucene.index.SegmentInfos.readCommit(SegmentInfos.java:291)
		... 53 more
		Suppressed: org.apache.lucene.index.CorruptIndexException: checksum passed (5a03ac17). possibly transient resource issue, or a Lucene or JVM bug (resource=BufferedChecksumIndexInput(MMapIndexInput(path="/var/opengrok/data/index/unix-v1/segments_3")))
			at org.apache.lucene.codecs.CodecUtil.checkFooter(CodecUtil.java:466)
			at org.apache.lucene.index.SegmentInfos.readCommit(SegmentInfos.java:434)
			... 54 more
```