### PR TITLE
Update README.md: "git pull --ff-only"

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -33,7 +33,7 @@ image based on the official one.
 * Configurable mirroring/reindexing (default every 10 min)
 
 The mirroring step works by going through all projects and attempting to
-synchronize all its repositories (e.g. it will do `git pull` for Git
+synchronize all its repositories (e.g. it will do `git pull --ff-only` for Git
 repositories).
 
 Projects are enabled in this setup and there is no way how to change that.


### PR DESCRIPTION
OpenGrok mirroring by default does a "git pull --ff-only" for Git repos, not a regular "git pull". This avoids merges occurring.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
