### PR TITLE
ignore errors for opengrok-mirror configuration

### DIFF
--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -372,8 +372,8 @@ def handle_disabled_project(config, project_name, disabled_msg, headers=None,
 def get_mirror_retcode(ignore_errors, value):
     if ignore_errors:
         logger = logging.getLogger(__name__)
-        logger.info("error code is {} however '{}' is on, "
-                    "so returning success".format(IGNORE_ERR_PROPERTY, value))
+        logger.info("error code is {} however '{}' property is true, "
+                    "so returning success".format(value, IGNORE_ERR_PROPERTY))
         return SUCCESS_EXITVAL
 
     return value

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -372,7 +372,7 @@ def handle_disabled_project(config, project_name, disabled_msg, headers=None,
 
 
 def get_mirror_retcode(ignore_errors, value):
-    if ignore_errors:
+    if ignore_errors and value != SUCCESS_EXITVAL:
         logger = logging.getLogger(__name__)
         logger.info("error code is {} however '{}' property is true, "
                     "so returning success".format(value, IGNORE_ERR_PROPERTY))

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -61,6 +61,8 @@ HOOKS_PROPERTY = 'hooks'
 LOGDIR_PROPERTY = 'logdir'
 PROJECTS_PROPERTY = 'projects'
 DISABLED_CMD_PROPERTY = 'disabled_command'
+HOOK_PRE_PROPERTY = "pre"
+HOOK_POST_PROPERTY = "post"
 
 
 def get_repos_for_project(project_name, uri, source_root,
@@ -206,10 +208,10 @@ def get_project_properties(project_config, project_name, hookdir):
         hooks = project_config.get(HOOKS_PROPERTY)
         if hooks:
             for hookname in hooks:
-                if hookname == "pre":
+                if hookname == HOOK_PRE_PROPERTY:
                     prehook = os.path.join(hookdir, hooks['pre'])
                     logger.debug("pre-hook = {}".format(prehook))
-                elif hookname == "post":
+                elif hookname == HOOK_POST_PROPERTY:
                     posthook = os.path.join(hookdir, hooks['post'])
                     logger.debug("post-hook = {}".format(posthook))
 
@@ -465,8 +467,8 @@ def mirror_project(config, project_name, check_changes, uri,
         if r != SUCCESS_EXITVAL:
             return get_mirror_retcode(ignore_errors, r)
 
-    if not process_hook("pre", prehook, source_root, project_name, proxy,
-                        hook_timeout):
+    if not process_hook(HOOK_PRE_PROPERTY, prehook, source_root, project_name,
+                        proxy, hook_timeout):
         return get_mirror_retcode(ignore_errors, FAILURE_EXITVAL)
 
     #
@@ -480,8 +482,8 @@ def mirror_project(config, project_name, check_changes, uri,
                          format(repo.path))
             ret = FAILURE_EXITVAL
 
-    if not process_hook("post", posthook, source_root, project_name, proxy,
-                        hook_timeout):
+    if not process_hook(HOOK_POST_PROPERTY, posthook, source_root, project_name,
+                        proxy, hook_timeout):
         return get_mirror_retcode(ignore_errors, FAILURE_EXITVAL)
 
     return get_mirror_retcode(ignore_errors, ret)

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -242,7 +242,7 @@ def test_disabled_command_run():
 @pytest.mark.parametrize("hook_type", [HOOK_PRE_PROPERTY, HOOK_POST_PROPERTY])
 def test_ignore_errors(monkeypatch, hook_type):
     """
-    Test that per project ignore errors property overrides failed pre hook.
+    Test that per project ignore errors property overrides failed hook.
     """
 
     def mock_get_repos(*args, **kwargs):

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -243,7 +243,7 @@ def test_disabled_command_run():
 @pytest.mark.parametrize("per_project", [True, False])
 def test_ignore_errors(monkeypatch, hook_type, per_project):
     """
-    Test that per project ignore errors property overrides failed hook.
+    Test that ignore errors property overrides failed hook.
     """
 
     def mock_get_repos(*args, **kwargs):


### PR DESCRIPTION
This change adds `ignore_errors` configuration parameter to the `opengrok-mirror` configuration, allowing to ignore any error during the mirroring process, be it repository sync or hook failure.