### PR TITLE
publish Docker image for non release builds as well

### DIFF
--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -3,7 +3,7 @@
 #
 # Build and optionally push new image to Docker hub.
 #
-# When pushing, this script uses the following Travis secure variables:
+# When pushing, this script uses the following secure variables:
 #  - DOCKER_USERNAME
 #  - DOCKER_PASSWORD
 #


### PR DESCRIPTION
This change should build and push `opengrok/docker:master` for each non release build in the main repo.