### PR TITLE
move log message to Repository

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -402,9 +402,6 @@ class FileHistoryCache implements HistoryCache {
                 new Object[]{repository.getDirectoryName(), histDir});
         } else {
             storeLatestCachedRevision(repository, latestRev);
-            LOGGER.log(Level.FINE,
-                "Done storing history for repository {0}",
-                repository.getDirectoryName());
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -383,6 +383,8 @@ public abstract class Repository extends RepositoryInfo {
         File directory = new File(getDirectoryName());
 
         doCreateCache(cache, sinceRevision, directory);
+
+        LOGGER.log(Level.FINE, "Done storing history cache for repository {0}", getDirectoryName());
     }
 
     void finishCreateCache(HistoryCache cache, History history, String tillRevision) throws HistoryException {


### PR DESCRIPTION
with per partes history the 'Done storing ...' log message is repeated:
```
2021-05-24 16:28:04.134+0200 FINE t31 FileHistoryCache.store: Stored history for 507 files in repository '/ws-local/linux'
2021-05-24 16:28:04.135+0200 FINE t31 FileHistoryCache.finishStore: Done storing history for repository /ws-local/linux
2021-05-24 16:28:04.135+0200 FINE t31 Statistics.logIt: finished chunk 1702/1981 of history cache for repository '/ws-local/linux' (took 0:02:36)
2021-05-24 16:30:27.573+0200 FINE t31 FileHistoryCache.store: Stored history for 1,107 files in repository '/ws-local/linux'
2021-05-24 16:30:59.614+0200 FINE t31 FileHistoryCache.storeRenamed: Stored history for 48 renamed files in repository '/ws-local/linux'
2021-05-24 16:30:59.615+0200 FINE t31 FileHistoryCache.finishStore: Done storing history for repository /ws-local/linux
2021-05-24 16:30:59.616+0200 FINE t31 Statistics.logIt: finished chunk 1703/1981 of history cache for repository '/ws-local/linux' (took 0:02:55)
```
This change moves it to function higher up to prevent this.