### PR TITLE
PageConfig#getLastRevFromHistory() should work with history efficiently

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -497,6 +497,11 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
 
     public History getHistory(File file, String sinceRevision, String tillRevision,
                               Integer numCommits) throws HistoryException {
+
+        if (numCommits == null || numCommits <= 0) {
+            return null;
+        }
+
         final List<HistoryEntry> entries = new ArrayList<>();
         final Set<String> renamedFiles = new HashSet<>();
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -81,6 +81,7 @@ import org.eclipse.jgit.treewalk.filter.TreeFilter;
 import org.eclipse.jgit.util.io.CountingOutputStream;
 import org.eclipse.jgit.util.io.NullOutputStream;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -483,7 +484,19 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
         }
     }
 
+    @Nullable
+    @Override
+    public HistoryEntry getLastHistoryEntry(File file, boolean ui) throws HistoryException {
+        History hist = getHistory(file, null, null, 1);
+        return getLastHistoryEntry(hist);
+    }
+
     public History getHistory(File file, String sinceRevision, String tillRevision) throws HistoryException {
+        return getHistory(file, sinceRevision, tillRevision, null);
+    }
+
+    public History getHistory(File file, String sinceRevision, String tillRevision,
+                              Integer numCommits) throws HistoryException {
         final List<HistoryEntry> entries = new ArrayList<>();
         final Set<String> renamedFiles = new HashSet<>();
 
@@ -517,6 +530,7 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
                 }
             }
 
