### PR TITLE
run reindex if period is 0

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -75,7 +75,7 @@ The volume mounted to `/opengrok/src` should contain the projects you want to ma
 
 | Docker Environment Var. | Default value | Description |
 | ----------------------- | ------------- | ----------- |
-`SYNC_TIME_MINUTES` | 10 | Period of automatic synchronization (i.e. mirroring + reindexing) in minutes. Setting to `0` will disable automatic syncing.
+`SYNC_PERIOD_MINUTES` | 10 | Period of automatic synchronization (i.e. mirroring + reindexing) in minutes. Setting to `0` will disable automatic syncing.
 `INDEXER_OPT` | empty | pass **extra** options to OpenGrok Indexer. The default set of indexer options is: `--remote on -P -H -W`. For example, `-i d:vendor` will remove all the `*/vendor/*` files from the index. You can check the indexer options on https://github.com/oracle/opengrok/wiki/Python-scripts-transition-guide
 `NOMIRROR` | empty | To avoid the mirroring step, set the variable to non-empty value.
 `URL_ROOT` | `/` | Override the sub-URL that OpenGrok should run on.

--- a/docker/README.md
+++ b/docker/README.md
@@ -75,7 +75,7 @@ The volume mounted to `/opengrok/src` should contain the projects you want to ma
 
 | Docker Environment Var. | Default value | Description |
 | ----------------------- | ------------- | ----------- |
-`SYNC_PERIOD_MINUTES` | 10 | Period of automatic synchronization (i.e. mirroring + reindexing) in minutes. Setting to `0` will disable automatic syncing.
+`SYNC_PERIOD_MINUTES` | 10 | Period of automatic synchronization (i.e. mirroring + reindexing) in minutes. Setting to `0` will disable periodic syncing (the sync after container startup will still be done).
 `INDEXER_OPT` | empty | pass **extra** options to OpenGrok Indexer. The default set of indexer options is: `--remote on -P -H -W`. For example, `-i d:vendor` will remove all the `*/vendor/*` files from the index. You can check the indexer options on https://github.com/oracle/opengrok/wiki/Python-scripts-transition-guide
 `NOMIRROR` | empty | To avoid the mirroring step, set the variable to non-empty value.
 `URL_ROOT` | `/` | Override the sub-URL that OpenGrok should run on.

--- a/docker/start.py
+++ b/docker/start.py
@@ -270,9 +270,6 @@ def indexer_no_projects(logger, uri, config_path, sync_period,
         periodic_sync = False
 
     while True:
-        if not periodic_sync:
-            sleep_event.wait()
-
         indexer_options = ['-s', OPENGROK_SRC_ROOT,
                            '-d', OPENGROK_DATA_ROOT,
                            '-c', '/usr/local/bin/ctags',
@@ -292,6 +289,8 @@ def indexer_no_projects(logger, uri, config_path, sync_period,
             sleep_seconds = sync_period * 60
             logger.info("Sleeping for {} seconds".format(sleep_seconds))
             time.sleep(sleep_seconds)
+        elif not periodic_sync:
+            sleep_event.wait()
 
 
 def project_syncer(logger, loglevel, uri, config_path, sync_period,
@@ -310,9 +309,6 @@ def project_syncer(logger, loglevel, uri, config_path, sync_period,
         periodic_sync = False
 
     while True:
-        if not periodic_sync:
-            sleep_event.wait()
-
         refresh_projects(logger, uri)
 
         if os.environ.get('OPENGROK_SYNC_YML'):  # debug only
@@ -352,6 +348,8 @@ def project_syncer(logger, loglevel, uri, config_path, sync_period,
             sleep_seconds = sync_period * 60
             logger.info("Sleeping for {} seconds".format(sleep_seconds))
             time.sleep(sleep_seconds)
+        elif not periodic_sync:
+            sleep_event.wait()
 
 
 def create_bare_config(logger, extra_indexer_options=None):
@@ -412,10 +410,9 @@ def main():
     logger.debug("URL_ROOT = {}".format(url_root))
     logger.debug("URI = {}".format(uri))
 
-    # default period for syncing (in minutes)
     sync_period = get_num_from_env(logger, 'SYNC_PERIOD_MINUTES', 10)
     if sync_period == 0:
-        logger.info("synchronization disabled")
+        logger.info("periodic synchronization disabled")
     else:
         logger.info("synchronization period = {} minutes".format(sync_period))
 

--- a/docker/start.py
+++ b/docker/start.py
@@ -413,7 +413,7 @@ def main():
     logger.debug("URI = {}".format(uri))
 
     # default period for syncing (in minutes)
-    sync_period = get_num_from_env(logger, 'SYNC_TIME_MINUTES', 10)
+    sync_period = get_num_from_env(logger, 'SYNC_PERIOD_MINUTES', 10)
     if sync_period == 0:
         logger.info("synchronization disabled")
     else:


### PR DESCRIPTION
This change runs the initial reindex if sync period is set to 0.

Also, renames `SYNC_TIME_MINUTES` to `SYNC_PERIOD_MINUTES`.