### PR TITLE
requests timeout for tools

### DIFF
--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -106,7 +106,7 @@ def main():
     parser.add_argument('-w', '--workers', default=cpu_count(),
                         help='Number of worker processes')
     add_http_headers(parser)
-    parser.add_argument('--api_timeout', proxies=None,
+    parser.add_argument('--api_timeout', type=int,
                         help='Set response timeout in seconds for RESTful API calls')
 
     try:

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -106,8 +106,8 @@ def main():
     parser.add_argument('-w', '--workers', default=cpu_count(),
                         help='Number of worker processes')
     add_http_headers(parser)
-    parser.add_argument('--api_timeout', help='Set response timeout in seconds'
-                                              'for RESTful API calls')
+    parser.add_argument('--api_timeout', proxies=None,
+                        help='Set response timeout in seconds for RESTful API calls')
 
     try:
         args = parser.parse_args()

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -58,12 +58,12 @@ major_version = sys.version_info[0]
 if major_version < 3:
     fatal("Need Python 3, you are running {}".format(major_version))
 
-__version__ = "1.0"
+__version__ = "1.1"
 
 
 def worker(args):
     project_name, logdir, loglevel, backupcount, config, check_changes, uri, \
-        source_root, batch, headers = args
+        source_root, batch, headers, api_timeout = args
 
     if batch:
         get_batch_logger(logdir, project_name,
@@ -73,7 +73,8 @@ def worker(args):
 
     return mirror_project(config, project_name,
                           check_changes,
-                          uri, source_root, headers=headers)
+                          uri, source_root, headers=headers,
+                          timeout=api_timeout)
 
 
 def main():
@@ -105,6 +106,8 @@ def main():
     parser.add_argument('-w', '--workers', default=cpu_count(),
                         help='Number of worker processes')
     add_http_headers(parser)
+    parser.add_argument('--api_timeout', help='Set response timeout in seconds'
+                                              'for RESTful API calls')
 
     try:
         args = parser.parse_args()
@@ -145,7 +148,7 @@ def main():
 
     # Save the source root to avoid querying the web application.
     source_root = get_config_value(logger, 'sourceRoot', uri,
-                                   headers=headers)
+                                   headers=headers, timeout=args.api_timeout)
     if not source_root:
         return 1
 
@@ -183,7 +186,9 @@ def main():
         lockfile = os.path.basename(sys.argv[0])
 
     if args.all:
-        projects = list_indexed_projects(logger, args.uri, headers=headers)
+        projects = list_indexed_projects(logger, args.uri,
+                                         headers=headers,
+                                         timeout=args.api_timeout)
 
     lock = FileLock(os.path.join(tempfile.gettempdir(), lockfile + ".lock"))
     try:
@@ -195,7 +200,8 @@ def main():
                                         args.backupcount, config,
                                         args.check_changes,
                                         args.uri, source_root,
-                                        args.batch, headers])
+                                        args.batch, headers,
+                                        args.api_timeout])
                 try:
                     project_results = pool.map(worker, worker_args, 1)
                 except KeyboardInterrupt:

--- a/tools/src/main/python/opengrok_tools/projadm.py
+++ b/tools/src/main/python/opengrok_tools/projadm.py
@@ -239,7 +239,7 @@ def main():
                         default=False, help='Do not delete source code when '
                                             'deleting a project')
     add_http_headers(parser)
-    parser.add_argument('--api_timeout', proxies=None,
+    parser.add_argument('--api_timeout', type=int,
                         help='Set response timeout in seconds for RESTful API calls')
 
     group = parser.add_mutually_exclusive_group()

--- a/tools/src/main/python/opengrok_tools/projadm.py
+++ b/tools/src/main/python/opengrok_tools/projadm.py
@@ -239,8 +239,8 @@ def main():
                         default=False, help='Do not delete source code when '
                                             'deleting a project')
     add_http_headers(parser)
-    parser.add_argument('--api_timeout', help='Set response timeout in seconds'
-                                              'for RESTful API calls')
+    parser.add_argument('--api_timeout', proxies=None,
+                        help='Set response timeout in seconds for RESTful API calls')
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-a', '--add', metavar='project', nargs='+',

