### PR TITLE
JGit related test/build cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+    - name: Checkout Universal ctags
+      uses: actions/checkout@v2
+      with:
+        repository: universal-ctags/ctags
+        path: ctags
     - name: Install pre-requisites (Unix)
       if: runner.os == 'Linux' || runner.os == 'macOS'
       run: ./dev/before_install

--- a/dev/before
+++ b/dev/before
@@ -3,7 +3,6 @@
 echo "SCM versions:"
 if command -v bk; then bk --version; fi
 if command -v hg; then hg --version; fi
-if command -v git; then git --version; fi
 if command -v svn; then svn --version; fi
 if command -v cvs; then cvs --version; fi
 if command -v mtn; then mtn --version; fi

--- a/dev/before_install
+++ b/dev/before_install
@@ -9,7 +9,6 @@ if [[ "$RUNNER_OS" == "Linux" ]]; then
 
 	sudo apt-get install -qq \
 	    cvs \
-	    git \
 	    mercurial \
 	    cssc \
 	    bzr \

--- a/dev/install-universal_ctags.sh
+++ b/dev/install-universal_ctags.sh
@@ -3,7 +3,6 @@
 #
 # Clone Universal ctags Github repository and compile from source.
 #
-git clone https://github.com/universal-ctags/ctags.git
 cd ctags
 ./autogen.sh
 ./configure && make && make install

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/condition/RepositoryInstalled.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/condition/RepositoryInstalled.java
@@ -27,7 +27,6 @@ import com.google.common.base.Suppliers;
 import org.opengrok.indexer.history.BazaarRepository;
 import org.opengrok.indexer.history.BitKeeperRepository;
 import org.opengrok.indexer.history.CVSRepository;
-import org.opengrok.indexer.history.GitRepository;
 import org.opengrok.indexer.history.MercurialRepository;
 import org.opengrok.indexer.history.PerforceRepository;
 import org.opengrok.indexer.history.RCSRepository;
