### PR TITLE
add check for commands section of the mirror configuration

### DIFF
--- a/tools/src/main/python/opengrok_tools/scm/repofactory.py
+++ b/tools/src/main/python/opengrok_tools/scm/repofactory.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 #
 # Portions Copyright 2020 Robert Williams
 
@@ -32,7 +32,10 @@ from .repo import RepoRepository
 from .svn import SubversionRepository
 from .teamware import TeamwareRepository
 
-logger = logging.getLogger(__name__)
+
+# Note: these have to correspond with get_repository().
+REPO_TYPES = ["mercurial", "hg", "teamware", "sccs", "cvs",
+              "svn", "subversion", "git", "perforce", "repo"]
 
 
 def get_repository(path, repo_type, project,
@@ -48,6 +51,8 @@ def get_repository(path, repo_type, project,
     :return: a Repository derived object according to the type specified
     or None if given repository type cannot be found.
     """
+
+    logger = logging.getLogger(__name__)
 
     repo_lower = repo_type.lower()
 

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -593,19 +593,23 @@ def check_commands(commands):
 
     for name, value in commands.items():
         if type(value) is not str:
-            logger.error("value of {} is not string".format(name))
+            logger.error("value of '{}' under '{}' is not string".
+                         format(name, COMMANDS_PROPERTY))
             return False
 
         if name not in REPO_TYPES:
-            logger.error("unknown repository type: {}".format(name))
+            logger.error("unknown repository type: {} under '{}'".
+                         format(name, COMMANDS_PROPERTY))
             return False
 
         if not os.path.exists(value):
-            logger.error("path for {} does not exist: {}".format(name, value))
+            logger.error("path for '{}' under '{}' does not exist: {}".
+                         format(name, COMMANDS_PROPERTY, value))
             return False
 
         if not os.path.isfile(value):
-            logger.error("path for {} is not a file: {}".format(name, value))
+            logger.error("path for '{}' under '{}' is not a file: {}".
+                         format(name, COMMANDS_PROPERTY, value))
             return False
 
     return True

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -47,7 +47,7 @@ from opengrok_tools.utils.mirror import check_project_configuration, \
     PROJECTS_PROPERTY, DISABLED_CMD_PROPERTY, DISABLED_PROPERTY, \
     CMD_TIMEOUT_PROPERTY, HOOK_TIMEOUT_PROPERTY, DISABLED_REASON_PROPERTY, \
     INCOMING_PROPERTY, IGNORE_ERR_PROPERTY, HOOK_PRE_PROPERTY, \
-    HOOKDIR_PROPERTY, HOOK_POST_PROPERTY
+    HOOKDIR_PROPERTY, HOOK_POST_PROPERTY, COMMANDS_PROPERTY
 from opengrok_tools.utils.patterns import COMMAND_PROPERTY, PROJECT_SUBST
 
 
@@ -95,6 +95,41 @@ def test_invalid_project_config_hooknames():
     with tempfile.TemporaryDirectory() as tmpdir:
         config = {"foo": {HOOKS_PROPERTY: {"blah": "value"}}}
         assert not check_project_configuration(config, hookdir=tmpdir)
+
+
+def test_invalid_configuration_commands_dict():
+    """
+    The value of the commands property has to be a dictionary.
+    """
+    config = {COMMANDS_PROPERTY: "foo"}
+    assert not check_configuration(config)
+
+
+def test_invalid_configuration_commands_scm():
+    """
+    The names in the commands section should be match recognized SCMs.
+    """
+    config = {COMMANDS_PROPERTY: {"foo": "bar"}}
+    assert not check_configuration(config)
+
+
+def test_invalid_configuration_commands_value():
+    """
+    The values in the command section should be strings.
+    """
+    config = {COMMANDS_PROPERTY: {"git": {"foo": "bar"}}}
+    assert not check_configuration(config)
+
+
+def test_invalid_configuration_commands_exists():
+    config = {COMMANDS_PROPERTY: {"git": "/usr/nonexistent/bin/git"}}
+    assert not check_configuration(config)
+
+
+@posix_only
+def test_configuration_commands():
+    config = {COMMANDS_PROPERTY: {"git": "/usr/bin/git"}}
+    assert check_configuration(config)
 
 
 @posix_only


### PR DESCRIPTION
As discovered in https://github.com/oracle/opengrok/issues/3664#issuecomment-883564423 , the `commands` part of the `opengrok-mirror` configuration has to be checked.