### PR TITLE
add port and REST endpoint to trigger reindex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ RUN mkdir -p /opengrok /opengrok/etc /opengrok/data /opengrok/src && \
 
 RUN python3 -m pip install /opengrok/tools/opengrok-tools*
 
+# for /reindex REST endpoint handled by start.py
+RUN python3 -m pip install Flask Flask-HTTPAuth waitress
+
 # environment variables
 ENV SRC_ROOT /opengrok/src
 ENV DATA_ROOT /opengrok/data

--- a/docker/README.md
+++ b/docker/README.md
@@ -81,6 +81,8 @@ The volume mounted to `/opengrok/src` should contain the projects you want to ma
 `URL_ROOT` | `/` | Override the sub-URL that OpenGrok should run on.
 `WORKERS` | number of CPUs in the container | number of workers to use for syncing (applies only to setup with projects enabled)
 `AVOID_PROJECTS` | empty | run in project less configuration. Set to non empty value disables projects.
+`REST_PORT` | 5000 | TCP port where simple REST app listens for GET requests on `/reindex` to trigger manual reindex.
+`REST_TOKEN` | None | if set, the REST app will require this token as Bearer token in order to trigger reindex.
 
 To specify environment variable for `docker run`, use the `-e` option, e.g. `-e SYNC_PERIOD_MINUTES=30`
 


### PR DESCRIPTION
This change allows to trigger reindex from outside of the Docker container via `GET` request to `/reindex` on certain port (5000 by default). This works only if the periodic reindex is disabled, i.e. when `SYNC_TIME_MINUTES` environment variable is set to 0.