--- a/tools/src/main/python/opengrok_tools/projadm.py
+++ b/tools/src/main/python/opengrok_tools/projadm.py
@@ -111,7 +111,7 @@ def install_config(doit, logger, src, dst):
 
 
 def config_refresh(doit, logger, basedir, uri, configmerge, jar_file,
-                   roconfig, java, headers=None):
+                   roconfig, java, headers=None, timeout=None):
     """
     Refresh current configuration file with configuration retrieved
     from webapp. If roconfig is not None, the current config is merged with
@@ -127,7 +127,8 @@ def config_refresh(doit, logger, basedir, uri, configmerge, jar_file,
         sys.exit(FAILURE_EXITVAL)
 
     if doit:
-        current_config = get_configuration(logger, uri, headers=headers)
+        current_config = get_configuration(logger, uri,
+                                           headers=headers, timeout=timeout)
         if not current_config:
             sys.exit(FAILURE_EXITVAL)
     else:
@@ -162,7 +163,7 @@ def config_refresh(doit, logger, basedir, uri, configmerge, jar_file,
                     install_config(doit, logger, fmerged.name, main_config)
 
 
-def project_add(doit, logger, project, uri, headers=None):
+def project_add(doit, logger, project, uri, headers=None, timeout=None):
     """
     Adds a project to configuration. Works in multiple steps:
 
@@ -173,10 +174,11 @@ def project_add(doit, logger, project, uri, headers=None):
     logger.info("Adding project {}".format(project))
 
     if doit:
-        add_project(logger, project, uri, headers=headers)
+        add_project(logger, project, uri, headers=headers, timeout=timeout)
 
 
-def project_delete(logger, project, uri, doit=True, deletesource=False, headers=None):
+def project_delete(logger, project, uri, doit=True, deletesource=False,
+                   headers=None, timeout=None):
     """
     Delete the project for configuration and all its data.
     Works in multiple steps:
@@ -193,10 +195,11 @@ def project_delete(logger, project, uri, doit=True, deletesource=False, headers=
     logger.info("Deleting project {} and its index data".format(project))
 
     if doit:
-        delete_project(logger, project, uri, headers=headers)
+        delete_project(logger, project, uri, headers=headers, timeout=timeout)
 
     if deletesource:
-        src_root = get_config_value(logger, 'sourceRoot', uri, headers=headers)
+        src_root = get_config_value(logger, 'sourceRoot', uri, headers=headers,
+                                    timeout=timeout)
         if not src_root or len(src_root) == 0:
             raise Exception("source root empty")
         logger.debug("Source root = {}".format(src_root))
@@ -236,6 +239,8 @@ def main():
                         default=False, help='Do not delete source code when '
                                             'deleting a project')
     add_http_headers(parser)
+    parser.add_argument('--api_timeout', help='Set response timeout in seconds'
+                                              'for RESTful API calls')
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-a', '--add', metavar='project', nargs='+',
@@ -322,7 +327,8 @@ def main():
                 for proj in args.add:
                     project_add(doit=doit, logger=logger,
                                 project=proj,
-                                uri=uri, headers=headers)
+                                uri=uri, headers=headers,
+                                timeout=args.api_timeout)
 
                 config_refresh(doit=doit, logger=logger,
                                basedir=args.base,
@@ -331,14 +337,16 @@ def main():
                                jar_file=args.jar,
                                roconfig=args.roconfig,
                                java=args.java,
-                               headers=headers)
+                               headers=headers,
+                               timeout=args.api_timeout)
             elif args.delete:
                 for proj in args.delete:
                     project_delete(logger=logger,
                                    project=proj,
                                    uri=uri, doit=doit,
                                    deletesource=not args.nosourcedelete,
-                                   headers=headers)
+                                   headers=headers,
+                                   timeout=args.api_timeout)
 
                 config_refresh(doit=doit, logger=logger,
                                basedir=args.base,
@@ -347,7 +355,8 @@ def main():
                                jar_file=args.jar,
                                roconfig=args.roconfig,
                                java=args.java,
-                               headers=headers)
+                               headers=headers,
+                               timeout=args.api_timeout)
             elif args.refresh:
                 config_refresh(doit=doit, logger=logger,
                                basedir=args.base,
@@ -356,7 +365,8 @@ def main():
                                jar_file=args.jar,
                                roconfig=args.roconfig,
                                java=args.java,
-                               headers=headers)
+                               headers=headers,
+                               timeout=args.api_timeout)
             else:
                 parser.print_help()
                 sys.exit(FAILURE_EXITVAL)
@@ -370,7 +380,8 @@ def main():
                             config_data = config_file.read().encode("utf-8")
                             if not set_configuration(logger,
                                                      config_data, uri,
-                                                     headers=headers):
+                                                     headers=headers,
+                                                     timeout=args.api_timeout):
                                 sys.exit(FAILURE_EXITVAL)
                 else:
                     logger.error("file {} does not exist".format(main_config))

--- a/tools/src/main/python/opengrok_tools/reindex_project.py
+++ b/tools/src/main/python/opengrok_tools/reindex_project.py
@@ -60,11 +60,11 @@ def get_logprop_file(logger, template, pattern, project):
     return tmpf.name
 
 
-def get_config_file(logger, uri, headers=None):
+def get_config_file(logger, uri, headers=None, timeout=None):
     """
     Get fresh configuration from the webapp and store it in temporary file.
     """
-    config = get_configuration(logger, uri, headers)
+    config = get_configuration(logger, uri, headers=headers, timeout=timeout)
 
     with tempfile.NamedTemporaryFile(delete=False) as tmpf:
         tmpf.write(config.encode())
@@ -90,6 +90,8 @@ def main():
                         help='URI of the webapp with context path')
     parser.add_argument('--printoutput', action='store_true', default=False)
     add_http_headers(parser)
+    parser.add_argument('--api_timeout', help='Set response timeout in seconds'
+                                              'for RESTful API calls')
 
     cmd_args = sys.argv[1:]
     extra_opts = os.environ.get("OPENGROK_INDEXER_OPTIONAL_ARGS")

--- a/tools/src/main/python/opengrok_tools/reindex_project.py
+++ b/tools/src/main/python/opengrok_tools/reindex_project.py
@@ -90,8 +90,8 @@ def main():
                         help='URI of the webapp with context path')
     parser.add_argument('--printoutput', action='store_true', default=False)
     add_http_headers(parser)
-    parser.add_argument('--api_timeout', help='Set response timeout in seconds'
-                                              'for RESTful API calls')
+    parser.add_argument('--api_timeout', type=int,
+                        help='Set response timeout in seconds for RESTful API calls')
 
     cmd_args = sys.argv[1:]
     extra_opts = os.environ.get("OPENGROK_INDEXER_OPTIONAL_ARGS")

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -52,7 +52,7 @@ if (major_version < 3):
     print("Need Python 3, you are running {}".format(major_version))
     sys.exit(1)
 
-__version__ = "1.2"
+__version__ = "1.3"
 
 
 def worker(base):
@@ -69,7 +69,7 @@ def worker(base):
 
 def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
             uri, numworkers, driveon=False, print_output=False, logger=None,
-            http_headers=None):
+            http_headers=None, timeout=None):
     """
     Process the list of directories in parallel.
     :param logger: logger to be used in this function
