### PR TITLE
incoming check override

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -99,6 +99,13 @@ The image contains these directories:
 
 To specify environment variable for `docker run`, use the `-e` option, e.g. `-e SYNC_PERIOD_MINUTES=30`
 
+## Repository synchronization
+
+To get more control over repository synchronization (enabled only when projects
+are enabled), the `/opengrok/etc/mirror.yml` configuration file can be modified
+as per the https://github.com/oracle/opengrok/wiki/Repository-synchronization
+wiki.
+
 ## OpenGrok Web-Interface
 
 The container has OpenGrok as default web app installed (accessible directly from `/`). With the above container setup, you can find it running on

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,6 +71,17 @@ The container exports ports 8080 for OpenGrok.
 
 The volume mounted to `/opengrok/src` should contain the projects you want to make searchable (in sub directories). You can use common revision control checkouts (git, svn, etc...) and OpenGrok will make history and blame information available.
 
+## Directories
+
+The image contains these directories:
+
+| Directory | Description |
+| --------- | ----------- |
+`/opengrok/etc` | stores the configuration for both web app and indexer
+`/opengrok/data` | data root - index data
+`/opengrok/src` | source root - input data
+`/scripts` | startup script and top level configuration. Do not override unless debugging.
+
 ## Environment Variables
 
 | Docker Environment Var. | Default value | Description |
@@ -80,7 +91,7 @@ The volume mounted to `/opengrok/src` should contain the projects you want to ma
 `NOMIRROR` | empty | To avoid the mirroring step, set the variable to non-empty value.
 `URL_ROOT` | `/` | Override the sub-URL that OpenGrok should run on.
 `WORKERS` | number of CPUs in the container | number of workers to use for syncing (applies only to setup with projects enabled)
-`AVOID_PROJECTS` | empty | run in project less configuration. Set to non empty value disables projects.
+`AVOID_PROJECTS` | empty | run in project less configuration. Set to non empty value disables projects. Also disables repository synchronization.
 `REST_PORT` | 5000 | TCP port where simple REST app listens for GET requests on `/reindex` to trigger manual reindex.
 `REST_TOKEN` | None | if set, the REST app will require this token as Bearer token in order to trigger reindex.
 `READONLY_CONFIG_FILE` | None | if set, the configuration will be merged with configuration from this file. This is run when the container starts.

--- a/docker/start.py
+++ b/docker/start.py
@@ -64,7 +64,8 @@ OPENGROK_LIB_DIR = os.path.join(OPENGROK_BASE_DIR, "lib")
 OPENGROK_DATA_ROOT = os.path.join(OPENGROK_BASE_DIR, "data")
 OPENGROK_SRC_ROOT = os.path.join(OPENGROK_BASE_DIR, "src")
 BODY_INCLUDE_FILE = os.path.join(OPENGROK_DATA_ROOT, "body_include")
