### PR TITLE
Add serial filtering when deserializing classes

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Scopes.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Scopes.java
@@ -22,9 +22,12 @@
  */
 package org.opengrok.indexer.analysis;
 
+import org.opengrok.indexer.util.WhitelistObjectInputFilter;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -37,6 +40,12 @@ import java.util.TreeSet;
 public class Scopes implements Serializable {
 
     private static final long serialVersionUID = 1191703801007779489L;
+
+    private static final ObjectInputFilter serialFilter = new WhitelistObjectInputFilter(
+            Scopes.class,
+            TreeSet.class,
+            Scope.class
+    );
 
     /**
      * Note: this class has a natural ordering that is inconsistent with equals.
@@ -164,10 +173,10 @@ public class Scopes implements Serializable {
      * @throws ClassCastException if the array contains an object of another
      * type than {@code Definitions}
      */
-    public static Scopes deserialize(byte[] bytes)
-            throws IOException, ClassNotFoundException {
-        ObjectInputStream in
-                = new ObjectInputStream(new ByteArrayInputStream(bytes));
-        return (Scopes) in.readObject();
+    public static Scopes deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            in.setObjectInputFilter(serialFilter);
+            return (Scopes) in.readObject();
+        }
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/WhitelistObjectInputFilter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/WhitelistObjectInputFilter.java
@@ -1,0 +1,45 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.ObjectInputFilter;
+import java.util.Set;
+
+public class WhitelistObjectInputFilter implements ObjectInputFilter {
+
+    private final Set<Class<?>> whitelist;
+
+    public WhitelistObjectInputFilter(@NotNull final Class<?>... whitelist) {
+        this.whitelist = Set.of(whitelist);
+    }
+
+    @Override
+    public Status checkInput(final FilterInfo filterInfo) {
+        if (filterInfo.serialClass() == null || whitelist.contains(filterInfo.serialClass())) {
+            return Status.ALLOWED;
+        }
+        return Status.REJECTED;
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ScopesTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ScopesTest.java
@@ -25,6 +25,8 @@ package org.opengrok.indexer.analysis;
 import org.junit.jupiter.api.Test;
 import org.opengrok.indexer.analysis.Scopes.Scope;
 
+import java.io.IOException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -63,4 +65,14 @@ public class ScopesTest {
         assertEquals(instance.getScope(101), globalScope);
         assertEquals(instance.getScope(500), globalScope);
     }
+
+    @Test
+    void testSerialize() throws IOException, ClassNotFoundException {
+        Scopes scopes = new Scopes();
+        scopes.addScope(new Scope(1, 100, "name", "namespace", "signature"));
+        byte[] bytes = scopes.serialize();
+        Scopes deserialized = Scopes.deserialize(bytes);
+        assertEquals(1, deserialized.size());
+    }
+
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexAnalysisSettingsUpgraderTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexAnalysisSettingsUpgraderTest.java
@@ -23,6 +23,7 @@
 package org.opengrok.indexer.index;
 
 import java.io.IOException;
+import java.io.InvalidClassException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +33,7 @@ import org.opengrok.indexer.analysis.AnalyzerGuru;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -123,13 +124,8 @@ public class IndexAnalysisSettingsUpgraderTest {
         byte[] bin = obj.serialize();
 
         IndexAnalysisSettingsUpgrader upgrader = new IndexAnalysisSettingsUpgrader();
-        IndexAnalysisSettings3 res = null;
-        try {
-            res = upgrader.upgrade(bin, 3); // wrong version
-        } catch (ClassCastException e) {
-            // expected
-        }
-        assertNull(res, "should not have produced an instance");
+        assertThrows(InvalidClassException.class, () -> upgrader.upgrade(bin, 3),
+                "should not have produced an instance");
     }
 
     @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/WhitelistObjectInputFilterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/WhitelistObjectInputFilterTest.java
@@ -1,0 +1,86 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.util;
+
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.io.ObjectInputFilter.FilterInfo;
+import java.io.ObjectInputFilter.Status;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WhitelistObjectInputFilterTest {
+
+    private static class DummyFilterInfo implements FilterInfo {
+
+        private final Class<?> cl;
+
+        DummyFilterInfo(@Nullable Class<?> cl) {
+            this.cl = cl;
+        }
+
+        @Override
+        public Class<?> serialClass() {
+            return cl;
+        }
+
+        @Override
+        public long arrayLength() {
+            return 0;
+        }
+
+        @Override
+        public long depth() {
+            return 0;
+        }
+
+        @Override
+        public long references() {
+            return 0;
+        }
+
+        @Override
+        public long streamBytes() {
+            return 0;
+        }
+    }
+
+    @Test
+    void testBlackListedClassIsRejected() {
+        var filter = new WhitelistObjectInputFilter();
+        assertEquals(Status.REJECTED, filter.checkInput(new DummyFilterInfo(Double.class)));
+    }
+
+    @Test
+    void testWhiteListedClassIsAllowed() {
+        var filter = new WhitelistObjectInputFilter(Integer.class);
+        assertEquals(Status.ALLOWED, filter.checkInput(new DummyFilterInfo(Integer.class)));
+    }
+
+    @Test
+    void testNullClassIsAllowed() {
+        var filter = new WhitelistObjectInputFilter();
+        assertEquals(Status.ALLOWED, filter.checkInput(new DummyFilterInfo(null)));
+    }
+}

--- a/suggester/src/main/java/org/opengrok/suggest/popular/impl/chronicle/ChronicleMapConfiguration.java
+++ b/suggester/src/main/java/org/opengrok/suggest/popular/impl/chronicle/ChronicleMapConfiguration.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest.popular.impl.chronicle;
 
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputFilter.Status;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -96,6 +97,9 @@ public class ChronicleMapConfiguration implements Serializable {
             return null;
         }
         try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(f))) {
+            ois.setObjectInputFilter(filterInfo ->
+                    filterInfo.serialClass() == null || filterInfo.serialClass() == ChronicleMapConfiguration.class ?
+                            Status.ALLOWED : Status.REJECTED);
             return (ChronicleMapConfiguration) ois.readObject();
         } catch (IOException | ClassNotFoundException e) {
             logger.log(Level.SEVERE, "Could not load chronicle map configuration", e);


### PR DESCRIPTION
I was debating whether to put some default allowed classes to the whitelist filter (e.g. `Integer.class`, `Double.class`) but since it's used only in a couple of places, I decided against it.

Thanks.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
