### PR TITLE
fix path filtering for Git

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -75,7 +75,9 @@ import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.treewalk.AbstractTreeIterator;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;
 import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.filter.AndTreeFilter;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
+import org.eclipse.jgit.treewalk.filter.TreeFilter;
 import org.eclipse.jgit.util.io.CountingOutputStream;
 import org.eclipse.jgit.util.io.NullOutputStream;
 import org.jetbrains.annotations.NotNull;
@@ -509,7 +511,9 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
                     FollowFilter followFilter = FollowFilter.create(getGitFilePath(getRepoRelativePath(file)), dc);
                     walk.setTreeFilter(followFilter);
                 } else {
-                    walk.setTreeFilter(PathFilter.create(getGitFilePath(getRepoRelativePath(file))));
+                    walk.setTreeFilter(AndTreeFilter.create(
+                            PathFilter.create(getGitFilePath(getRepoRelativePath(file))),
+                            TreeFilter.ANY_DIFF));
                 }
             }
 

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -256,7 +255,6 @@ public class PageConfigTest {
         }
     }
 
-    @Disabled("jgit changes")
     @Test
     public void testGetLatestRevisionValid() {
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
@@ -272,7 +270,6 @@ public class PageConfigTest {
         assertEquals("aa35c258", rev);
     }
 
-    @Disabled("jgit changes")
     @Test
     public void testGetRevisionLocation() {
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
@@ -299,7 +296,6 @@ public class PageConfigTest {
         assertEquals("source/xref/git/main.c?r=aa35c258&a=true", location);
     }
 
-    @Disabled("jgit changes")
     @Test
     public void testGetRevisionLocationNullQuery() {
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {


### PR DESCRIPTION
As noticed in #3602, path filtering for Git is broken. The tree filter needs to be used in different way as noted on https://stackoverflow.com/a/12697369/11582827