### PR TITLE
print list of analyzers with -h guru

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -391,7 +391,7 @@ public class AnalyzerGuru {
         return Collections.unmodifiableMap(fileTypeDescriptions);
     }
 
-    public List<AnalyzerFactory> getAnalyzerFactories() {
+    public static List<AnalyzerFactory> getAnalyzerFactories() {
         return Collections.unmodifiableList(factories);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
@@ -48,6 +48,18 @@ public class AnalyzerGuruHelp {
      */
     public static String getUsage() {
         StringBuilder b = new StringBuilder();
+
+        b.append("List of analyzers:\n");
+        b.append("The names of the analyzers (left column) can be used for the -A indexer option:\n\n");
+        byFactory(AnalyzerGuru.getAnalyzerFactories().stream().
+                collect(Collectors.toMap(f -> f.getClass().getSimpleName(), f -> f))).
+                forEach((factory) -> {
+            b.append(String.format("%-10s : %s\n",
+                    factory.fac.getClass().getSimpleName().replace("AnalyzerFactory", ""),
+                    factory.fac.getName() != null ? factory.fac.getName() : "N/A"));
+        });
+        b.append("\n");
+
         b.append("AnalyzerGuru prefixes:\n");
         byKey(AnalyzerGuru.getPrefixesMap()).forEach((kv) -> {
             b.append(String.format("%-10s : %s\n", reportable(kv.key + '*'),
@@ -172,8 +184,7 @@ public class AnalyzerGuruHelp {
         return res.stream().toArray(String[]::new);
     }
 
-    private static List<MappedFactory> byKey(
-        Map<String, AnalyzerFactory> mapped) {
+    private static List<MappedFactory> byKey(Map<String, AnalyzerFactory> mapped) {
 
         List<MappedFactory> res = mapped.entrySet().stream().map((t) -> {
             return new MappedFactory(t.getKey(), t.getValue());
@@ -186,8 +197,7 @@ public class AnalyzerGuruHelp {
         return res;
     }
 
-    private static List<MappedFactory> byFactory(
-        Map<String, AnalyzerFactory> mapped) {
+    private static List<MappedFactory> byFactory(Map<String, AnalyzerFactory> mapped) {
 
         List<MappedFactory> res = mapped.entrySet().stream().map((t) -> {
             return new MappedFactory(t.getKey(), t.getValue());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
@@ -50,36 +50,37 @@ public class AnalyzerGuruHelp {
     public static String getUsage() {
         StringBuilder b = new StringBuilder();
 
-        b.append("List of analyzers:\n");
-        b.append("The names of the analyzers (left column) can be used for the -A indexer option:\n\n");
+        b.append("List of analyzers:" + System.lineSeparator());
+        b.append("The names of the analyzers (left column) can be used for the -A indexer option:" +
+                System.lineSeparator() + System.lineSeparator());
         byFactory(AnalyzerGuru.getAnalyzerFactories().stream().
                 collect(Collectors.toMap(f -> f.getClass().getSimpleName(), f -> f))).
                 forEach((factory) -> {
-            b.append(String.format("%-10s : %s\n",
+            b.append(String.format("%-10s : %s" + System.lineSeparator(),
                     factory.fac.getClass().getSimpleName().replace("AnalyzerFactory", ""),
                     factory.fac.getName() != null ? factory.fac.getName() : "N/A"));
         });
 
-        b.append("\nAnalyzerGuru prefixes:\n");
+        b.append(System.lineSeparator() + "AnalyzerGuru prefixes:" + System.lineSeparator());
         byKey(AnalyzerGuru.getPrefixesMap()).forEach((kv) -> {
-            b.append(String.format("%-10s : %s\n", reportable(kv.key + '*'),
+            b.append(String.format("%-10s : %s" + System.lineSeparator(), reportable(kv.key + '*'),
                 reportable(kv.fac)));
         });
 
-        b.append("\nAnalyzerGuru extensions:\n");
+        b.append(System.lineSeparator() + "AnalyzerGuru extensions:" + System.lineSeparator());
         byKey(AnalyzerGuru.getExtensionsMap()).forEach((kv) -> {
-            b.append(String.format("*.%-7s : %s\n",
+            b.append(String.format("*.%-7s : %s" + System.lineSeparator(),
                 reportable(kv.key.toLowerCase(Locale.ROOT)),
                 reportable(kv.fac)));
         });
 
-        b.append("\nAnalyzerGuru magic strings:\n");
+        b.append(System.lineSeparator() + "AnalyzerGuru magic strings:" + System.lineSeparator());
         byFactory(AnalyzerGuru.getMagicsMap()).forEach((kv) -> {
-            b.append(String.format("%-23s : %s\n", reportable(kv.key),
+            b.append(String.format("%-23s : %s" + System.lineSeparator(), reportable(kv.key),
                 reportable(kv.fac)));
         });
 
-        b.append("\nAnalyzerGuru magic matchers:\n");
+        b.append(System.lineSeparator() + "AnalyzerGuru magic matchers:" + System.lineSeparator());
         AnalyzerGuru.getAnalyzerFactoryMatchers().forEach((m) -> {
             if (m.getIsPreciseMagic()) {
                 b.append(reportable(m));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
@@ -58,9 +58,8 @@ public class AnalyzerGuruHelp {
                     factory.fac.getClass().getSimpleName().replace("AnalyzerFactory", ""),
                     factory.fac.getName() != null ? factory.fac.getName() : "N/A"));
         });
-        b.append("\n");
 
-        b.append("AnalyzerGuru prefixes:\n");
+        b.append("\nAnalyzerGuru prefixes:\n");
         byKey(AnalyzerGuru.getPrefixesMap()).forEach((kv) -> {
             b.append(String.format("%-10s : %s\n", reportable(kv.key + '*'),
                 reportable(kv.fac)));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
@@ -56,27 +56,27 @@ public class AnalyzerGuruHelp {
         byFactory(AnalyzerGuru.getAnalyzerFactories().stream().
                 collect(Collectors.toMap(f -> f.getClass().getSimpleName(), f -> f))).
                 forEach((factory) -> {
-            b.append(String.format("%-10s : %s" + System.lineSeparator(),
+            b.append(String.format("%-10s : %s%n",
                     factory.fac.getClass().getSimpleName().replace("AnalyzerFactory", ""),
                     factory.fac.getName() != null ? factory.fac.getName() : "N/A"));
         });
 
         b.append(System.lineSeparator() + "AnalyzerGuru prefixes:" + System.lineSeparator());
         byKey(AnalyzerGuru.getPrefixesMap()).forEach((kv) -> {
-            b.append(String.format("%-10s : %s" + System.lineSeparator(), reportable(kv.key + '*'),
+            b.append(String.format("%-10s : %s%n", reportable(kv.key + '*'),
                 reportable(kv.fac)));
         });
 
         b.append(System.lineSeparator() + "AnalyzerGuru extensions:" + System.lineSeparator());
         byKey(AnalyzerGuru.getExtensionsMap()).forEach((kv) -> {
-            b.append(String.format("*.%-7s : %s" + System.lineSeparator(),
+            b.append(String.format("*.%-7s : %s%n",
                 reportable(kv.key.toLowerCase(Locale.ROOT)),
                 reportable(kv.fac)));
         });
 
         b.append(System.lineSeparator() + "AnalyzerGuru magic strings:" + System.lineSeparator());
         byFactory(AnalyzerGuru.getMagicsMap()).forEach((kv) -> {
-            b.append(String.format("%-23s : %s" + System.lineSeparator(), reportable(kv.key),
+            b.append(String.format("%-23s : %s%n", reportable(kv.key),
                 reportable(kv.fac)));
         });
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuruHelp.java
@@ -134,7 +134,7 @@ public class AnalyzerGuruHelp {
     }
 
     private static String reportable(FileAnalyzerFactory.Matcher m) {
-        final String MATCHER_FMT = "%-11s %-1s %s\n";
+        final String MATCHER_FMT = "%-11s %-1s %s%n";
         StringBuilder b = new StringBuilder();
         String[] lines = splitLines(m.description(), 66);
         for (int i = 0; i < lines.length; ++i) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.document;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.document;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzerFactory.java
@@ -32,7 +32,7 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
 public class MandocAnalyzerFactory extends FileAnalyzerFactory {
 
-    private static final String NAME = "Mandoc";
+    private static final String NAME = "Manual pages";
 
     public static final Matcher MATCHER = new Matcher() {
         @Override

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/LuceneCompatibilityTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/LuceneCompatibilityTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/LuceneCompatibilityTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/LuceneCompatibilityTest.java
@@ -89,7 +89,7 @@ public class LuceneCompatibilityTest extends TestCase {
     }
 
     public void testCompatibility() throws Exception {
-        for (AnalyzerFactory fa : guru.getAnalyzerFactories()) {
+        for (AnalyzerFactory fa : AnalyzerGuru.getAnalyzerFactories()) {
             String input = "Hello world";
             String[] output = new String[]{"Hello", "world"};
             testA = fa.getAnalyzer();


### PR DESCRIPTION
This change adds table of analyzer -> name to the output of `-h guru`:

```
List of analyzers:
The names of the analyzers (left column) can be used for the -A indexer option:

Ada        : Ada
Asm        : Asm
BZip2      : Bzip(2)
C          : C
CSharp     : C#
Cxx        : C++
Clojure    : Clojure
Eiffel     : Eiffel
ELF        : ELF
Erlang     : Erlang
File       : N/A
Fortran    : Fortran
Golang     : Golang
GZIP       : GZIP
Haskell    : Haskell
HCL        : HCL
Ignorant   : N/A
Image      : Image file
Jar        : Jar
Java       : Java
JavaClass  : Java class
JavaScript : JavaScript
Json       : Json
Kotlin     : Kotlin
Lisp       : Lisp
Lua        : Lua
Mandoc     : Manual pages
Pascal     : Pascal
Perl       : Perl
Php        : PHP
PLSQL      : PL/SQL
Plain      : Plain Text
Powershell : PowerShell script
Python     : Python
R          : R
Ruby       : Ruby
Rust       : Rust
Scala      : Scala
Sh         : Shell script
SQL        : SQL
Swift      : Swift
Tar        : Tar
Tcl        : Tcl
Terraform  : Terraform
Troff      : Troff
TypeScript : TypeScript
Uuencode   : UUEncoded
Verilog    : Verilog
VB         : Visual Basic
XML        : XML
Zip        : Zip

AnalyzerGuru prefixes:
MAKEFILE*  : Shell script
...
```