### PR TITLE
get last revision date from the index first

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -110,6 +110,8 @@ import org.opengrok.indexer.analysis.verilog.VerilogAnalyzerFactory;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.Annotation;
+import org.opengrok.indexer.history.History;
+import org.opengrok.indexer.history.HistoryEntry;
 import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.history.HistoryReader;
@@ -591,10 +593,18 @@ public class AnalyzerGuru {
 
         if (RuntimeEnvironment.getInstance().isHistoryEnabled()) {
             try {
-                HistoryReader hr = HistoryGuru.getInstance().getHistoryReader(file);
+                HistoryGuru histGuru = HistoryGuru.getInstance();
+                HistoryReader hr = histGuru.getHistoryReader(file);
                 if (hr != null) {
                     doc.add(new TextField(QueryBuilder.HIST, hr));
-                    // date = hr.getLastCommentDate() //RFE
+                    History history;
+                    if ((history = histGuru.getHistory(file)) != null) {
+                        List<HistoryEntry> historyEntries = history.getHistoryEntries(1, 0);
+                        if (historyEntries.size() > 0) {
+                            HistoryEntry histEntry = historyEntries.get(0);
+                            doc.add(new TextField(QueryBuilder.LASTREV, histEntry.getRevision(), Store.YES));
+                        }
+                    }
                 }
             } catch (HistoryException e) {
                 LOGGER.log(Level.WARNING, "An error occurred while reading history: ", e);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzer.java
@@ -191,6 +191,8 @@ public class FileAnalyzer extends AbstractAnalyzer {
             }
             case QueryBuilder.DEFS:
                 return new TokenStreamComponents(createPlainSymbolTokenizer());
+            case QueryBuilder.LASTREV:
+                return new TokenStreamComponents(createPlainFullTokenizer());
             default:
                 LOGGER.log(
                         Level.WARNING, "Have no analyzer for: {0}", fieldName);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryExtraReader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryExtraReader.java
@@ -90,7 +90,8 @@ public class DirectoryExtraReader {
             String filepath = d.get(QueryBuilder.PATH);
             Integer numlines = tryParseInt(d.get(QueryBuilder.NUML));
             Integer loc = tryParseInt(d.get(QueryBuilder.LOC));
-            FileExtra extra = new FileExtra(filepath, numlines, loc);
+            String lastRev = d.get(QueryBuilder.LASTREV);
+            FileExtra extra = new FileExtra(filepath, numlines, loc, lastRev);
             results.add(extra);
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/FileExtra.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/FileExtra.java
@@ -30,6 +30,7 @@ public class FileExtra {
     private final String filepath;
     private final Integer numlines;
     private final Integer loc;
+    private final String lastRev;
 
     /**
      * Initializes an instance with specified file path, number of lines, and
@@ -37,11 +38,13 @@ public class FileExtra {
      * @param filepath the file path
      * @param numlines the number of lines (null if unknown)
      * @param loc the lines-of-code (null if unknown)
+     * @param lastRev last revision string (null if unknown)
      */
-    public FileExtra(String filepath, Integer numlines, Integer loc) {
+    public FileExtra(String filepath, Integer numlines, Integer loc, String lastRev) {
         this.filepath = filepath;
         this.numlines = numlines;
         this.loc = loc;
+        this.lastRev = lastRev;
     }
 
     /**
@@ -63,5 +66,12 @@ public class FileExtra {
      */
     public Integer getLoc() {
         return loc;
+    }
+
+    /**
+     * @return last revision string (null if unknown)
+     */
+    public String getLastRev() {
+        return lastRev;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/QueryBuilder.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/QueryBuilder.java
@@ -60,8 +60,9 @@ public class QueryBuilder {
     public static final String SCOPES = "scopes";
     public static final String NUML = "numl";
     public static final String LOC = "loc";
+    public static final String LASTREV = "lastrev"; // last revision
     /**
-     * Fields we use in lucene: internal ones.
+     * Fields we use in Lucene: internal ones.
      */
     public static final String U = "u";
     public static final String TAGS = "tags";

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -25,16 +25,19 @@ package org.opengrok.indexer.index;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.TreeSet;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.ScoreDoc;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -188,5 +191,13 @@ public class IndexDatabaseTest {
             assertFalse("PATH field should not contain backslash characters",
                     doc.getField(QueryBuilder.PATH).stringValue().contains("\\"));
         }
+    }
+
+    @Test
+    public void testGetLastRev() throws IOException, ParseException {
+        Document doc = IndexDatabase.getDocument(Paths.get(repository.getSourceRoot(),
+                "git", "main.c").toFile());
+        assertNotNull(doc);
+        assertEquals("aa35c258", doc.get(QueryBuilder.LASTREV));
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -61,6 +61,8 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.ws.rs.core.HttpHeaders;
+import org.apache.lucene.document.Document;
+import org.jetbrains.annotations.Nullable;
 import org.opengrok.indexer.Info;
 import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
@@ -76,6 +78,7 @@ import org.opengrok.indexer.history.History;
 import org.opengrok.indexer.history.HistoryEntry;
 import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.history.HistoryGuru;
+import org.opengrok.indexer.index.IndexDatabase;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.IOUtils;
@@ -1291,11 +1294,24 @@ public final class PageConfig {
                 getPath(), env.isCompressXref());
     }
 
+    /**
+     * @return last revision string for {@code file} or null
+     */
     public String getLatestRevision() {
         if (!getEnv().isHistoryEnabled()) {
             return null;
         }
 
+        String lastRev = getLastRevFromIndex();
+        if (lastRev != null) return lastRev;
+
+        // fallback
+        return getLastRevFromHistory();
+    }
+
+    @Nullable
+    private String getLastRevFromHistory() {
+        // fallback
         History hist;
         try {
             hist = HistoryGuru.getInstance().
@@ -1323,6 +1339,19 @@ public final class PageConfig {
         }
 
         return he.getRevision();
+    }
+
+    @Nullable
+    private String getLastRevFromIndex() {
+        Document doc = null;
+        try {
+            doc = IndexDatabase.getDocument(getResourceFile());
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, String.format("cannot get document for %s", path), e);
+        }
+
+        String lastRev = doc.get(QueryBuilder.LASTREV);
+        return lastRev;
     }
 
     /**
@@ -1529,7 +1558,7 @@ public final class PageConfig {
         sh.start = getSearchStart();
         sh.maxItems = getSearchMaxItems();
         sh.contextPath = req.getContextPath();
-        // jel: this should be IMHO a config param since not only core dependend
+        // jel: this should be IMHO a config param since not only core dependent
         sh.parallel = Runtime.getRuntime().availableProcessors() > 1;
         sh.isCrossRefSearch = getPrefix() == Prefix.SEARCH_R;
         sh.isGuiSearch = sh.isCrossRefSearch || getPrefix() == Prefix.SEARCH_P;

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1313,7 +1313,6 @@ public final class PageConfig {
 
     @Nullable
     private String getLastRevFromHistory() {
-        // fallback
         History hist;
         try {
             hist = HistoryGuru.getInstance().

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2011, Jens Elkner.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1303,7 +1303,9 @@ public final class PageConfig {
         }
 
         String lastRev = getLastRevFromIndex();
-        if (lastRev != null) return lastRev;
+        if (lastRev != null) {
+            return lastRev;
+        }
 
         // fallback
         return getLastRevFromHistory();

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1352,8 +1352,11 @@ public final class PageConfig {
             LOGGER.log(Level.WARNING, String.format("cannot get document for %s", path), e);
         }
 
-        String lastRev = doc.get(QueryBuilder.LASTREV);
-        return lastRev;
+        if (doc != null) {
+            return doc.get(QueryBuilder.LASTREV);
+        }
+
+        return null;
     }
 
     /**

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web;

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web;


### PR DESCRIPTION
This change stores last revision of given file in the index. Web app will then take advantage of this when getting the revision number in order to perform redirection. If the newly introduced `LASTREV` field is not found, it will fall back to the old behavior.

In general this should be quicker than getting the history from the history cache since the index is usually memory mapped, i.e. avoids reading the history cache file, deserializing potentially huge `History` object and picking just one `HistoryEntry`.