### PR TITLE
avoid warning in case of mkdirs() races

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -462,7 +462,8 @@ class FileHistoryCache implements HistoryCache {
         history.strip();
 
         File histDataDir = new File(getRepositoryHistDataDirname(repository));
-        if (!histDataDir.isDirectory() && !histDataDir.mkdirs()) {
+        // Check the directory again in case of races (might happen in the presence of sub-repositories).
+        if (!histDataDir.isDirectory() && !histDataDir.mkdirs() && !histDataDir.isDirectory()) {
             LOGGER.log(Level.WARNING, "cannot create history cache directory for ''{0}''", histDataDir);
         }
 


### PR DESCRIPTION
As explained in https://github.com/oracle/opengrok/pull/3669#issuecomment-885519978
