### PR TITLE
Add user-specific settings page

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/Scripts.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/Scripts.java
@@ -114,7 +114,7 @@ public class Scripts implements Iterable<Scripts.Script> {
         putFromWebJar("jquery-tablesorter", "jquery.tablesorter.min.js", 12);
         putjs("tablesorter-parsers", "js/tablesorter-parsers-0.0.3", 13, true);
         putjs("searchable-option-list", "js/searchable-option-list-2.0.14", 14);
-        putjs("utils", "js/utils-0.0.40", 15, true);
+        putjs("utils", "js/utils-0.0.41", 15, true);
         putjs("repos", "js/repos-0.0.3", 20, true);
         putjs("diff", "js/diff-0.0.5", 20, true);
         putjs("jquery-caret", "js/jquery.caret-1.5.2", 25);

--- a/opengrok-web/src/main/webapp/default/style-1.0.3.css
+++ b/opengrok-web/src/main/webapp/default/style-1.0.3.css
@@ -1351,3 +1351,17 @@ td#typeLabelTd {
 .ui-autocomplete-loading {
     background:url('img/indicator.gif') no-repeat right center;
 }
+
+/** --------------- settings -------------------- */
+
+.local-setting {
+    background-color: inherit;
+}
+
+.header-half-bottom-margin {
+    margin-bottom: 0.5rem;
+}
+
+.no-margin-left {
+    margin-left: 0;
+}

--- a/opengrok-web/src/main/webapp/httpheader.jspf
+++ b/opengrok-web/src/main/webapp/httpheader.jspf
@@ -45,7 +45,7 @@ org.opengrok.web.Scripts"
     PageConfig cfg = PageConfig.get(request);
     String styleDir = cfg.getCssDir();
     String ctxPath = request.getContextPath();
-    String dstyle = styleDir + '/' + "style-1.0.2.min.css";
+    String dstyle = styleDir + '/' + "style-1.0.3.min.css";
     String pstyle = styleDir + '/' + "print-1.0.1.min.css";
     String mstyle = styleDir + '/' + "mandoc-1.0.0.min.css";
 %><!DOCTYPE html>

--- a/opengrok-web/src/main/webapp/js/utils-0.0.41.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.41.js
@@ -2426,10 +2426,19 @@ function resetAllSettings() {
  * @param el settings {@code input} element
  */
 function setDefaultSettingsValue(el) {
+    setSettingsInputValue(el, el.dataset.defaultValue);
+}
+
+/**
+ * Sets the settings {@code input} element value to the provided one.
+ * @param el element to change
+ * @param value value to set
+ */
+function setSettingsInputValue(el, value) {
     if (el.type === 'checkbox') {
-        el.checked = el.dataset.defaultValue === el.dataset.checkedValue;
+        el.checked = el.dataset.checkedValue === value;
     } else {
-        el.value = el.dataset.defaultValue;
+        el.value = value;
     }
 }
 
@@ -2440,11 +2449,7 @@ function initSettings() {
     for (const el of document.getElementsByClassName('local-setting')) {
         const value = getSettingsValue(el.name);
         if (value) {
-            if (el.type === 'checkbox') {
-                el.checked = el.dataset.checkedValue === value;
-            } else {
-                el.value = value;
-            }
+            setSettingsInputValue(el, value);
         } else {
             setDefaultSettingsValue(el);
         }

--- a/opengrok-web/src/main/webapp/js/utils-0.0.41.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.41.js
@@ -1700,8 +1700,7 @@ function pageReadyMast() {
 }
 
 function domReadyMenu(minisearch) {
-    if (getCookie('OpenGrokSuggester.enabled') === 'false') {
-        console.log('Suggester disabled by a cookie');
+    if (getSettingsValue('suggester-enabled') === 'false') {
         return;
     }
 
@@ -2378,22 +2377,76 @@ function escapeHtml(string) { // taken from https://stackoverflow.com/questions/
 }
 
 /**
- * Taken from https://www.w3schools.com/js/js_cookies.asp .
- * @param cname cookie name to retrieve
- * @returns {string} cookie value
+ * Returns user-specific local settings for a provided key.
+ * @param key settings key
+ * @returns {string} settings value or {@code undefined} if not set
  */
-function getCookie(cname) {
-    const name = cname + "=";
-    const decodedCookie = decodeURIComponent(document.cookie);
-    const ca = decodedCookie.split(';');
-    for (let i = 0; i < ca.length; i++) {
-        let c = ca[i];
-        while (c.charAt(0) == ' ') {
-            c = c.substring(1);
+function getSettingsValue(key) {
+    return localStorage.getItem(key);
+}
+
+/**
+ * Event listener which stores user-specific settings change for an {@code input} element.
+ * @param el settings {@code input} element
+ */
+function onSettingsValueChange(el) {
+    let value = getSettingsInputValue(el);
+    localStorage.setItem(el.name, value);
+}
+
+/**
+ * Decodes a settings value from a settings {@code input} element.
+ * @param el settings {@code input} element
+ * @returns {string|*} settings value
+ */
+function getSettingsInputValue(el) {
+    if (el.type === 'checkbox') {
+        if (el.checked) {
+            return el.dataset.checkedValue;
+        } else {
+            return el.dataset.uncheckedValue;
         }
-        if (c.indexOf(name) === 0) {
-            return c.substring(name.length, c.length);
+    } else {
+        return el.value;
+    }
+}
+
+/**
+ * Resets all settings elements with class {@code local-setting} to their default values.
+ */
+function resetAllSettings() {
+    for (const el of document.getElementsByClassName('local-setting')) {
+        setDefaultSettingsValue(el);
+        onSettingsValueChange(el);
+    }
+}
+
+/**
+ * Sets a default value for a settings {@code input} element.
+ * @param el settings {@code input} element
+ */
+function setDefaultSettingsValue(el) {
+    if (el.type === 'checkbox') {
+        el.checked = el.dataset.defaultValue === el.dataset.checkedValue;
+    } else {
+        el.value = el.dataset.defaultValue;
+    }
+}
+
+/**
+ * Initializes all settings elements with {@code local-setting} class.
+ */
+function initSettings() {
+    for (const el of document.getElementsByClassName('local-setting')) {
+        const value = getSettingsValue(el.name);
+        if (value) {
+            if (el.type === 'checkbox') {
+                el.checked = el.dataset.checkedValue === value;
+            } else {
+                el.value = value;
+            }
+        } else {
+            setDefaultSettingsValue(el);
         }
     }
-    return "";
 }

--- a/opengrok-web/src/main/webapp/menu.jspf
+++ b/opengrok-web/src/main/webapp/menu.jspf
@@ -222,6 +222,8 @@ document.domReady.push(function() { domReadyMenu(); });
            type="button" value="Clear"/>
     <input tabindex="11" class="submit btn" onclick="window.open('help.jsp', '_blank');"
            type="button" value="Help"/>
+    <input tabindex="12" class="submit btn" onclick="window.open('settings.jsp', '_self');"
+           type="button" value="Settings"/>
 </div>
 </div>
 <div id="ltbl">

--- a/opengrok-web/src/main/webapp/settings.jsp
+++ b/opengrok-web/src/main/webapp/settings.jsp
@@ -1,0 +1,64 @@
+<%--
+CDDL HEADER START
+
+The contents of this file are subject to the terms of the
+Common Development and Distribution License (the "License").
+You may not use this file except in compliance with the License.
+
+See LICENSE.txt included in this distribution for the specific
+language governing permissions and limitations under the License.
+
+When distributing Covered Code, include this CDDL HEADER in each
+file and include the License file at LICENSE.txt.
+If applicable, add the following below this CDDL HEADER, with the
+fields enclosed by brackets "[]" replaced with your own identifying
+information: Portions Copyright [yyyy] [name of copyright owner]
+
+CDDL HEADER END
+
+Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+--%>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@page session="false" errorPage="error.jsp" import="org.opengrok.web.PageConfig" %>
+<%@ page import="org.opengrok.indexer.configuration.RuntimeEnvironment" %>
+<%
+    {
+        PageConfig cfg = PageConfig.get(request);
+        cfg.setTitle("OpenGrok Settings");
+    }
+%>
+<%@ include file="httpheader.jspf" %>
+<body>
+<div id="page">
+    <div id="whole_header">
+        <div id="header">
+            <%@include file="pageheader.jspf" %>
+        </div>
+        <div id="Masthead">
+            <a href="<%= request.getContextPath() %>/"><span id="home"></span>Home</a>
+        </div>
+    </div>
+    <div id="sbar"></div>
+    <div style="padding-left: 1rem;">
+        <h1>Settings</h1>
+        <h3 class="header-half-bottom-margin">Suggester</h3>
+        <%
+            boolean suggesterEnabled = RuntimeEnvironment.getInstance().getSuggesterConfig().isEnabled();
+        %>
+        <label>Enabled
+            <input class="local-setting" name="suggester-enabled" type="checkbox" data-checked-value="true"
+                   data-unchecked-value="false" data-default-value="<%= suggesterEnabled ? "true" : "false" %>"
+                   <%= suggesterEnabled ? "" : "disabled" %>
+                   onchange="onSettingsValueChange(this)">
+        </label>
+        <br>
+        <br>
+        <input class="submit btn no-margin-left" onclick="resetAllSettings()" type="button" value="Reset to defaults"/>
+    </div>
+</div>
+<script type="text/javascript">
+    /* <![CDATA[ */
+    document.pageReady.push(() => initSettings());
+    /* ]]> */
+</script>
+<%@include file="foot.jspf" %>


### PR DESCRIPTION
![Screen Shot 2021-06-19 at 12 31 45](https://user-images.githubusercontent.com/12401160/122649460-f6becc00-d0fb-11eb-9a52-42ef64829dfb.png)

This is an attempt to introduce user settings page which would allow every user to slightly modify their OpenGrok experience in a nicer way (i.e. not using cookies). It uses local storage to store the values which should be persisted for a long time unless user explicitly clears them.

This change just introduces suggester enabled/disabled checkbox and is meant to be a founding stone for more things like:
- suggester configuration (show projects, speed time, number of results, min chars, ...)
- font type or size
- line spacing
- color themes
- default project
- ...

https://github.com/oracle/opengrok/wiki/Cookies will need to be modified.

Tested in Chrome and Safari.

Thanks!

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
