### PR TITLE
fix misplaced comment

### DIFF
--- a/opengrok-web/src/main/webapp/xref.jspf
+++ b/opengrok-web/src/main/webapp/xref.jspf
@@ -187,5 +187,5 @@ org.opengrok.indexer.web.QueryParameters"
 </div><%
     }
 }
-%>
 /* ---------------------- xref.jspf end --------------------- */
+%>


### PR DESCRIPTION
The xref page for binary files contains the misplaced comment, this change fixes that.