### PR TITLE
attempt at graceful exit in Docker

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -487,7 +487,6 @@ def main():
                        extra_indexer_options)
 
     logger.debug("Starting sync thread")
-    global sync_thread
     sync_thread = threading.Thread(target=worker_function, name="Sync thread",
                                    args=syncer_args, daemon=True)
     sync_thread.start()
@@ -500,7 +499,6 @@ def main():
                      "on port {} to '{}'".format(rest_port, token))
         expected_token = token
     logger.debug("Starting REST thread")
-    global rest_thread
     rest_thread = threading.Thread(target=rest_function, name="REST thread",
                                    args=(logger, rest_port), daemon=True)
     rest_thread.start()


### PR DESCRIPTION
This change is sort of low effort approach to addressing termination of the Docker container via Ctrl-C when running as `docker run`. Setting the threads with `daemon=True` allows them to be terminated (https://stackoverflow.com/a/2564282/11582827) along with the main thread. Otherwise Tomcat would exit and the threads would be still running with the root process/thread waiting in `sys.exit()`. Perhaps more proper way to address that would be to wake them up and let them finish on their own, using a global termination flag. For the REST thread that would probably mean adding a separate API endpoint solely for the purpose of terminating the Flask server (use something like https://code-examples.net/en/q/ed76ce) or muck around with `waitress` internals  (https://stackoverflow.com/a/59923433/11582827).

This is probably not 100% robust (https://exceptionshub.com/why-cant-i-handle-a-keyboardinterrupt-in-python-3.html) and will not be graceful if sync is in progress.

Lastly, this will not help with `docker stop` since it uses different signal (on Unix) to terminate the root process (https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/). For that it would be prudent to install proper signal handlers (also, `docker kill` can specify arbitrary signal number such as `SIGQUIT`).

The code is `flake8` clean.