### PR TITLE
handle SIG{TERM,INT} in Docker

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -24,6 +24,7 @@
 import os
 import logging
 import multiprocessing
+import signal
 import shutil
 import subprocess
 import sys
@@ -545,12 +546,16 @@ def main():
     tomcat_popen.wait()
 
 
-if __name__ == "__main__":
-    try:
-        main()
-    except KeyboardInterrupt:
-        global tomcat_popen
-        print("Terminating Tomcat {}".format(tomcat_popen))
-        tomcat_popen.terminate()
+def signal_handler(signum, frame):
+    global tomcat_popen
+    print("Terminating Tomcat {}".format(tomcat_popen))
+    tomcat_popen.terminate()
 
-        sys.exit(1)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+
+    main()


### PR DESCRIPTION
This takes care of the Ctrl+C case in `docker-compose`, at least in the basic sense. This event leads to `docker stop` which sends `SIGTERM` to PID 1 in the container (https://github.com/docker/compose/issues/7135#issuecomment-573621185).

Still, the sync and REST thread could be dealt with in a better way.