@@ -85,6 +85,7 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
                          using the supplied logger
     :param logger: optional logger
     :param http_headers: optional dictionary of HTTP headers
+    :param timeout: optional timeout in seconds for API call response
     :return SUCCESS_EXITVAL on success, FAILURE_EXITVAL on error
     """
 
@@ -93,7 +94,8 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
         cmd_base = CommandSequenceBase(dir, commands, loglevel=loglevel,
                                        cleanup=cleanup,
                                        driveon=driveon, url=uri,
-                                       http_headers=http_headers)
+                                       http_headers=http_headers,
+                                       api_timeout=timeout)
         cmds_base.append(cmd_base)
 
     # Map the commands into pool of workers so they can be processed.
@@ -150,6 +152,8 @@ def main():
     parser.add_argument('--nolock', action='store_false', default=True,
                         help='do not acquire lock that prevents multiple '
                         'instances from running')
+    parser.add_argument('--api_timeout', help='Set response timeout in seconds'
+                        'for RESTful API calls')
     add_http_headers(parser)
 
     try:
@@ -197,7 +201,8 @@ def main():
     directory = args.directory
     if not args.directory and not args.project and not args.indexed:
         # Assume directory, get the source root value from the webapp.
-        directory = get_config_value(logger, 'sourceRoot', uri, headers=headers)
+        directory = get_config_value(logger, 'sourceRoot', uri,
+                                     headers=headers, timeout=args.api_timeout)
         if not directory:
             logger.error("Neither -d or -P or -I specified and cannot get "
                          "source root from the webapp")
@@ -221,7 +226,9 @@ def main():
         logger.debug("Processing directories: {}".
                      format(dirs_to_process))
     elif args.indexed:
-        indexed_projects = list_indexed_projects(logger, uri, headers=headers)
+        indexed_projects = list_indexed_projects(logger, uri,
+                                                 headers=headers,
+                                                 timeout=args.api_timeout)
         logger.debug("Processing indexed projects: {}".
                      format(indexed_projects))
 
@@ -264,7 +271,8 @@ def main():
         r = do_sync(args.loglevel, commands, config.get("cleanup"),
                     dirs_to_process,
                     ignore_errors, uri, args.workers,
-                    driveon=args.driveon, http_headers=headers)
+                    driveon=args.driveon, http_headers=headers,
+                    timeout=args.api_timeout)
     else:
         lock = FileLock(os.path.join(tempfile.gettempdir(),
                                      lockfile_name + ".lock"))
@@ -273,7 +281,8 @@ def main():
                 r = do_sync(args.loglevel, commands, config.get("cleanup"),
                             dirs_to_process,
                             ignore_errors, uri, args.workers,
-                            driveon=args.driveon, http_headers=headers)
+                            driveon=args.driveon, http_headers=headers,
+                            timeout=args.api_timeout)
         except Timeout:
             logger.warning("Already running")
             return FAILURE_EXITVAL

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -152,7 +152,8 @@ def main():
     parser.add_argument('--nolock', action='store_false', default=True,
                         help='do not acquire lock that prevents multiple '
                         'instances from running')
-    parser.add_argument('--api_timeout', help='Set response timeout in seconds'
+    parser.add_argument('--api_timeout', type=int,
+                        help='Set response timeout in seconds'
                         'for RESTful API calls')
     add_http_headers(parser)
 

--- a/tools/src/main/python/opengrok_tools/utils/commandsequence.py
+++ b/tools/src/main/python/opengrok_tools/utils/commandsequence.py
@@ -46,7 +46,8 @@ class CommandSequenceBase:
     """
 
     def __init__(self, name, commands, loglevel=logging.INFO, cleanup=None,
-                 driveon=False, url=None, env=None, http_headers=None):
+                 driveon=False, url=None, env=None, http_headers=None,
+                 api_timeout=None):
         self.name = name
         self.commands = commands
         self.failed = False
