### PR TITLE
Use label for minisearch's "current directory" checkbox

### DIFF
--- a/opengrok-web/src/main/webapp/minisearch.jspf
+++ b/opengrok-web/src/main/webapp/minisearch.jspf
@@ -101,9 +101,9 @@ org.opengrok.indexer.web.Util"%><%
             <li><input type="submit" value="Search" class="submit" /></li><%
     Project proj = cfg.getProject();
     String[] vals = cfg.getSearchOnlyIn();
-        %><li><input id="minisearch-path" type="checkbox"
+        %><li><label><input id="minisearch-path" type="checkbox"
                   name="<%= QueryParameters.PATH_SEARCH_PARAM %>" value='"<%= vals[0]
-            %>"' <%= vals[2] %>/> current directory</li>
+            %>"' <%= vals[2] %>/> current directory</label></li>
     </ul><%
     if (proj != null) {
     %>


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
The look is the same but now clicking on the text also checks the checkbox.

Thanks.