### PR TITLE
LdapServerTest redux

### DIFF
--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -81,7 +81,7 @@ public class LdapServerTest {
     public void testIsReachable() throws IOException, InterruptedException, URISyntaxException {
         // Start simple TCP server on test port.
         InetAddress localhostAddr = InetAddress.getLoopbackAddress();
-        try (ServerSocket serverSocket = new ServerSocket(0, 1, localhostAddr)) {
+        try (ServerSocket serverSocket = new ServerSocket(0, 1)) {
             Thread thread = new Thread(() -> {
                 try {
                     while (true) {

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -80,7 +80,7 @@ public class LdapServerTest {
     @Test
     public void testIsReachablePositive() throws IOException, InterruptedException, URISyntaxException {
         // Start simple TCP server on test port.
-        InetAddress localhostAddr = InetAddress.getLoopbackAddress();
+        InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
         try (ServerSocket serverSocket = new ServerSocket(0, 1)) {
             Thread thread = new Thread(() -> {
                 try {
@@ -98,7 +98,7 @@ public class LdapServerTest {
             Socket socket = null;
             for (int i = 0; i < 3; i++) {
                 try {
-                    socket = new Socket(localhostAddr, testPort);
+                    socket = new Socket(loopbackAddress, testPort);
                 } catch (IOException e) {
                     Thread.sleep(1000);
                 }
@@ -110,7 +110,7 @@ public class LdapServerTest {
             // Mock getAddresses() to return single localhost IP address and getPort() to return the test port.
             LdapServer server = new LdapServer("ldaps://foo.bar.com");
             LdapServer serverSpy = Mockito.spy(server);
-            Mockito.when(serverSpy.getAddresses(any())).thenReturn(new InetAddress[]{localhostAddr});
+            Mockito.when(serverSpy.getAddresses(any())).thenReturn(new InetAddress[]{loopbackAddress});
             doReturn(testPort).when(serverSpy).getPort();
 
             // Test reachability.
@@ -124,12 +124,12 @@ public class LdapServerTest {
 
     @Test
     void testsReachableNegative() throws Exception {
-        InetAddress localhostAddr = InetAddress.getLoopbackAddress();
+        InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
 
         // Mock getAddresses() to return single localhost IP address and getPort() to return the test port.
         LdapServer server = new LdapServer("ldaps://foo.bar.com");
         LdapServer serverSpy = Mockito.spy(server);
-        Mockito.when(serverSpy.getAddresses(any())).thenReturn(new InetAddress[]{localhostAddr});
+        Mockito.when(serverSpy.getAddresses(any())).thenReturn(new InetAddress[]{loopbackAddress});
         // port 0 should not be reachable.
         doReturn(0).when(serverSpy).getPort();
 

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -80,7 +80,7 @@ public class LdapServerTest {
     @Test
     public void testIsReachable() throws IOException, InterruptedException, URISyntaxException {
         // Start simple TCP server on test port.
-        InetAddress localhostAddr = InetAddress.getLocalHost();
+        InetAddress localhostAddr = InetAddress.getLoopbackAddress();
         try (ServerSocket serverSocket = new ServerSocket(0, 1, localhostAddr)) {
             Thread thread = new Thread(() -> {
                 try {

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapServerTest.java
@@ -78,7 +78,7 @@ public class LdapServerTest {
     }
 
     @Test
-    public void testIsReachable() throws IOException, InterruptedException, URISyntaxException {
+    public void testIsReachablePositive() throws IOException, InterruptedException, URISyntaxException {
         // Start simple TCP server on test port.
         InetAddress localhostAddr = InetAddress.getLoopbackAddress();
         try (ServerSocket serverSocket = new ServerSocket(0, 1)) {
@@ -115,15 +115,25 @@ public class LdapServerTest {
 
             // Test reachability.
             boolean reachable = serverSpy.isReachable();
-            serverSocket.close();
-            thread.join(5000);
-            thread.interrupt();
             assertTrue(reachable);
 
-            // Test non-reachability.
-            reachable = serverSpy.isReachable();
-            assertFalse(reachable);
+            thread.interrupt();
+            thread.join(5000);
         }
+    }
+
+    @Test
+    void testsReachableNegative() throws Exception {
+        InetAddress localhostAddr = InetAddress.getLoopbackAddress();
+
+        // Mock getAddresses() to return single localhost IP address and getPort() to return the test port.
+        LdapServer server = new LdapServer("ldaps://foo.bar.com");
+        LdapServer serverSpy = Mockito.spy(server);
+        Mockito.when(serverSpy.getAddresses(any())).thenReturn(new InetAddress[]{localhostAddr});
+        // port 0 should not be reachable.
+        doReturn(0).when(serverSpy).getPort();
+
+        assertFalse(serverSpy.isReachable());
     }
 
     @Test


### PR DESCRIPTION
The LdapServerTest is still failing due to

```
Error:  Tests run: 6, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.225 s <<< FAILURE! - in opengrok.auth.plugin.LdapServerTest
Error:  testIsReachable  Time elapsed: 0.019 s  <<< ERROR!
java.net.BindException: Cannot assign requested address (Bind failed)
	at java.base/java.net.PlainSocketImpl.socketBind(Native Method)
	at java.base/java.net.AbstractPlainSocketImpl.bind(AbstractPlainSocketImpl.java:436)
	at java.base/java.net.ServerSocket.bind(ServerSocket.java:395)
	at java.base/java.net.ServerSocket.<init>(ServerSocket.java:257)
	at opengrok.auth.plugin.LdapServerTest.testIsReachable(LdapServerTest.java:84)
```

The fix done in 476443edddbb606ccf738095d424034494b8dd71 was not sufficient it seems so reintroducing the original approach.