@@ -60,6 +61,7 @@ class CommandSequenceBase:
         self.driveon = driveon
         self.env = env
         self.http_headers = http_headers
+        self.api_timeout = api_timeout
 
         self.url = url
 
@@ -93,7 +95,8 @@ class CommandSequence(CommandSequenceBase):
         super().__init__(base.name, base.commands, loglevel=base.loglevel,
                          cleanup=base.cleanup, driveon=base.driveon,
                          url=base.url, env=base.env,
-                         http_headers=base.http_headers)
+                         http_headers=base.http_headers,
+                         api_timeout=base.api_timeout)
 
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(base.loglevel)
@@ -130,7 +133,7 @@ class CommandSequence(CommandSequenceBase):
                 try:
                     call_rest_api(command, {PROJECT_SUBST: self.name,
                                             URL_SUBST: self.url},
-                                  self.http_headers)
+                                  self.http_headers, self.api_timeout)
                 except HTTPError as e:
                     self.logger.error("RESTful command {} failed: {}".
                                       format(command, e))
@@ -188,7 +191,7 @@ class CommandSequence(CommandSequenceBase):
                 try:
                     call_rest_api(cleanup_cmd, {PROJECT_SUBST: self.name,
                                                 URL_SUBST: self.url},
-                                  self.http_headers)
+                                  self.http_headers, self.api_timeout)
                 except HTTPError as e:
                     self.logger.error("RESTful command {} failed: {}".
                                       format(cleanup_cmd, e))

--- a/tools/src/main/python/opengrok_tools/utils/opengrok.py
+++ b/tools/src/main/python/opengrok_tools/utils/opengrok.py
@@ -26,11 +26,13 @@ from .webutil import get_uri
 from .restful import do_api_call
 
 
-def get_repos(logger, project, uri, headers=None):
+def get_repos(logger, project, uri, headers=None, timeout=None):
     """
     :param logger: logger instance
     :param project: project name
     :param uri: web application URI
+    :param headers: optional dictionary of HTTP headers
+    :param timeout: optional timeout in seconds
     :return: list of repository paths (can be empty if no match)
              or None on failure
     """
@@ -39,7 +41,7 @@ def get_repos(logger, project, uri, headers=None):
         r = do_api_call('GET', get_uri(uri, 'api', 'v1', 'projects',
                                        urllib.parse.quote_plus(project),
                                        'repositories'),
-                        headers=headers)
+                        headers=headers, timeout=timeout)
     except Exception:
         logger.error('could not get repositories for ' + project)
         return None
@@ -51,7 +53,7 @@ def get_repos(logger, project, uri, headers=None):
     return ret
 
 
