### PR TITLE
allow to use API token with Python tools

### DIFF
--- a/dev/before_install
+++ b/dev/before_install
@@ -14,7 +14,6 @@ if [[ "$RUNNER_OS" == "Linux" ]]; then
 	    cssc \
 	    bzr \
 	    subversion \
-	    monotone \
 	    rcs \
 	    rcs-blame \
 	    python3 \

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -305,6 +305,7 @@ public final class Configuration {
 
     private Set<String> authenticationTokens; // for non-localhost API access
     private String indexerAuthenticationToken;
+    private boolean allowInsecureTokens;
 
     /*
      * types of handling history for remote SCM repositories:
@@ -1354,6 +1355,14 @@ public final class Configuration {
 
     public void setIndexerAuthenticationToken(String token) {
         this.indexerAuthenticationToken = token;
+    }
+
+    public boolean isAllowInsecureTokens() {
+        return this.allowInsecureTokens;
+    }
+
+    public void setAllowInsecureTokens(boolean value) {
+        this.allowInsecureTokens = value;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1967,6 +1967,14 @@ public final class RuntimeEnvironment {
         syncWriteConfiguration(tokens, Configuration::setAuthenticationTokens);
     }
 
+    public boolean isAllowInsecureTokens() {
+        return syncReadConfiguration(Configuration::isAllowInsecureTokens);
+    }
+
+    public void setAllowInsecureTokens(boolean value) {
+        syncWriteConfiguration(value, Configuration::setAllowInsecureTokens);
+    }
+
     public void registerListener(ConfigurationChangedListener listener) {
         listeners.add(listener);
     }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
@@ -122,13 +122,15 @@ public class IncomingFilter implements ContainerRequestFilter, ConfigurationChan
 
         String path = context.getUriInfo().getPath();
 
-        if (request.isSecure()) {
-            String authHeaderValue = request.getHeader(HttpHeaders.AUTHORIZATION);
-            if (authHeaderValue != null && authHeaderValue.startsWith(BEARER)) {
-                String tokenValue = authHeaderValue.substring(BEARER.length());
-                if (getTokens().contains(tokenValue)) {
-                    LOGGER.log(Level.FINEST, "allowing request to {0} based on authentication header token", path);
+        String authHeaderValue = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authHeaderValue != null && authHeaderValue.startsWith(BEARER)) {
+            String tokenValue = authHeaderValue.substring(BEARER.length());
+            if (getTokens().contains(tokenValue)) {
+                if (request.isSecure() || RuntimeEnvironment.getInstance().isAllowInsecureTokens()) {
+                    LOGGER.log(Level.FINEST, "allowing request to {0} based on authentication token", path);
                     return;
+                } else {
+                    LOGGER.log(Level.FINEST, "request to {0} has a valid token however is not secure", path);
                 }
             }
         }

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -104,6 +104,7 @@ def main():
                              ' if no change is found.')
     parser.add_argument('-w', '--workers', default=cpu_count(),
                         help='Number of worker processes')
+    # TODO HTTP headers
 
     try:
         args = parser.parse_args()

--- a/tools/src/main/python/opengrok_tools/projadm.py
+++ b/tools/src/main/python/opengrok_tools/projadm.py
@@ -263,7 +263,7 @@ def main():
     #
     logger = get_console_logger(get_class_basename(), args.loglevel)
 
-    headers = get_headers(args.headers)
+    headers = get_headers(args.header)
 
     if args.nosourcedelete and not args.delete:
         logger.error("The no source delete option is only valid for delete")

--- a/tools/src/main/python/opengrok_tools/reindex_project.py
+++ b/tools/src/main/python/opengrok_tools/reindex_project.py
@@ -30,7 +30,7 @@ import tempfile
 from .utils.indexer import Indexer
 from .utils.log import get_console_logger, get_class_basename, fatal
 from .utils.opengrok import get_configuration
-from .utils.parsers import get_java_parser
+from .utils.parsers import get_java_parser, add_http_headers, get_headers
 from .utils.exitvals import (
     FAILURE_EXITVAL,
     SUCCESS_EXITVAL
@@ -89,8 +89,7 @@ def main():
     parser.add_argument('-U', '--uri', default='http://localhost:8080/source',
                         help='URI of the webapp with context path')
     parser.add_argument('--printoutput', action='store_true', default=False)
-    headers = {}
-    # TODO HTTP headers - append headers
+    add_http_headers(parser)
 
     cmd_args = sys.argv[1:]
     extra_opts = os.environ.get("OPENGROK_INDEXER_OPTIONAL_ARGS")
@@ -112,6 +111,7 @@ def main():
             os.makedirs(args.directory)
 
     # Get files needed for per-project reindex.
+    headers = get_headers(args.header)
     conf_file = get_config_file(logger, args.uri, headers=headers)
     logprop_file = None
     if args.template and args.pattern:

--- a/tools/src/main/python/opengrok_tools/reindex_project.py
+++ b/tools/src/main/python/opengrok_tools/reindex_project.py
@@ -60,11 +60,11 @@ def get_logprop_file(logger, template, pattern, project):
     return tmpf.name
 
 
-def get_config_file(logger, uri):
+def get_config_file(logger, uri, headers=None):
     """
     Get fresh configuration from the webapp and store it in temporary file.
     """
-    config = get_configuration(logger, uri)
+    config = get_configuration(logger, uri, headers)
 
     with tempfile.NamedTemporaryFile(delete=False) as tmpf:
         tmpf.write(config.encode())
@@ -89,6 +89,8 @@ def main():
     parser.add_argument('-U', '--uri', default='http://localhost:8080/source',
                         help='URI of the webapp with context path')
     parser.add_argument('--printoutput', action='store_true', default=False)
+    headers = {}
+    # TODO HTTP headers - append headers
 
     cmd_args = sys.argv[1:]
     extra_opts = os.environ.get("OPENGROK_INDEXER_OPTIONAL_ARGS")
@@ -110,7 +112,7 @@ def main():
             os.makedirs(args.directory)
 
     # Get files needed for per-project reindex.
-    conf_file = get_config_file(logger, args.uri)
+    conf_file = get_config_file(logger, args.uri, headers=headers)
     logprop_file = None
     if args.template and args.pattern:
         logprop_file = get_logprop_file(logger, args.template, args.pattern,

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -39,7 +39,7 @@ from filelock import Timeout, FileLock
 from .utils.commandsequence import CommandSequence, CommandSequenceBase
 from .utils.log import get_console_logger, get_class_basename, fatal
 from .utils.opengrok import list_indexed_projects, get_config_value
-from .utils.parsers import get_base_parser
+from .utils.parsers import get_base_parser, add_http_headers, get_headers
 from .utils.readconfig import read_config
 from .utils.utils import is_web_uri
 from .utils.exitvals import (
@@ -52,7 +52,7 @@ if (major_version < 3):
     print("Need Python 3, you are running {}".format(major_version))
     sys.exit(1)
 
-__version__ = "1.0"
+__version__ = "1.1"
 
 
 def worker(base):
@@ -68,7 +68,8 @@ def worker(base):
 
 
 def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
-            uri, numworkers, driveon=False, print_output=False, logger=None):
+            uri, numworkers, driveon=False, print_output=False, logger=None,
+            http_headers=None):
     """
     Process the list of directories in parallel.
     :param logger: logger to be used in this function
@@ -82,6 +83,8 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
     :param driveon: continue even if encountering failure
     :param print_output: whether to print the output of the commands
                          using the supplied logger
+    :param logger: optional logger
+    :param http_headers: optional dictionary of HTTP headers
     :return SUCCESS_EXITVAL on success, FAILURE_EXITVAL on error
     """
 
@@ -89,7 +92,8 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
     for dir in dirs_to_process:
         cmd_base = CommandSequenceBase(dir, commands, loglevel=loglevel,
                                        cleanup=cleanup,
-                                       driveon=driveon, url=uri)
+                                       driveon=driveon, url=uri,
+                                       http_headers=http_headers)
         cmds_base.append(cmd_base)
 
     # Map the commands into pool of workers so they can be processed.
@@ -144,6 +148,7 @@ def main():
     parser.add_argument('--nolock', action='store_false', default=True,
                         help='do not acquire lock that prevents multiple '
                         'instances from running')
+    add_http_headers(parser)
 
     try:
         args = parser.parse_args()
@@ -180,10 +185,17 @@ def main():
         logger.error("The config file has to contain key \"commands\"")
         return FAILURE_EXITVAL
 
+    headers = get_headers(args.headers)
+    config_headers = config.get("headers")
+    if config_headers:
+        logger.debug("Updating HTTP headers with headers from the configuration: {}".
+                     format(config_headers))
+        headers.update(config_headers)
+
     directory = args.directory
     if not args.directory and not args.projects and not args.indexed:
         # Assume directory, get the source root value from the webapp.
-        directory = get_config_value(logger, 'sourceRoot', uri)
+        directory = get_config_value(logger, 'sourceRoot', uri, headers=headers)
         if not directory:
             logger.error("Neither -d or -P or -I specified and cannot get "
                          "source root from the webapp")
@@ -207,7 +219,7 @@ def main():
         logger.debug("Processing directories: {}".
                      format(dirs_to_process))
     elif args.indexed:
-        indexed_projects = list_indexed_projects(logger, uri)
+        indexed_projects = list_indexed_projects(logger, uri, headers=headers)
         logger.debug("Processing indexed projects: {}".
                      format(indexed_projects))
 
@@ -229,7 +241,7 @@ def main():
         r = do_sync(args.loglevel, commands, config.get("cleanup"),
                     dirs_to_process,
                     ignore_errors, uri, args.workers,
-                    driveon=args.driveon)
+                    driveon=args.driveon, http_headers=headers)
     else:
         lock = FileLock(os.path.join(tempfile.gettempdir(),
                                      "opengrok-sync.lock"))
@@ -238,7 +250,7 @@ def main():
                 r = do_sync(args.loglevel, commands, config.get("cleanup"),
                             dirs_to_process,
                             ignore_errors, uri, args.workers,
-                            driveon=args.driveon)
+                            driveon=args.driveon, http_headers=headers)
         except Timeout:
             logger.warning("Already running")
             return FAILURE_EXITVAL

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -185,7 +185,7 @@ def main():
         logger.error("The config file has to contain key \"commands\"")
         return FAILURE_EXITVAL
 
-    headers = get_headers(args.headers)
+    headers = get_headers(args.header)
     config_headers = config.get("headers")
     if config_headers:
         logger.debug("Updating HTTP headers with headers from the configuration: {}".

--- a/tools/src/main/python/opengrok_tools/utils/commandsequence.py
+++ b/tools/src/main/python/opengrok_tools/utils/commandsequence.py
@@ -46,7 +46,7 @@ class CommandSequenceBase:
     """
 
     def __init__(self, name, commands, loglevel=logging.INFO, cleanup=None,
-                 driveon=False, url=None, env=None):
+                 driveon=False, url=None, env=None, http_headers=None):
         self.name = name
         self.commands = commands
         self.failed = False
@@ -59,6 +59,7 @@ class CommandSequenceBase:
         self.loglevel = loglevel
         self.driveon = driveon
         self.env = env
+        self.http_headers = http_headers
 
         self.url = url
 
@@ -127,7 +128,8 @@ class CommandSequence(CommandSequenceBase):
             if cmd_value.startswith(URL_SUBST) or is_web_uri(cmd_value):
                 try:
                     call_rest_api(command, {PROJECT_SUBST: self.name,
-                                            URL_SUBST: self.url})
+                                            URL_SUBST: self.url},
+                                  self.http_headers)
                 except HTTPError as e:
                     self.logger.error("RESTful command {} failed: {}".
                                       format(command, e))

--- a/tools/src/main/python/opengrok_tools/utils/commandsequence.py
+++ b/tools/src/main/python/opengrok_tools/utils/commandsequence.py
@@ -92,7 +92,8 @@ class CommandSequence(CommandSequenceBase):
     def __init__(self, base):
         super().__init__(base.name, base.commands, loglevel=base.loglevel,
                          cleanup=base.cleanup, driveon=base.driveon,
-                         url=base.url, env=base.env)
+                         url=base.url, env=base.env,
+                         http_headers=base.http_headers)
 
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(base.loglevel)
@@ -186,7 +187,8 @@ class CommandSequence(CommandSequenceBase):
             if arg0.startswith(URL_SUBST) or is_web_uri(arg0):
                 try:
                     call_rest_api(cleanup_cmd, {PROJECT_SUBST: self.name,
-                                                URL_SUBST: self.url})
+                                                URL_SUBST: self.url},
+                                  self.http_headers)
                 except HTTPError as e:
                     self.logger.error("RESTful command {} failed: {}".
                                       format(cleanup_cmd, e))

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -307,7 +307,7 @@ def run_command(cmd, project_name):
                             cmd.getoutputstr()))
 
 
-def handle_disabled_project(config, project_name, disabled_msg):
+def handle_disabled_project(config, project_name, disabled_msg, headers=None):
     disabled_command = config.get(DISABLED_CMD_PROPERTY)
     if disabled_command:
         logger = logging.getLogger(__name__)
@@ -329,7 +329,8 @@ def handle_disabled_project(config, project_name, disabled_msg):
                 command_args[2]["text"] = text + ": " + disabled_msg
 
             try:
-                call_rest_api(disabled_command, {PROJECT_SUBST: project_name})
+                call_rest_api(disabled_command, {PROJECT_SUBST: project_name},
+                              http_headers=headers)
             except HTTPError as e:
                 logger.error("API call failed for disabled command of "
                              "project '{}': {}".
@@ -384,7 +385,8 @@ def mirror_project(config, project_name, check_changes, uri,
         if project_config.get(DISABLED_PROPERTY):
             handle_disabled_project(config, project_name,
                                     project_config.
-                                    get(DISABLED_REASON_PROPERTY))
+                                    get(DISABLED_REASON_PROPERTY),
+                                    headers=headers)
             logger.info("Project '{}' disabled, exiting".
                         format(project_name))
             return CONTINUE_EXITVAL

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -63,7 +63,8 @@ DISABLED_CMD_PROPERTY = 'disabled_command'
 
 def get_repos_for_project(project_name, uri, source_root,
                           ignored_repos=None,
-                          commands=None, proxy=None, command_timeout=None):
+                          commands=None, proxy=None, command_timeout=None,
+                          headers=None):
     """
     :param project_name: project name
     :param uri: web application URI
@@ -73,13 +74,14 @@ def get_repos_for_project(project_name, uri, source_root,
     :param proxy: dictionary of proxy servers - to be used as environment
                   variables
     :param command_timeout: command timeout value in seconds
+    :param headers: optional HTTP headers dictionary
     :return: list of Repository objects
     """
 
     logger = logging.getLogger(__name__)
 
     repos = []
-    for repo_path in get_repos(logger, project_name, uri):
+    for repo_path in get_repos(logger, project_name, uri, headers=headers):
         logger.debug("Repository path = {}".format(repo_path))
 
         if ignored_repos:
@@ -344,7 +346,7 @@ def handle_disabled_project(config, project_name, disabled_msg):
 
 
 def mirror_project(config, project_name, check_changes, uri,
-                   source_root):
+                   source_root, headers=None):
     """
     Mirror the repositories of single project.
     :param config global configuration dictionary
@@ -396,7 +398,8 @@ def mirror_project(config, project_name, check_changes, uri,
                                   commands=config.
                                   get(COMMANDS_PROPERTY),
                                   proxy=proxy,
-                                  command_timeout=command_timeout)
+                                  command_timeout=command_timeout,
+                                  headers=headers)
     if not repos:
         logger.info("No repositories for project {}".
                     format(project_name))

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -91,7 +91,7 @@ def get_repos_for_project(project_name, uri, source_root,
                 logger.info("repository {} ignored".format(repo_path))
                 continue
 
-        repo_type = get_repo_type(logger, repo_path, uri)
+        repo_type = get_repo_type(logger, repo_path, uri, headers=headers)
         if not repo_type:
             raise RepositoryException("cannot determine type of repository {}".
                                       format(repo_path))
@@ -243,10 +243,11 @@ def process_hook(hook_ident, hook, source_root, project_name, proxy,
     return True
 
 
-def process_changes(repos, project_name, uri):
+def process_changes(repos, project_name, uri, headers=None):
     """
     :param repos: repository list
     :param project_name: project name
+    :param headers: optional dictionary of HTTP headers
     :return: exit code
     """
     logger = logging.getLogger(__name__)
@@ -257,7 +258,8 @@ def process_changes(repos, project_name, uri):
     try:
         r = do_api_call('GET', get_uri(uri, 'api', 'v1', 'projects',
                                        urllib.parse.quote_plus(project_name),
-                                       'property', 'indexed'))
+                                       'property', 'indexed'),
+                        headers=headers)
         if not bool(r.json()):
             changes_detected = True
             logger.info('Project {} has not been indexed yet'
@@ -407,7 +409,7 @@ def mirror_project(config, project_name, check_changes, uri,
 
     # Check if the project or any of its repositories have changed.
     if check_changes:
-        r = process_changes(repos, project_name, uri)
+        r = process_changes(repos, project_name, uri, headers=headers)
         if r != SUCCESS_EXITVAL:
             return r
 

--- a/tools/src/main/python/opengrok_tools/utils/opengrok.py
+++ b/tools/src/main/python/opengrok_tools/utils/opengrok.py
@@ -26,7 +26,7 @@ from .webutil import get_uri
 from .restful import do_api_call
 
 
-def get_repos(logger, project, uri):
+def get_repos(logger, project, uri, headers=None):
     """
     :param logger: logger instance
     :param project: project name
@@ -38,7 +38,8 @@ def get_repos(logger, project, uri):
     try:
         r = do_api_call('GET', get_uri(uri, 'api', 'v1', 'projects',
                                        urllib.parse.quote_plus(project),
-                                       'repositories'))
+                                       'repositories'),
+                        headers=headers)
     except Exception:
         logger.error('could not get repositories for ' + project)
         return None
@@ -50,7 +51,7 @@ def get_repos(logger, project, uri):
     return ret
 
 
-def get_config_value(logger, name, uri):
+def get_config_value(logger, name, uri, headers=None):
     """
     Get list of repositories for given project name.
 
@@ -58,7 +59,8 @@ def get_config_value(logger, name, uri):
     """
     try:
         r = do_api_call('GET', get_uri(uri, 'api', 'v1', 'configuration',
-                                       urllib.parse.quote_plus(name)))
+                                       urllib.parse.quote_plus(name)),
+                        headers=headers)
     except Exception:
         logger.error("Cannot get the '{}' config value from the web "
                      "application on {}".format(name, uri))
@@ -67,7 +69,7 @@ def get_config_value(logger, name, uri):
     return r.text
 
 
-def get_repo_type(logger, repository, uri):
+def get_repo_type(logger, repository, uri, headers=None):
     """
     Get repository type for given path relative to sourceRoot.
 
@@ -77,7 +79,8 @@ def get_repo_type(logger, repository, uri):
 
     try:
         r = do_api_call('GET', get_uri(uri, 'api', 'v1', 'repositories',
-                                       'property', 'type'), params=payload)
+                                       'property', 'type'), params=payload,
+                        headers=headers)
     except Exception:
         logger.error('could not get repository type for {} from web'
                      'application on {}'.format(repository, uri))
@@ -89,9 +92,10 @@ def get_repo_type(logger, repository, uri):
     return line[idx + 1:]
 
 
-def get_configuration(logger, uri):
+def get_configuration(logger, uri, headers=None):
     try:
-        r = do_api_call('GET', get_uri(uri, 'api', 'v1', 'configuration'))
+        r = do_api_call('GET', get_uri(uri, 'api', 'v1', 'configuration'),
+                        headers=headers)
     except Exception:
         logger.error('could not get configuration from web application on {}'.
                      format(uri))
@@ -100,10 +104,10 @@ def get_configuration(logger, uri):
     return r.text
 
 
-def set_configuration(logger, configuration, uri):
+def set_configuration(logger, configuration, uri, headers=None):
     try:
         do_api_call('PUT', get_uri(uri, 'api', 'v1', 'configuration'),
-                    data=configuration)
+                    data=configuration, headers=headers)
     except Exception:
         logger.error('could not set configuration for web application on {}'.
                      format(uri))
@@ -112,10 +116,11 @@ def set_configuration(logger, configuration, uri):
     return True
 
 
-def list_projects(logger, uri):
+def list_projects(logger, uri, headers=None):
     try:
         r = do_api_call('GET',
-                        get_uri(uri, 'api', 'v1', 'projects'))
+                        get_uri(uri, 'api', 'v1', 'projects'),
+                        headers=headers)
     except Exception:
         logger.error('could not list projects from web application '
                      'on {}'.format(uri))
@@ -124,10 +129,11 @@ def list_projects(logger, uri):
     return r.json()
 
 
-def list_indexed_projects(logger, uri):
+def list_indexed_projects(logger, uri, headers=None):
     try:
         r = do_api_call('GET',
-                        get_uri(uri, 'api', 'v1', 'projects', 'indexed'))
+                        get_uri(uri, 'api', 'v1', 'projects', 'indexed'),
+                        headers=headers)
     except Exception:
         logger.error('could not list indexed projects from web application '
                      'on {}'.format(uri))
@@ -136,10 +142,10 @@ def list_indexed_projects(logger, uri):
     return r.json()
 
 
-def add_project(logger, project, uri):
+def add_project(logger, project, uri, headers=None):
     try:
         do_api_call('POST', get_uri(uri, 'api', 'v1', 'projects'),
-                    data=project)
+                    data=project, headers=headers)
     except Exception:
         logger.error('could not add project {} for web application on {}'.
                      format(project, uri))
@@ -148,10 +154,11 @@ def add_project(logger, project, uri):
     return True
 
 
-def delete_project(logger, project, uri):
+def delete_project(logger, project, uri, headers=None):
     try:
         do_api_call('DELETE', get_uri(uri, 'api', 'v1', 'projects',
-                                      urllib.parse.quote_plus(project)))
+                                      urllib.parse.quote_plus(project)),
+                    headers=headers)
     except Exception:
         logger.error('could not delete project {} in web application on {}'.
                      format(project, uri))

--- a/tools/src/main/python/opengrok_tools/utils/parsers.py
+++ b/tools/src/main/python/opengrok_tools/utils/parsers.py
@@ -1,3 +1,27 @@
+#!/usr/bin/env python3
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+#
+
 import argparse
 
 from .log import add_log_level_argument
@@ -17,6 +41,39 @@ def str2bool(v):
 
     raise argparse.ArgumentTypeError('Boolean value or its string '
                                      'representation expected.')
+
+
+def add_http_headers(parser):
+    parser.add_argument('-H', '--header', nargs='+',
+                        help='add HTTP header(s) to API requests. '
+                             'In the form of \'name: value\' or @file_path '
+                             'to read headers from input file')
+
+
+def get_headers(headers_list):
+    """
+    Complement to add_http_headers() for parsing the data
+    acquired from argument parsing.
+
+    :param headers_list: list of 'name: value' strings
+    :return: dictionary indexed with names
+    """
+    headers = {}
+    if headers_list:
+        for arg in headers_list:
+            if arg.startswith("@"):
+                file_path = arg[1:]
+                with open(file_path) as file:
+                    for line in file:
+                        line = line.rstrip()
+                        if ': ' in line:
+                            name, value = line.split(': ')
+                            headers[name] = value
+            else:
+                name, value = arg.split(': ')
+                headers[name] = value
+
+    return headers
 
 
 def get_base_parser(tool_version=None):

--- a/tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/tools/src/main/python/opengrok_tools/utils/restful.py
@@ -76,17 +76,18 @@ def subst(src, substitutions):
     return src
 
 
-def call_rest_api(command, substitutions=None):
+def call_rest_api(command, substitutions=None, http_headers=None):
     """
     Make RESTful API call. Occurrence of the pattern in the URI
     (first part of the command) or data payload will be replaced by the name.
 
     Default content type is application/json.
 
-    :param command: command (list of URI, HTTP verb, data payload)
+    :param command: command (list of URI, HTTP verb, data payload,
+                             HTTP header dictionary)
     :param substitutions: dictionary of pattern:value for command and/or
                           data substitution
-    :param name: command name
+    :param http_headers: optional dictionary of HTTP headers to be appended
     :return return value from given requests method
     """
 
@@ -107,6 +108,9 @@ def call_rest_api(command, substitutions=None):
 
     if headers is None:
         headers = {}
+
+    if http_headers:
+        headers.update(http_headers)
 
     uri = subst(uri, substitutions)
     header_names = [x.lower() for x in headers.keys()]

--- a/tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/tools/src/main/python/opengrok_tools/utils/restful.py
@@ -109,7 +109,10 @@ def call_rest_api(command, substitutions=None, http_headers=None):
     if headers is None:
         headers = {}
 
+    logger.debug("Headers from the command: {}".format(headers))
     if http_headers:
+        logger.debug("Updating HTTP headers for command {} with {}".
+                     format(command, http_headers))
         headers.update(http_headers)
 
     uri = subst(uri, substitutions)

--- a/tools/src/test/python/test_command_sequence.py
+++ b/tools/src/test/python/test_command_sequence.py
@@ -20,7 +20,7 @@
 #
 
 #
-# Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
 #
 
 import os
@@ -180,3 +180,20 @@ def test_restful_fail(monkeypatch):
                   mock_response)
         commands.run()
         assert commands.check([]) == 1
+
+
+def test_headers_init():
+    headers = {'foo': 'bar'}
+
+    # First verify that header parameter of a command does not impact class member.
+    commands = CommandSequence(CommandSequenceBase("opengrok-master",
+                                                   [{'command': ['http://foo', 'PUT', 'data', headers]}]))
+
+    assert commands.http_headers is None
+
+    # Second, verify that init function propagates the headers.
+    commands = CommandSequence(CommandSequenceBase("opengrok-master",
+                                                   [{'command': ['http://foo', 'PUT', 'data']}],
+                                                   http_headers=headers))
+
+    assert commands.http_headers == headers

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -20,7 +20,7 @@
 #
 
 #
-# Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -135,8 +135,11 @@ def test_disabled_command_api():
     Test that mirror_project() calls call_rest_api() if API
     call is specified in the configuration for disabled project.
     """
+    def mock_call_rest_api(command, b, http_headers=None):
+        return mock(spec=requests.Response)
+
     with patch(opengrok_tools.utils.mirror.call_rest_api,
-               lambda a, b: mock(spec=requests.Response)):
+               mock_call_rest_api):
         project_name = "foo"
         config = {
             DISABLED_CMD_PROPERTY: {
@@ -153,7 +156,8 @@ def test_disabled_command_api():
                               None, None) == CONTINUE_EXITVAL
         verify(opengrok_tools.utils.mirror). \
             call_rest_api(config.get(DISABLED_CMD_PROPERTY),
-                          {PROJECT_SUBST: project_name})
+                          {PROJECT_SUBST: project_name},
+                          http_headers=None)
 
 
 def test_disabled_command_api_text_append(monkeypatch):
@@ -163,7 +167,7 @@ def test_disabled_command_api_text_append(monkeypatch):
 
     text_to_append = "foo bar"
 
-    def mock_call_rest_api(command, b):
+    def mock_call_rest_api(command, b, http_headers=None):
         disabled_command = config.get(DISABLED_CMD_PROPERTY)
         assert disabled_command
         command_args = disabled_command.get(COMMAND_PROPERTY)

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -308,10 +308,10 @@ def test_get_repos_for_project(monkeypatch):
     timeout = 314159
     test_repo = "/" + project_name
 
-    def mock_get_repos(*args):
+    def mock_get_repos(*args, headers=None):
         return [test_repo]
 
-    def mock_get_repo_type(*args):
+    def mock_get_repo_type(*args, headers=None):
         return "Git"
 
     with tempfile.TemporaryDirectory() as source_root:

--- a/tools/src/test/python/test_mirror_incoming_retval.py
+++ b/tools/src/test/python/test_mirror_incoming_retval.py
@@ -20,7 +20,7 @@
 #
 
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -76,6 +76,9 @@ def test_incoming_retval(monkeypatch):
         def mock_get(*args, **kwargs):
             return MockResponse()
 
+        def mock_get_config_value(*args, **kwargs):
+            return source_root
+
         # Clone a Git repository so that it can pull.
         repo = Repo.init(repo_path)
         with repo.config_writer() as git_config:
@@ -96,7 +99,7 @@ def test_incoming_retval(monkeypatch):
 
             # With mocking done via pytest it is necessary to patch
             # the call-site rather than the absolute object path.
-            m.setattr("opengrok_tools.mirror.get_config_value", lambda x, y, z: source_root)
+            m.setattr("opengrok_tools.mirror.get_config_value", mock_get_config_value)
             m.setattr("opengrok_tools.utils.mirror.get_repos_for_project", mock_get_repos)
             m.setattr("opengrok_tools.utils.mirror.do_api_call", mock_get)
 

--- a/tools/src/test/python/test_opengrok.py
+++ b/tools/src/test/python/test_opengrok.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+#
+
+import logging
+
+from inspect import getmembers, isfunction, signature
+from opengrok_tools.utils import opengrok
+
+
+def test_headers(monkeypatch):
+    headers_expected = {'foo': 'bar'}
+
+    def mock_response(ri, verb, headers, data):
+        assert headers == headers_expected
+
+    logger = logging.getLogger("test_headers")
+
+    for func in getmembers(opengrok, isfunction):
+        f = func[1]
+        with monkeypatch.context() as m:
+            m.setattr("opengrok_tools.utils.restful.do_api_call",
+                      mock_response)
+            if len(signature(f).parameters) == 4:
+                f(logger, "data", "http://localhost:8080/source/api/v1/bah",
+                  headers=headers_expected)
+            elif len(signature(f).parameters) == 3:
+                f(logger, "http://localhost:8080/source/api/v1/bah",
+                  headers=headers_expected)

--- a/tools/src/test/python/test_parsers.py
+++ b/tools/src/test/python/test_parsers.py
@@ -20,12 +20,13 @@
 #
 
 #
-# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
 #
 
 import argparse
 import pytest
-from opengrok_tools.utils.parsers import str2bool
+import os
+from opengrok_tools.utils.parsers import str2bool, get_headers
 
 
 def test_str2bool_exception():
@@ -51,3 +52,24 @@ def test_str2bool():
     for val in ['false', 'n', 'no']:
         assert not str2bool(val)
         assert not str2bool(val.upper())
+
+
+def test_get_headers():
+    assert get_headers(None) == {}
+    assert get_headers([]) == {}
+
+    assert get_headers(['foo: bar', 'mumble: bumble']) == {'foo': 'bar', 'mumble': 'bumble'}
+
+
+def test_get_headers_file(tmp_path):
+    assert get_headers(None) == {}
+    assert get_headers([]) == {}
+
+    headers_file = {'Moomintroll': 'Snorkmaiden', 'Mymble': 'Little My'}
+    file_path = tmp_path / "headers"
+    headers_text = os.linesep.join(key + ': ' + str(val) for key, val in headers_file.items())
+    file_path.write_text(headers_text)
+
+    headers_expected = {'mumble': 'bumble'}
+    headers_expected.update(headers_file)
+    assert get_headers(['@' + str(file_path), 'mumble: bumble']) == headers_expected

--- a/tools/src/test/python/test_restful.py
+++ b/tools/src/test/python/test_restful.py
@@ -75,9 +75,9 @@ def test_unknown_verb():
         call_rest_api(command, {pattern: value})
 
 
-def test_headers(monkeypatch):
+def test_content_type(monkeypatch):
     """
-    Test HTTP header handling.
+    Test HTTP Content-type header handling.
     """
     for verb in ["PUT", "POST", "DELETE"]:
         text_plain_header = {CONTENT_TYPE: 'text/plain'}
@@ -96,6 +96,28 @@ def test_headers(monkeypatch):
                 m.setattr("opengrok_tools.utils.restful.do_api_call",
                           mock_response)
                 call_rest_api(command)
+
+
+def test_headers(monkeypatch):
+    """
+    Test that HTTP headers from command specification are united with
+    HTTP headers passed to call_res_api()
+    :param monkeypatch: monkey fixture
+    """
+    headers = {'Tatsuo': 'Yasuko'}
+    command = {"command": ["http://localhost:8080/source/api/v1/bar",
+                           'GET', "data", headers]}
+    extra_headers = {'Mei': 'Totoro'}
+
+    def mock_response(uri, verb, headers, data):
+        all_headers = headers
+        all_headers.update(extra_headers)
+        assert headers == all_headers
+
+    with monkeypatch.context() as m:
+        m.setattr("opengrok_tools.utils.restful.do_api_call",
+                  mock_response)
+        call_rest_api(command, http_headers=extra_headers)
 
 
 def test_restful_fail(monkeypatch):


### PR DESCRIPTION
This change broadens the HTTP header support in the Python tools. This is primarily done to allow Bearer API token to be used e.g. for `opengrok-sync` arguments and configuration.

For `opengrok-sync` specifically, this allows to specify the headers both as command line (`-H/--header` , accepts multiple values) and also in the configuration file, e.g.:
```yml
headers:
  'Authorization': 'Bearer foo'
  'X-Special-header': 'bar'
commands:
- command:
  ...
```