### PR TITLE
skip over false tags

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -632,8 +632,13 @@ public class GitRepository extends Repository {
                 Map<RevCommit, String> commit2Tags = new HashMap<>();
                 for (Ref ref : refList) {
                     String tagName = ref.getName().replace("refs/tags/", "");
-                    RevCommit commit = getCommit(repository, ref);
-                    commit2Tags.merge(commit, tagName, (oldValue, newValue) -> oldValue + TAGS_SEPARATOR + newValue);
+                    try {
+                        RevCommit commit = getCommit(repository, ref);
+                        commit2Tags.merge(commit, tagName, (oldValue, newValue) -> oldValue + TAGS_SEPARATOR + newValue);
+                    } catch (IOException e) {
+                        LOGGER.log(Level.FINEST,
+                                String.format("cannot get tags for \"" + directory.getAbsolutePath() + "\""), e);
+                    }
                 }
 
                 for (Map.Entry<RevCommit, String> entry : commit2Tags.entrySet()) {
@@ -649,7 +654,7 @@ public class GitRepository extends Repository {
             // In case of partial success, do not null-out tagList here.
         }
 
-        if (LOGGER.isLoggable(Level.FINEST)) {
+        if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.log(Level.FINEST, "Read tags count={0} for {1}",
                     new Object[] {tagList.size(), directory});
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -655,7 +655,7 @@ public class GitRepository extends Repository {
         }
 
         if (LOGGER.isLoggable(Level.FINER)) {
-            LOGGER.log(Level.FINEST, "Read tags count={0} for {1}",
+            LOGGER.log(Level.FINER, "Read tags count={0} for {1}",
                     new Object[] {tagList.size(), directory});
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -631,9 +631,9 @@ public class GitRepository extends Repository {
                 List<Ref> refList = git.tagList().call(); // refs sorted according to tag names
                 Map<RevCommit, String> commit2Tags = new HashMap<>();
                 for (Ref ref : refList) {
-                    String tagName = ref.getName().replace("refs/tags/", "");
                     try {
                         RevCommit commit = getCommit(repository, ref);
+                        String tagName = ref.getName().replace("refs/tags/", "");
                         commit2Tags.merge(commit, tagName, (oldValue, newValue) -> oldValue + TAGS_SEPARATOR + newValue);
                     } catch (IOException e) {
                         LOGGER.log(Level.FINEST,


### PR DESCRIPTION
With this change the tag rebuild for the linux-mainline repository finishes fine, with some 687 `tagList` entries currently.