-def get_config_value(logger, name, uri, headers=None):
+def get_config_value(logger, name, uri, headers=None, timeout=None):
     """
     Get list of repositories for given project name.
 
@@ -60,7 +62,7 @@ def get_config_value(logger, name, uri, headers=None):
     try:
         r = do_api_call('GET', get_uri(uri, 'api', 'v1', 'configuration',
                                        urllib.parse.quote_plus(name)),
-                        headers=headers)
+                        headers=headers, timeout=timeout)
     except Exception:
         logger.error("Cannot get the '{}' config value from the web "
                      "application on {}".format(name, uri))
@@ -69,7 +71,7 @@ def get_config_value(logger, name, uri, headers=None):
     return r.text
 
 
-def get_repo_type(logger, repository, uri, headers=None):
+def get_repo_type(logger, repository, uri, headers=None, timeout=None):
     """
     Get repository type for given path relative to sourceRoot.
 
@@ -80,7 +82,7 @@ def get_repo_type(logger, repository, uri, headers=None):
     try:
         r = do_api_call('GET', get_uri(uri, 'api', 'v1', 'repositories',
                                        'property', 'type'), params=payload,
-                        headers=headers)
+                        headers=headers, timeout=None)
     except Exception:
         logger.error('could not get repository type for {} from web'
                      'application on {}'.format(repository, uri))
@@ -92,10 +94,10 @@ def get_repo_type(logger, repository, uri, headers=None):
     return line[idx + 1:]
 
 
-def get_configuration(logger, uri, headers=None):
+def get_configuration(logger, uri, headers=None, timeout=None):
     try:
         r = do_api_call('GET', get_uri(uri, 'api', 'v1', 'configuration'),
-                        headers=headers)
+                        headers=headers, timeout=timeout)
     except Exception:
         logger.error('could not get configuration from web application on {}'.
                      format(uri))
@@ -104,10 +106,10 @@ def get_configuration(logger, uri, headers=None):
     return r.text
 
 
-def set_configuration(logger, configuration, uri, headers=None):
+def set_configuration(logger, configuration, uri, headers=None, timeout=None):
     try:
         do_api_call('PUT', get_uri(uri, 'api', 'v1', 'configuration'),
-                    data=configuration, headers=headers)
+                    data=configuration, headers=headers, timeout=timeout)
     except Exception:
         logger.error('could not set configuration for web application on {}'.
                      format(uri))
@@ -116,11 +118,11 @@ def set_configuration(logger, configuration, uri, headers=None):
     return True
 
 
-def list_projects(logger, uri, headers=None):
+def list_projects(logger, uri, headers=None, timeout=None):
     try:
         r = do_api_call('GET',
                         get_uri(uri, 'api', 'v1', 'projects'),
-                        headers=headers)
+                        headers=headers, timeout=timeout)
     except Exception:
         logger.error('could not list projects from web application '
                      'on {}'.format(uri))
@@ -129,11 +131,11 @@ def list_projects(logger, uri, headers=None):
     return r.json()
 
 
-def list_indexed_projects(logger, uri, headers=None):
+def list_indexed_projects(logger, uri, headers=None, timeout=None):
     try:
         r = do_api_call('GET',
                         get_uri(uri, 'api', 'v1', 'projects', 'indexed'),
-                        headers=headers)
+                        headers=headers, timeout=timeout)
     except Exception:
         logger.error('could not list indexed projects from web application '
                      'on {}'.format(uri))
@@ -142,10 +144,10 @@ def list_indexed_projects(logger, uri, headers=None):
     return r.json()
 
 
-def add_project(logger, project, uri, headers=None):
+def add_project(logger, project, uri, headers=None, timeout=None):
     try:
         do_api_call('POST', get_uri(uri, 'api', 'v1', 'projects'),
-                    data=project, headers=headers)
+                    data=project, headers=headers, timeout=timeout)
     except Exception:
         logger.error('could not add project {} for web application on {}'.
                      format(project, uri))
@@ -154,11 +156,11 @@ def add_project(logger, project, uri, headers=None):
     return True
 
 
-def delete_project(logger, project, uri, headers=None):
+def delete_project(logger, project, uri, headers=None, timeout=None):
     try:
         do_api_call('DELETE', get_uri(uri, 'api', 'v1', 'projects',
                                       urllib.parse.quote_plus(project)),
-                    headers=headers)
+                    headers=headers, timeout=timeout)
     except Exception:
         logger.error('could not delete project {} in web application on {}'.
                      format(project, uri))