@@ -42,7 +41,6 @@ public class RepositoryInstalled {
     public enum Type {
         BITKEEPER(new BitKeeperRepository()),
         MERCURIAL(new MercurialRepository()),
-        GIT(new GitRepository()),
         RCS(new RCSRepository()),
         BAZAAR(new BazaarRepository()),
         CVS(new CVSRepository()),

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheOctopusTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheOctopusTest.java
@@ -26,7 +26,6 @@ package org.opengrok.indexer.history;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opengrok.indexer.condition.EnabledForRepository;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.TestRepository;
 
@@ -35,7 +34,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.opengrok.indexer.condition.RepositoryInstalled.Type.GIT;
 
 /**
  * Test file-based history cache with for git-octopus.
@@ -65,7 +63,6 @@ public class FileHistoryCacheOctopusTest {
         cache = null;
     }
 
-    @EnabledForRepository(GIT)
     @Test
     public void testStoreAndGet() throws Exception {
         File reposRoot = new File(repositories.getSourceRoot(), "git-octopus");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryOctopusTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryOctopusTest.java
@@ -26,12 +26,10 @@ package org.opengrok.indexer.history;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opengrok.indexer.condition.RepositoryInstalled.Type.GIT;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.opengrok.indexer.condition.EnabledForRepository;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.TestRepository;
 import org.opengrok.indexer.web.Util;
@@ -45,7 +43,6 @@ import java.util.stream.Collectors;
 /**
  * @author austvik
  */
-@EnabledForRepository(GIT)
 public class GitRepositoryOctopusTest {
 
     private static TestRepository repository = new TestRepository();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.CVS;
-import static org.opengrok.indexer.condition.RepositoryInstalled.Type.GIT;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.SUBVERSION;
 
@@ -152,7 +151,6 @@ public class HistoryGuruTest {
     }
 
     @Test
-    @EnabledForRepository(GIT)
     public void testAddRemoveRepositories() {
         HistoryGuru instance = HistoryGuru.getInstance();
         final int numReposOrig = instance.getRepositories().size();
@@ -177,7 +175,7 @@ public class HistoryGuruTest {
     }
 
     @Test
-    @EnabledForRepository({CVS, GIT})
+    @EnabledForRepository(CVS)
     public void testAddSubRepositoryNotNestable() {
         HistoryGuru instance = HistoryGuru.getInstance();
 
@@ -251,7 +249,6 @@ public class HistoryGuruTest {
     }
 
     @Test
-    @EnabledForRepository(GIT)
     public void testScanningDepth() throws IOException {
         String topLevelDirName = "scanDepthTest";
         File repoRoot = new File(repository.getSourceRoot(), topLevelDirName);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
@@ -53,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Represents a container for additional tests of {@link IndexDatabase} for symlinks.
  */
 @EnabledOnOs({OS.LINUX, OS.MAC, OS.SOLARIS, OS.AIX, OS.OTHER})
-@EnabledForRepository({RepositoryInstalled.Type.GIT, RepositoryInstalled.Type.MERCURIAL})
+@EnabledForRepository(RepositoryInstalled.Type.MERCURIAL)
 public class IndexDatabaseSymlinksTest {
 
     private static RuntimeEnvironment env;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerRepoTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerRepoTest.java
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opengrok.indexer.condition.RepositoryInstalled.Type.GIT;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
 
 import org.junit.jupiter.api.AfterEach;
@@ -77,7 +76,7 @@ public class IndexerRepoTest {
      * Test it is possible to disable history per project.
      */
     @Test
-    @EnabledForRepository({MERCURIAL, GIT})
+    @EnabledForRepository(MERCURIAL)
     public void testPerProjectHistoryGlobalOn() throws IndexerException, IOException, HistoryException {
         testPerProjectHistory(true);
     }
@@ -86,7 +85,7 @@ public class IndexerRepoTest {
      * Test it is possible to enable history per project.
      */
     @Test
-    @EnabledForRepository({MERCURIAL, GIT})
+    @EnabledForRepository(MERCURIAL)
     public void testPerProjectHistoryGlobalOff() throws IndexerException, IOException, HistoryException {
         testPerProjectHistory(false);
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opengrok.indexer.condition.RepositoryInstalled.Type.GIT;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
 
 import java.io.BufferedWriter;
@@ -366,7 +365,7 @@ public class IndexerTest {
     }
 
     @Test
-    @EnabledForRepository({MERCURIAL, GIT})
+    @EnabledForRepository(MERCURIAL)
     public void testSetRepositories() throws Exception {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -57,7 +57,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.opengrok.indexer.condition.RepositoryInstalled.Type.GIT;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
 
 /**
@@ -257,7 +256,6 @@ public class PageConfigTest {
     }
 
     @Test
-    @EnabledForRepository(GIT)
     public void testGetLatestRevisionValid() {
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
             @Override
@@ -273,7 +271,6 @@ public class PageConfigTest {
     }
 
     @Test
-    @EnabledForRepository(GIT)
     public void testGetRevisionLocation() {
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
             @Override
@@ -300,7 +297,6 @@ public class PageConfigTest {
     }
 
     @Test
-    @EnabledForRepository(GIT)
     public void testGetRevisionLocationNullQuery() {
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
             @Override
@@ -327,7 +323,6 @@ public class PageConfigTest {
     }
 
     @Test
-    @EnabledForRepository(GIT)
     public void testGetLatestRevisionNotValid() {
         DummyHttpServletRequest req2 = new DummyHttpServletRequest() {
             @Override
@@ -368,7 +363,6 @@ public class PageConfigTest {
     }
 
     @Test
-    @EnabledForRepository(GIT)
     public void testGetAnnotation() {
         final String[] revisions = {"aa35c258", "bb74b7e8"};
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/AnnotationControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/AnnotationControllerTest.java
@@ -29,7 +29,6 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opengrok.indexer.condition.EnabledForRepository;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.history.RepositoryFactory;
@@ -50,9 +49,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opengrok.indexer.condition.RepositoryInstalled.Type.GIT;
 
-@EnabledForRepository(GIT)
 public class AnnotationControllerTest extends OGKJerseyTest {
 
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -29,7 +29,6 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opengrok.indexer.condition.EnabledForRepository;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.History;
 import org.opengrok.indexer.history.HistoryEntry;
@@ -48,10 +47,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.opengrok.indexer.condition.RepositoryInstalled.Type.GIT;
 import static org.opengrok.web.api.v1.controller.HistoryController.getHistoryDTO;
 
-@EnabledForRepository(GIT)
 public class HistoryControllerTest extends OGKJerseyTest {
 
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
@@ -68,14 +68,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opengrok.indexer.condition.RepositoryInstalled.Type.GIT;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.SUBVERSION;
 import static org.opengrok.indexer.history.RepositoryFactory.getRepository;
 import static org.opengrok.indexer.util.IOUtils.removeRecursive;
 
 @ExtendWith(MockitoExtension.class)
-@EnabledForRepository({MERCURIAL, GIT, SUBVERSION})
+@EnabledForRepository({MERCURIAL, SUBVERSION})
 class ProjectsControllerTest extends OGKJerseyTest {
 
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/RepositoriesControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/RepositoriesControllerTest.java
@@ -44,10 +44,9 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.opengrok.indexer.condition.RepositoryInstalled.Type.GIT;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
 
-@EnabledForRepository({MERCURIAL, GIT})
+@EnabledForRepository(MERCURIAL)
 public class RepositoriesControllerTest extends OGKJerseyTest {
 
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();

--- a/tools/src/main/python/opengrok_tools/utils/indexer.py
+++ b/tools/src/main/python/opengrok_tools/utils/indexer.py
@@ -67,7 +67,6 @@ def get_SCM_properties(logger):
         'svn': '-Dorg.opengrok.indexer.history.Subversion',
         'sccs': '-Dorg.opengrok.indexer.history.SCCS',
         'cleartool': '-Dorg.opengrok.indexer.history.ClearCase',
-        'git': '-Dorg.opengrok.indexer.history.git',
         'p4': '-Dorg.opengrok.indexer.history.Perforce',
         'mtn': '-Dorg.opengrok.indexer.history.Monotone',
         'blame': '-Dorg.opengrok.indexer.history.RCS',


### PR DESCRIPTION
Last piece of the changes for #1113. Cleans the tests + removes the need for the `git` command during build. The javadoc workflow still needs it (installed by default) however that is separate from the regular build.

The Docker image still needs the `git` command to perform repository synchronization (until #2852 is implemented).