### PR TITLE
deal with read_config() for empty YAML file properly

### DIFF
--- a/tools/src/main/python/opengrok_tools/utils/readconfig.py
+++ b/tools/src/main/python/opengrok_tools/utils/readconfig.py
@@ -62,6 +62,9 @@ def read_config(logger, inputfile):
                 # Not a valid YAML file.
                 logger.debug("got exception {}".format(sys.exc_info()[0]))
             else:
+                if cfg is None:
+                    cfg = {}
+
                 return cfg
     except IOError as e:
         logger.error("cannot open '{}': {}".format(inputfile, e.strerror))

--- a/tools/src/test/python/test_readconfig.py
+++ b/tools/src/test/python/test_readconfig.py
@@ -22,7 +22,6 @@
 #
 # Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 #
-import pytest
 import tempfile
 from mockito import mock
 import logging
@@ -30,8 +29,10 @@ import logging
 from opengrok_tools.utils.readconfig import read_config
 
 
-def test_read_config_empty():
+def test_read_config_empty_yaml():
     with tempfile.NamedTemporaryFile() as tmpf:
         tmpf.file.write(b'#foo\n')
         res = read_config(mock(spec=logging.Logger), tmpf.name)
-        assert res is None
+        assert res is not None
+        assert type(res) == dict
+        assert len(res) == 0

--- a/tools/src/test/python/test_readconfig.py
+++ b/tools/src/test/python/test_readconfig.py
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 #
+import os
 import tempfile
 from mockito import mock
 import logging
@@ -31,7 +32,7 @@ from opengrok_tools.utils.readconfig import read_config
 
 def test_read_config_empty_yaml():
     with tempfile.NamedTemporaryFile() as tmpf:
-        tmpf.file.write(b'#foo\n')
+        tmpf.file.write(b'#foo' + os.linesep)
         res = read_config(mock(spec=logging.Logger), tmpf.name)
         assert res is not None
         assert type(res) == dict

--- a/tools/src/test/python/test_readconfig.py
+++ b/tools/src/test/python/test_readconfig.py
@@ -32,7 +32,8 @@ from opengrok_tools.utils.readconfig import read_config
 
 def test_read_config_empty_yaml():
     with tempfile.NamedTemporaryFile() as tmpf:
-        tmpf.file.write(b'#foo' + os.linesep)
+        tmpf.file.write(b'#foo\n')
+        tmpf.flush()
         res = read_config(mock(spec=logging.Logger), tmpf.name)
         assert res is not None
         assert type(res) == dict

--- a/tools/src/test/python/test_readconfig.py
+++ b/tools/src/test/python/test_readconfig.py
@@ -30,8 +30,8 @@ from opengrok_tools.utils.readconfig import read_config
 
 
 def test_read_config_empty_yaml():
-    with tempfile.NamedTemporaryFile() as tmpf:
-        tmpf.file.write(b'#foo\n')
+    with tempfile.NamedTemporaryFile(mode='w+t') as tmpf:
+        tmpf.file.write('#foo\n')
         tmpf.flush()
         res = read_config(mock(spec=logging.Logger), tmpf.name)
         assert res is not None

--- a/tools/src/test/python/test_readconfig.py
+++ b/tools/src/test/python/test_readconfig.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+#
+import pytest
+import tempfile
+from mockito import mock
+import logging
+
+from opengrok_tools.utils.readconfig import read_config
+
+
+def test_read_config_empty():
+    with tempfile.NamedTemporaryFile() as tmpf:
+        tmpf.file.write(b'#foo\n')
+        res = read_config(mock(spec=logging.Logger), tmpf.name)
+        assert res is None

--- a/tools/src/test/python/test_readconfig.py
+++ b/tools/src/test/python/test_readconfig.py
@@ -22,7 +22,6 @@
 #
 # Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 #
-import os
 import tempfile
 from mockito import mock
 import logging

--- a/tools/src/test/python/test_readconfig.py
+++ b/tools/src/test/python/test_readconfig.py
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 #
+import os
 import tempfile
 from mockito import mock
 import logging
@@ -30,10 +31,11 @@ from opengrok_tools.utils.readconfig import read_config
 
 
 def test_read_config_empty_yaml():
-    with tempfile.NamedTemporaryFile(mode='w+t') as tmpf:
-        tmpf.file.write('#foo\n')
-        tmpf.flush()
-        res = read_config(mock(spec=logging.Logger), tmpf.name)
-        assert res is not None
-        assert type(res) == dict
-        assert len(res) == 0
+    tmpf = tempfile.NamedTemporaryFile(mode='w+t', delete=False)
+    tmpf.file.write('#foo\n')
+    tmpf.close()
+    res = read_config(mock(spec=logging.Logger), tmpf.name)
+    os.remove(tmpf.name)
+    assert res is not None
+    assert type(res) == dict
+    assert len(res) == 0


### PR DESCRIPTION
This fixes a problem in the recent PR #3614 which assumed that `read_config()` returns empty dictionary on a valid yet empty YAML config however `None` is returned.