### PR TITLE
check None from get_configuration()

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -244,8 +244,11 @@ def save_config(logger, uri, config_path):
     :param config_path: file path
     """
 
-    logger.info('Saving configuration to {}'.format(config_path))
     config = get_configuration(logger, uri)
+    if config is None:
+        return
+
+    logger.info('Saving configuration to {}'.format(config_path))
     with open(config_path, "w+") as config_file:
         config_file.write(config)
 

--- a/tools/src/main/python/opengrok_tools/reindex_project.py
+++ b/tools/src/main/python/opengrok_tools/reindex_project.py
@@ -63,6 +63,7 @@ def get_logprop_file(logger, template, pattern, project):
 def get_config_file(logger, uri, headers=None, timeout=None):
     """
     Get fresh configuration from the webapp and store it in temporary file.
+    Return file name on success, None on failure.
     """
     config = get_configuration(logger, uri, headers=headers, timeout=timeout)
     if config is None:


### PR DESCRIPTION
Fixes this problem:
```
24-Jun-2021 13:27:17.091 INFO [Thread-11] org.apache.coyote.AbstractProtocol.stop Stopping ProtocolHandler ["http-nio-8080"]
24-Jun-2021 13:27:17.158 INFO [Thread-11] org.apache.coyote.AbstractProtocol.destroy Destroying ProtocolHandler ["http-nio-8080"]
could not get configuration from web application on http://localhost:8080/
Exception in thread Sync thread:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/scripts/start.py", line 350, in project_syncer
    save_config(logger, uri, config_path)
  File "/scripts/start.py", line 250, in save_config
    config_file.write(config)
TypeError: write() argument must be str, not None
```
Seems to be caused by the sync running at the time Tomcat was going down. Noticed on the demo instance.