### PR TITLE
Rejuvenate log levels

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -132,7 +132,7 @@ public final class WebappListener
                     }
                 }
             }
-            LOGGER.log(Level.FINE, "Index check for all projects done");
+            LOGGER.log(Level.FINER, "Index check for all projects done");
         } else {
             LOGGER.log(Level.FINE, "Checking index");
             try {
@@ -140,7 +140,7 @@ public final class WebappListener
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, "index check failed", e);
             }
-            LOGGER.log(Level.FINE, "Index check done");
+            LOGGER.log(Level.FINER, "Index check done");
         }
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -167,7 +167,7 @@ public class ProjectsController {
         projectName = Laundromat.launderInput(projectName);
 
         Project project = disableProject(projectName);
-        logger.log(Level.INFO, "deleting configuration for project {0}", projectName);
+        logger.log(Level.FINE, "deleting configuration for project {0}", projectName);
 
         // Delete index data associated with the project.
         deleteProjectData(projectName);
@@ -200,7 +200,7 @@ public class ProjectsController {
         final String projectName = Laundromat.launderInput(projectNameParam);
 
         Project project = disableProject(projectName);
-        logger.log(Level.INFO, "deleting data for project {0}", projectName);
+        logger.log(Level.FINE, "deleting data for project {0}", projectName);
 
         // Delete index and xrefs.
         for (String dirName: new String[]{IndexDatabase.INDEX_DIR, IndexDatabase.XREF_DIR}) {
@@ -229,7 +229,7 @@ public class ProjectsController {
         projectName = Laundromat.launderInput(projectName);
 
         Project project = disableProject(projectName);
-        logger.log(Level.INFO, "deleting history cache for project {0}", projectName);
+        logger.log(Level.FINE, "deleting history cache for project {0}", projectName);
 
         List<RepositoryInfo> repos = env.getProjectRepositoriesMap().get(project);
         if (repos == null || repos.isEmpty()) {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
@@ -78,7 +78,7 @@ public class SystemController {
     public void loadPathDescriptions(@Valid final PathDescription[] descriptions) throws IOException {
         EftarFile ef = new EftarFile();
         ef.create(Set.of(descriptions), env.getDtagsEftarPath().toString());
-        LOGGER.log(Level.INFO, "reloaded path descriptions with {0} entries", descriptions.length);
+        LOGGER.log(Level.FINE, "reloaded path descriptions with {0} entries", descriptions.length);
     }
 
     @GET

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
@@ -110,7 +110,7 @@ public class IncomingFilter implements ContainerRequestFilter, ConfigurationChan
 
     @Override
     public void onConfigurationChanged() {
-        LOGGER.log(Level.FINER, "refreshing token cache");
+        LOGGER.log(Level.FINEST, "refreshing token cache");
         setTokens(RuntimeEnvironment.getInstance().getAuthenticationTokens());
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -157,7 +157,7 @@ public class SuggesterServiceImpl implements SuggesterService {
     /** {@inheritDoc} */
     @Override
     public void refresh() {
-        logger.log(Level.FINE, "Refreshing suggester for new configuration {0}", env.getSuggesterConfig());
+        logger.log(Level.FINER, "Refreshing suggester for new configuration {0}", env.getSuggesterConfig());
         lock.writeLock().lock();
         try {
             // close and init from scratch because many things may have changed in the configuration
@@ -309,7 +309,7 @@ public class SuggesterServiceImpl implements SuggesterService {
         if (rebuildParalleismLevel == 0) {
             rebuildParalleismLevel = 1;
         }
-        logger.log(Level.FINER, "Suggester rebuild parallelism level: " + rebuildParalleismLevel);
+        logger.log(Level.FINEST, "Suggester rebuild parallelism level: " + rebuildParalleismLevel);
         suggester = new Suggester(suggesterDir,
                 suggesterConfig.getMaxResults(),
                 Duration.ofSeconds(suggesterConfig.getBuildTerminationTime()),
@@ -367,7 +367,7 @@ public class SuggesterServiceImpl implements SuggesterService {
             return;
         }
 
-        logger.log(Level.INFO, "Scheduling suggester rebuild in {0}", timeToNextRebuild);
+        logger.log(Level.FINE, "Scheduling suggester rebuild in {0}", timeToNextRebuild);
 
         future = instance.scheduler.schedule(instance.getRebuildAllProjectsRunnable(), timeToNextRebuild.toMillis(),
                 TimeUnit.MILLISECONDS);

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
@@ -111,7 +111,7 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
             throw new IllegalArgumentException(String.format("Unable to read the file \"%s\"", filePath), e);
         }
 
-        LOGGER.log(Level.FINE, "LdapAttrPlugin plugin loaded with attr={0}, whitelist={1} ({2} entries), " +
+        LOGGER.log(Level.FINER, "LdapAttrPlugin plugin loaded with attr={0}, whitelist={1} ({2} entries), " +
                         "instance={3}", new Object[]{ldapAttr, filePath, whitelist.size(), ldapUserInstance});
     }
 

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapFilterPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapFilterPlugin.java
@@ -93,7 +93,7 @@ public class LdapFilterPlugin extends AbstractLdapPlugin {
             loadTransforms(transformsString);
         }
 
-        LOGGER.log(Level.FINE, "LdapFilter plugin loaded with filter={0}, instance={1}, transforms={2}",
+        LOGGER.log(Level.FINER, "LdapFilter plugin loaded with filter={0}, instance={1}, transforms={2}",
                 new Object[]{ldapFilter, ldapUserInstance, transforms});
     }
 
@@ -135,7 +135,7 @@ public class LdapFilterPlugin extends AbstractLdapPlugin {
         AbstractLdapProvider ldapProvider = getLdapProvider();
         try {
             if ((ldapProvider.lookupLdapContent(null, expandedFilter)) == null) {
-                LOGGER.log(Level.FINER,
+                LOGGER.log(Level.FINE,
                         "empty content for LDAP user {0} with filter ''{1}'' on {2}",
                         new Object[]{ldapUser, expandedFilter, ldapProvider});
                 return;

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapUserPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapUserPlugin.java
@@ -105,7 +105,7 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
             instance = Integer.parseInt(instance_param);
         }
 
-        LOGGER.log(Level.FINE, "LdapUser plugin loaded with filter={0}, " +
+        LOGGER.log(Level.FINER, "LdapUser plugin loaded with filter={0}, " +
                         "attributes={1}, useDN={2}, instance={3}",
                 new Object[]{ldapFilter, attributes, useDN, instance});
     }

--- a/plugins/src/main/java/opengrok/auth/plugin/UserPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/UserPlugin.java
@@ -75,7 +75,7 @@ public class UserPlugin implements IAuthorizationPlugin {
                     DECODER_CLASS_PARAM, UserPlugin.class.getName()));
         }
 
-        LOGGER.log(Level.INFO, "loading decoder: {0}", decoder_name);
+        LOGGER.log(Level.FINE, "loading decoder: {0}", decoder_name);
         try {
             decoder = getDecoder(decoder_name);
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException |

--- a/plugins/src/main/java/opengrok/auth/plugin/UserWhiteListPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/UserWhiteListPlugin.java
@@ -75,7 +75,7 @@ public class UserWhiteListPlugin implements IAuthorizationPlugin {
             throw new IllegalArgumentException(String.format("Unable to read the file \"%s\"", filePath), e);
         }
 
-        LOGGER.log(Level.FINE, "UserWhiteList plugin loaded with filePath={0} ({1} entries), fieldName={2}",
+        LOGGER.log(Level.FINER, "UserWhiteList plugin loaded with filePath={0} ({1} entries), fieldName={2}",
                 new Object[]{filePath, whitelist.size(), fieldName});
     }
 

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
@@ -197,7 +197,7 @@ public class LdapFacade extends AbstractLdapProvider {
      * Go through all servers in the pool and record the first working.
      */
     void prepareServers() {
-        LOGGER.log(Level.FINER, "checking servers for {0}", this);
+        LOGGER.log(Level.FINEST, "checking servers for {0}", this);
         for (int i = 0; i < servers.size(); i++) {
             LdapServer server = servers.get(i);
             if (server.isWorking() && actualServer == -1) {
@@ -206,7 +206,7 @@ public class LdapFacade extends AbstractLdapProvider {
         }
 
         // Close the connections to the inactive servers.
-        LOGGER.log(Level.FINER, "closing unused servers");
+        LOGGER.log(Level.FINEST, "closing unused servers");
         for (int i = 0; i < servers.size(); i++) {
             if (i != actualServer) {
                 servers.get(i).close();

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -242,7 +242,7 @@ public class LdapServer implements Serializable {
      * @return the new connection or null
      */
     private synchronized LdapContext connect() {
-        LOGGER.log(Level.INFO, "Connecting to LDAP server {0} ", this);
+        LOGGER.log(Level.FINE, "Connecting to LDAP server {0} ", this);
 
         if (errorTimestamp > 0 && errorTimestamp + interval > System.currentTimeMillis()) {
             LOGGER.log(Level.WARNING, "LDAP server {0} is down", this.url);
@@ -269,7 +269,7 @@ public class LdapServer implements Serializable {
             try {
                 ctx = new InitialLdapContext(env, null);
                 ctx.setRequestControls(null);
-                LOGGER.log(Level.INFO, "Connected to LDAP server {0}", this);
+                LOGGER.log(Level.FINE, "Connected to LDAP server {0}", this);
                 errorTimestamp = 0;
             } catch (NamingException ex) {
                 LOGGER.log(Level.WARNING, "LDAP server {0} is not responding", env.get(Context.PROVIDER_URL));

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -263,7 +263,7 @@ public final class Suggester implements Closeable {
             executorService.awaitTermination(awaitTerminationTime.toMillis(), TimeUnit.MILLISECONDS);
             Duration duration = Duration.between(start, Instant.now());
             timer.record(duration);
-            LOGGER.log(Level.INFO, "{0} (took {1})", new Object[]{logMessageOnSuccess,
+            LOGGER.log(Level.FINE, "{0} (took {1})", new Object[]{logMessageOnSuccess,
                     DurationFormatUtils.formatDurationWords(duration.toMillis(),
                             true, true)});
         } catch (InterruptedException e) {
@@ -292,7 +292,7 @@ public final class Suggester implements Closeable {
             }
 
             Instant start = Instant.now();
-            LOGGER.log(Level.INFO, "Rebuilding the following suggesters: {0}", indexDirs);
+            LOGGER.log(Level.FINE, "Rebuilding the following suggesters: {0}", indexDirs);
 
             ExecutorService executor = Executors.newWorkStealingPool(rebuildParallelismLevel);
 
@@ -343,7 +343,7 @@ public final class Suggester implements Closeable {
                 }
 
                 Instant start = Instant.now();
-                LOGGER.log(Level.FINE, "Rebuilding {0}", data);
+                LOGGER.log(Level.FINER, "Rebuilding {0}", data);
                 data.rebuild();
 
                 Duration d = Duration.between(start, Instant.now());
@@ -364,7 +364,7 @@ public final class Suggester implements Closeable {
         }
 
         synchronized (lock) {
-            LOGGER.log(Level.INFO, "Removing following suggesters: {0}", names);
+            LOGGER.log(Level.FINE, "Removing following suggesters: {0}", names);
 
             for (String suggesterName : names) {
                 SuggesterProjectData collection = projectData.get(suggesterName);


### PR DESCRIPTION
Here's a reissue of https://github.com/oracle/opengrok/pull/2978 which is closed due to inactivity and conflicts. We have run our [logging tool](https://github.com/ponder-lab/Rejuvenate-Logging-Levels) on the last version of the project and solved all conflicts. We appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

- Treat CONFIG, WARNING, and SEVERE levels as a category and not a traditional level, i.e., our tool ignores these log levels.
- Never lower the logging level of logging statements within catch blocks.
- Never lower the logging level of logging statements within if statements.
- Never lower the logging level of logging statements containing certain (important) keywords.
- Never raise the logging level of logging statements without particular keywords in their messages.
- Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
- Only consistently transform the level of logging statements appearing in overriding methods.
- Adjust transformations if their transformation distances are over maximum transformation distance.

The greatest number of commits from HEAD evaluated: 5000.
The head at the time of analysis was: a31748b478960db5458c5383e8a9282fa6037af6

OCA
---
I signed and emailed the OCA to Oracle. I am also providing a written acceptance of the OCA line:

I am signing on behalf of myself as an individual and no other person or entity, including my employer, has or will have rights with respect my contributions.
