### PR TITLE
Mercurial history per partes

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -492,6 +492,8 @@ class FileHistoryCache implements HistoryCache {
          * hash map entry for the file) in a file. Skip renamed files
          * which will be handled separately below.
          */
+        LOGGER.log(Level.FINE, "Storing history for {0} files in repository ''{1}''",
+                new Object[]{map.entrySet().size(), repository.getDirectoryName()});
         final File root = env.getSourceRootFile();
         int fileHistoryCount = 0;
         for (Map.Entry<String, List<HistoryEntry>> map_entry : map.entrySet()) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -537,6 +537,8 @@ class FileHistoryCache implements HistoryCache {
 
         renamedFiles = renamedFiles.stream().filter(f -> new File(env.getSourceRootPath() + f).exists()).
                 collect(Collectors.toSet());
+        LOGGER.log(Level.FINE, "Storing history for {0} renamed files in repository ''{1}''",
+                new Object[]{renamedFiles.size(), repository.getDirectoryName()});
 
         // The directories for the renamed files have to be created before
         // the actual files otherwise storeFile() might be racing for

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
@@ -33,6 +33,7 @@ import java.nio.file.InvalidPathException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -70,6 +71,7 @@ class MercurialHistoryParser implements Executor.StreamHandler {
      * @param file the file or directory to get history for
      * @param sinceRevision the changeset right before the first one to fetch, or
      * {@code null} if all changesets should be fetched
+     * @param tillRevision end revision or {@code null}
      * @return history for the specified file or directory
      * @throws HistoryException if an error happens when parsing the history
      */
@@ -97,7 +99,22 @@ class MercurialHistoryParser implements Executor.StreamHandler {
             repository.removeAndVerifyOldestChangeset(entries, sinceRevision);
         }
 
+        // TODO: add comment
+        if (repository.isHandleRenamedFiles() && file.isFile() && tillRevision != null) {
+            removeChangesets(entries, tillRevision);
+        }
+
         return new History(entries, renamedFiles);
+    }
+
+    private void removeChangesets(List<HistoryEntry> entries, String tillRevision) {
+        for (Iterator<HistoryEntry> iter = entries.listIterator(); iter.hasNext(); ) {
+            HistoryEntry entry = iter.next();
+            if (entry.getRevision().equals(tillRevision)) {
+                break;
+            }
+            iter.remove();
+        }
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
@@ -68,15 +68,15 @@ class MercurialHistoryParser implements Executor.StreamHandler {
      * specified one.
      *
      * @param file the file or directory to get history for
-     * @param changeset the changeset right before the first one to fetch, or
+     * @param sinceRevision the changeset right before the first one to fetch, or
      * {@code null} if all changesets should be fetched
      * @return history for the specified file or directory
      * @throws HistoryException if an error happens when parsing the history
      */
-    History parse(File file, String changeset) throws HistoryException {
+    History parse(File file, String sinceRevision, String tillRevision) throws HistoryException {
         isDir = file.isDirectory();
         try {
-            Executor executor = repository.getHistoryLogExecutor(file, changeset);
+            Executor executor = repository.getHistoryLogExecutor(file, sinceRevision, tillRevision,false);
             int status = executor.exec(true, this);
 
             if (status != 0) {
@@ -93,8 +93,8 @@ class MercurialHistoryParser implements Executor.StreamHandler {
         // from the list, since only the ones following it should be returned.
         // Also check that the specified changeset was found, otherwise throw
         // an exception.
-        if (changeset != null) {
-            repository.removeAndVerifyOldestChangeset(entries, changeset);
+        if (sinceRevision != null) {
+            repository.removeAndVerifyOldestChangeset(entries, sinceRevision);
         }
 
         return new History(entries, renamedFiles);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
@@ -76,7 +76,7 @@ class MercurialHistoryParser implements Executor.StreamHandler {
     History parse(File file, String sinceRevision, String tillRevision) throws HistoryException {
         isDir = file.isDirectory();
         try {
-            Executor executor = repository.getHistoryLogExecutor(file, sinceRevision, tillRevision,false);
+            Executor executor = repository.getHistoryLogExecutor(file, sinceRevision, tillRevision, false);
             int status = executor.exec(true, this);
 
             if (status != 0) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
@@ -99,7 +99,7 @@ class MercurialHistoryParser implements Executor.StreamHandler {
             repository.removeAndVerifyOldestChangeset(entries, sinceRevision);
         }
 
-        // TODO: add comment
+        // See getHistoryLogExecutor() for explanation.
         if (repository.isHandleRenamedFiles() && file.isFile() && tillRevision != null) {
             removeChangesets(entries, tillRevision);
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
@@ -1,0 +1,67 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.history;
+
+import org.opengrok.indexer.util.Executor;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.function.Consumer;
+
+class MercurialHistoryParserRevisionsOnly implements Executor.StreamHandler {
+    private final MercurialRepository repository;
+    private final Consumer<String> visitor;
+
+    MercurialHistoryParserRevisionsOnly(MercurialRepository repository, Consumer<String> visitor) {
+        this.repository = repository;
+        this.visitor = visitor;
+    }
+
+    void parse(File file, String sinceRevision) throws HistoryException {
+        try {
+            Executor executor = repository.getHistoryLogExecutor(file, sinceRevision, null, true);
+            int status = executor.exec(true, this);
+
+            if (status != 0) {
+                throw new HistoryException("Failed to get revisions for: \"" +
+                        file.getAbsolutePath() +
+                        "\" Exit code: " + status); // TODO log sinceRevision
+            }
+        } catch (IOException e) {
+            throw new HistoryException("Failed to get history for: \"" +
+                    file.getAbsolutePath() + "\"", e);
+        }
+    }
+
+    @Override
+    public void processStream(InputStream input) throws IOException {
+        BufferedReader in = new BufferedReader(new InputStreamReader(input));
+        String s;
+        while ((s = in.readLine()) != null) {
+            visitor.accept(s);
+        }
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 
 class MercurialHistoryParserRevisionsOnly implements Executor.StreamHandler {
@@ -46,9 +47,9 @@ class MercurialHistoryParserRevisionsOnly implements Executor.StreamHandler {
             int status = executor.exec(true, this);
 
             if (status != 0) {
-                throw new HistoryException("Failed to get revisions for: \"" +
-                        file.getAbsolutePath() +
-                        "\" Exit code: " + status); // TODO log sinceRevision
+                throw new HistoryException(
+                        String.format("Failed to get revisions for: \"%s\" since revision %s Exit code: %d",
+                                file.getAbsolutePath(), sinceRevision, status));
             }
         } catch (IOException e) {
             throw new HistoryException("Failed to get history for: \"" +

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
@@ -59,10 +59,11 @@ class MercurialHistoryParserRevisionsOnly implements Executor.StreamHandler {
 
     @Override
     public void processStream(InputStream input) throws IOException {
-        BufferedReader in = new BufferedReader(new InputStreamReader(input));
-        String s;
-        while ((s = in.readLine()) != null) {
-            visitor.accept(s);
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(input))) {
+            String s;
+            while ((s = in.readLine()) != null) {
+                visitor.accept(s);
+            }
         }
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 
 class MercurialHistoryParserRevisionsOnly implements Executor.StreamHandler {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -209,14 +209,18 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
             // when handling renamed files)
             // It is not needed to filter on a branch as 'hg log' will follow
             // the active branch.
-            // TODO: revisit:
             // Due to behavior of recent Mercurial versions, it is not possible
             // to filter the changesets of a file based on revision.
             // For files this does not matter since if getHistory() is called
             // for a file, the file has to be renamed so we want its complete history
             // if renamed file handling is enabled for this repository.
-            // TODO: why no reverse() ?
+            //
+            // Getting history for individual files should only be done when generating history for renamed files
+            // so the fact that filtering on sinceRevision does not work does not matter there as history
+            // from the initial changeset is needed. The tillRevision filtering works.
+
             if (this.isHandleRenamedFiles()) {
+                // When using --follow, the returned revisions are from newest to oldest, hence no reverse() is needed.
                 cmd.add("--follow");
             }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -192,7 +192,7 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
                 } else {
                     // If this is non-default branch we would like to get the changesets
                     // on that branch and also follow any changesets from the parent branch.
-                    stringBuilder.append("'" + getBranch() + "'");
+                    stringBuilder.append("'").append(getBranch()).append("'");
                 }
                 if (!revisionsOnly) {
                     stringBuilder.append(")");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -223,25 +223,11 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
             //
             // Getting history for individual files should only be done when generating history for renamed files
             // so the fact that filtering on sinceRevision does not work does not matter there as history
-            // from the initial changeset is needed. The tillRevision filtering works.
-
+            // from the initial changeset is needed. The tillRevision filtering works however not
+            // in combination with --follow.
             if (this.isHandleRenamedFiles()) {
                 // When using --follow, the returned revisions are from newest to oldest, hence no reverse() is needed.
                 cmd.add("--follow");
-            }
-
-            // Note: assumes one of them is not null
-            if ((sinceRevision != null) || (tillRevision != null)) {
-                cmd.add("-r");
-                StringBuilder stringBuilder = new StringBuilder();
-                if (sinceRevision != null) {
-                    stringBuilder.append(getRevisionNum(sinceRevision));
-                }
-                stringBuilder.append(":");
-                if (tillRevision != null) {
-                    stringBuilder.append(getRevisionNum(tillRevision));
-                }
-                cmd.add(stringBuilder.toString());
             }
         }
 
@@ -584,7 +570,7 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
         // so no sinceRevision filter is needed.
         // See findOriginalName() code for more details.
         History result = new MercurialHistoryParser(this).parse(file, sinceRevision, tillRevision);
-        
+
         // Assign tags to changesets they represent.
         // We don't need to check if this repository supports tags,
         // because we know it :-)

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -82,7 +82,7 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
     static final String END_OF_ENTRY
             = "mercurial_history_end_of_entry";
 
-    private static final String TEMPLATE_REVS = "{rev}\\n";
+    private static final String TEMPLATE_REVS = "{rev}:\\n";
     private static final String TEMPLATE_STUB
             = CHANGESET + "{rev}:{node|short}\\n"
             + USER + "{author}\\n" + DATE + "{date|isodate}\\n"

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -57,6 +57,8 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
 
     private static final long serialVersionUID = 1L;
 
+    public static final int MAX_CHANGESETS = 256;
+
     /**
      * The property name used to obtain the client command for this repository.
      */
@@ -143,6 +145,10 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
         }
 
         return executor.getOutputString().trim();
+    }
+
+    public int getPerPartesCount() {
+        return MAX_CHANGESETS;
     }
 
     private String getRevisionNum(String changeset) throws HistoryException {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -224,7 +224,8 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
             // Getting history for individual files should only be done when generating history for renamed files
             // so the fact that filtering on sinceRevision does not work does not matter there as history
             // from the initial changeset is needed. The tillRevision filtering works however not
-            // in combination with --follow.
+            // in combination with --follow so the filtering is done in MercurialHistoryParser.parse().
+            // Even if the revision filtering worked, this approach would be probably faster and consumed less memory.
             if (this.isHandleRenamedFiles()) {
                 // When using --follow, the returned revisions are from newest to oldest, hence no reverse() is needed.
                 cmd.add("--follow");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -82,7 +82,7 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
     static final String END_OF_ENTRY
             = "mercurial_history_end_of_entry";
 
-    private static final String TEMPLATE_REVS = "{rev}:\\n";
+    private static final String TEMPLATE_REVS = "{rev}:\\n"; // use colon so that getRevisionNum() works
     private static final String TEMPLATE_STUB
             = CHANGESET + "{rev}:{node|short}\\n"
             + USER + "{author}\\n" + DATE + "{date|isodate}\\n"

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -186,8 +186,7 @@ public abstract class Repository extends RepositoryInfo {
     void removeAndVerifyOldestChangeset(List<HistoryEntry> entries,
             String revision)
             throws HistoryException {
-        HistoryEntry entry
-                = entries.isEmpty() ? null : entries.remove(entries.size() - 1);
+        HistoryEntry entry = entries.isEmpty() ? null : entries.remove(entries.size() - 1);
 
         // TODO We should check more thoroughly that the changeset is the one
         // we expected it to be, since some SCMs may change the revision

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -125,8 +125,7 @@ public class MercurialRepositoryTest {
         runHgCommand(root, "import",
                 Paths.get(getClass().getResource("/history/hg-export-subdir.txt").toURI()).toString());
 
-        MercurialRepository mr
-                = (MercurialRepository) RepositoryFactory.getRepository(root);
+        MercurialRepository mr = (MercurialRepository) RepositoryFactory.getRepository(root);
         History hist = mr.getHistory(new File(root, "subdir"));
         List<HistoryEntry> entries = hist.getHistoryEntries();
         assertEquals(1, entries.size());

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -24,6 +24,7 @@
 package org.opengrok.indexer.history;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opengrok.indexer.condition.EnabledForRepository;
 import org.opengrok.indexer.util.Executor;
@@ -85,6 +86,11 @@ public class MercurialRepositoryTest {
         repository.create(getClass().getResourceAsStream("repositories.zip"));
     }
 
+    @BeforeEach
+    public void setup() throws IOException {
+        setUpTestRepository();
+    }
+
     @AfterEach
     public void tearDown() {
         if (repository != null) {
@@ -95,7 +101,6 @@ public class MercurialRepositoryTest {
 
     @Test
     public void testGetHistory() throws Exception {
-        setUpTestRepository();
         File root = new File(repository.getSourceRoot(), "mercurial");
         MercurialRepository mr
                 = (MercurialRepository) RepositoryFactory.getRepository(root);
@@ -114,7 +119,6 @@ public class MercurialRepositoryTest {
 
     @Test
     public void testGetHistorySubdir() throws Exception {
-        setUpTestRepository();
         File root = new File(repository.getSourceRoot(), "mercurial");
 
         // Add a subdirectory with some history.
@@ -135,10 +139,8 @@ public class MercurialRepositoryTest {
      */
     @Test
     public void testGetHistoryPartial() throws Exception {
-        setUpTestRepository();
         File root = new File(repository.getSourceRoot(), "mercurial");
-        MercurialRepository mr
-                = (MercurialRepository) RepositoryFactory.getRepository(root);
+        MercurialRepository mr = (MercurialRepository) RepositoryFactory.getRepository(root);
         // Get all but the oldest revision.
         History hist = mr.getHistory(root, REVISIONS[REVISIONS.length - 1]);
         List<HistoryEntry> entries = hist.getHistoryEntries();
@@ -180,7 +182,6 @@ public class MercurialRepositoryTest {
      */
     @Test
     public void testGetHistoryBranch() throws Exception {
-        setUpTestRepository();
         File root = new File(repository.getSourceRoot(), "mercurial");
 
         // Branch the repo and add one changeset.
@@ -228,7 +229,6 @@ public class MercurialRepositoryTest {
      */
     @Test
     public void testGetHistoryGet() throws Exception {
-        setUpTestRepository();
         File root = new File(repository.getSourceRoot(), "mercurial");
         MercurialRepository mr
                 = (MercurialRepository) RepositoryFactory.getRepository(root);
@@ -260,7 +260,6 @@ public class MercurialRepositoryTest {
      */
     @Test
     public void testgetHistoryGetForAll() throws Exception {
-        setUpTestRepository();
         File root = new File(repository.getSourceRoot(), "mercurial");
         MercurialRepository mr
                 = (MercurialRepository) RepositoryFactory.getRepository(root);
@@ -279,7 +278,6 @@ public class MercurialRepositoryTest {
      */
     @Test
     public void testGetHistoryGetRenamed() throws Exception {
-        setUpTestRepository();
         File root = new File(repository.getSourceRoot(), "mercurial");
         MercurialRepository mr
                 = (MercurialRepository) RepositoryFactory.getRepository(root);
@@ -306,7 +304,6 @@ public class MercurialRepositoryTest {
      */
     @Test
     public void testGetHistoryWithNoSuchRevision() throws Exception {
-        setUpTestRepository();
         File root = new File(repository.getSourceRoot(), "mercurial");
         MercurialRepository mr = (MercurialRepository) RepositoryFactory.getRepository(root);
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -102,8 +102,7 @@ public class MercurialRepositoryTest {
     @Test
     public void testGetHistory() throws Exception {
         File root = new File(repository.getSourceRoot(), "mercurial");
-        MercurialRepository mr
-                = (MercurialRepository) RepositoryFactory.getRepository(root);
+        MercurialRepository mr = (MercurialRepository) RepositoryFactory.getRepository(root);
         History hist = mr.getHistory(root);
         List<HistoryEntry> entries = hist.getHistoryEntries();
         assertEquals(REVISIONS.length, entries.size());
@@ -230,8 +229,7 @@ public class MercurialRepositoryTest {
     @Test
     public void testGetHistoryGet() throws Exception {
         File root = new File(repository.getSourceRoot(), "mercurial");
-        MercurialRepository mr
-                = (MercurialRepository) RepositoryFactory.getRepository(root);
+        MercurialRepository mr = (MercurialRepository) RepositoryFactory.getRepository(root);
         String exp_str = "This will be a first novel of mine.\n"
                 + "\n"
                 + "Chapter 1.\n"
@@ -261,8 +259,7 @@ public class MercurialRepositoryTest {
     @Test
     public void testgetHistoryGetForAll() throws Exception {
         File root = new File(repository.getSourceRoot(), "mercurial");
-        MercurialRepository mr
-                = (MercurialRepository) RepositoryFactory.getRepository(root);
+        MercurialRepository mr = (MercurialRepository) RepositoryFactory.getRepository(root);
 
         for (String rev : REVISIONS_novel) {
             InputStream input = mr.getHistoryGet(root.getCanonicalPath(),
@@ -279,8 +276,7 @@ public class MercurialRepositoryTest {
     @Test
     public void testGetHistoryGetRenamed() throws Exception {
         File root = new File(repository.getSourceRoot(), "mercurial");
-        MercurialRepository mr
-                = (MercurialRepository) RepositoryFactory.getRepository(root);
+        MercurialRepository mr = (MercurialRepository) RepositoryFactory.getRepository(root);
         String exp_str = "This is totally plaintext file.\n";
         byte[] buffer = new byte[1024];
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -312,5 +313,58 @@ public class MercurialRepositoryTest {
         // Construct a revision identifier that doesn't exist.
         String constructedRevision = (number + 1) + ":" + hash;
         assertThrows(HistoryException.class, () -> mr.getHistory(root, constructedRevision));
+    }
+
+    // TODO: also for (renamed) file
+    @Test
+    void testGetHistorySinceTillNullNull() throws Exception {
+        File root = new File(repository.getSourceRoot(), "mercurial");
+        MercurialRepository hgRepo = (MercurialRepository) RepositoryFactory.getRepository(root);
+        History history = hgRepo.getHistory(root, null, null);
+        assertNotNull(history);
+        assertNotNull(history.getHistoryEntries());
+        assertEquals(10, history.getHistoryEntries().size());
+        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).
+                collect(Collectors.toList());
+        assertEquals(List.of(REVISIONS), revisions);
+    }
+
+    @Test
+    void testGetHistorySinceTillNullRev() throws Exception {
+        File root = new File(repository.getSourceRoot(), "mercurial");
+        MercurialRepository hgRepo = (MercurialRepository) RepositoryFactory.getRepository(root);
+        History history = hgRepo.getHistory(root, null, REVISIONS[4]);
+        assertNotNull(history);
+        assertNotNull(history.getHistoryEntries());
+        assertEquals(6, history.getHistoryEntries().size());
+        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).
+                collect(Collectors.toList());
+        assertEquals(List.of(Arrays.copyOfRange(REVISIONS, 4, REVISIONS.length)), revisions);
+    }
+
+    @Test
+    void testGetHistorySinceTillRevNull() throws Exception {
+        File root = new File(repository.getSourceRoot(), "mercurial");
+        MercurialRepository hgRepo = (MercurialRepository) RepositoryFactory.getRepository(root);
+        History history = hgRepo.getHistory(root, REVISIONS[3], null);
+        assertNotNull(history);
+        assertNotNull(history.getHistoryEntries());
+        assertEquals(3, history.getHistoryEntries().size());
+        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).
+                collect(Collectors.toList());
+        assertEquals(List.of(Arrays.copyOfRange(REVISIONS, 0, 3)), revisions);
+    }
+
+    @Test
+    void testGetHistorySinceTillRevRev() throws Exception {
+        File root = new File(repository.getSourceRoot(), "mercurial");
+        MercurialRepository hgRepo = (MercurialRepository) RepositoryFactory.getRepository(root);
+        History history = hgRepo.getHistory(root, REVISIONS[7], REVISIONS[2]);
+        assertNotNull(history);
+        assertNotNull(history.getHistoryEntries());
+        assertEquals(5, history.getHistoryEntries().size());
+        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).
+                collect(Collectors.toList());
+        assertEquals(List.of(Arrays.copyOfRange(REVISIONS, 2, 7)), revisions);
     }
 }


### PR DESCRIPTION
Converts Mercurial history handling to the per partes style done in #3589 for Git.

In Mercurial I happen to be using (5.3.1) the revision filtering for file history log is still broken, i.e. `hg log -r X:Y --follow <file>` does not display expected list of changesets. This is only relevant to renamed file handling. I strip the unwanted `HistoryEntry` objects as a workaround. Even if it worked, it would be probably unusable - thinking the revision filtering for files works, I tried it first and it resulted in some of the `hg` processes to consume over 12 GB RSS and the system got into unhappy place (heavy swapping, the OOM killer striking).

The history cache was much slower to generate with the repository I tried this on (OpenSolaris ON gate with some 16k changesets, the majority of files added in the first changeset), like 4 minutes vs. 10 minutes (renamed handling on, 8 GB heap), however I think this is partly due to the fact that the history cache for renamed files is generated in parallel (there are some 2800 renamed files there) and for the regular files still sequentially (#3542).