+            int num = 0;
             for (RevCommit commit : walk) {
                 if (commit.getParentCount() > 1 && !isMergeCommitsEnabled()) {
                     continue;
@@ -535,6 +549,10 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
                 }
 
                 entries.add(historyEntry);
+
+                if (numCommits != null && ++num >= numCommits) {
+                    break;
+                }
             }
         } catch (IOException | ForbiddenSymlinkException e) {
             throw new HistoryException(String.format("failed to get history for ''%s''", file), e);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -498,7 +498,7 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
     public History getHistory(File file, String sinceRevision, String tillRevision,
                               Integer numCommits) throws HistoryException {
 
-        if (numCommits == null || numCommits <= 0) {
+        if (numCommits != null && numCommits <= 0) {
             return null;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -235,6 +235,11 @@ public final class HistoryGuru {
         return getHistory(file, true, true);
     }
 
+    public HistoryEntry getLastHistoryEntry(File file, boolean ui) throws HistoryException {
+        final Repository repo = getRepository(file);
+        return repo.getLastHistoryEntry(file, ui);
+    }
+
     /**
      * Get the history for the specified file.
      *

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
@@ -74,15 +74,15 @@ class MercurialHistoryParser implements Executor.StreamHandler {
      * @param sinceRevision the changeset right before the first one to fetch, or
      * {@code null} if all changesets should be fetched
      * @param tillRevision end revision or {@code null}
-     * @param numRevisions number of revisions to get
+     * @param numCommits number of revisions to get
      * @return history for the specified file or directory
      * @throws HistoryException if an error happens when parsing the history
      */
-    History parse(File file, String sinceRevision, String tillRevision, Integer numRevisions) throws HistoryException {
+    History parse(File file, String sinceRevision, String tillRevision, Integer numCommits) throws HistoryException {
         isDir = file.isDirectory();
         try {
             Executor executor = repository.getHistoryLogExecutor(file, sinceRevision, tillRevision, false,
-                    numRevisions);
+                    numCommits);
             int status = executor.exec(true, this);
 
             if (status != 0) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParser.java
@@ -74,13 +74,15 @@ class MercurialHistoryParser implements Executor.StreamHandler {
      * @param sinceRevision the changeset right before the first one to fetch, or
      * {@code null} if all changesets should be fetched
      * @param tillRevision end revision or {@code null}
+     * @param numRevisions number of revisions to get
      * @return history for the specified file or directory
      * @throws HistoryException if an error happens when parsing the history
      */
-    History parse(File file, String sinceRevision, String tillRevision) throws HistoryException {
+    History parse(File file, String sinceRevision, String tillRevision, Integer numRevisions) throws HistoryException {
         isDir = file.isDirectory();
         try {
-            Executor executor = repository.getHistoryLogExecutor(file, sinceRevision, tillRevision, false);
+            Executor executor = repository.getHistoryLogExecutor(file, sinceRevision, tillRevision, false,
+                    numRevisions);
             int status = executor.exec(true, this);
 
             if (status != 0) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -586,7 +586,11 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
     }
 
     History getHistory(File file, String sinceRevision, String tillRevision,
-                       Integer numRevisions) throws HistoryException {
+                       Integer numCommits) throws HistoryException {
+
+        if (numCommits != null && numCommits <= 0) {
+            return null;
+        }
 
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         // Note that the filtering of revisions based on sinceRevision is done
@@ -597,7 +601,7 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
         // so no sinceRevision filter is needed.
         // See findOriginalName() code for more details.
         History result = new MercurialHistoryParser(this).
-                parse(file, sinceRevision, tillRevision, numRevisions);
+                parse(file, sinceRevision, tillRevision, numCommits);
 
         // Assign tags to changesets they represent.
         // We don't need to check if this repository supports tags,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -660,7 +660,6 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
 
     @Override
     public String determineCurrentVersion(CommandTimeoutType cmdType) throws IOException {
-        String line = null;
         File directory = new File(getDirectoryName());
 
         List<String> cmd = new ArrayList<>();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -111,6 +111,42 @@ public abstract class Repository extends RepositoryInfo {
      */
     abstract History getHistory(File file) throws HistoryException;
 
+    HistoryEntry getLastHistoryEntry(History hist) {
+        if (hist == null) {
+            return null;
+        }
+
+        List<HistoryEntry> hlist = hist.getHistoryEntries();
+        if (hlist == null) {
+            return null;
+        }
+
+        if (hlist.size() == 0) {
+            return null;
+        }
+
+        return hlist.get(0);
+    }
+
+    /**
+     * This is generic implementation that retrieves the full history of given file
+     * and returns the latest history entry. This is obviously very inefficient, both in terms of memory and I/O.
+     * The extending classes are encouraged to implement their own version.
+     * @param file file
+     * @return last history entry or null
+     * @throws HistoryException on error
+     */
+    public HistoryEntry getLastHistoryEntry(File file, boolean ui) throws HistoryException {
+        History hist;
+        try {
+            hist = HistoryGuru.getInstance().getHistory(file, false, ui);
+        } catch (HistoryException ex) {
+            return null;
+        }
+
+        return getLastHistoryEntry(hist);
+    }
+
     public Repository() {
         super();
         ignoredFiles = new ArrayList<>();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -117,11 +117,7 @@ public abstract class Repository extends RepositoryInfo {
         }
 
         List<HistoryEntry> hlist = hist.getHistoryEntries();
-        if (hlist == null) {
-            return null;
-        }
-
-        if (hlist.size() == 0) {
+        if (hlist == null || hlist.isEmpty()) {
             return null;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -137,6 +137,7 @@ public abstract class Repository extends RepositoryInfo {
         try {
             hist = HistoryGuru.getInstance().getHistory(file, false, ui);
         } catch (HistoryException ex) {
+            LOGGER.log(Level.WARNING, "failed to get history for {0}", file);
             return null;
         }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -383,4 +383,15 @@ public class MercurialRepositoryTest {
                 collect(Collectors.toList());
         assertEquals(List.of(Arrays.copyOfRange(REVISIONS, 2, 7)), revisions);
     }
+
+    @Test
+    void testGetLastHistoryEntry() throws Exception {
+        File root = new File(repository.getSourceRoot(), "mercurial");
+        File file = new File(root, "novel.txt");
+        assertTrue(file.exists() && file.isFile());
+        MercurialRepository hgRepo = (MercurialRepository) RepositoryFactory.getRepository(root);
+        HistoryEntry historyEntry = hgRepo.getLastHistoryEntry(file, true);
+        assertNotNull(historyEntry);
+        assertEquals("8:6a8c423f5624", historyEntry.getRevision());
+    }
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -76,7 +76,6 @@ import org.opengrok.indexer.configuration.IgnoredNames;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.Annotation;
-import org.opengrok.indexer.history.History;
 import org.opengrok.indexer.history.HistoryEntry;
 import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.history.HistoryGuru;

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1285,38 +1285,23 @@ public final class PageConfig {
         }
 
         // fallback
-        return getLastRevFromHistory();
+        try {
+            return getLastRevFromHistory();
+        } catch (HistoryException e) {
+            LOGGER.log(Level.WARNING, "cannot get latest revision for {0}", getPath());
+            return null;
+        }
     }
 
     @Nullable
-    private String getLastRevFromHistory() {
-        History hist;
-        try {
-            hist = HistoryGuru.getInstance().
-                    getHistory(new File(getEnv().getSourceRootFile(), getPath()), false, true);
-        } catch (HistoryException ex) {
-            return null;
+    private String getLastRevFromHistory() throws HistoryException {
+        HistoryEntry he = HistoryGuru.getInstance().
+                getLastHistoryEntry(new File(getEnv().getSourceRootFile(), getPath()), true);
+        if (he != null) {
+            return he.getRevision();
         }
 
-        if (hist == null) {
-            return null;
-        }
-
-        List<HistoryEntry> hlist = hist.getHistoryEntries();
-        if (hlist == null) {
-            return null;
-        }
-
-        if (hlist.size() == 0) {
-            return null;
-        }
-
-        HistoryEntry he = hlist.get(0);
-        if (he == null) {
-            return null;
-        }
-
-        return he.getRevision();
+        return null;
     }
 
     /**


### PR DESCRIPTION
When looking at #3622 I realized that `PageConfig#getLastRevFromHistory()` retrieves complete history for given file only to throw most of it away. This change fixes that for Git. This is covered by tests in `PageConfigTest`.

The `ui` parameter is ignored in `GitRepository#getLastHistoryEntry()`, assuming this sort of operation will be quick.