### PR TITLE
parallelize creation of file history cache for individual files

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AccuRevHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AccuRevHistoryParser.java
@@ -71,7 +71,7 @@ public class AccuRevHistoryParser implements Executor.StreamHandler {
             List<HistoryEntry> entries = new ArrayList<>();
 
             entries.add(new HistoryEntry(
-                    "", new Date(), "OpenGrok", null, "Workspace Root", true));
+                    "", new Date(), "OpenGrok", "Workspace Root", true));
 
             history = new History(entries);
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarTagParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarTagParser.java
@@ -23,7 +23,7 @@
  */
 package org.opengrok.indexer.history;
 
-import static org.opengrok.indexer.history.HistoryEntry.TAGS_SEPARATOR;
+import static org.opengrok.indexer.history.History.TAGS_SEPARATOR;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
@@ -104,7 +104,7 @@ class CVSHistoryParser implements Executor.StreamHandler {
                 String commit = s.substring("revision".length()).trim();
                 entry.setRevision(commit);
                 if (tags.containsKey(commit)) {
-                    entry.setTags(tags.get(commit));
+                    history.addTags(entry, tags.get(commit));
                 }
                 state = ParseState.METADATA;
                 s = in.readLine();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/DirectoryHistoryReader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/DirectoryHistoryReader.java
@@ -225,7 +225,7 @@ public class DirectoryHistoryReader {
 
         icomment = citer.next();
 
-        currentEntry = new HistoryEntry(icomment.get(1), idate, iauthor, null, icomment.get(0), true);
+        currentEntry = new HistoryEntry(icomment.get(1), idate, iauthor, icomment.get(0), true);
         currentEntry.setFiles(hash.get(idate).get(iauthor).get(icomment));
 
         return true;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -580,7 +580,7 @@ class FileHistoryCache implements HistoryCache {
 
             if (!dir.isDirectory() && !dir.mkdirs()) {
                 LOGGER.log(Level.WARNING,
-                        "Unable to create cache directory ' {0} '.", dir);
+                        "Unable to create cache directory ''{0}''.", dir);
             }
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -471,13 +471,12 @@ class FileHistoryCache implements HistoryCache {
         createDirectoriesForFiles(regularFiles);
 
         /*
-         * Now traverse the list of files from the hash map built above
-         * and for each file store its history (saved in the value of the
-         * hash map entry for the file) in a file. Skip renamed files
-         * which will be handled separately below.
+         * Now traverse the list of files from the hash map built above and for each file store its history
+         * (saved in the value of the hash map entry for the file) in a file.
+         * The renamed files will be handled separately.
          */
-        LOGGER.log(Level.FINE, "Storing history for {0} files in repository ''{1}''",
-                new Object[]{map.entrySet().size(), repository.getDirectoryName()});
+        LOGGER.log(Level.FINE, "Storing history for {0} regular files in repository ''{1}''",
+                new Object[]{regularFiles.size(), repository.getDirectoryName()});
         final File root = env.getSourceRootFile();
 
         final CountDownLatch latch = new CountDownLatch(regularFiles.size());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -521,7 +521,7 @@ class FileHistoryCache implements HistoryCache {
         final CountDownLatch latch = new CountDownLatch(renamedFiles.size());
         AtomicInteger renamedFileHistoryCount = new AtomicInteger();
         for (final String file : renamedFiles) {
-            env.getIndexerParallelizer().getHistoryRenamedExecutor().submit(() -> {
+            env.getIndexerParallelizer().getHistoryFileExecutor().submit(() -> {
                 try {
                     doRenamedFileHistory(file,
                             new File(env.getSourceRootPath() + file),

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -140,10 +140,6 @@ class FileHistoryCache implements HistoryCache {
             return;
         }
 
-        // File based history cache does not store files for individual
-        // changesets so strip them unless it is history for the repository.
-        history.strip();
-
         // Assign tags to changesets they represent.
         if (env.isTagsEnabled() && repository.hasFileBasedTags()) {
             repository.assignTagsInHistory(history);
@@ -460,6 +456,9 @@ class FileHistoryCache implements HistoryCache {
                 list.add(e);
             }
         }
+
+        // File based history cache does not store files for individual changesets so strip them.
+        history.strip();
 
         File histDataDir = new File(getRepositoryHistDataDirname(repository));
         if (!histDataDir.isDirectory() && !histDataDir.mkdirs()) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -61,6 +61,7 @@ import java.util.zip.GZIPOutputStream;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.jetbrains.annotations.TestOnly;
 import org.opengrok.indexer.Metrics;
 import org.opengrok.indexer.configuration.PathAccepter;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -215,7 +216,7 @@ class FileHistoryCache implements HistoryCache {
         return new XMLDecoder(in, null, null, new HistoryClassLoader());
     }
 
-    // for testing
+    @TestOnly
     static History readCache(String xmlconfig) {
         final ByteArrayInputStream in = new ByteArrayInputStream(xmlconfig.getBytes());
         try (XMLDecoder d = getDecoder(in)) {
@@ -312,9 +313,7 @@ class FileHistoryCache implements HistoryCache {
                 // retroactively tagging changesets from listOld so we resort
                 // to this somewhat crude solution.
                 if (env.isTagsEnabled() && repo.hasFileBasedTags()) {
-                    for (HistoryEntry ent : history.getHistoryEntries()) {
-                        ent.setTags(null);
-                    }
+                    history.strip();
                     repo.assignTagsInHistory(history);
                 }
             }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -307,12 +307,12 @@ class FileHistoryCache implements HistoryCache {
                 }
                 history = new History(listOld);
 
-                // Retag the last changesets in case there have been some new
+                // Retag the changesets in case there have been some new
                 // tags added to the repository. Technically we should just
                 // retag the last revision from the listOld however this
                 // does not solve the problem when listNew contains new tags
                 // retroactively tagging changesets from listOld so we resort
-                // to this somewhat crude solution.
+                // to this somewhat crude solution of retagging from scratch.
                 if (env.isTagsEnabled() && repo.hasFileBasedTags()) {
                     history.strip();
                     repo.assignTagsInHistory(history);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -122,6 +122,7 @@ class FileHistoryCache implements HistoryCache {
             history = repository.getHistory(file);
         }
 
+        history.strip();
         doFileHistory(filename, history, repository, root, true);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -496,7 +496,6 @@ class FileHistoryCache implements HistoryCache {
 
         // Wait for the executors to finish.
         try {
-            // Wait for the executors to finish.
             latch.await();
         } catch (InterruptedException ex) {
             LOGGER.log(Level.SEVERE, "latch exception", ex);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -87,7 +87,7 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
 
-import static org.opengrok.indexer.history.HistoryEntry.TAGS_SEPARATOR;
+import static org.opengrok.indexer.history.History.TAGS_SEPARATOR;
 
 /**
  * Access to a Git repository.
@@ -545,7 +545,7 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
                         commit.getAuthorIdent().getWhen(),
                         commit.getAuthorIdent().getName() +
                                 " <" + commit.getAuthorIdent().getEmailAddress() + ">",
-                        null, commit.getFullMessage(), true);
+                        commit.getFullMessage(), true);
 
                 if (isDirectory) {
                     SortedSet<String> files = new TreeSet<>();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
@@ -64,7 +64,7 @@ public class History implements Serializable {
         this.entries = entries;
     }
 
-    // TODO: use History entry identification (revision) as key ?
+    // revision to tag list. Individual tags are joined via TAGS_SEPARATOR.
     private Map<String, String> tags = new HashMap<>();
 
     public History() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
@@ -51,19 +51,6 @@ public class History implements Serializable {
      */
     private final Set<String> renamedFiles;
 
-    // Needed for serialization
-    public Map<String, String> getTags() {
-        return tags;
-    }
-
-    public void setTags(Map<String, String> tags) {
-        this.tags = tags;
-    }
-
-    public void setEntries(List<HistoryEntry> entries) {
-        this.entries = entries;
-    }
-
     // revision to tag list. Individual tags are joined via TAGS_SEPARATOR.
     private Map<String, String> tags = new HashMap<>();
 
@@ -83,6 +70,20 @@ public class History implements Serializable {
     History(List<HistoryEntry> entries, Set<String> renamed) {
         this.entries = entries;
         this.renamedFiles = renamed;
+    }
+
+    // Needed for serialization.
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    // Needed for serialization.
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags;
+    }
+
+    public void setEntries(List<HistoryEntry> entries) {
+        this.entries = entries;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
@@ -23,6 +23,7 @@
  */
 package org.opengrok.indexer.history;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Objects;
@@ -38,16 +39,15 @@ import org.opengrok.indexer.logger.LoggerFactory;
  *
  * @author Trond Norbye
  */
-public class HistoryEntry {
+public class HistoryEntry implements Serializable {
 
-    static final String TAGS_SEPARATOR = ", ";
+    private static final long serialVersionUID = -1;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HistoryEntry.class);
 
     private String revision;
     private Date date;
     private String author;
-    private String tags;
 
     @SuppressWarnings("PMD.AvoidStringBufferField")
     private final StringBuffer message;
@@ -69,18 +69,15 @@ public class HistoryEntry {
         this.revision = that.revision;
         this.date = that.date;
         this.author = that.author;
-        this.tags = that.tags;
         this.message = that.message;
         this.active = that.active;
         this.files = that.files;
     }
 
-    public HistoryEntry(String revision, Date date, String author,
-            String tags, String message, boolean active) {
+    public HistoryEntry(String revision, Date date, String author, String message, boolean active) {
         this.revision = revision;
         setDate(date);
         this.author = author;
-        this.tags = tags;
         this.message = new StringBuffer(message);
         this.active = active;
         this.files = new TreeSet<>();
@@ -88,7 +85,7 @@ public class HistoryEntry {
 
     public HistoryEntry(String revision, Date date, String author,
                         String tags, String message, boolean active, Collection<String> files) {
-        this(revision, date, author, tags, message, active);
+        this(revision, date, author, message, active);
         this.files.addAll(files);
     }
 
@@ -100,7 +97,6 @@ public class HistoryEntry {
     public void dump() {
 
         LOGGER.log(Level.FINE, "HistoryEntry : revision       = {0}", revision);
-        LOGGER.log(Level.FINE, "HistoryEntry : tags           = {0}", tags);
         LOGGER.log(Level.FINE, "HistoryEntry : date           = {0}", date);
         LOGGER.log(Level.FINE, "HistoryEntry : author         = {0}", author);
         LOGGER.log(Level.FINE, "HistoryEntry : active         = {0}", (active ?
@@ -123,10 +119,6 @@ public class HistoryEntry {
     public String getAuthor() {
         return author;
     }
-    
-    public String getTags() {
-        return tags;
-    }
 
     public Date getDate() {
         return (date == null) ? null : (Date) date.clone();
@@ -142,10 +134,6 @@ public class HistoryEntry {
 
     public void setAuthor(String author) {
         this.author = author;
-    }
-    
-    public void setTags(String tags) {
-        this.tags = tags;
     }
 
     public final void setDate(Date date) {
@@ -201,7 +189,6 @@ public class HistoryEntry {
      */
     public void strip() {
         stripFiles();
-        stripTags();
     }
 
     /**
@@ -209,13 +196,6 @@ public class HistoryEntry {
      */
     public void stripFiles() {
         files.clear();
-    }
-
-    /**
-     * Remove tags.
-     */
-    public void stripTags() {
-        tags = null;
     }
 
     @Override
@@ -232,12 +212,11 @@ public class HistoryEntry {
                 Objects.equals(this.getRevision(), that.getRevision()) &&
                 Objects.equals(this.getDate(), that.getDate()) &&
                 Objects.equals(this.getMessage(), that.getMessage()) &&
-                Objects.equals(this.getFiles(), that.getFiles()) &&
-                Objects.equals(this.getTags(), that.getTags());
+                Objects.equals(this.getFiles(), that.getFiles());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getAuthor(), getRevision(), getDate(), getMessage(), getFiles(), getTags());
+        return Objects.hash(getAuthor(), getRevision(), getDate(), getMessage(), getFiles());
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -23,8 +23,6 @@
  */
 package org.opengrok.indexer.history;
 
-import static org.opengrok.indexer.history.HistoryEntry.TAGS_SEPARATOR;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -324,7 +322,6 @@ public abstract class Repository extends RepositoryInfo {
         TagEntry lastTagEntry = null;
         for (HistoryEntry ent : hist.getHistoryEntries()) {
             // Assign all tags created since the last revision
-            // Revision in this HistoryEntry must be already specified !
             // TODO: is there better way to do this? We need to "repeat"
             //   last element returned by call to next()
             while (lastTagEntry != null || it.hasNext()) {
@@ -332,11 +329,7 @@ public abstract class Repository extends RepositoryInfo {
                     lastTagEntry = it.next();
                 }
                 if (lastTagEntry.compareTo(ent) >= 0) {
-                    if (ent.getTags() == null) {
-                        ent.setTags(lastTagEntry.getTags());
-                    } else {
-                        ent.setTags(ent.getTags() + TAGS_SEPARATOR + lastTagEntry.getTags());
-                    }
+                    hist.addTags(ent, lastTagEntry.getTags());
                 } else {
                     break;
                 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
@@ -59,7 +59,7 @@ public class IndexerParallelizer implements AutoCloseable {
     private LazilyInstantiate<ObjectPool<Ctags>> lzCtagsPool;
     private LazilyInstantiate<ExecutorService> lzFixedExecutor;
     private LazilyInstantiate<ExecutorService> lzHistoryExecutor;
-    private LazilyInstantiate<ExecutorService> lzHistoryRenamedExecutor;
+    private LazilyInstantiate<ExecutorService> lzHistoryFileExecutor;
     private LazilyInstantiate<ExecutorService> lzCtagsWatcherExecutor;
 
     /**
@@ -108,17 +108,17 @@ public class IndexerParallelizer implements AutoCloseable {
     }
 
     /**
-     * @return the ExecutorService used for history parallelism
+     * @return the ExecutorService used for history parallelism (repository level)
      */
     public ExecutorService getHistoryExecutor() {
         return lzHistoryExecutor.get();
     }
 
     /**
-     * @return the ExecutorService used for history-renamed parallelism
+     * @return the ExecutorService used for history parallelism (file level)
      */
-    public ExecutorService getHistoryRenamedExecutor() {
-        return lzHistoryRenamedExecutor.get();
+    public ExecutorService getHistoryFileExecutor() {
+        return lzHistoryFileExecutor.get();
     }
 
     /**
@@ -195,8 +195,8 @@ public class IndexerParallelizer implements AutoCloseable {
     }
 
     private void bounceHistoryRenamedExecutor() {
-        if (lzHistoryRenamedExecutor.isActive()) {
-            ExecutorService formerHistoryRenamedExecutor = lzHistoryRenamedExecutor.get();
+        if (lzHistoryFileExecutor.isActive()) {
+            ExecutorService formerHistoryRenamedExecutor = lzHistoryFileExecutor.get();
             createLazyHistoryRenamedExecutor();
             formerHistoryRenamedExecutor.shutdown();
         }
@@ -241,7 +241,7 @@ public class IndexerParallelizer implements AutoCloseable {
     }
 
     private void createLazyHistoryRenamedExecutor() {
-        lzHistoryRenamedExecutor = LazilyInstantiate.using(() ->
+        lzHistoryFileExecutor = LazilyInstantiate.using(() ->
                 Executors.newFixedThreadPool(env.getHistoryRenamedParallelism()));
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSHistoryParserTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSHistoryParserTest.java
@@ -114,7 +114,7 @@ public class CVSHistoryParserTest {
         assertEquals(0, e0.getFiles().size());
         HistoryEntry e1 = result.getHistoryEntries().get(1);
         assertEquals(revId2, e1.getRevision());
-        assertEquals(tag1, e1.getTags());
+        // TODO assertEquals(tag1, e1.getTags());
         assertEquals(author2, e1.getAuthor());
         assertEquals(0, e1.getFiles().size());
         HistoryEntry e2 = result.getHistoryEntries().get(2);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSHistoryParserTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSHistoryParserTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -114,7 +116,6 @@ public class CVSHistoryParserTest {
         assertEquals(0, e0.getFiles().size());
         HistoryEntry e1 = result.getHistoryEntries().get(1);
         assertEquals(revId2, e1.getRevision());
-        // TODO assertEquals(tag1, e1.getTags());
         assertEquals(author2, e1.getAuthor());
         assertEquals(0, e1.getFiles().size());
         HistoryEntry e2 = result.getHistoryEntries().get(2);
@@ -123,5 +124,7 @@ public class CVSHistoryParserTest {
         assertEquals(0, e2.getFiles().size());
         assertTrue(e2.getMessage().contains("some"), "Should contain comment of both lines: line 1");
         assertTrue(e2.getMessage().contains("two"), "Should contain comment of both lines: line 2");
+
+        assertEquals(Map.of(revId2, tag1), result.getTags());
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -150,7 +150,6 @@ public class FileHistoryCacheTest {
         } else {
             assertEquals(0, actual.getFiles().size());
         }
-        assertEquals(expected.getTags(), actual.getTags());
     }
 
     /**
@@ -219,13 +218,13 @@ public class FileHistoryCacheTest {
         assertEquals(3, entries.size(), "Unexpected number of entries for main.c");
         HistoryEntry e0 = entries.get(0);
         assertEquals("13:3d386f6bd848", e0.getRevision(), "Unexpected revision for entry 0");
-        assertEquals("tag3", e0.getTags(), "Invalid tag list for revision 13");
+        // TODO assertEquals("tag3", e0.getTags(), "Invalid tag list for revision 13");
         HistoryEntry e1 = entries.get(1);
         assertEquals("2:585a1b3f2efb", e1.getRevision(), "Unexpected revision for entry 1");
-        assertEquals("tag2, tag1, start_of_novel", e1.getTags(), "Invalid tag list for revision 2");
+        // TODO assertEquals("tag2, tag1, start_of_novel", e1.getTags(), "Invalid tag list for revision 2");
         HistoryEntry e2 = entries.get(2);
         assertEquals("1:f24a5fd7a85d", e2.getRevision(), "Unexpected revision for entry 2");
-        assertNull(e2.getTags(), "Invalid tag list for revision 1");
+        // TODO assertNull(e2.getTags(), "Invalid tag list for revision 1");
 
         // Reindex from scratch.
         File dir = new File(cache.getRepositoryHistDataDirname(repo));
@@ -249,6 +248,7 @@ public class FileHistoryCacheTest {
         History retrievedUpdatedHistoryMainC = cache.get(main, repo, true);
         assertSameEntries(retrievedHistoryMainC.getHistoryEntries(),
                 retrievedUpdatedHistoryMainC.getHistoryEntries(), false);
+        // TODO: check tags
     }
 
     /**
@@ -329,7 +329,6 @@ public class FileHistoryCacheTest {
                 "10:1e392ef0b0ed",
                 new Date(1245446973L / 60 * 60 * 1000), // whole minutes only
                 "xyz",
-                null,
                 "Return failure when executed with no arguments",
                 true);
         newEntry1.addFile("/mercurial/main.c");
@@ -337,7 +336,6 @@ public class FileHistoryCacheTest {
                 "11:bbb3ce75e1b8",
                 new Date(1245447973L / 60 * 60 * 1000), // whole minutes only
                 "xyz",
-                null,
                 "Do something else",
                 true);
         newEntry2.addFile("/mercurial/main.c");
@@ -418,42 +416,36 @@ public class FileHistoryCacheTest {
                 "13:e55a793086da",
                 new Date(1245447973L / 60 * 60 * 1000), // whole minutes only
                 "xyz",
-                null,
                 "Do something else",
                 true);
         HistoryEntry e1 = new HistoryEntry(
                 "12:97b5392fec0d",
                 new Date(1393515253L / 60 * 60 * 1000), // whole minutes only
                 "Vladimir Kotal <Vladimir.Kotal@oracle.com>",
-                null,
                 "rename2",
                 true);
         HistoryEntry e2 = new HistoryEntry(
                 "11:5c203a0bc12b",
                 new Date(1393515291L / 60 * 60 * 1000), // whole minutes only
                 "Vladimir Kotal <Vladimir.Kotal@oracle.com>",
-                null,
                 "rename1",
                 true);
         HistoryEntry e3 = new HistoryEntry(
                 "10:1e392ef0b0ed",
                 new Date(1245446973L / 60 * 60 * 1000), // whole minutes only
                 "xyz",
-                null,
                 "Return failure when executed with no arguments",
                 true);
         HistoryEntry e4 = new HistoryEntry(
                 "2:585a1b3f2efb",
                 new Date(1218571989L / 60 * 60 * 1000), // whole minutes only
                 "Trond Norbye <trond.norbye@sun.com>",
-                "start_of_novel",
                 "Add lint make target and fix lint warnings",
                 true);
         HistoryEntry e5 = new HistoryEntry(
                 "1:f24a5fd7a85d",
                 new Date(1218571413L / 60 * 60 * 1000), // whole minutes only
                 "Trond Norbye <trond.norbye@sun.com>",
-                null,
                 "Created a small dummy program",
                 true);
 
@@ -480,7 +472,7 @@ public class FileHistoryCacheTest {
         HistoryEntry e6 = new HistoryEntry(
                 "14:55c41cd4b348",
                 new Date(1489505558L / 60 * 60 * 1000), // whole minutes only
-                "Vladimir Kotal <Vladimir.Kotal@oracle.com>", null, "rename + cstyle",
+                "Vladimir Kotal <Vladimir.Kotal@oracle.com>", "rename + cstyle",
                 true);
         entriesConstruct = new LinkedList<>();
         entriesConstruct.add(e6);
@@ -560,56 +552,48 @@ public class FileHistoryCacheTest {
                 "15:709c7a27f9fa",
                 new Date(1489160275L / 60 * 60 * 1000), // whole minutes only
                 "Vladimir Kotal <Vladimir.Kotal@oracle.com>",
-                null,
                 "novels are so last century. Let's write a blog !",
                 true);
         HistoryEntry e1 = new HistoryEntry(
                 "10:c4518ca0c841",
                 new Date(1415483555L / 60 * 60 * 1000), // whole minutes only
                 "Vladimir Kotal <Vladimir.Kotal@oracle.com>",
-                null,
                 "branched",
                 true);
         HistoryEntry e2 = new HistoryEntry(
                 "8:6a8c423f5624",
                 new Date(1362586899L / 60 * 60 * 1000), // whole minutes only
                 "Vladimir Kotal <vlada@devnull.cz>",
-                null,
                 "first words of the novel",
                 true);
         HistoryEntry e3 = new HistoryEntry(
                 "7:db1394c05268",
                 new Date(1362586862L / 60 * 60 * 1000), // whole minutes only
                 "Vladimir Kotal <vlada@devnull.cz>",
-                "start_of_novel",
                 "book sounds too boring, let's do a novel !",
                 true);
         HistoryEntry e4 = new HistoryEntry(
                 "6:e386b51ddbcc",
                 new Date(1362586839L / 60 * 60 * 1000), // whole minutes only
                 "Vladimir Kotal <vlada@devnull.cz>",
-                null,
                 "stub of chapter 1",
                 true);
         HistoryEntry e5 = new HistoryEntry(
                 "5:8706402863c6",
                 new Date(1362586805L / 60 * 60 * 1000), // whole minutes only
                 "Vladimir Kotal <vlada@devnull.cz>",
-                null,
                 "I decided to actually start writing a book based on the first plaintext file.",
                 true);
         HistoryEntry e6 = new HistoryEntry(
                 "4:e494d67af12f",
                 new Date(1362586747L / 60 * 60 * 1000), // whole minutes only
                 "Vladimir Kotal <vlada@devnull.cz>",
-                null,
                 "first change",
                 true);
         HistoryEntry e7 = new HistoryEntry(
                 "3:2058725c1470",
                 new Date(1362586483L / 60 * 60 * 1000), // whole minutes only
                 "Vladimir Kotal <vlada@devnull.cz>",
-                null,
                 "initial checking of text files",
                 true);
 
@@ -658,21 +642,18 @@ public class FileHistoryCacheTest {
                 "10",
                 DateUtils.parseDate("2020-03-28T07:24:43.921Z", SVN_DATE_FORMAT),
                 "RichardH",
-                null,
                 "Rename FileA to FileZ and FileB to FileX in a single commit",
                 true);
         HistoryEntry e1 = new HistoryEntry(
                 "7",
                 DateUtils.parseDate("2020-03-28T07:21:55.273Z", SVN_DATE_FORMAT),
                 "RichardH",
-                null,
                 "Amend file A",
                 true);
         HistoryEntry e2 = new HistoryEntry(
                 "6",
                 DateUtils.parseDate("2020-03-28T07:21:05.888Z", SVN_DATE_FORMAT),
                 "RichardH",
-                null,
                 "Add file A",
                 true);
 
@@ -790,28 +771,24 @@ public class FileHistoryCacheTest {
                 "5",
                 DateUtils.parseDate("2020-03-28T07:20:11.821Z", SVN_DATE_FORMAT),
                 "RichardH",
-                null,
                 "Moved file to subfolder and renamed",
                 true);
         HistoryEntry e1 = new HistoryEntry(
                 "3",
                 DateUtils.parseDate("2020-03-28T07:19:03.145Z", SVN_DATE_FORMAT),
                 "RichardH",
-                null,
                 "Edited content",
                 true);
         HistoryEntry e2 = new HistoryEntry(
                 "2",
                 DateUtils.parseDate("2020-03-28T07:18:29.481Z", SVN_DATE_FORMAT),
                 "RichardH",
-                null,
                 "Rename file",
                 true);
         HistoryEntry e3 = new HistoryEntry(
                 "1",
                 DateUtils.parseDate("2020-03-28T07:17:54.756Z", SVN_DATE_FORMAT),
                 "RichardH",
-                null,
                 "Add initial file",
                 true);
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -218,13 +218,15 @@ public class FileHistoryCacheTest {
         assertEquals(3, entries.size(), "Unexpected number of entries for main.c");
         HistoryEntry e0 = entries.get(0);
         assertEquals("13:3d386f6bd848", e0.getRevision(), "Unexpected revision for entry 0");
-        // TODO assertEquals("tag3", e0.getTags(), "Invalid tag list for revision 13");
+        assertEquals("tag3", retrievedHistoryMainC.getTags().get(e0.getRevision()),
+                "Invalid tag list for revision 13");
         HistoryEntry e1 = entries.get(1);
         assertEquals("2:585a1b3f2efb", e1.getRevision(), "Unexpected revision for entry 1");
-        // TODO assertEquals("tag2, tag1, start_of_novel", e1.getTags(), "Invalid tag list for revision 2");
+        assertEquals("tag2, tag1, start_of_novel", retrievedHistoryMainC.getTags().get(e1.getRevision()),
+                "Invalid tag list for revision 2");
         HistoryEntry e2 = entries.get(2);
         assertEquals("1:f24a5fd7a85d", e2.getRevision(), "Unexpected revision for entry 2");
-        // TODO assertNull(e2.getTags(), "Invalid tag list for revision 1");
+        assertNull(retrievedHistoryMainC.getTags().get(e2.getRevision()), "Invalid tag list for revision 1");
 
         // Reindex from scratch.
         File dir = new File(cache.getRepositoryHistDataDirname(repo));

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -45,7 +45,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.apache.commons.lang3.time.DateUtils;
 import org.eclipse.jgit.api.Git;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -44,6 +44,8 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import org.apache.commons.lang3.time.DateUtils;
 import org.eclipse.jgit.api.Git;
@@ -242,15 +244,15 @@ public class FileHistoryCacheTest {
                 updatedHistoryFromScratch.getHistoryEntries().size(),
                 "Unexpected number of history entries");
 
-        // Verify that the result for the directory is the same as incremental
-        // reindex.
+        // Verify that the result for the directory is the same as incremental reindex.
         assertSameEntries(updatedHistory.getHistoryEntries(),
                 updatedHistoryFromScratch.getHistoryEntries(), true);
         // Do the same for main.c.
         History retrievedUpdatedHistoryMainC = cache.get(main, repo, true);
         assertSameEntries(retrievedHistoryMainC.getHistoryEntries(),
                 retrievedUpdatedHistoryMainC.getHistoryEntries(), false);
-        // TODO: check tags
+        assertEquals(Map.of("13:3d386f6bd848", "tag3", "2:585a1b3f2efb", "tag2, tag1, start_of_novel"),
+                retrievedUpdatedHistoryMainC.getTags());
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryEntryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryEntryTest.java
@@ -55,7 +55,7 @@ public class HistoryEntryTest {
     @BeforeEach
     public void setUp() {
         instance = new HistoryEntry(historyRevision, historyDate,
-            historyAuthor, null, historyMessage, true);
+            historyAuthor, historyMessage, true);
     }
 
     @AfterEach
@@ -245,10 +245,8 @@ public class HistoryEntryTest {
         files.add("file1.file");
         files.add("file2.file");
         instance.setFiles(files);
-        instance.setTags("test tag");
         instance.strip();
         assertEquals(0, instance.getFiles().size());
-        assertNull(instance.getTags());
     }
 
     @Test
@@ -268,7 +266,7 @@ public class HistoryEntryTest {
     @Test
     public void testEquals() {
         HistoryEntry e = new HistoryEntry(historyRevision, historyDate,
-                historyAuthor, null, historyMessage, true);
+                historyAuthor, historyMessage, true);
         assertNotSame(e, instance);
         assertEquals(e, instance);
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryTest.java
@@ -72,9 +72,9 @@ public class HistoryTest {
         History history = new History();
         HistoryEntry historyEntry = entries.get(0);
         history.addTags(historyEntry, "foo");
-        assertEquals(history.getTags().get(historyEntry.getRevision()), "foo");
+        assertEquals("foo", history.getTags().get(historyEntry.getRevision()));
         history.addTags(historyEntry, "bar");
-        assertEquals(history.getTags().get(historyEntry.getRevision()), "foo" + History.TAGS_SEPARATOR + "bar");
+        assertEquals("foo" + History.TAGS_SEPARATOR + "bar", history.getTags().get(historyEntry.getRevision()));
     }
 
     @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryTest.java
@@ -28,10 +28,14 @@ import java.io.File;
 import java.nio.file.Paths;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HistoryTest {
     private final List<HistoryEntry> entries = List.of(
@@ -61,5 +65,54 @@ public class HistoryTest {
         History historySmaller = new History(entries.subList(1, 2));
         assertEquals(1, historySmaller.getHistoryEntries().size());
         assertNotEquals(history, historySmaller);
+    }
+
+    @Test
+    void testAddTags() {
+        History history = new History();
+        HistoryEntry historyEntry = entries.get(0);
+        history.addTags(historyEntry, "foo");
+        assertEquals(history.getTags().get(historyEntry.getRevision()), "foo");
+        history.addTags(historyEntry, "bar");
+        assertEquals(history.getTags().get(historyEntry.getRevision()), "foo" + History.TAGS_SEPARATOR + "bar");
+    }
+
+    @Test
+    void testGetSetTags() {
+        History history = new History();
+        assertTrue(history.getTags().isEmpty());
+        Map<String, String> tags = new TreeMap<>();
+        tags.put("foo", "bar");
+        tags.put("bar", "foo");
+        history.setTags(tags);
+        assertFalse(history.getTags().isEmpty());
+        assertEquals(tags, history.getTags());
+    }
+
+    @Test
+    void testEqualsTagsEmpty() {
+        History history1 = new History();
+        History history2 = new History();
+        assertTrue(history1.getTags().isEmpty());
+        assertTrue(history2.getTags().isEmpty());
+        assertEquals(history1, history2);
+    }
+
+    @Test
+    void testEqualsTagsPositive() {
+        History history1 = new History();
+        History history2 = new History();
+        history1.setTags(Map.of("foo", "bar", "bar", "foo"));
+        history2.setTags(Map.of("foo", "bar", "bar", "foo"));
+        assertEquals(history1, history2);
+    }
+
+    @Test
+    void testEqualsTagsNegative() {
+        History history1 = new History();
+        History history2 = new History();
+        history1.setTags(Map.of("foo", "bar", "Bar", "foo"));
+        history2.setTags(Map.of("foo", "bar", "bar", "foo"));
+        assertNotEquals(history1, history2);
     }
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/HistoryController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/HistoryController.java
@@ -79,7 +79,7 @@ public final class HistoryController {
             this.revision = entry.getRevision();
             this.date = entry.getDate();
             this.author = entry.getAuthor();
-            this.tags = entry.getTags();
+            // TODO this.tags = entry.getTags();
             this.message = entry.getMessage();
             this.files = entry.getFiles();
         }

--- a/opengrok-web/src/main/webapp/history.jsp
+++ b/opengrok-web/src/main/webapp/history.jsp
@@ -256,7 +256,7 @@ document.domReady.push(function() {domReadyHistory();});
                 if (rev == null || rev.length() == 0) {
                     rev = "";
                 }
-                String tags = entry.getTags();
+                String tags = hist.getTags().get(rev);
 
                 if (tags != null) {
 			int colspan;

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -133,7 +133,7 @@ public class HistoryControllerTest extends OGKJerseyTest {
         assertEquals("Kryštof Tulinger <krystof.tulinger@oracle.com>", history.getEntries().get(0).getAuthor());
 
         History repoHistory = HistoryGuru.getInstance().getHistory(new File(repository.getSourceRoot(), path));
-        assertEquals(history, getHistoryDTO(repoHistory.getHistoryEntries(size, start),
+        assertEquals(history, getHistoryDTO(repoHistory.getHistoryEntries(size, start), repoHistory.getTags(),
                 start, size, repoHistory.getHistoryEntries().size()));
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -101,7 +101,6 @@ public class HistoryControllerTest extends OGKJerseyTest {
                 "1",
                 new Date(1245446973L / 60 * 60 * 1000),
                 "xyz",
-                null,
                 "foo",
                 true);
         HistoryEntryDTO entry1 = new HistoryEntryDTO(historyEntry);


### PR DESCRIPTION
This change parallelizes the creation of file history cache for individual files, mimicking what is already done for renamed files.

On my laptop with i7-8665U (4 cores) and built in SSD I am seeing some decent speedup (6 vs 9 minutes) when creating history cache for the OpenSSL Git repository (renamed files on, merge commits on).

There is some potential for further speedup - the directories are still created sequentially and the process should avoid duplications.