### PR TITLE
update dependency-check to 6.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>6.0.2</version>
+                <version>6.1.5</version>
                 <configuration>
                     <skipSystemScope>true</skipSystemScope>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>


### PR DESCRIPTION
Recently the dependency check caused some build instability, this update hopefully fixes that.
