### PR TITLE
Merge commits tunable

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -232,6 +232,8 @@ public final class Configuration {
      */
     private boolean handleHistoryOfRenamedFiles;
 
+    private boolean mergeCommitsEnabled;
+
     public static final double defaultRamBufferSize = 16;
 
     /**
@@ -829,6 +831,14 @@ public final class Configuration {
 
     public void setHandleHistoryOfRenamedFiles(boolean enable) {
         this.handleHistoryOfRenamedFiles = enable;
+    }
+
+    public void setMergeCommitsEnabled(boolean flag) {
+        this.mergeCommitsEnabled = flag;
+    }
+
+    public boolean isMergeCommitsEnabled() {
+        return mergeCommitsEnabled;
     }
 
     public boolean isNavigateWindowEnabled() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, Aleksandr Kirillov <alexkirillovsamara@gmail.com>.
  */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -543,6 +543,7 @@ public final class Configuration {
         //mandoc is default(String)
         setMaxSearchThreadCount(2 * Runtime.getRuntime().availableProcessors());
         setMaxRevisionThreadCount(Runtime.getRuntime().availableProcessors());
+        setMergeCommitsEnabled(true);
         setMessageLimit(500);
         setNavigateWindowEnabled(false);
         setNestingMaximum(1);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -84,6 +84,11 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     private Boolean historyEnabled = null;
 
     /**
+     * This flag enables/disables per project merge commits.
+     */
+    private Boolean mergeCommitsEnabled = null;
+
+    /**
      * This marks the project as (not)ready before initial index is done. this
      * is to avoid all/multi-project searches referencing this project from
      * failing.
@@ -238,6 +243,13 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     }
 
     /**
+     * @return true if merge commits are enabled.
+     */
+    public boolean isMergeCommitsEnabled() {
+        return mergeCommitsEnabled != null && mergeCommitsEnabled;
+    }
+
+    /**
      * @param flag true if project should handle renamed files, false otherwise.
      */
     public void setHandleRenamedFiles(boolean flag) {
@@ -256,6 +268,13 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
      */
     public void setHistoryEnabled(boolean flag) {
         this.historyEnabled = flag;
+    }
+
+    /**
+     * @param flag true if project's repositories should deal with merge commits.
+     */
+    public void setMergeCommitsEnabled(boolean flag) {
+        this.mergeCommitsEnabled = flag;
     }
 
     /**
@@ -321,6 +340,11 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
         // Allow project to override global setting of navigate window.
         if (navigateWindowEnabled == null) {
             setNavigateWindowEnabled(env.isNavigateWindowEnabled());
+        }
+
+        // Allow project to override global setting of merge commits.
+        if (mergeCommitsEnabled == null) {
+            setMergeCommitsEnabled(env.isMergeCommitsEnabled());
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1251,6 +1251,14 @@ public final class RuntimeEnvironment {
         return syncReadConfiguration(Configuration::isHandleHistoryOfRenamedFiles);
     }
 
+    public void setMergeCommitsEnabled(boolean flag) {
+        syncWriteConfiguration(flag, Configuration::setMergeCommitsEnabled);
+    }
+
+    public boolean isMergeCommitsEnabled() {
+        return syncReadConfiguration(Configuration::isMergeCommitsEnabled);
+    }
+
     public void setNavigateWindowEnabled(boolean navigateWindowEnabled) {
         syncWriteConfiguration(navigateWindowEnabled, Configuration::setNavigateWindowEnabled);
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -60,6 +60,7 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
+import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
@@ -171,7 +172,9 @@ public class GitRepository extends Repository {
         cmd.add("--name-only");
         cmd.add("--pretty=fuller");
         cmd.add(GIT_DATE_OPT);
-        cmd.add("-m");
+        if (isMergeCommitsEnabled()) {
+            cmd.add("-m");
+        }
 
         if (file.isFile() && isHandleRenamedFiles()) {
             cmd.add("--follow");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -60,7 +60,6 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
-import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -77,6 +77,8 @@ public class RepositoryInfo implements Serializable {
     private boolean handleRenamedFiles;
     @DTOElement
     private boolean historyEnabled;
+    @DTOElement
+    private boolean mergeCommitsEnabled;
 
     /**
      * Empty constructor to support serialization.
@@ -108,6 +110,20 @@ public class RepositoryInfo implements Serializable {
      */
     public void setHandleRenamedFiles(boolean flag) {
         this.handleRenamedFiles = flag;
+    }
+
+    /**
+     * @return true if the repository handles merge commits.
+     */
+    public boolean isMergeCommitsEnabled() {
+        return this.mergeCommitsEnabled;
+    }
+
+    /**
+     * @param flag true if the repository should handle merge commits, false otherwise.
+     */
+    public void setMergeCommitsEnabled(boolean flag) {
+        this.mergeCommitsEnabled = flag;
     }
 
     /**
@@ -293,11 +309,13 @@ public class RepositoryInfo implements Serializable {
         if (proj != null) {
             setHistoryEnabled(proj.isHistoryEnabled());
             setHandleRenamedFiles(proj.isHandleRenamedFiles());
+            setMergeCommitsEnabled(proj.isMergeCommitsEnabled());
         } else {
             RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
             setHistoryEnabled(env.isHistoryEnabled());
             setHandleRenamedFiles(env.isHandleHistoryOfRenamedFiles());
+            setMergeCommitsEnabled(env.isMergeCommitsEnabled());
         }
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryOctopusTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryOctopusTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryOctopusTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryOctopusTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.opengrok.indexer.condition.ConditionalRun;
 import org.opengrok.indexer.condition.ConditionalRunRule;
 import org.opengrok.indexer.condition.RepositoryInstalled;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.TestRepository;
 import org.opengrok.indexer.web.Util;
 
@@ -59,6 +60,7 @@ public class GitRepositoryOctopusTest {
         repository = new TestRepository();
         repository.create(GitRepositoryOctopusTest.class.getResourceAsStream(
                 "/history/git-octopus.zip"));
+        RuntimeEnvironment.getInstance().setMergeCommitsEnabled(true);
     }
 
     @AfterClass


### PR DESCRIPTION
This change allows to control whether the merge commits should be stored in history. Should work as workaround with indexing large repositories that have rich history. This is relevant only to Git so far.

I did not want to introduce yet another command line option so this needs to be used via read-only configuration.