### PR TITLE
disable merge commits by default

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -542,7 +542,7 @@ public final class Configuration {
         //mandoc is default(String)
         setMaxSearchThreadCount(2 * Runtime.getRuntime().availableProcessors());
         setMaxRevisionThreadCount(Runtime.getRuntime().availableProcessors());
-        setMergeCommitsEnabled(true);
+        setMergeCommitsEnabled(false);
         setMessageLimit(500);
         setNavigateWindowEnabled(false);
         setNestingMaximum(1);


### PR DESCRIPTION
After trying to create history for linux-mainline Git repository from scratch (https://github.com/oracle/opengrok/issues/3539#issuecomment-818752840) and seeing the difference when merge commits are disabled I think it is reasonable to disable merge commits by default.

This is the difference on Java 11 VM with 16 GB heap:

![linux-merge-on_vs_off](https://user-images.githubusercontent.com/2934284/114566744-dba28c80-9c72-11eb-91c1-30d47d92cc86.png)

The indexer with merge commits disabled was started at 16:00 and very quickly progressed to create the file history cache while the first actually ended with OOM and did not even get to storing a single file history cache entry on disk.