### PR TITLE
Remove stale links on gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
             </li>
 
             <li>
-                <a href="https://github.com/oracle/opengrok/wiki/How-to-install-OpenGrok">How to install OpenGrok</a>
+                <a href="https://github.com/oracle/opengrok/wiki/How-to-setup-OpenGrok">How to setup OpenGrok</a>
             </li>
 
             <li>
@@ -134,17 +134,7 @@
             </li>
 
             <li>
-                OpenGrok related blogs can be found using the
-                <a href="http://blogs.oracle.com/main/tags/opengrok">opengrok tag</a>.
-            </li>
-
-            <li>
                 Join the OpenGrok users group on <a href="http://linkedin.com/">LinkedIn</a>.
-            </li>
-
-            <li>
-                See the summary of the project on
-                <a href="http://www.ohloh.net/p/opengrok">Ohloh</a>.
             </li>
         </ul>
 


### PR DESCRIPTION
Just a couple of stale links I noticed while searching for javadoc.

Thanks!