### PR TITLE
Fix "on the fly" xref generation for empty revisions

### DIFF
--- a/opengrok-web/src/main/webapp/xref.jspf
+++ b/opengrok-web/src/main/webapp/xref.jspf
@@ -56,7 +56,7 @@ org.opengrok.indexer.web.QueryParameters"
         InputStream in = null;
         File tempf = null;
         try {
-            if (rev.equals(DUMMY_REVISION)) {
+            if (rev.isBlank() || rev.equals(DUMMY_REVISION)) {
                 in = new BufferedInputStream(new FileInputStream(resourceFile));
             } else {
                 tempf = File.createTempFile("ogtags", basename);


### PR DESCRIPTION
fixes #3620

I've reproduced the error by removing the xref file. The implementation tried to get the file contents from history with empty revision which then produced an error from jgit.

At first I wanted to use `PageConfig#isLatestRevision` method but we map `rev` to empty string whereas `isLatestRevision` can use a `null` value and it did not work properly.

Thanks!

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
