### PR TITLE
Fix suggester display of hiragana terms

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/Scripts.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/Scripts.java
@@ -114,7 +114,7 @@ public class Scripts implements Iterable<Scripts.Script> {
         putFromWebJar("jquery-tablesorter", "jquery.tablesorter.min.js", 12);
         putjs("tablesorter-parsers", "js/tablesorter-parsers-0.0.3", 13, true);
         putjs("searchable-option-list", "js/searchable-option-list-2.0.14", 14);
-        putjs("utils", "js/utils-0.0.41", 15, true);
+        putjs("utils", "js/utils-0.0.42", 15, true);
         putjs("repos", "js/repos-0.0.3", 20, true);
         putjs("diff", "js/diff-0.0.5", 20, true);
         putjs("jquery-caret", "js/jquery.caret-1.5.2", 25);

--- a/opengrok-web/src/main/webapp/js/utils-0.0.42.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.42.js
@@ -1963,7 +1963,7 @@ function getSuggestionListItem(itemData, config) {
 
     $("<span>", {
         text: itemData.phrase,
-        style: "float: left; padding-left: 5px;"
+        style: "float: left; padding-left: 5px; max-height: 20px;"
     }).appendTo(listItemChild);
 
     let projectInfoText = "";


### PR DESCRIPTION
fixes #3603

Now it seems that hiragana terms work properly. I'm not sure if I made a mistake during my testing of #3603 or the new Lucene version made a difference.

This is just a quick hack to fix the suggester display. The problem was caused by hiragana characters being slightly taller than latin letters.

![Screen Shot 2021-06-26 at 16 40 26](https://user-images.githubusercontent.com/12401160/123525292-85ec5680-d69d-11eb-98bd-6337e2fa3f36.png)

Thanks!

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
