### PR TITLE
Use provided scope for jetbrains annotations

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -217,7 +217,6 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>20.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -196,6 +196,10 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,12 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>21.0.0</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -87,6 +87,11 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>chronicle-map</artifactId>
             <version>3.20.84</version>
@@ -94,6 +99,14 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
                 <exclusion>
                     <groupId>com.sun.java</groupId>
                     <artifactId>tools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.intellij</groupId>
+                    <artifactId>annotations</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
These annotations are only for IDE and are not being processed at runtime so there is no need to include them. `provided` scope is also specified at their github page: https://github.com/JetBrains/java-annotations

Thanks!