### PR TITLE
allow directory in commands

### DIFF
--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -607,8 +607,8 @@ def check_commands(commands):
                          format(name, COMMANDS_PROPERTY, value))
             return False
 
-        if not os.path.isfile(value):
-            logger.error("path for '{}' under '{}' is not a file: {}".
+        if not os.path.isfile(value) and not os.path.isdir(value):
+            logger.error("path for '{}' under '{}' is not a file or directory: {}".
                          format(name, COMMANDS_PROPERTY, value))
             return False
 

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -133,6 +133,12 @@ def test_configuration_commands():
 
 
 @posix_only
+def test_configuration_commands_dir():
+    config = {COMMANDS_PROPERTY: {"teamware": "/usr/bin"}}
+    assert check_configuration(config)
+
+
+@posix_only
 def test_invalid_project_config_nonexec_hook():
     with tempfile.TemporaryDirectory() as tmpdir:
         with open(os.path.join(tmpdir, "foo.sh"), 'w+') as tmpfile:


### PR DESCRIPTION
The recently added check for commands in `opengrok-mirror` configuration is too strict. Specifically, Teamware needs to accept a directory: https://github.com/oracle/opengrok/blob/7f430e467c592672b420a552530c6e091e5b87f3/tools/src/main/python/opengrok_tools/scm/teamware.py#L34-L47

While I could just remove the check for file, this still captures (rare) cases such as FIFOs and such. Possibly better approach would be to reach out to the `scm` module and perform per repository type check however I need a quick fix.