--- a/tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/tools/src/main/python/opengrok_tools/utils/restful.py
@@ -33,7 +33,7 @@ CONTENT_TYPE = 'Content-Type'
 APPLICATION_JSON = 'application/json'   # default
 
 
-def do_api_call(verb, uri, params=None, headers=None, data=None):
+def do_api_call(verb, uri, params=None, headers=None, data=None, timeout=None):
     """
     Perform an API call. Will raise an exception if the request fails.
     :param verb: string holding HTTP verb
@@ -41,6 +41,8 @@ def do_api_call(verb, uri, params=None, headers=None, data=None):
     :param params: request parameters
     :param headers: HTTP headers dictionary
     :param data: data or None
+    :param timeout: optional connect timeout in seconds.
+                    If None, default (60 seconds) will be used.
     :return: the result of the handler call, can be None
     """
     logger = logging.getLogger(__name__)
@@ -49,14 +51,18 @@ def do_api_call(verb, uri, params=None, headers=None, data=None):
     if handler is None or not callable(handler):
         raise Exception('Unknown HTTP verb: {}'.format(verb))
 
-    logger.debug("{} API call: {} with data '{}' and headers: {}".
-                 format(verb, uri, data, headers))
+    if timeout is None:
+        timeout = 60
+
+    logger.debug("{} API call: {} with data '{}', timeout {} seconds and headers: {}".
+                 format(verb, uri, data, timeout, headers))
     r = handler(
         uri,
         data=data,
         params=params,
         headers=headers,
-        proxies=get_proxies(uri)
+        proxies=get_proxies(uri),
+        timeout=timeout
     )
 
     if r is None:
@@ -76,7 +82,7 @@ def subst(src, substitutions):
     return src
 
 
-def call_rest_api(command, substitutions=None, http_headers=None):
+def call_rest_api(command, substitutions=None, http_headers=None, timeout=None):
     """
     Make RESTful API call. Occurrence of the pattern in the URI
     (first part of the command) or data payload will be replaced by the name.
@@ -88,6 +94,7 @@ def call_rest_api(command, substitutions=None, http_headers=None):
     :param substitutions: dictionary of pattern:value for command and/or
                           data substitution
     :param http_headers: optional dictionary of HTTP headers to be appended
+    :param timeout: optional timeout in seconds for API call response
     :return return value from given requests method
     """
 
@@ -134,4 +141,4 @@ def call_rest_api(command, substitutions=None, http_headers=None):
         data = subst(data, substitutions)
         logger.debug("entity data: {}".format(data))
 
-    return do_api_call(verb, uri, headers=headers, data=data)
+    return do_api_call(verb, uri, headers=headers, data=data, timeout=timeout)

--- a/tools/src/test/python/test_command_sequence.py
+++ b/tools/src/test/python/test_command_sequence.py
@@ -168,7 +168,7 @@ def test_restful_fail(monkeypatch):
             self.status_code = 500
             self.raise_for_status = self.p
 
-    def mock_response(uri, headers, data, params, proxies):
+    def mock_response(uri, headers, data, params, proxies, timeout):
         return MockResponse()
 
     commands = CommandSequence(
@@ -176,8 +176,7 @@ def test_restful_fail(monkeypatch):
                             [{'command': ['http://foo', 'PUT', 'data']}]))
     assert commands is not None
     with monkeypatch.context() as m:
