### PR TITLE
share the OPENGROK_NO_MIRROR env var definition

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -48,6 +48,7 @@ from opengrok_tools.utils.opengrok import list_projects, \
 from opengrok_tools.utils.readconfig import read_config
 from opengrok_tools.utils.exitvals import SUCCESS_EXITVAL
 from opengrok_tools.utils.mirror import check_configuration
+from opengrok_tools.mirror import OPENGROK_NO_MIRROR_ENV
 
 
 fs_root = os.path.abspath('.').split(os.path.sep)[0] + os.path.sep
@@ -489,7 +490,7 @@ def main():
         logger.info("extra indexer options: {}".format(extra_indexer_options))
         env['OPENGROK_INDEXER_OPTIONAL_ARGS'] = extra_indexer_options
     if os.environ.get(NOMIRROR_ENV_NAME):
-        env['OPENGROK_NO_MIRROR'] = os.environ.get(NOMIRROR_ENV_NAME)
+        env[OPENGROK_NO_MIRROR_ENV] = os.environ.get(NOMIRROR_ENV_NAME)
     logger.debug('Extra environment: {}'.format(env))
 
     use_projects = True

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -60,6 +60,8 @@ if major_version < 3:
 
 __version__ = "1.1"
 
+OPENGROK_NO_MIRROR_ENV = "OPENGROK_NO_MIRROR"
+
 
 def worker(args):
     project_name, logdir, loglevel, backupcount, config, check_changes, uri, \
@@ -134,7 +136,7 @@ def main():
         logger.debug("Configuration check passed, exiting")
         return 0
 
-    nomirror = os.environ.get("OPENGROK_NO_MIRROR")
+    nomirror = os.environ.get(OPENGROK_NO_MIRROR_ENV)
     if nomirror and len(nomirror) > 0:
         logger.debug("skipping mirror based on the OPENGROK_NO_MIRROR " +
                      "environment variable")

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -111,7 +111,8 @@ def main():
                         help='Number of worker processes')
     add_http_headers(parser)
     parser.add_argument('--api_timeout', type=int,
-                        help='Set response timeout in seconds for RESTful API calls')
+                        help='Set response timeout in seconds '
+                             'for RESTful API calls')
 
     try:
         args = parser.parse_args()

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -138,8 +138,8 @@ def main():
 
     nomirror = os.environ.get(OPENGROK_NO_MIRROR_ENV)
     if nomirror and len(nomirror) > 0:
-        logger.debug("skipping mirror based on the OPENGROK_NO_MIRROR " +
-                     "environment variable")
+        logger.debug("skipping mirror based on the {} " +
+                     "environment variable".format(OPENGROK_NO_MIRROR_ENV))
         return SUCCESS_EXITVAL
 
     if len(args.project) > 0 and args.all:

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -139,8 +139,8 @@ def main():
 
     nomirror = os.environ.get(OPENGROK_NO_MIRROR_ENV)
     if nomirror and len(nomirror) > 0:
-        logger.debug("skipping mirror based on the {} " +
-                     "environment variable".format(OPENGROK_NO_MIRROR_ENV))
+        logger.debug("skipping mirror based on the {} environment variable".
+                     format(OPENGROK_NO_MIRROR_ENV))
         return SUCCESS_EXITVAL
 
     if len(args.project) > 0 and args.all:


### PR DESCRIPTION
When looking at #3709 I noticed that the `OPENGROK_NO_MIRROR` environment variable name is not shared properly between the main Docker program and the tooling. This change fixes that.