-OPENGROK_CONFIG_FILE = os.path.join(OPENGROK_BASE_DIR, "etc",
+OPENGROK_CONFIG_DIR = os.path.join(OPENGROK_BASE_DIR, "etc")
+OPENGROK_CONFIG_FILE = os.path.join(OPENGROK_CONFIG_DIR,
                                     "configuration.xml")
 OPENGROK_WEBAPPS_DIR = os.path.join(tomcat_root, "webapps")
 OPENGROK_JAR = os.path.join(OPENGROK_LIB_DIR, 'opengrok.jar')
@@ -531,6 +532,11 @@ def main():
         num_workers = get_num_from_env(logger, 'WORKERS',
                                        multiprocessing.cpu_count())
         logger.info('Number of sync workers: {}'.format(num_workers))
+
+        mirror_config = os.path.join(OPENGROK_CONFIG_DIR, "mirror.yml")
+        if not os.path.exists(mirror_config):
+            with open(mirror_config, 'w') as fp:
+                pass
 
         worker_function = project_syncer
         syncer_args = (logger, log_level, uri,

--- a/docker/start.py
+++ b/docker/start.py
@@ -536,7 +536,7 @@ def main():
         mirror_config = os.path.join(OPENGROK_CONFIG_DIR, "mirror.yml")
         if not os.path.exists(mirror_config):
             with open(mirror_config, 'w') as fp:
-                pass
+                fp.write("# Empty config file for opengrok-mirror\n")
 
         worker_function = project_syncer
         syncer_args = (logger, log_level, uri,

--- a/docker/sync.yml
+++ b/docker/sync.yml
@@ -6,7 +6,7 @@ commands:
     duration: PT1H
     tags: ['%PROJECT%']
     text: resync + reindex in progress
-- command: [opengrok-mirror, -I, -U, '%URL%', '%PROJECT%']
+- command: [opengrok-mirror, -c, '/opengrok/etc/mirror.yml', -I, -U, '%URL%', '%PROJECT%']
 - command: [opengrok-reindex-project, --printoutput,
     --jar, /opengrok/lib/opengrok.jar, -U, '%URL%', -P, '%PROJECT%', --,
     -r, dirbased, -G, -m, '256', --leadingWildCards, 'on',

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -477,7 +477,7 @@ def check_project_configuration(multiple_project_config, hookdir=False,
     known_project_tunables = [DISABLED_PROPERTY, CMD_TIMEOUT_PROPERTY,
                               HOOK_TIMEOUT_PROPERTY, PROXY_PROPERTY,
                               IGNORED_REPOS_PROPERTY, HOOKS_PROPERTY,
-                              DISABLED_REASON_PROPERTY]
+                              DISABLED_REASON_PROPERTY, INCOMING_PROPERTY]
 
     if not multiple_project_config:
         return True
@@ -557,7 +557,7 @@ def check_configuration(config):
     global_tunables = [HOOKDIR_PROPERTY, PROXY_PROPERTY, LOGDIR_PROPERTY,
                        COMMANDS_PROPERTY, PROJECTS_PROPERTY,
                        HOOK_TIMEOUT_PROPERTY, CMD_TIMEOUT_PROPERTY,
-                       DISABLED_CMD_PROPERTY]
+                       DISABLED_CMD_PROPERTY, INCOMING_PROPERTY]
     diff = set(config.keys()).difference(global_tunables)
     if diff:
         logger.error("unknown global configuration option(s): '{}'"

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -448,8 +448,7 @@ def mirror_project(config, project_name, check_changes, uri,
     # is treated as failed, i.e. the program will return FAILURE_EXITVAL.
     #
     for repo in repos:
-        logger.info("Synchronizing repository {}".
-                    format(repo.path))
+        logger.info("Synchronizing repository {}".format(repo.path))
         if repo.sync() != SUCCESS_EXITVAL:
             logger.error("failed to synchronize repository {}".
                          format(repo.path))

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -317,7 +317,8 @@ def run_command(cmd, project_name):
                             cmd.getoutputstr()))
 
 
-def handle_disabled_project(config, project_name, disabled_msg, headers=None, timeout=None):
+def handle_disabled_project(config, project_name, disabled_msg, headers=None,
+                            timeout=None):
     disabled_command = config.get(DISABLED_CMD_PROPERTY)
     if disabled_command:
         logger = logging.getLogger(__name__)
@@ -381,13 +382,19 @@ def mirror_project(config, project_name, check_changes, uri,
     prehook, posthook, hook_timeout, command_timeout, use_proxy, \
         ignored_repos, \
         check_changes_proj = get_project_properties(project_config,
-                                               project_name,
-                                               config.get(HOOKDIR_PROPERTY))
+                                                    project_name,
+                                                    config.
+                                                    get(HOOKDIR_PROPERTY))
 
     if not command_timeout:
         command_timeout = config.get(CMD_TIMEOUT_PROPERTY)
     if not hook_timeout:
         hook_timeout = config.get(HOOK_TIMEOUT_PROPERTY)
+
+    if check_changes_proj is None:
+        check_changes_config = config.get(INCOMING_PROPERTY)
+    else:
+        check_changes_config = check_changes_proj
 
     proxy = None
     if use_proxy:
@@ -423,8 +430,8 @@ def mirror_project(config, project_name, check_changes, uri,
                     format(project_name))
         return CONTINUE_EXITVAL
 
-    if check_changes_proj is not None:
-        check_changes = check_changes_proj
+    if check_changes_config is not None:
+        check_changes = check_changes_config
 
     # Check if the project or any of its repositories have changed.
     if check_changes:

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -215,7 +215,7 @@ def get_project_properties(project_config, project_name, hookdir):
             logger.debug("will use proxy")
             use_proxy = True
 
-        if project_config.get(INCOMING_PROPERTY):
+        if project_config.get(INCOMING_PROPERTY) is not None:
             check_changes = get_bool(logger, ("incoming check for project {}".
                                               format(project_name)),
                                      project_config.get(INCOMING_PROPERTY))
@@ -263,6 +263,8 @@ def process_changes(repos, project_name, uri, headers=None):
     logger = logging.getLogger(__name__)
 
     changes_detected = False
+
+    logger.debug("Checking incoming changes for project {}".format(project_name))
 
     # check if the project is a new project - full index is necessary
     try:

--- a/tools/src/main/python/opengrok_tools/utils/utils.py
+++ b/tools/src/main/python/opengrok_tools/utils/utils.py
@@ -27,6 +27,7 @@ from logging import log
 import logging
 import sys
 from urllib.parse import urlparse
+from distutils import util
 from .exitvals import (
     FAILURE_EXITVAL,
 )
@@ -92,6 +93,20 @@ def get_int(logger, name, value):
 
     try:
         return int(value)
+    except ValueError:
+        logger.error("'{}' is not a number: {}".format(name, value))
+        return None
+
+
+def get_bool(logger, name, value):
+    """
+    If the supplied value is bool, return it. Otherwise return None.
+    """
+    if value is None:
+        return None
+
+    try:
+        return bool(util.strtobool(value))
     except ValueError:
         logger.error("'{}' is not a number: {}".format(name, value))
         return None

--- a/tools/src/main/python/opengrok_tools/utils/utils.py
+++ b/tools/src/main/python/opengrok_tools/utils/utils.py
@@ -100,10 +100,14 @@ def get_int(logger, name, value):
 
 def get_bool(logger, name, value):
     """
-    If the supplied value is bool, return it. Otherwise return None.
+    If the supplied value is bool or its representation, return the bool value.
+    Otherwise return None.
     """
     if value is None:
         return None
+
+    if type(value) is bool:
+        return value
 
     try:
         return bool(util.strtobool(value))

--- a/tools/src/main/python/opengrok_tools/utils/utils.py
+++ b/tools/src/main/python/opengrok_tools/utils/utils.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 #
 
 import os

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -45,7 +45,8 @@ from opengrok_tools.utils.mirror import check_project_configuration, \
     check_configuration, mirror_project, run_command, get_repos_for_project, \
     HOOKS_PROPERTY, PROXY_PROPERTY, IGNORED_REPOS_PROPERTY, \
     PROJECTS_PROPERTY, DISABLED_CMD_PROPERTY, DISABLED_PROPERTY, \
-    CMD_TIMEOUT_PROPERTY, HOOK_TIMEOUT_PROPERTY, DISABLED_REASON_PROPERTY
+    CMD_TIMEOUT_PROPERTY, HOOK_TIMEOUT_PROPERTY, DISABLED_REASON_PROPERTY, \
+    INCOMING_PROPERTY
 from opengrok_tools.utils.patterns import COMMAND_PROPERTY, PROJECT_SUBST
 
 
@@ -119,11 +120,23 @@ def test_invalid_config_option():
     assert not check_configuration({"nonexistent": True})
 
 
-def test_valid_config():
+def test_valid_config_proxy():
     assert check_configuration({
         PROJECTS_PROPERTY: {"foo": {PROXY_PROPERTY: True}},
         PROXY_PROPERTY: "proxy"
     })
+
+
+def test_valid_config_incoming():
+    assert check_configuration({
+        PROJECTS_PROPERTY: {"foo": {INCOMING_PROPERTY: True}},
+        INCOMING_PROPERTY: "False"
+    })
+
+
+def test_project_config_incoming_valid():
+    assert check_project_configuration({'foo': {INCOMING_PROPERTY: "T"}})
+    assert check_project_configuration({'foo': {INCOMING_PROPERTY: "F"}})
 
 
 def test_empty_project_config():


### PR DESCRIPTION
This change allows to override the incoming check in `opengrok-mirror`. It also adds mirror configuration to Docker.

Sort of paves the way for #3500.