### PR TITLE
remove remnants of history cache for top level directory

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -82,7 +82,6 @@ class FileHistoryCache implements HistoryCache {
 
     private static final String HISTORY_CACHE_DIR_NAME = "historycache";
     private static final String LATEST_REV_FILE_NAME = "OpenGroklatestRev";
-    private static final String DIRECTORY_FILE_PREFIX = "OpenGrokDirHist";
 
     private final PathAccepter pathAccepter = env.getPathAccepter();
     private boolean historyIndexDone = false;
@@ -224,10 +223,6 @@ class FileHistoryCache implements HistoryCache {
                 add = File.separator;
             }
             sb.append(add);
-            if (file.isDirectory()) {
-                sb.append(File.separator);
-                sb.append(DIRECTORY_FILE_PREFIX);
-            }
         } catch (IOException e) {
             throw new HistoryException("Failed to get path relative to " +
                     "source root for " + file, e);


### PR DESCRIPTION
With the history per partes change I forgot to remove one piece of history cache for directories.