### PR TITLE
detect Git submodules properly

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
@@ -58,7 +58,7 @@ public class BoundaryChangesets {
         }
         if (maxCount <= 1) {
             throw new RuntimeException(String.format("per partes count for repository ''%s'' " +
-                    "must be stricly greater than 1", repository.getDirectoryName()));
+                    "must be strictly greater than 1", repository.getDirectoryName()));
         }
         LOGGER.log(Level.FINER, "using history cache chunks with {0} entries for repository {1}",
                 new Object[]{this.maxCount, repository});

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -690,7 +690,8 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
             throw new IOException("cannot get gitDir value from " + dotGitFile);
         }
 
-        // If the gitDir value is relative path, make it absolute. This is necessary for the
+        // If the gitDir value is relative path, make it absolute.
+        // This is necessary for the JGit Repository construction.
         File gitDirFile = new File(gitDirValue);
         if (!gitDirFile.isAbsolute()) {
             gitDirFile = new File(directory, gitDirValue);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -685,8 +685,8 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
         }
 
         // Assume this is a sub-module so dotGitFile is a file.
-        String gitDirValue;
-        if ((gitDirValue = getGitDirValue(dotGitFile)) == null) {
+        String gitDirValue = getGitDirValue(dotGitFile);
+        if (gitDirValue == null) {
             throw new IOException("cannot get gitDir value from " + dotGitFile);
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -183,25 +183,25 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
     @Override
     boolean getHistoryGet(OutputStream out, String parent, String basename, String rev) {
 
-        String fullpath;
+        String fullPath;
         try {
-            fullpath = new File(parent, basename).getCanonicalPath();
+            fullPath = new File(parent, basename).getCanonicalPath();
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, e, () -> String.format(
                     "Failed to get canonical path: %s/%s", parent, basename));
             return false;
         }
 
-        HistoryRevResult result = getHistoryRev(out, fullpath, rev);
+        HistoryRevResult result = getHistoryRev(out, fullPath, rev);
         if (!result.success && result.iterations < 1) {
             /*
              * If we failed to get the contents it might be that the file was
              * renamed so we need to find its original name in that revision
              * and retry with the original name.
              */
-            String origpath;
+            String origPath;
             try {
-                origpath = findOriginalName(fullpath, rev);
+                origPath = findOriginalName(fullPath, rev);
             } catch (IOException exp) {
                 LOGGER.log(Level.SEVERE, exp, () -> String.format(
                         "Failed to get original revision: %s/%s (revision %s)",
@@ -209,16 +209,16 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
                 return false;
             }
 
-            if (origpath != null) {
+            if (origPath != null) {
                 String fullRenamedPath;
                 try {
-                    fullRenamedPath = Paths.get(getCanonicalDirectoryName(), origpath).toString();
+                    fullRenamedPath = Paths.get(getCanonicalDirectoryName(), origPath).toString();
                 } catch (IOException e) {
                     LOGGER.log(Level.WARNING, e, () -> String.format(
-                            "Failed to get canonical path: .../%s", origpath));
+                            "Failed to get canonical path: .../%s", origPath));
                     return false;
                 }
-                if (!fullRenamedPath.equals(fullpath)) {
+                if (!fullRenamedPath.equals(fullPath)) {
                     result = getHistoryRev(out, fullRenamedPath, rev);
                 }
             }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -404,7 +404,7 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
     @Override
     boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
         if (file.isDirectory()) {
-            File f = new File(file, ".git");
+            File f = new File(file, Constants.DOT_GIT);
             // No check for directory or file as submodules contain '.git' file.
             return f.exists();
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -232,13 +232,12 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
         return result.success;
     }
 
-    private String getPathRelativeToCanonicalRepositoryRoot(String fullpath)
-            throws IOException {
+    private String getPathRelativeToCanonicalRepositoryRoot(String fullPath) throws IOException {
         String repoPath = getCanonicalDirectoryName() + File.separator;
-        if (fullpath.startsWith(repoPath)) {
-            return fullpath.substring(repoPath.length());
+        if (fullPath.startsWith(repoPath)) {
+            return fullPath.substring(repoPath.length());
         }
-        return fullpath;
+        return fullPath;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -708,7 +708,7 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
                 parentAbsPath = gitDirValue.substring(0, dotGitIndex - 1);
             } else {
                 File parent = new File(directory, gitDirValue.substring(0, dotGitIndex + Constants.DOT_GIT.length()));
-                parentAbsPath = parent.getAbsolutePath();
+                parentAbsPath = parent.getCanonicalPath();
                 int indexDotGitParent = parentAbsPath.indexOf(File.separator + Constants.DOT_GIT);
                 if (indexDotGitParent == -1) {
                     return null;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -70,7 +70,6 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-import org.eclipse.jgit.submodule.SubmoduleWalk;
 import org.eclipse.jgit.treewalk.AbstractTreeIterator;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;
 import org.eclipse.jgit.treewalk.TreeWalk;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -685,7 +685,7 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
      * @return value of the {@code gitdir} property from the file
      */
     private String getGitDirValue(File dotGit) {
-        try (Scanner scanner = new Scanner(dotGit)) {   // Assumes UTF-8.
+        try (Scanner scanner = new Scanner(dotGit, StandardCharsets.UTF_8)) {
             while (scanner.hasNextLine()) {
                 String line = scanner.nextLine();
                 if (line.startsWith(Constants.GITDIR)) {
@@ -695,7 +695,7 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
                     }
                 }
             }
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             LOGGER.log(Level.WARNING, "failed to scan the contents of file ''{0}''", dotGit);
             return null;
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -24,10 +24,8 @@
  */
 package org.opengrok.indexer.history;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -683,48 +683,46 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
         File dotGit = Paths.get(directory, Constants.DOT_GIT).toFile();
         if (dotGit.isDirectory()) {
             return FileRepositoryBuilder.create(dotGit);
-        } else if (dotGit.isFile()) {
-            // Assume this is a sub-module.
-            String gitDirValue;
-            if ((gitDirValue = getGitDirValue(dotGit)) == null) {
-                return null;
-            }
-
-            int dotGitIndex = gitDirValue.indexOf(Constants.DOT_GIT);
-            if (dotGitIndex == -1) {
-                return null;
-            }
-
-            String parentAbsPath;
-            if (Paths.get(gitDirValue).isAbsolute()) {
-                parentAbsPath = gitDirValue.substring(0, dotGitIndex - 1);
-            } else {
-                File parent = new File(directory, gitDirValue.substring(0, dotGitIndex + Constants.DOT_GIT.length()));
-                parentAbsPath = parent.getCanonicalPath();
-                int indexDotGitParent = parentAbsPath.indexOf(File.separator + Constants.DOT_GIT);
-                if (indexDotGitParent == -1) {
-                    return null;
-                }
-
-                parentAbsPath = parentAbsPath.substring(0, indexDotGitParent);
-                if (!directory.startsWith(parentAbsPath)) {
-                    return null;
-                }
-            }
-
-            // Assumes directory is canonical path too.
-            String directoryRelative = directory.substring(parentAbsPath.length() + 1);
-
-            Repository parentRepository = FileRepositoryBuilder.
-                    create(Paths.get(parentAbsPath, Constants.DOT_GIT).toFile());
-            if (parentRepository == null) {
-                return null;
-            }
-
-            return SubmoduleWalk.getSubmoduleRepository(parentRepository, directoryRelative);
         }
 
-        return null;
+        // Assume this is a sub-module so dotGit is a file.
+        String gitDirValue;
+        if ((gitDirValue = getGitDirValue(dotGit)) == null) {
+            throw new IOException("cannot get gitDir value from " + dotGit);
+        }
+
+        int dotGitIndex = gitDirValue.indexOf(Constants.DOT_GIT);
+        if (dotGitIndex == -1) {
+            throw new IOException("no .git in " + gitDirValue);
+        }
+
+        String parentAbsPath;
+        if (Paths.get(gitDirValue).isAbsolute()) {
+            parentAbsPath = gitDirValue.substring(0, dotGitIndex - 1);
+        } else {
+            File parent = new File(directory, gitDirValue.substring(0, dotGitIndex + Constants.DOT_GIT.length()));
+            parentAbsPath = parent.getCanonicalPath();
+            int indexDotGitParent = parentAbsPath.indexOf(File.separator + Constants.DOT_GIT);
+            if (indexDotGitParent == -1) {
+                throw new IOException("not .git in " + parentAbsPath);
+            }
+
+            parentAbsPath = parentAbsPath.substring(0, indexDotGitParent);
+            if (!directory.startsWith(parentAbsPath)) {
+                throw new IOException(directory + " does not start with " + parentAbsPath);
+            }
+        }
+
+        // Assumes directory is canonical path too.
+        String directoryRelative = directory.substring(parentAbsPath.length() + 1);
+
+        Repository parentRepository = FileRepositoryBuilder.
+                create(Paths.get(parentAbsPath, Constants.DOT_GIT).toFile());
+        if (parentRepository == null) {
+            throw new IOException("cannot create parent repository from " + parentAbsPath);
+        }
+
+        return SubmoduleWalk.getSubmoduleRepository(parentRepository, directoryRelative);
     }
 
     private void rebuildTagList(File directory) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -797,7 +797,7 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
     String determineParent(CommandTimeoutType cmdType) throws IOException {
         try (org.eclipse.jgit.lib.Repository repository = getJGitRepository(getDirectoryName())) {
             if (repository.getConfig() != null) {
-                return repository.getConfig().getString("remote", "origin", "url");
+                return repository.getConfig().getString("remote", Constants.DEFAULT_REMOTE_NAME, "url");
             } else {
                 return null;
             }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -232,21 +232,6 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
         return result.success;
     }
 
-    /**
-     * Create a {@code Reader} that reads an {@code InputStream} using the
-     * correct character encoding.
-     *
-     * @param input a stream with the output from a log or blame command
-     * @return a reader that reads the input
-     */
-    static Reader newLogReader(InputStream input) {
-        // Bug #17731: Git always encodes the log output using UTF-8 (unless
-        // overridden by i18n.logoutputencoding, but let's assume that hasn't
-        // been done for now). Create a reader that uses UTF-8 instead of the
-        // platform's default encoding.
-        return new InputStreamReader(input, StandardCharsets.UTF_8);
-    }
-
     private String getPathRelativeToCanonicalRepositoryRoot(String fullpath)
             throws IOException {
         String repoPath = getCanonicalDirectoryName() + File.separator;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -673,15 +673,11 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
             while (scanner.hasNextLine()) {
                 String line = scanner.nextLine();
                 if (line.startsWith(Constants.GITDIR)) {
-                    String[] array = line.split(": ");
-                    if (array.length == 2) {
-                        return array[1];
-                    }
+                    return line.substring(Constants.GITDIR.length());
                 }
             }
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "failed to scan the contents of file ''{0}''", dotGit);
-            return null;
         }
 
         return null;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -793,9 +793,14 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
     }
 
     @Override
+    @Nullable
     String determineParent(CommandTimeoutType cmdType) throws IOException {
         try (org.eclipse.jgit.lib.Repository repository = getJGitRepository(getDirectoryName())) {
-            return repository.getConfig().getString("remote", "origin", "url");
+            if (repository.getConfig() != null) {
+                return repository.getConfig().getString("remote", "origin", "url");
+            } else {
+                return null;
+            }
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -25,12 +25,8 @@
 package org.opengrok.indexer.history;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Date;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
@@ -816,8 +816,9 @@ public class GitRepositoryTest {
 
     @Test
     void testSubmodule() throws Exception {
-        String submoduleOriginPath = addSubmodule("submodule");
-        Path submodulePath = Paths.get(repository.getSourceRoot(), "git", "submodule");
+        String submoduleName = "submodule";
+        String submoduleOriginPath = addSubmodule(submoduleName);
+        Path submodulePath = Paths.get(repository.getSourceRoot(), "git", submoduleName);
 
         Repository subRepo = RepositoryFactory.getRepository(submodulePath.toFile());
         assertNotNull(subRepo);
@@ -829,7 +830,7 @@ public class GitRepositoryTest {
         assertTrue(gitFile.isFile());
         try (Writer writer = new FileWriter(gitFile)) {
             writer.write(Constants.GITDIR + ".." + File.separator + Constants.DOT_GIT +
-                    File.separator + Constants.MODULES + File.separator + "submodule");
+                    File.separator + Constants.MODULES + File.separator + submoduleName);
         }
         subRepo = RepositoryFactory.getRepository(submodulePath.toFile());
         assertNotNull(subRepo);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
@@ -835,6 +835,6 @@ public class GitRepositoryTest {
         assertNotNull(subRepo);
         assertNotNull(subRepo.getParent());
 
-        // TODO: cleanup
+        removeRecursive(submodulePath.toFile());
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
@@ -60,7 +60,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
@@ -806,7 +806,7 @@ public class GitRepositoryTest {
                 .build();
         try (Git git = new Git(mainRepo)) {
             git.submoduleAdd().
-                    setURI("file:///" + newRepoFile).
+                    setURI(newRepoFile.toPath().toUri().toString()).
                     setPath(submoduleName).
                     call();
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
@@ -804,14 +804,15 @@ public class GitRepositoryTest {
         org.eclipse.jgit.lib.Repository mainRepo = new FileRepositoryBuilder().
                 setGitDir(Paths.get(repository.getSourceRoot(), "git", Constants.DOT_GIT).toFile())
                 .build();
+        String parent = newRepoFile.toPath().toUri().toString();
         try (Git git = new Git(mainRepo)) {
             git.submoduleAdd().
-                    setURI(newRepoFile.toPath().toUri().toString()).
+                    setURI(parent).
                     setPath(submoduleName).
                     call();
         }
 
-        return newRepoFile.toString();
+        return parent;
     }
 
     @Test
@@ -823,7 +824,7 @@ public class GitRepositoryTest {
         Repository subRepo = RepositoryFactory.getRepository(submodulePath.toFile());
         assertNotNull(subRepo);
         assertNotNull(subRepo.getParent());
-        assertTrue(subRepo.getParent().contains(submoduleOriginPath));
+        assertEquals(submoduleOriginPath, subRepo.getParent());
 
         // Test relative path too. JGit always writes absolute path so overwrite the contents directly.
         File gitFile = Paths.get(submodulePath.toString(), Constants.DOT_GIT).toFile();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
@@ -805,8 +805,8 @@ public class GitRepositoryTest {
                 setGitDir(Paths.get(repository.getSourceRoot(), "git", ".git").toFile())
                 .build();
         try (Git git = new Git(mainRepo)) {
-            org.eclipse.jgit.lib.Repository subRepoInit = git.submoduleAdd().
-                    setURI("file:///" + newRepoFile.toString()).
+            git.submoduleAdd().
+                    setURI("file:///" + newRepoFile).
                     setPath(submoduleName).
                     call();
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/GitRepositoryTest.java
@@ -802,7 +802,7 @@ public class GitRepositoryTest {
 
         // Add this repository as a submodule to the existing Git repository.
         org.eclipse.jgit.lib.Repository mainRepo = new FileRepositoryBuilder().
-                setGitDir(Paths.get(repository.getSourceRoot(), "git", ".git").toFile())
+                setGitDir(Paths.get(repository.getSourceRoot(), "git", Constants.DOT_GIT).toFile())
                 .build();
         try (Git git = new Git(mainRepo)) {
             git.submoduleAdd().


### PR DESCRIPTION
This change fixes Git submodule detection. The `SubmoduleWalk` is not really suitable for this and is `RepositoryBuilder()` wrapper anyway.

fixes #3666.

Also I did some semi-related cleanup.