-        m.setattr("requests.put",
-                  mock_response)
+        m.setattr("requests.put", mock_response)
         commands.run()
         assert commands.check([]) == 1
 

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -135,7 +135,7 @@ def test_disabled_command_api():
     Test that mirror_project() calls call_rest_api() if API
     call is specified in the configuration for disabled project.
     """
-    def mock_call_rest_api(command, b, http_headers=None):
+    def mock_call_rest_api(command, b, http_headers=None, timeout=None):
         return mock(spec=requests.Response)
 
     with patch(opengrok_tools.utils.mirror.call_rest_api,
@@ -157,7 +157,7 @@ def test_disabled_command_api():
         verify(opengrok_tools.utils.mirror). \
             call_rest_api(config.get(DISABLED_CMD_PROPERTY),
                           {PROJECT_SUBST: project_name},
-                          http_headers=None)
+                          http_headers=None, timeout=None)
 
 
 def test_disabled_command_api_text_append(monkeypatch):
@@ -167,7 +167,7 @@ def test_disabled_command_api_text_append(monkeypatch):
 
     text_to_append = "foo bar"
 
-    def mock_call_rest_api(command, b, http_headers=None):
+    def mock_call_rest_api(command, b, http_headers=None, timeout=None):
         disabled_command = config.get(DISABLED_CMD_PROPERTY)
         assert disabled_command
         command_args = disabled_command.get(COMMAND_PROPERTY)
@@ -312,10 +312,10 @@ def test_get_repos_for_project(monkeypatch):
     timeout = 314159
     test_repo = "/" + project_name
 
-    def mock_get_repos(*args, headers=None):
+    def mock_get_repos(*args, headers=None, timeout=None):
         return [test_repo]
 
-    def mock_get_repo_type(*args, headers=None):
+    def mock_get_repo_type(*args, headers=None, timeout=None):
         return "Git"
 
     with tempfile.TemporaryDirectory() as source_root:

--- a/tools/src/test/python/test_opengrok.py
+++ b/tools/src/test/python/test_opengrok.py
@@ -29,7 +29,11 @@ from inspect import getmembers, isfunction, signature
 from opengrok_tools.utils import opengrok
 
 
-def test_headers(monkeypatch):
+def test_headers_timout(monkeypatch):
+    """
+    Test that all functions in the opengrok module propagate the timeout and
+    HTTP headers to do_api_call().
+    """
     headers_expected = {'foo': 'bar'}
     timeout_expected = 42
 
@@ -37,7 +41,7 @@ def test_headers(monkeypatch):
         assert headers == headers_expected
         assert timeout == timeout_expected
 
-    logger = logging.getLogger("test_headers")
+    logger = logging.getLogger("test_headers_timeout")
 
     for func in getmembers(opengrok, isfunction):
         f = func[1]

--- a/tools/src/test/python/test_opengrok.py
+++ b/tools/src/test/python/test_opengrok.py
@@ -31,9 +31,11 @@ from opengrok_tools.utils import opengrok
 
 def test_headers(monkeypatch):
     headers_expected = {'foo': 'bar'}
+    timeout_expected = 42
 
-    def mock_response(ri, verb, headers, data):
+    def mock_response(ri, verb, headers, data, timeout):
         assert headers == headers_expected
+        assert timeout == timeout_expected
 
     logger = logging.getLogger("test_headers")
 
@@ -42,9 +44,9 @@ def test_headers(monkeypatch):
         with monkeypatch.context() as m:
             m.setattr("opengrok_tools.utils.restful.do_api_call",
                       mock_response)
-            if len(signature(f).parameters) == 4:
+            if len(signature(f).parameters) == 5:
                 f(logger, "data", "http://localhost:8080/source/api/v1/bah",
-                  headers=headers_expected)
-            elif len(signature(f).parameters) == 3:
+                  headers=headers_expected, timeout=timeout_expected)
+            elif len(signature(f).parameters) == 4:
                 f(logger, "http://localhost:8080/source/api/v1/bah",
-                  headers=headers_expected)
+                  headers=headers_expected, timeout=timeout_expected)

--- a/tools/src/test/python/test_restful.py
+++ b/tools/src/test/python/test_restful.py
@@ -98,13 +98,14 @@ def test_content_type(monkeypatch):
                 call_rest_api(command)
 
 
-def test_headers(monkeypatch):
+def test_headers_timeout(monkeypatch):
     """
     Test that HTTP headers from command specification are united with
