### PR TITLE
rework reindex/sync event triggers in Docker

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -564,7 +564,7 @@ def signal_handler(signum, frame):
     print("Terminating Tomcat {}".format(tomcat_popen))
     tomcat_popen.terminate()
 
-    sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/docker/start.py
+++ b/docker/start.py
@@ -558,6 +558,8 @@ def main():
 
 
 def signal_handler(signum, frame):
+    print("Received signal {}".format(signum))
+
     global tomcat_popen
     print("Terminating Tomcat {}".format(tomcat_popen))
     tomcat_popen.terminate()

--- a/docker/start.py
+++ b/docker/start.py
@@ -530,17 +530,21 @@ def main():
                                    args=syncer_args, daemon=True)
     sync_thread.start()
 
-    rest_port = get_num_from_env(logger, 'REST_PORT', 5000)
-    token = os.environ.get('REST_TOKEN')
-    global expected_token
-    if token:
-        logger.debug("Setting expected token for REST endpoint"
-                     "on port {} to '{}'".format(rest_port, token))
-        expected_token = token
-    logger.debug("Starting REST thread")
-    rest_thread = threading.Thread(target=rest_function, name="REST thread",
-                                   args=(logger, rest_port), daemon=True)
-    rest_thread.start()
+    if sync_period == 0:
+        rest_port = get_num_from_env(logger, 'REST_PORT', 5000)
+        token = os.environ.get('REST_TOKEN')
+        global expected_token
+        if token:
+            logger.debug("Setting expected token for REST endpoint"
+                         "on port {}".format(rest_port))
+            expected_token = token
+        logger.debug("Starting REST thread to listen for requests "
+                     "on port {} on the {} endpoint".
+                     format(rest_port, REINDEX_POINT))
+        rest_thread = threading.Thread(target=rest_function,
+                                       name="REST thread",
+                                       args=(logger, rest_port), daemon=True)
+        rest_thread.start()
 
     # Start Tomcat last. It will be the foreground process.
     logger.info("Starting Tomcat")

--- a/docker/start.py
+++ b/docker/start.py
@@ -74,6 +74,7 @@ expected_token = None
 sleep_event = threading.Event()
 app = Flask(__name__)
 auth = HTTPTokenAuth(scheme='Bearer')
+REINDEX_POINT = '/reindex'
 
 
 @auth.verify_token
@@ -85,7 +86,7 @@ def verify_token(token):
         return "yes"
 
 
-@app.route('/reindex')
+@app.route(REINDEX_POINT)
 @auth.login_required
 def index():
     # Signal the sync/indexer thread.
@@ -295,6 +296,8 @@ def indexer_no_projects(logger, uri, config_path, sync_period,
             logger.info("Sleeping for {} seconds".format(sleep_seconds))
             time.sleep(sleep_seconds)
         elif not periodic_sync:
+            logger.info("Waiting for reindex trigger on {} endpoint".
+                        format(REINDEX_POINT))
             sleep_event.wait()
 
 
@@ -353,6 +356,8 @@ def project_syncer(logger, loglevel, uri, config_path, sync_period,
             logger.info("Sleeping for {} seconds".format(sleep_seconds))
             time.sleep(sleep_seconds)
         elif not periodic_sync:
+            logger.info("Waiting for reindex trigger on {} endpoint".
+                        format(REINDEX_POINT))
             sleep_event.wait()
 
 


### PR DESCRIPTION
This change allows to the reindex/sync to be triggered based on both timeout and RESTful API call. This has some limitiations that stem from the underlying implementation, e.g. if reindex is already running and the `/reindex` API endpoint is called, the event will be lost.

Inspired by #3578.

Also added some signal handling related changes that I think prevent `watchtower` from restarting the container on image update.