### PR TITLE
Fix clicking on revision in annotation mode returns 400

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Date;
 import java.util.HashSet;
@@ -324,14 +325,15 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
         if (revision == null) {
             revision = getFirstRevision(filePath);
         }
-        Annotation annotation = getAnnotation(revision, filePath);
+        String fileName = Path.of(filePath).getFileName().toString();
+        Annotation annotation = getAnnotation(revision, filePath, fileName);
 
         if (annotation.getRevisions().isEmpty() && isHandleRenamedFiles()) {
             // The file might have changed its location if it was renamed.
             // Try to lookup its original name and get the annotation again.
             String origName = findOriginalName(file.getCanonicalPath(), revision);
             if (origName != null) {
-                annotation = getAnnotation(revision, origName);
+                annotation = getAnnotation(revision, origName, fileName);
             }
         }
 
@@ -361,8 +363,8 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
     }
 
     @NotNull
-    private Annotation getAnnotation(String revision, String filePath) throws IOException {
-        Annotation annotation = new Annotation(filePath);
+    private Annotation getAnnotation(String revision, String filePath, String fileName) throws IOException {
+        Annotation annotation = new Annotation(fileName);
 
         try (org.eclipse.jgit.lib.Repository repository = getJGitRepository(getDirectoryName())) {
             BlameCommand blameCommand = new Git(repository).blame().setFilePath(getGitFilePath(filePath));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -913,15 +912,7 @@ public final class Util {
      * @see URLEncoder#encode(String, String)
      */
     public static String URIEncode(String q) {
-        try {
-            return q == null ? "" : URLEncoder.encode(q,
-                StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            // Should not happen. UTF-8 must be supported by JVMs.
-            LOGGER.log(
-                    Level.WARNING, "Failed to URL-encode UTF-8: ", e);
-        }
-        return null;
+        return q == null ? "" : URLEncoder.encode(q, StandardCharsets.UTF_8);
     }
 
     /**
@@ -1680,15 +1671,8 @@ public final class Util {
                 continue;
             }
 
-            String key = pair.substring(0, idx);
-            String value = pair.substring(idx + 1);
-
-            try {
-                key = URLDecoder.decode(key, StandardCharsets.UTF_8.toString());
-                value = URLDecoder.decode(value, StandardCharsets.UTF_8.toString());
-            } catch (UnsupportedEncodingException e) {
-                throw new IllegalStateException("Could not find UTF-8 encoding", e);
-            }
+            String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+            String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
 
             List<String> paramValues = returnValue.computeIfAbsent(key, k -> new LinkedList<>());
             paramValues.add(value);


### PR DESCRIPTION
fixes #3689

The problem was that the new git history implementation was passing the relative path to the source directory instead of the file name. I also improved the url encoding while I was at it.

Thanks.
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
