### PR TITLE
revamp forbidden check

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1104,6 +1104,9 @@ public final class PageConfig {
         return path;
     }
 
+    /**
+     * @return true if file/directory corrsponding to the request path exists however is unreadable, false otherwise
+     */
     public boolean isUnreadable() {
         File f = new File(getSourceRootPath(), getPath());
         return f.exists() && !f.canRead();

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1104,6 +1104,11 @@ public final class PageConfig {
         return path;
     }
 
+    public boolean isUnreadable() {
+        File f = new File(getSourceRootPath(), getPath());
+        return f.exists() && !f.canRead();
+    }
+
     /**
      * Get the on disk file for the given path.
      *

--- a/opengrok-web/src/main/webapp/WEB-INF/web.xml
+++ b/opengrok-web/src/main/webapp/WEB-INF/web.xml
@@ -269,6 +269,10 @@
         <location>/enoent</location>
     </error-page>
     <error-page>
+        <error-code>403</error-code>
+        <location>/eforbidden</location>
+    </error-page>
+    <error-page>
         <error-code>500</error-code>
         <location>/error</location>
     </error-page>

--- a/opengrok-web/src/main/webapp/eforbidden.jsp
+++ b/opengrok-web/src/main/webapp/eforbidden.jsp
@@ -16,17 +16,37 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 --%>
-<%@page  session="false" import="org.opengrok.web.PageConfig" %>
+<%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@page session="false" import="org.opengrok.web.PageConfig" %>
+<%@ page import="jakarta.servlet.http.HttpServletResponse" %>
 <%
-/* ---------------------- eforbidden.jspf start --------------------- */
+/* ---------------------- eforbidden.jsp start --------------------- */
 {
     response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-%>
+%><%@
+
+        include file="httpheader.jspf"
+
+%><body>
+<div id="page">
+    <div id="whole_header">
+        <div id="header"><%@
+
+                include file="pageheader.jspf"
+
+        %></div>
+    </div>
+<h3 class="error">Error: access forbidden</h3>
+<p>The request was forbidden. This can be either file/directory permissions problem or insufficient authorization.</p>
 <%= PageConfig.get(request).getEnv().getIncludeFiles().getForbiddenIncludeFileContent(false) %>
 <%
 }
-/* ---------------------- eforbidden.jspf end --------------------- */
+/* ---------------------- eforbidden.jsp end --------------------- */
+%><%@
+
+        include file="foot.jspf"
+
 %>

--- a/opengrok-web/src/main/webapp/enoent.jsp
+++ b/opengrok-web/src/main/webapp/enoent.jsp
@@ -16,16 +16,13 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
 --%>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@page session="false" errorPage="error.jsp" isErrorPage="true" import="
-org.opengrok.indexer.web.Prefix,
-org.opengrok.indexer.configuration.RuntimeEnvironment"
- %><%
+<%@page session="false" errorPage="error.jsp" isErrorPage="true"%><%
 /* ---------------------- enoent.jsp start --------------------- */
 {
     PageConfig cfg = PageConfig.get(request);

--- a/opengrok-web/src/main/webapp/mast.jsp
+++ b/opengrok-web/src/main/webapp/mast.jsp
@@ -34,10 +34,16 @@ org.opengrok.web.PageConfig,
 org.opengrok.indexer.web.Prefix,
 org.opengrok.indexer.web.Util"%>
 <%@ page import="org.opengrok.indexer.web.messages.MessagesUtils" %>
+<%@ page import="jakarta.servlet.http.HttpServletResponse" %>
 <%
 /* ---------------------- mast.jsp start --------------------- */
 {
     PageConfig cfg = PageConfig.get(request);
+    if (cfg.isUnreadable()) {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+        return;
+    }
+
     String redir = cfg.canProcess();
     if (redir == null || redir.length() > 0) {
         if (redir == null) {            


### PR DESCRIPTION
This change performs the check for forbidden access right in `mast.jsp` in order to produce better looking forbidden page. Unlike the `enoent` page it does not add the full menu (a practice which I find confusing).