### PR TITLE
add more search.latency categories

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1635,7 +1635,8 @@ public class IndexDatabase {
             Statistics stat = new Statistics();
             TopDocs top = searcher.search(q, 1);
             stat.report(LOGGER, Level.FINEST, "search via getDocument done",
-                    "search.latency", new String[]{"category", "getdocument"});
+                    "search.latency", new String[]{"category", "getdocument",
+                            "outcome", top.totalHits.value == 0 ? "empty" : "success"});
             if (top.totalHits.value == 0) {
                 // No hits, no document...
                 return null;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1632,7 +1632,10 @@ public class IndexDatabase {
             Document doc;
             Query q = new QueryBuilder().setPath(path).build();
             IndexSearcher searcher = new IndexSearcher(ireader);
+            Statistics stat = new Statistics();
             TopDocs top = searcher.search(q, 1);
+            stat.report(LOGGER, Level.FINEST, "search via getDocument done",
+                    "search.latency", new String[]{"category", "getdocument"});
             if (top.totalHits.value == 0) {
                 // No hits, no document...
                 return null;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryExtraReader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryExtraReader.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryExtraReader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryExtraReader.java
@@ -34,6 +34,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.Statistics;
 
 /**
  * Represents a searcher to supplement metadata from the file-system with
@@ -75,7 +76,12 @@ public class DirectoryExtraReader {
             throw new IOException(PARSE_ERROR);
         }
 
+        Statistics stat = new Statistics();
         TopDocs hits = searcher.search(query, DIR_LIMIT_NUM);
+        stat.report(LOGGER, Level.FINEST, "search via DirectoryExtraReader done",
+                "search.latency", new String[]{"category", "extra",
+                        "outcome", hits.scoreDocs.length > 0 ? "success" : "empty"});
+
         List<FileExtra> results = processHits(searcher, hits);
         return results;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -65,6 +65,7 @@ import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.search.Summary.Fragment;
 import org.opengrok.indexer.search.context.Context;
 import org.opengrok.indexer.search.context.HistoryContext;
+import org.opengrok.indexer.util.Statistics;
 import org.opengrok.indexer.util.TandemPath;
 import org.opengrok.indexer.web.Prefix;
 
@@ -210,8 +211,12 @@ public class SearchEngine {
 
     private void searchIndex(IndexSearcher searcher, boolean paging) throws IOException {
         collector = TopScoreDocCollector.create(hitsPerPage * cachePages, Short.MAX_VALUE);
+        Statistics stat = new Statistics();
         searcher.search(query, collector);
         totalHits = collector.getTotalHits();
+        stat.report(LOGGER, Level.FINEST, "search via SearchEngine done",
+                "search.latency", new String[]{"category", "engine",
+                        "outcome", totalHits > 0 ? "success" : "empty"});
         if (!paging && totalHits > 0) {
             collector = TopScoreDocCollector.create(totalHits, Short.MAX_VALUE);
             searcher.search(query, collector);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
@@ -68,6 +68,20 @@ public class Statistics {
      * @see Metrics#getRegistry()
      */
     public void report(Logger logger, Level logLevel, String msg, String meterName) {
+        report(logger, logLevel, msg, meterName, new String[]{});
+    }
+
+    /**
+     * Log a message along with how much time it took since the constructor was called.
+     * If there is a metrics registry, it will update the timer specified by the meter name.
+     * @param logger logger instance
+     * @param logLevel log level
+     * @param msg message string
+     * @param meterName name of the meter
+     * @param tags array of tags for the meter
+     * @see Metrics#getRegistry()
+     */
+    public void report(Logger logger, Level logLevel, String msg, String meterName, String[] tags) {
         Duration duration = Duration.between(startTime, Instant.now());
 
         logIt(logger, logLevel, msg, duration);
@@ -75,6 +89,7 @@ public class Statistics {
         MeterRegistry registry = Metrics.getRegistry();
         if (registry != null) {
             Timer.builder(meterName).
+                    tags(tags).
                     register(registry).
                     record(duration);
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.util;
 

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web;
 

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 import java.time.Instant;
 
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -46,13 +47,6 @@ public class StatisticsFilter implements Filter {
     static final String REQUESTS_METRIC = "requests";
 
     private final DistributionSummary requests = Metrics.getPrometheusRegistry().summary(REQUESTS_METRIC);
-
-    private final Timer emptySearch = Timer.builder("search.latency").
-            tags("outcome", "empty").
-            register(Metrics.getPrometheusRegistry());
-    private final Timer successfulSearch = Timer.builder("search.latency").
-            tags("outcome", "success").
-            register(Metrics.getPrometheusRegistry());
 
     @Override
     public void init(FilterConfig fc) throws ServletException {
@@ -87,10 +81,17 @@ public class StatisticsFilter implements Filter {
 
         SearchHelper helper = (SearchHelper) config.getRequestAttribute(SearchHelper.REQUEST_ATTR);
         if (helper != null) {
-            if (helper.hits == null || helper.hits.length == 0) {
-                emptySearch.record(duration);
+            MeterRegistry registry = Metrics.getRegistry();
+            if (registry != null && (helper.hits == null || helper.hits.length == 0)) {
+                Timer.builder("search.latency").
+                        tags("category", "ui", "outcome", "empty").
+                        register(registry).
+                        record(duration);
             } else {
-                successfulSearch.record(duration);
+                Timer.builder("search.latency").
+                        tags("category", "ui", "outcome", "success").
+                        register(registry).
+                        record(duration);
             }
         }
     }

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -80,9 +80,9 @@ public class StatisticsFilter implements Filter {
         categoryTimer.record(duration);
 
         SearchHelper helper = (SearchHelper) config.getRequestAttribute(SearchHelper.REQUEST_ATTR);
-        if (helper != null) {
-            MeterRegistry registry = Metrics.getRegistry();
-            if (registry != null && (helper.hits == null || helper.hits.length == 0)) {
+        MeterRegistry registry = Metrics.getRegistry();
+        if (helper != null && registry != null) {
+            if (helper.hits == null || helper.hits.length == 0) {
                 Timer.builder("search.latency").
                         tags("category", "ui", "outcome", "empty").
                         register(registry).


### PR DESCRIPTION
When investigating big latencies I came across the `search.latency` meter and realized that it is only used when searching the index via part of the UI. This change adds more categories. Because of Prometheus limitation the set of tags for the common meter name has to be the same.

Tested by performing search in the main form and via RESTful API and listing a directory.