### PR TITLE
bump history cache chunk counts and make it tunable

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -308,6 +308,8 @@ public final class Configuration {
     private String indexerAuthenticationToken;
     private boolean allowInsecureTokens;
 
+    private int historyChunkCount;
+
     /*
      * types of handling history for remote SCM repositories:
      *  ON - index history and display it in webapp
@@ -1373,6 +1375,14 @@ public final class Configuration {
 
     public void setAllowInsecureTokens(boolean value) {
         this.allowInsecureTokens = value;
+    }
+
+    public int getHistoryChunkCount() {
+        return historyChunkCount;
+    }
+
+    public void setHistoryChunkCount(int historyChunkCount) {
+        this.historyChunkCount = historyChunkCount;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1360,6 +1360,14 @@ public final class RuntimeEnvironment {
         return syncReadConfiguration(Configuration::getContextSurround);
     }
 
+    public int getHistoryChunkCount() {
+        return syncReadConfiguration(Configuration::getHistoryChunkCount);
+    }
+
+    public void setHistoryChunkCount(int chunkCount) {
+        syncWriteConfiguration(chunkCount, Configuration::setHistoryChunkCount);
+    }
+
     public Set<String> getDisabledRepositories() {
         return syncReadConfiguration(Configuration::getDisabledRepositories);
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
@@ -22,6 +22,7 @@
  */
 package org.opengrok.indexer.history;
 
+import org.jetbrains.annotations.TestOnly;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.Statistics;
@@ -66,6 +67,11 @@ public class BoundaryChangesets {
     private void reset() {
         cnt = 0;
         result.clear();
+    }
+
+    @TestOnly
+    int getMaxCount() {
+        return maxCount;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
@@ -22,6 +22,7 @@
  */
 package org.opengrok.indexer.history;
 
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.Statistics;
 
@@ -47,11 +48,19 @@ public class BoundaryChangesets {
 
     public BoundaryChangesets(RepositoryWithPerPartesHistory repository) {
         this.repository = repository;
-        this.maxCount = repository.getPerPartesCount();
+
+        int globalPerPartesCount = RuntimeEnvironment.getInstance().getHistoryChunkCount();
+        if (globalPerPartesCount > 0) {
+            this.maxCount = globalPerPartesCount;
+        } else {
+            this.maxCount = repository.getPerPartesCount();
+        }
         if (maxCount <= 1) {
             throw new RuntimeException(String.format("per partes count for repository ''%s'' " +
                     "must be stricly greater than 1", repository.getDirectoryName()));
         }
+        LOGGER.log(Level.FINER, "using history cache chunks with {0} entries for repository {1}",
+                new Object[]{this.maxCount, repository});
     }
 
     private void reset() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -100,7 +100,7 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
     private static final long serialVersionUID = -6126297612958508386L;
 
     public static final int GIT_ABBREV_LEN = 8;
-    public static final int MAX_CHANGESETS = 512;
+    public static final int MAX_CHANGESETS = 65536;
 
     public GitRepository() {
         type = "git";

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -58,7 +58,7 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
 
     private static final long serialVersionUID = 1L;
 
-    public static final int MAX_CHANGESETS = 256;
+    public static final int MAX_CHANGESETS = 131072;
 
     /**
      * The property name used to obtain the client command for this repository.

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BoundaryChangesetsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BoundaryChangesetsTest.java
@@ -25,18 +25,22 @@ package org.opengrok.indexer.history;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.TestRepository;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -72,6 +76,16 @@ public class BoundaryChangesetsTest {
         GitRepository gitSpyRepository = Mockito.spy(gitRepository);
         Mockito.when(gitSpyRepository.getPerPartesCount()).thenReturn(maxCount);
         assertThrows(RuntimeException.class, () -> new BoundaryChangesets(gitSpyRepository));
+    }
+
+    @Test
+    void testMaxCountConfiguration() {
+        int maxCount = 42 * new Random().nextInt(100) + 1;
+        assertNotEquals(0, maxCount);
+        RuntimeEnvironment.getInstance().setHistoryChunkCount(maxCount);
+        GitRepository gitSpyRepository = Mockito.spy(gitRepository);
+        assertEquals(maxCount, new BoundaryChangesets(gitSpyRepository).getMaxCount());
+        RuntimeEnvironment.getInstance().setHistoryChunkCount(0);
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BoundaryChangesetsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BoundaryChangesetsTest.java
@@ -80,7 +80,7 @@ public class BoundaryChangesetsTest {
 
     @Test
     void testMaxCountConfiguration() {
-        int maxCount = 42 * new Random().nextInt(100) + 1;
+        int maxCount = (RuntimeEnvironment.getInstance().getHistoryChunkCount() + 1) * 2;
         assertNotEquals(0, maxCount);
         RuntimeEnvironment.getInstance().setHistoryChunkCount(maxCount);
         int actualCount = new BoundaryChangesets(gitRepository).getMaxCount();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BoundaryChangesetsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BoundaryChangesetsTest.java
@@ -36,7 +36,6 @@ import org.opengrok.indexer.util.TestRepository;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BoundaryChangesetsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/BoundaryChangesetsTest.java
@@ -83,9 +83,9 @@ public class BoundaryChangesetsTest {
         int maxCount = 42 * new Random().nextInt(100) + 1;
         assertNotEquals(0, maxCount);
         RuntimeEnvironment.getInstance().setHistoryChunkCount(maxCount);
-        GitRepository gitSpyRepository = Mockito.spy(gitRepository);
-        assertEquals(maxCount, new BoundaryChangesets(gitSpyRepository).getMaxCount());
+        int actualCount = new BoundaryChangesets(gitRepository).getMaxCount();
         RuntimeEnvironment.getInstance().setHistoryChunkCount(0);
+        assertEquals(maxCount, actualCount);
     }
 
     /**


### PR DESCRIPTION
This change increases the default counts of changesets in history cache chunks. In general this is hard to get right because this is inherently dependent on the input data (i.e. the resitories being indexed) and because of nested parallelism - both the history cache for repositories and individual files for each repository are processed in parallel. Also, by default the thread pool sizes for these parallelisms depend on the number of CPUs; the more CPUs, the more memory will be consumed. (maybe there is a way to flatten this using similar concept as `IndexerParallelizer` for the 2nd phase of indexing ? That would require some pre-processing such as creating the history cache directories.)

Lastly, this depends on the heap size available. The baseline I used is 8 GB however some users might want to push this down at the cost of slower history cache creation/refresh, hence the new `historyChunkCount` tunable (that overrides all repositories - I did not want to add per project tunable as this would be too big hammer and introducing per repository type tunable would take longer as the concept is not there yet). So, this is sort of a band aid until someone comes with some cool formula to compute the chunk size that would be based on the number of CPUs, number of indexed projects and available heap (still making assumptions about the input data) and/or flatten the history cache parallelism.

For the measurement I used AMD based OCI shape with 8 OCPUs (16 processors reported in `/proc/cpuinfo`) and 48 GB RAM, setting the indexer to use 8 GB heap:
```
/usr/bin/time -o /dev/stdout --format '%e' java -Xmx8g -classpath 'distribution/target/dist/*' \
    org.opengrok.indexer.index.Indexer -s $HOME/opengrok/src -d $HOME/opengrok/data -c /usr/local/bin/ctags \
    -H -S -P -c /usr/bin/ctags -R ~/opengrok/etc/ro.xml
```
The read-only configuration contained just StatsD export variables. The source root contained fresh checkout of the Linux Git repository. Since this is using otherwise default configuration, merge commits and renamed files are disabled.

The times in seconds to create history cache (I modified `Indexer.java` to exit after `prepareIndexer()`):

```
8192	1814.90
16384	1456.70
32768	1086.02
65536	813.16
131072	633.39
262144	518.22
524288	445.40
```

This is how it looked like:

![linux-chunks](https://user-images.githubusercontent.com/2934284/123127205-57c30880-d44a-11eb-8b3c-7680b537ceb1.png)

The blue annotation triangles at the bottom of the JVM graph correspond to the chunk sizes above.

Obviously, this is just one repository. Indexing multiple Linux repositories at once would probably need more heap or smaller chunk size or both. That's why I decided to leave the defaults low.

I left the Mercurial chunk count higher (the number being arbitrary) because the processing is done by external command (as opposed to JGit), assuming it consumes less heap.

The new tunable and the 8 GB heap assumption should be documented in respective wiki pages after this goes in.