-    HTTP headers passed to call_res_api()
+    HTTP headers passed to call_res_api(). Also test timeout.
     :param monkeypatch: monkey fixture
     """
     headers = {'Tatsuo': 'Yasuko'}
+    expected_timeout = 42
     command = {"command": ["http://localhost:8080/source/api/v1/bar",
                            'GET', "data", headers]}
     extra_headers = {'Mei': 'Totoro'}
@@ -113,14 +114,20 @@ def test_headers(monkeypatch):
         all_headers = headers
         all_headers.update(extra_headers)
         assert headers == all_headers
+        assert timeout == expected_timeout
 
     with monkeypatch.context() as m:
         m.setattr("opengrok_tools.utils.restful.do_api_call",
                   mock_response)
-        call_rest_api(command, http_headers=extra_headers)
+        call_rest_api(command, http_headers=extra_headers,
+                      timeout=expected_timeout)
 
 
 def test_restful_fail(monkeypatch):
+    """
+    Test that failures in call_rest_api() result in HTTPError exception.
+    This is done only for the PUT HTTP verb.
+    """
     class MockResponse:
         def p(self):
             raise HTTPError("foo")

--- a/tools/src/test/python/test_restful.py
+++ b/tools/src/test/python/test_restful.py
@@ -46,7 +46,7 @@ def test_replacement(monkeypatch):
             self.status_code = okay_status
             self.raise_for_status = self.p
 
-    def mock_response(verb, uri, headers, data):
+    def mock_response(verb, uri, headers, data, timeout):
         # Spying on mocked function is maybe too much so verify
         # the arguments here.
         assert uri == "http://localhost:8080/source/api/v1/BAR"
@@ -85,7 +85,7 @@ def test_content_type(monkeypatch):
             command = {"command": ["http://localhost:8080/source/api/v1/foo",
                                    verb, "data", header_arg]}
 
-            def mock_response(uri, verb, headers, data):
+            def mock_response(uri, verb, headers, data, timeout):
                 if header_arg:
                     assert text_plain_header.items() <= headers.items()
                 else:
@@ -109,7 +109,7 @@ def test_headers(monkeypatch):
                            'GET', "data", headers]}
     extra_headers = {'Mei': 'Totoro'}
 
-    def mock_response(uri, verb, headers, data):
+    def mock_response(uri, verb, headers, data, timeout):
         all_headers = headers
         all_headers.update(extra_headers)
         assert headers == all_headers
@@ -129,7 +129,7 @@ def test_restful_fail(monkeypatch):
             self.status_code = 400
             self.raise_for_status = self.p
 
-    def mock_response(uri, headers, data, params, proxies):
+    def mock_response(uri, headers, data, params, proxies, timeout):
         return MockResponse()
 
     with monkeypatch.context() as m:

--- a/tools/src/test/python/test_restful.py
+++ b/tools/src/test/python/test_restful.py
@@ -24,11 +24,14 @@
 #
 
 import pytest
+import requests
 
 from requests.exceptions import HTTPError
 
+from mockito import verify, patch, mock
+
 from opengrok_tools.utils.restful import call_rest_api,\
-    CONTENT_TYPE, APPLICATION_JSON
+    CONTENT_TYPE, APPLICATION_JSON, do_api_call
 from opengrok_tools.utils.patterns import COMMAND_PROPERTY
 
 
@@ -46,7 +49,7 @@ def test_replacement(monkeypatch):
             self.status_code = okay_status
             self.raise_for_status = self.p
 
-    def mock_response(verb, uri, headers, data, timeout):
+    def mock_do_api_call(verb, uri, headers, data, timeout):
         # Spying on mocked function is maybe too much so verify
         # the arguments here.
         assert uri == "http://localhost:8080/source/api/v1/BAR"
@@ -61,7 +64,7 @@ def test_replacement(monkeypatch):
         value = "BAR"
         with monkeypatch.context() as m:
             m.setattr("opengrok_tools.utils.restful.do_api_call",
-                      mock_response)
+                      mock_do_api_call)
             assert call_rest_api(command, {pattern: value}). \
                 status_code == okay_status
 
@@ -110,7 +113,7 @@ def test_headers_timeout(monkeypatch):
                            'GET', "data", headers]}
     extra_headers = {'Mei': 'Totoro'}
 
-    def mock_response(uri, verb, headers, data, timeout):
+    def mock_do_api_call(uri, verb, headers, data, timeout):
         all_headers = headers
         all_headers.update(extra_headers)
         assert headers == all_headers
@@ -118,9 +121,32 @@ def test_headers_timeout(monkeypatch):
 
     with monkeypatch.context() as m:
         m.setattr("opengrok_tools.utils.restful.do_api_call",
-                  mock_response)
-        call_rest_api(command, http_headers=extra_headers,
+                  mock_do_api_call)
+        call_rest_api(command,
+                      http_headers=extra_headers,
                       timeout=expected_timeout)
+
+
+def test_headers_timeout_requests():
+    """
+    Test that headers and timeout parameters from do_call_api() are passed
+    to the appropriate function in the requests module.
+    Currently done for the GET HTTP verb only.
+    """
+
+    uri = "http://foo:8080"
+    headers = {"foo": "bar"}
+    timeout = 44
+
+    def mock_requests_get(uri, **kwargs):
+        return mock(spec=requests.Response)
+
+    with patch(requests.get, mock_requests_get):
+        do_api_call("GET", uri, headers=headers, timeout=timeout)
+
+        verify(requests).get(uri, data=None, params=None,
+                             headers=headers, proxies=None,
+                             timeout=timeout)
 
 
 def test_restful_fail(monkeypatch):


### PR DESCRIPTION
This change introduces the request timeout to the tools. The default is set to 60 seconds in `requests#do_api_call()`. The command line tools received the `--api_timeout` option.

So far it is not possible to specify per command (as in command sequence) timeout, tracked by #3453.