### PR TITLE
check source and data root access

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -871,11 +871,11 @@ public final class Indexer {
             die("Repositories were specified; history is off however");
         }
 
-        if (! new File(cfg.getSourceRoot()).canRead()) {
+        if (!new File(cfg.getSourceRoot()).canRead()) {
             die("Source root '" + cfg.getSourceRoot() + "' must be readable");
         }
 
-        if (! new File(cfg.getDataRoot()).canWrite()) {
+        if (!new File(cfg.getDataRoot()).canWrite()) {
             die("Data root '" + cfg.getDataRoot() + "' must be writable");
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -870,6 +870,14 @@ public final class Indexer {
         if (repositories.size() > 0 && !cfg.isHistoryEnabled()) {
             die("Repositories were specified; history is off however");
         }
+
+        if (! new File(cfg.getSourceRoot()).canRead()) {
+            die("Source root '" + cfg.getSourceRoot() + "' must be readable");
+        }
+
+        if (! new File(cfg.getDataRoot()).canWrite()) {
+            die("Data root '" + cfg.getDataRoot() + "' must be writable");
+        }
     }
 
     private static void die(String message) {


### PR DESCRIPTION
#3536 inspired me to add permissions checks for source and data root. Granted, this is still prone to the _TOUTOC_ problem however will provide early exit. Also, the existence of the directories is checked only when parsing the -s/-d options, i.e. will not apply to read-only configuration.