### PR TITLE
Fix subrepository display on Windows

### DIFF
--- a/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
+++ b/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
@@ -32,7 +32,7 @@ Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
 <%@ attribute name="repositoryInfo" required="true" type="org.opengrok.indexer.history.RepositoryInfo" %>
 <%@ attribute name="isFirst" required="true" type="java.lang.Boolean" %>
 
-<c:set var="isSubrepository" value="${!repositoryInfo.getDirectoryNameRelative().equals(project.getPath())}"/>
+<c:set var="isSubrepository" value="${!Util.fixPathIfWindows(repositoryInfo.getDirectoryNameRelative()).equals(project.getPath())}"/>
 <c:set var="name" value="${project.name}"/>
 <c:set var="defaultLength" value="${Integer.valueOf(10)}"/>
 <c:set var="NA" value="N/A"/>


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
On Windows the repository can be misinterpreted as subrepository which can cause display similar to below:
![repo_win](https://user-images.githubusercontent.com/12401160/118565793-d092be80-b740-11eb-922d-bc7ba28735b5.png)

The problem seems to be that `Project`s are using `/` as path separator  whereas `RepositoryInfo` can have it as `\` which is causing the inequality:
http://demo.opengrok.org/xref/OpenGrok/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java?r=93915c65#192

I believe the best way would be to use `/` in `RepositoryInfo` as well but I'm not sure what else such change could affect. @vladak what do you think?

Thanks!