### PR TITLE
Interpret .cu/.cuh files as .cxx files

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CxxAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CxxAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.c;
 
@@ -26,23 +26,25 @@ import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.opengrok.indexer.analysis.FileAnalyzerFactory;
 
 public class CxxAnalyzerFactory extends FileAnalyzerFactory {
-    
-    private static final String name = "C++";
-    
+
+    private static final String NAME = "C++";
+
     private static final String[] SUFFIXES = {
-        "CPP",
-        "HPP",
-        "CC",
-        "C++",
-        "HH",
-        "CXX",
-        "HXX",
-        "TXX",
-        "TCC"
+            "CPP",
+            "HPP",
+            "CC",
+            "C++",
+            "HH",
+            "CXX",
+            "HXX",
+            "TXX",
+            "TCC",
+            "CU",
+            "CUH"
     };
 
     public CxxAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, name);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
     }
 
     @Override


### PR DESCRIPTION
fixes #3518

From https://en.wikipedia.org/wiki/CUDA : "CUDA source code is now processed according to C++ syntax rules".

I've tested on https://github.com/NVIDIA/cuda-samples and the results looked good.

Thanks to @saltuser16

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
