### PR TITLE
run hg binary only once per isWorking()

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -109,7 +110,7 @@ public class MercurialRepository extends Repository {
      * This is a static replacement for 'working' field. Effectively, check if hg is working once in a JVM
      * instead of calling it for every MercurialRepository instance.
      */
-    private static final LazilyInstantiate<Boolean> HG_IS_WORKING = LazilyInstantiate.using(MercurialRepository::isHgWorking);
+    private static final Supplier<Boolean> HG_IS_WORKING = LazilyInstantiate.using(MercurialRepository::isHgWorking);
 
     public MercurialRepository() {
         type = "Mercurial";

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -495,6 +495,7 @@ public class MercurialRepository extends Repository {
     public boolean isWorking() {
         if (working == null) {
             working = HG_IS_WORKING.get();
+            ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         }
         return working;
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialIsWorkingTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialIsWorkingTest.java
@@ -1,0 +1,64 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.history;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opengrok.indexer.util.ForbiddenSymlinkException;
+import org.opengrok.indexer.util.TestRepository;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.opengrok.indexer.history.RepositoryFactoryTest.testNotWorkingRepository;
+
+/**
+ * This test needs to be in separate class since it tests static initializer
+ * of {@code MercurialRepository#HG_IS_WORKING}. Assuming the test will be run
+ * in separate JVM by JUnit.
+ */
+public class MercurialIsWorkingTest {
+    private static TestRepository repository = new TestRepository();
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        repository.create(RepositoryFactoryTest.class.getResourceAsStream("repositories.zip"));
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        if (repository != null) {
+            repository.destroy();
+            repository = null;
+        }
+    }
+
+    @Test
+    public void testNotWorkingMercurialRepository()
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException,
+            IOException, ForbiddenSymlinkException {
+        testNotWorkingRepository(repository, "mercurial", MercurialRepository.CMD_PROPERTY_KEY);
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialIsWorkingTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialIsWorkingTest.java
@@ -20,7 +20,6 @@
 /*
  * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  */
-
 package org.opengrok.indexer.history;
 
 import org.junit.AfterClass;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
@@ -160,7 +160,7 @@ public class RepositoryFactoryTest {
     public void testNotWorkingBitkeeperRepository()
             throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException,
             IOException, ForbiddenSymlinkException {
-        testNotWorkingRepository(repository,"bitkeeper", BitKeeperRepository.CMD_PROPERTY_KEY);
+        testNotWorkingRepository(repository, "bitkeeper", BitKeeperRepository.CMD_PROPERTY_KEY);
     }
 
     @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryFactoryTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -136,14 +136,14 @@ public class RepositoryFactoryTest {
      * There is no conditional run based on whether given repository is installed because
      * this test is not supposed to have working Mercurial anyway.
      */
-    private void testNotWorkingRepository(String repoPath, String propName)
+    static void testNotWorkingRepository(TestRepository repository, String repoPath, String propName)
             throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException,
             IOException, ForbiddenSymlinkException {
 
         String origPropValue = System.setProperty(propName, "/foo/bar/nonexistent");
         try {
             File root = new File(repository.getSourceRoot(), repoPath);
-            env.setSourceRoot(repository.getSourceRoot());
+            RuntimeEnvironment.getInstance().setSourceRoot(repository.getSourceRoot());
             Repository repo = RepositoryFactory.getRepository(root);
             assertNotNull("should have defined repo", repo);
             assertFalse("repo should not be working", repo.isWorking());
@@ -155,19 +155,12 @@ public class RepositoryFactoryTest {
             }
         }
     }
-    
-    @Test
-    public void testNotWorkingMercurialRepository()
-            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException,
-            IOException, ForbiddenSymlinkException {
-        testNotWorkingRepository("mercurial", MercurialRepository.CMD_PROPERTY_KEY);
-    }
-    
+
     @Test
     public void testNotWorkingBitkeeperRepository()
             throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException,
             IOException, ForbiddenSymlinkException {
-        testNotWorkingRepository("bitkeeper", BitKeeperRepository.CMD_PROPERTY_KEY);
+        testNotWorkingRepository(repository,"bitkeeper", BitKeeperRepository.CMD_PROPERTY_KEY);
     }
 
     @Test


### PR DESCRIPTION
This mimics the changes done in `GitRepository` to avoid checking Mercurial command for some of repository operations repeatedly. Should help repository scan/invalidation performance and thus web app startup.