### PR TITLE
Fix github webpage links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ your source tree. It can understand various program file formats and
 version control histories of many source code management systems.
 
 Official page of the project is on:
-<http://opengrok.github.com/OpenGrok/>
+<https://oracle.github.io/opengrok/>
 
 ## 2. OpenGrok install and setup
 

--- a/opengrok-web/src/main/webapp/foot.jspf
+++ b/opengrok-web/src/main/webapp/foot.jspf
@@ -42,7 +42,7 @@ org.opengrok.indexer.web.Prefix"
     
         %>
     <div id="footer">
-<p><a href="http://opengrok.github.com/OpenGrok/"
+<p><a href="https://oracle.github.io/opengrok/"
  title="Served by OpenGrok (<%= Info.getVersion() %> - <%= Info.getShortRevision() %>)"><span id="fti"></span></a></p>
 <% if(dateForLastIndexRun != null) { %>
 <p>Last Index update <%= dateForLastIndexRun %></p>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 
 -->
@@ -31,7 +31,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
     <packaging>pom</packaging>
 
     <name>OpenGrok</name>
-    <url>http://opengrok.github.com/OpenGrok/</url>
+    <url>https://oracle.github.io/opengrok/</url>
     <organization>
         <name>Oracle</name>
         <url>http://www.oracle.com</url>


### PR DESCRIPTION
![Screen Shot 2021-04-17 at 17 49 22](https://user-images.githubusercontent.com/12401160/115127852-dd888a80-9fa7-11eb-9bed-a06818b8a713.png)

The github.com webpage links stopped working.

Thanks!

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
