### PR TITLE
check Java version

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -81,6 +81,7 @@ import org.opengrok.indexer.logger.LoggerUtil;
 import org.opengrok.indexer.util.CtagsUtil;
 import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.HostUtil;
+import org.opengrok.indexer.util.JavaVersionUtil;
 import org.opengrok.indexer.util.OptionParser;
 import org.opengrok.indexer.util.Statistics;
 
@@ -159,6 +160,11 @@ public final class Indexer {
         Executor.registerErrorHandler();
         List<String> subFiles = RuntimeEnvironment.getInstance().getSubFiles();
         ArrayList<String> subFilesList = new ArrayList<>();
+
+        if (!JavaVersionUtil.isSupportedVersion()) {
+            System.err.println("Java version not supported: " + System.getProperty("java.version"));
+            System.exit(1);
+        }
 
         boolean createDict = false;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/JavaVersionUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/JavaVersionUtil.java
@@ -20,7 +20,6 @@
 /*
  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  */
-
 package org.opengrok.indexer.util;
 
 public class JavaVersionUtil {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/JavaVersionUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/JavaVersionUtil.java
@@ -1,0 +1,58 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+
+package org.opengrok.indexer.util;
+
+public class JavaVersionUtil {
+    private JavaVersionUtil() {
+        // private to enforce static
+    }
+
+    /**
+     * Return major numeric Java version, e.g. 11 for Java 11
+     * @return integer
+     */
+    private static int getVersion() {
+        String version = System.getProperty("java.version");
+        if (version.startsWith("1.")) {
+            // older Java versions (before 9)
+            version = String.valueOf(version.charAt(2));
+        } else {
+            // The version number could be freestanding integer.
+            int dotIndex = version.indexOf(".");
+            if (dotIndex != -1) {
+                version = version.substring(0, dotIndex);
+            }
+        }
+
+        return Integer.parseInt(version);
+    }
+
+    /**
+     * @return true if given Java version is supported, false otherwise
+     */
+    public static boolean isSupportedVersion() {
+        int version = getVersion();
+        return version <= 12 && version >= 11;
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/JavaVersionUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/JavaVersionUtil.java
@@ -32,19 +32,7 @@ public class JavaVersionUtil {
      * @return integer
      */
     private static int getVersion() {
-        String version = System.getProperty("java.version");
-        if (version.startsWith("1.")) {
-            // older Java versions (before 9)
-            version = String.valueOf(version.charAt(2));
-        } else {
-            // The version number could be freestanding integer.
-            int dotIndex = version.indexOf(".");
-            if (dotIndex != -1) {
-                version = version.substring(0, dotIndex);
-            }
-        }
-
-        return Integer.parseInt(version);
+        return Runtime.version().feature();
     }
 
     /**

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -39,6 +39,7 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.index.IndexCheck;
 import org.opengrok.indexer.index.IndexDatabase;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.JavaVersionUtil;
 import org.opengrok.indexer.web.SearchHelper;
 import org.opengrok.web.api.v1.suggester.provider.service.SuggesterServiceFactory;
 
@@ -75,7 +76,12 @@ public final class WebappListener
 
         LOGGER.log(Level.INFO, "Starting webapp with version {0} ({1})",
                     new Object[]{Info.getVersion(), Info.getRevision()});
-        
+
+        if (!JavaVersionUtil.isSupportedVersion()) {
+            LOGGER.log(Level.SEVERE, "Java version not supported: " + System.getProperty("java.version"));
+            throw new RuntimeException("unsupported Java version");
+        }
+
         String config = context.getInitParameter("CONFIGURATION");
         if (config == null) {
             throw new Error("CONFIGURATION parameter missing in the web.xml file");


### PR DESCRIPTION
This change introduces Java version check. If indexer or web app is run with Java version outside the allowed range, it is terminated. Currently allows 11 and 12. We don't really test with 12 however I wanted to give it some leeway.