### PR TITLE
check index and wipe out data root on mismatch

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -84,6 +84,7 @@ The volume mounted to `/opengrok/src` should contain the projects you want to ma
 `REST_PORT` | 5000 | TCP port where simple REST app listens for GET requests on `/reindex` to trigger manual reindex.
 `REST_TOKEN` | None | if set, the REST app will require this token as Bearer token in order to trigger reindex.
 `READONLY_CONFIG_FILE` | None | if set, the configuration will be merged with configuration from this file. This is run when the container starts.
+`CHECK_INDEX` | None | if set, the format of the index will be checked first. **If the index is not compatible with the currently running version, the data root will be wiped out and reindex from scratch will be performed.**
 
 To specify environment variable for `docker run`, use the `-e` option, e.g. `-e SYNC_PERIOD_MINUTES=30`
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -516,7 +516,8 @@ public final class Indexer {
                 canonicalRoots.add(root);
             });
 
-            parser.on("--checkIndex", "Check index.").execute(v -> checkIndex = true);
+            parser.on("--checkIndex", "Check index, exit with 0 on success,",
+                    "with 1 on failure.").execute(v -> checkIndex = true);
 
             parser.on("-d", "--dataRoot", "=/path/to/data/root",
                 "The directory where OpenGrok stores the generated data.").

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -279,6 +279,8 @@ public final class Indexer {
                             " under the data root and reindex\n");
                     System.exit(1);
                 }
+
+                System.exit(0);
             }
 
             // Let repository types to add items to ignoredNames.


### PR DESCRIPTION
Another piece for the OpenGrok demo. This change introduces the `CHECK_INDEX` environment variable that triggers the run of the indexer with `--checkIndex`. If this fails, the data root is wiped out. This is necessary for upgrades across major versions.