### PR TITLE
Suggester rebuild does not reflect fields change

### DIFF
--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterProjectDataTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterProjectDataTest.java
@@ -316,7 +316,7 @@ public class SuggesterProjectDataTest {
         }
         init(false);
 
-        // add new field after suggester data were initialized
+        // add new field after suggester data was initialized
         addText(FIELD, "term1 term2");
 
         assertTrue(getSuggestions(FIELD, "t", 10).isEmpty());

--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterProjectDataTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterProjectDataTest.java
@@ -308,4 +308,22 @@ public class SuggesterProjectDataTest {
         assertThat(searchCounts, contains(new SimpleEntry<>(t1.bytes(), 10), new SimpleEntry<>(t2.bytes(), 5)));
     }
 
+    @Test
+    public void testRebuildPicksUpNewFields() throws IOException {
+        // create dummy index
+        try (IndexWriter iw = new IndexWriter(dir, new IndexWriterConfig())) {
+            iw.isOpen(); // dummy operation
+        }
+        init(false);
+
+        // add new field after suggester data were initialized
+        addText(FIELD, "term1 term2");
+
+        assertTrue(getSuggestions(FIELD, "t", 10).isEmpty());
+
+        data.rebuild();
+
+        assertFalse(getSuggestions(FIELD, "t", 10).isEmpty());
+    }
+
 }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
Fixes issue when suggester did not work in docker image due to changes in https://github.com/oracle/opengrok/pull/3402

Thanks.