### PR TITLE
reintroduce setTags() in HistoryEntry

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
@@ -181,7 +181,9 @@ public class HistoryEntry implements Serializable {
     /**
      * The method is kept only for backward compatibility to avoid warnings when deserializing objects
      * from the previous format. The tags were moved to the {@link History} class.
+     * Will be removed sometime after the OpenGrok 1.8.0 version.
      */
+    @Deprecated
     public void setTags(String tags) {
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
@@ -183,7 +183,7 @@ public class HistoryEntry implements Serializable {
      * from the previous format. The tags were moved to the {@link History} class.
      * Will be removed sometime after the OpenGrok 1.8.0 version.
      */
-    @Deprecated(since = "1.7.11")
+    @Deprecated(since = "1.7.11", forRemoval = true)
     public void setTags(String tags) {
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
@@ -183,7 +183,7 @@ public class HistoryEntry implements Serializable {
      * from the previous format. The tags were moved to the {@link History} class.
      * Will be removed sometime after the OpenGrok 1.8.0 version.
      */
-    @Deprecated
+    @Deprecated(since = "1.7.11")
     public void setTags(String tags) {
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
@@ -178,6 +178,13 @@ public class HistoryEntry implements Serializable {
         this.files = files;
     }
 
+    /**
+     * The method is kept only for backward compatibility to avoid warnings when deserializing objects
+     * from the previous format. The tags were moved to the {@link History} class.
+     */
+    public void setTags(String tags) {
+    }
+
     @Override
     public String toString() {
         return String.join(" ",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
@@ -179,8 +179,9 @@ public class HistoryEntry implements Serializable {
     }
 
     /**
-     * The method is kept only for backward compatibility to avoid warnings when deserializing objects
-     * from the previous format. The tags were moved to the {@link History} class.
+     * @deprecated The method is kept only for backward compatibility to avoid warnings when deserializing objects
+     * from the previous format.
+     * The tags were moved to the {@link History} class.
      * Will be removed sometime after the OpenGrok 1.8.0 version.
      */
     @Deprecated(since = "1.7.11", forRemoval = true)


### PR DESCRIPTION
This is another follow up change to #3636. The removal of tags in `HistoryEntry` does not cause a functional problem with old history cache however produces warning messages when deserializing these objects as visible in  `FileHistoryCacheTest#testReadCacheValid()`:
```
java.lang.NoSuchMethodException: <unbound>=HistoryEntry.setTags("1.6.4, 1.6.3, 1.6.2, 1.6.1, 1.6.0");
Continuing ...
...
```