### PR TITLE
add link to project property documentation

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -357,9 +357,12 @@ This entry point is used by the Indexer once it finishes indexing given project.
 
             ["/project/foo.txt","/project/bar.txt"]
 
-## Project metadata [/projects/{project}/property/{field}]
+## Project metadata [/projects/{project}/property/{propertyname}]
 
-### sets property field for the project [PUT]
+The list of per project properties can be found on
+https://github.com/oracle/opengrok/wiki/Per-project-configuration#properties
+
+### sets property value for the project [PUT]
 
 + Request
   + Body
@@ -368,7 +371,7 @@ This entry point is used by the Indexer once it finishes indexing given project.
 
 + Response 204
 
-### returns the field value [GET]
+### returns the property value [GET]
 
 + Response 200 (application/json)
 


### PR DESCRIPTION
This change adds wiki link to project properties to the API documentation and renames field to property.