### PR TITLE
introduce timeout for generating xrefs

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -425,8 +425,8 @@ public class Ctags implements Resettable {
      * @throws IOException I/O exception
      * @throws InterruptedException interrupted command
      */
-    public Definitions doCtags(String file) throws IOException,
-            InterruptedException {
+    public Definitions doCtags(String file) throws IOException, InterruptedException {
+
         if (file.length() < 1 || "\n".equals(file)) {
             return null;
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -214,6 +214,7 @@ public final class Configuration {
     private int webappStartCommandTimeout; // in seconds
     private int restfulCommandTimeout; // in seconds
     private long ctagsTimeout; // in seconds
+    private long xrefTimeout; // in seconds
     private boolean scopesEnabled;
     private boolean projectsEnabled;
     private boolean foldingEnabled;
@@ -475,6 +476,24 @@ public final class Configuration {
         this.ctagsTimeout = timeout;
     }
 
+    public long getXrefTimeout() {
+        return xrefTimeout;
+    }
+
+    /**
+     * Set the timeout for generating xrefs to a new value.
+     *
+     * @param timeout the new value
+     * @throws IllegalArgumentException when the timeout is negative
+     */
+    public void setXrefTimeout(long timeout) throws IllegalArgumentException {
+        if (timeout < 0) {
+            throw new IllegalArgumentException(
+                    String.format(NEGATIVE_NUMBER_ERROR, "xrefTimeout", timeout));
+        }
+        this.xrefTimeout = timeout;
+    }
+
     public boolean isLastEditedDisplayMode() {
         return lastEditedDisplayMode;
     }
@@ -569,11 +588,11 @@ public final class Configuration {
         //setTabSize(4);
         setTagsEnabled(false);
         //setUserPage("http://www.myserver.org/viewProfile.jspa?username=");
-        // Set to empty string so we can append it to the URL
-        // unconditionally later.
+        // Set to empty string so we can append it to the URL unconditionally later.
         setUserPageSuffix("");
         setWebappLAF("default");
         // webappCtags is default(boolean)
+        setXrefTimeout(30);
     }
 
     public String getRepoCmd(String clazzName) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -298,6 +298,14 @@ public final class RuntimeEnvironment {
         syncWriteConfiguration(timeout, Configuration::setCtagsTimeout);
     }
 
+    public long getXrefTimeout() {
+        return syncReadConfiguration(Configuration::getXrefTimeout);
+    }
+
+    public void setXrefTimeout(long timeout) {
+        syncWriteConfiguration(timeout, Configuration::setXrefTimeout);
+    }
+
     public void setLastEditedDisplayMode(boolean lastEditedDisplayMode) {
         syncWriteConfiguration(lastEditedDisplayMode, Configuration::setLastEditedDisplayMode);
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1330,8 +1330,7 @@ public class IndexDatabase {
         AtomicInteger successCounter = new AtomicInteger();
         AtomicInteger currentCounter = new AtomicInteger();
         AtomicInteger alreadyClosedCounter = new AtomicInteger();
-        IndexerParallelizer parallelizer = RuntimeEnvironment.getInstance().
-                getIndexerParallelizer();
+        IndexerParallelizer parallelizer = RuntimeEnvironment.getInstance().getIndexerParallelizer();
         ObjectPool<Ctags> ctagsPool = parallelizer.getCtagsPool();
 
         Map<Boolean, List<IndexFileWork>> bySuccess = null;
@@ -1355,8 +1354,7 @@ public class IndexDatabase {
                             }
                         } catch (AlreadyClosedException e) {
                             alreadyClosedCounter.incrementAndGet();
-                            String errmsg = String.format("ERROR addFile(): %s",
-                                x.file);
+                            String errmsg = String.format("ERROR addFile(): %s", x.file);
                             LOGGER.log(Level.SEVERE, errmsg, e);
                             x.exception = e;
                             ret = false;
@@ -1369,8 +1367,7 @@ public class IndexDatabase {
                             x.exception = e;
                             ret = false;
                         } catch (RuntimeException | IOException e) {
-                            String errmsg = String.format("ERROR addFile(): %s",
-                                x.file);
+                            String errmsg = String.format("ERROR addFile(): %s", x.file);
                             LOGGER.log(Level.WARNING, errmsg, e);
                             x.exception = e;
                             ret = false;
@@ -1390,8 +1387,7 @@ public class IndexDatabase {
         } catch (InterruptedException | ExecutionException e) {
             int successCount = successCounter.intValue();
             double successPct = 100.0 * successCount / worksCount;
-            String exmsg = String.format(
-                "%d successes (%.1f%%) after aborting parallel-indexing",
+            String exmsg = String.format("%d successes (%.1f%%) after aborting parallel-indexing",
                 successCount, successPct);
             LOGGER.log(Level.SEVERE, exmsg, e);
         }
@@ -1401,28 +1397,24 @@ public class IndexDatabase {
         // Start with failureCount=worksCount, and then subtract successes.
         int failureCount = worksCount;
         if (bySuccess != null) {
-            List<IndexFileWork> successes = bySuccess.getOrDefault(
-                Boolean.TRUE, null);
+            List<IndexFileWork> successes = bySuccess.getOrDefault(Boolean.TRUE, null);
             if (successes != null) {
                 failureCount -= successes.size();
             }
         }
         if (failureCount > 0) {
             double pctFailed = 100.0 * failureCount / worksCount;
-            String exmsg = String.format(
-                "%d failures (%.1f%%) while parallel-indexing",
-                failureCount, pctFailed);
+            String exmsg = String.format("%d failures (%.1f%%) while parallel-indexing", failureCount, pctFailed);
             LOGGER.log(Level.WARNING, exmsg);
         }
 
-        /**
+        /*
          * Encountering an AlreadyClosedException is severe enough to abort the
          * run, since it will fail anyway later upon trying to commit().
          */
         int numAlreadyClosed = alreadyClosedCounter.get();
         if (numAlreadyClosed > 0) {
-            throw new AlreadyClosedException(String.format("count=%d",
-                numAlreadyClosed));
+            throw new AlreadyClosedException(String.format("count=%d", numAlreadyClosed));
         }
     }
 


### PR DESCRIPTION
This change introduces time out for xref processing/generation. Also, I took the opportunity to join some short wrapped lines.

The default timeout will be 30 seconds (default ctags timeout is 10 seconds).

In the indexer log this will look like this:
```
2021-08-12 13:44:00.802+0000 WARNING t143 IndexDatabase.addFile: File '/solaris-userland/components/desktop/firefox/firefox-78.11.0/accessible/windows/msaa/HyperTextAccessibleWrap.cpp' interrupted--failed to gen
erate xref :java.util.concurrent.ExecutionException: java.util.concurrent.TimeoutException
```