### PR TITLE
 cleanup of renamed file handling in FileHistoryCache

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -152,21 +152,6 @@ class FileHistoryCache implements HistoryCache {
         storeFile(history, file, repository, !renamed);
     }
 
-    private boolean isRenamedFile(String filename, Repository repository, History history)
-            throws IOException {
-
-        String repodir;
-        try {
-            repodir = env.getPathRelativeToSourceRoot(new File(repository.getDirectoryName()));
-        } catch (ForbiddenSymlinkException e) {
-            LOGGER.log(Level.FINER, e.getMessage());
-            return false;
-        }
-        String shortestfile = filename.substring(repodir.length() + 1);
-
-        return (history.isRenamed(shortestfile));
-    }
-
     static class FilePersistenceDelegate extends PersistenceDelegate {
         @Override
         protected Expression instantiate(Object oldInstance, Encoder out) {
@@ -495,12 +480,8 @@ class FileHistoryCache implements HistoryCache {
         final File root = env.getSourceRootFile();
         int fileHistoryCount = 0;
         for (Map.Entry<String, List<HistoryEntry>> map_entry : map.entrySet()) {
-            try {
-                if (handleRenamedFiles && isRenamedFile(map_entry.getKey(), repository, history)) {
-                    continue;
-                }
-            } catch (IOException ex) {
-               LOGGER.log(Level.WARNING, "isRenamedFile() got exception", ex);
+            if (handleRenamedFiles && history.isRenamed(map_entry.getKey())) {
+                continue;
             }
 
             doFileHistory(map_entry.getKey(), new History(map_entry.getValue()),

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -532,8 +532,7 @@ class FileHistoryCache implements HistoryCache {
             return;
         }
 
-        renamedFiles = renamedFiles.stream().map(e -> repository.getDirectoryNameRelative() + File.separator + e).
-                filter(f -> new File(env.getSourceRootPath() + f).exists()).
+        renamedFiles = renamedFiles.stream().filter(f -> new File(env.getSourceRootPath() + f).exists()).
                 collect(Collectors.toSet());
         LOGGER.log(Level.FINE, "Storing history for {0} renamed files in repository ''{1}''",
                 new Object[]{renamedFiles.size(), repository.getDirectoryName()});

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -47,7 +47,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -437,7 +436,6 @@ class FileHistoryCache implements HistoryCache {
 
         HashMap<String, List<HistoryEntry>> map = new HashMap<>();
         HashMap<String, Boolean> acceptanceCache = new HashMap<>();
-        Set<String> renamedFiles = new HashSet<>();
 
         /*
          * Go through all history entries for this repository (acquired through
@@ -499,7 +497,6 @@ class FileHistoryCache implements HistoryCache {
         for (Map.Entry<String, List<HistoryEntry>> map_entry : map.entrySet()) {
             try {
                 if (handleRenamedFiles && isRenamedFile(map_entry.getKey(), repository, history)) {
-                    renamedFiles.add(map_entry.getKey());
                     continue;
                 }
             } catch (IOException ex) {
@@ -519,7 +516,7 @@ class FileHistoryCache implements HistoryCache {
             return;
         }
 
-        storeRenamed(renamedFiles, repository, tillRevision);
+        storeRenamed(history.getRenamedFiles(), repository, tillRevision);
 
         finishStore(repository, latestRev);
     }
@@ -535,7 +532,8 @@ class FileHistoryCache implements HistoryCache {
             return;
         }
 
-        renamedFiles = renamedFiles.stream().filter(f -> new File(env.getSourceRootPath() + f).exists()).
+        renamedFiles = renamedFiles.stream().map(e -> repository.getDirectoryNameRelative() + File.separator + e).
+                filter(f -> new File(env.getSourceRootPath() + f).exists()).
                 collect(Collectors.toSet());
         LOGGER.log(Level.FINE, "Storing history for {0} renamed files in repository ''{1}''",
                 new Object[]{renamedFiles.size(), repository.getDirectoryName()});

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -623,7 +623,8 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
                 }
 
                 if (diff.getChangeType() == DiffEntry.ChangeType.RENAME && isHandleRenamedFiles()) {
-                    renamedFiles.add(getNativePath(diff.getNewPath()));
+                    renamedFiles.add(getNativePath(getDirectoryNameRelative()) + File.separator +
+                            getNativePath(diff.getNewPath()));
                 }
             }
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
@@ -170,7 +170,7 @@ class MercurialHistoryParser implements Executor.StreamHandler {
                         }
                     }
                 }
-            } else if (s.startsWith(MercurialRepository.FILE_COPIES) &&
+            } else if (repository.isHandleRenamedFiles() && s.startsWith(MercurialRepository.FILE_COPIES) &&
                 entry != null && isDir) {
                 /*
                  * 'file_copies:' should be present only for directories but
@@ -185,8 +185,8 @@ class MercurialHistoryParser implements Executor.StreamHandler {
                      String[] move = part.split(" \\(");
                      File f = new File(mydir + move[0]);
                      if (!move[0].isEmpty() && f.exists() &&
-                         !renamedFiles.contains(move[0])) {
-                             renamedFiles.add(move[0]);
+                         !renamedFiles.contains(repository.getDirectoryNameRelative() + File.separator + move[0])) {
+                             renamedFiles.add(repository.getDirectoryNameRelative() + File.separator + move[0]);
                      }
                 }
             } else if (s.startsWith(DESC_PREFIX) && entry != null) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
@@ -33,8 +33,10 @@ import java.nio.file.InvalidPathException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -56,7 +58,7 @@ class MercurialHistoryParser implements Executor.StreamHandler {
     private final MercurialRepository repository;
     private final String mydir;
     private boolean isDir;
-    private final List<String> renamedFiles = new ArrayList<>();
+    private final Set<String> renamedFiles = new HashSet<>();
 
     MercurialHistoryParser(MercurialRepository repository) {
         this.repository = repository;
@@ -184,8 +186,7 @@ class MercurialHistoryParser implements Executor.StreamHandler {
                       */
                      String[] move = part.split(" \\(");
                      File f = new File(mydir + move[0]);
-                     if (!move[0].isEmpty() && f.exists() &&
-                         !renamedFiles.contains(repository.getDirectoryNameRelative() + File.separator + move[0])) {
+                     if (!move[0].isEmpty() && f.exists()) {
                              renamedFiles.add(repository.getDirectoryNameRelative() + File.separator + move[0]);
                      }
                 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionHistoryParser.java
@@ -133,7 +133,7 @@ class SubversionHistoryParser implements Executor.StreamHandler {
                     // so intern them to reduce the memory footprint.
                     entry.addFile(path.intern());
                     if (isRenamed) {
-                        renamedFiles.add(file.getAbsolutePath().substring(home.length() + 1));
+                        renamedFiles.add(path.intern());
                     }
                 } else {
                     LOGGER.log(Level.FINER, "Skipping file outside repository: " + s);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
@@ -558,9 +558,10 @@ public class GitRepositoryTest {
                                 File.separator + Paths.get("git", "header.h"),
                                 File.separator + Paths.get("git", "main.c"))));
 
-        List<String> expectedRenamedFiles = List.of(Paths.get("moved", "renamed2.c").toString(),
-                Paths.get("moved2", "renamed2.c").toString(),
-                Paths.get("moved", "renamed.c").toString());
+        List<String> expectedRenamedFiles = List.of(
+                File.separator + Paths.get("git", "moved", "renamed2.c"),
+                File.separator + Paths.get("git", "moved2", "renamed2.c"),
+                File.separator + Paths.get("git", "moved", "renamed.c"));
 
         History history = gitrepo.getHistory(root);
         assertNotNull(history);


### PR DESCRIPTION
This set of changes should save same memory and make the code in `FileHistoryCache#store()` more readable.