### PR TITLE
fix opengrok-mirror configuration check in the presence of overridden commands

### DIFF
--- a/tools/src/main/python/opengrok_tools/scm/cvs.py
+++ b/tools/src/main/python/opengrok_tools/scm/cvs.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -29,8 +29,8 @@ from ..utils.command import Command
 
 
 class CVSRepository(Repository):
-    def __init__(self, logger, path, project, command, env, hooks, timeout):
-        super().__init__(logger, path, project, command, env, hooks, timeout)
+    def __init__(self, name, logger, path, project, command, env, hooks, timeout):
+        super().__init__(name, logger, path, project, command, env, hooks, timeout)
 
         self.command = self._repository_command(command, default=lambda: which('cvs'))
 
@@ -39,8 +39,8 @@ class CVSRepository(Repository):
 
     def reposync(self):
         hg_command = [self.command, "update", "-dP"]
-        cmd = self.getCommand(hg_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
+        cmd = self.get_command(hg_command, work_dir=self.path,
+                               env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info("output of {}:".format(cmd))
         self.logger.info(cmd.getoutputstr())

--- a/tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -29,8 +29,8 @@ from ..utils.command import Command
 
 
 class MercurialRepository(Repository):
-    def __init__(self, logger, path, project, command, env, hooks, timeout):
-        super().__init__(logger, path, project, command, env, hooks, timeout)
+    def __init__(self, name, logger, path, project, command, env, hooks, timeout):
+        super().__init__(name, logger, path, project, command, env, hooks, timeout)
 
         self.command = self._repository_command(command, default=lambda: which('hg'))
 
@@ -39,8 +39,8 @@ class MercurialRepository(Repository):
 
     def get_branch(self):
         hg_command = [self.command, "branch"]
-        cmd = self.getCommand(hg_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
+        cmd = self.get_command(hg_command, work_dir=self.path,
+                               env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info("output of {}:".format(cmd))
         self.logger.info(cmd.getoutputstr())
@@ -68,8 +68,8 @@ class MercurialRepository(Repository):
         if branch != "default":
             hg_command.append("-b")
             hg_command.append(branch)
-        cmd = self.getCommand(hg_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
+        cmd = self.get_command(hg_command, work_dir=self.path,
+                               env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info("output of {}:".format(cmd))
         self.logger.info(cmd.getoutputstr())
@@ -82,8 +82,8 @@ class MercurialRepository(Repository):
         # some servers do not support it.
         if branch == "default":
             hg_command.append("--check")
-        cmd = self.getCommand(hg_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
+        cmd = self.get_command(hg_command, work_dir=self.path,
+                               env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info("output of {}:".format(cmd))
         self.logger.info(cmd.getoutputstr())
@@ -104,8 +104,8 @@ class MercurialRepository(Repository):
         if branch != "default":
             hg_command.append("-b")
             hg_command.append(branch)
-        cmd = self.getCommand(hg_command, work_dir=self.path,
-                              env_vars=self.env, logger=self.logger)
+        cmd = self.get_command(hg_command, work_dir=self.path,
+                               env_vars=self.env, logger=self.logger)
         cmd.execute()
         self.logger.info("output of {}:".format(cmd))
         self.logger.info(cmd.getoutputstr())

--- a/tools/src/main/python/opengrok_tools/scm/perforce.py
+++ b/tools/src/main/python/opengrok_tools/scm/perforce.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright 2020 Robert Williams
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
@@ -29,8 +29,8 @@ from .repository import Repository, RepositoryException
 
 
 class PerforceRepository(Repository):
-    def __init__(self, logger, path, project, command, env, hooks, timeout):
-        super().__init__(logger, path, project, command, env, hooks, timeout)
+    def __init__(self, name, logger, path, project, command, env, hooks, timeout):
+        super().__init__(name, logger, path, project, command, env, hooks, timeout)
 
         self.command = self._repository_command(command, default=lambda: which('p4'))
 

--- a/tools/src/main/python/opengrok_tools/scm/repo.py
+++ b/tools/src/main/python/opengrok_tools/scm/repo.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -28,8 +28,8 @@ from .repository import Repository, RepositoryException
 
 
 class RepoRepository(Repository):
-    def __init__(self, logger, path, project, command, env, hooks, timeout):
-        super().__init__(logger, path, project, command, env, hooks, timeout)
+    def __init__(self, name, logger, path, project, command, env, hooks, timeout):
+        super().__init__(logger, name, path, project, command, env, hooks, timeout)
 
         self.command = self._repository_command(command, default=lambda: which('repo'))
 

--- a/tools/src/main/python/opengrok_tools/scm/repofactory.py
+++ b/tools/src/main/python/opengrok_tools/scm/repofactory.py
@@ -33,16 +33,11 @@ from .svn import SubversionRepository
 from .teamware import TeamwareRepository
 
 
-# Note: these have to correspond with get_repository().
-REPO_TYPES = ["mercurial", "hg", "teamware", "sccs", "cvs",
-              "svn", "subversion", "git", "perforce", "repo"]
-
-
 def get_repository(path, repo_type, project,
                    commands=None, env=None, hooks=None, timeout=None):
     """
-    :param path: full path
-    :param repo_type: repository type
+    :param path: full path for the working directory
+    :param repo_type: repository type name
     :param project: project name
     :param commands: commands dictionary with paths to SCM utilities
     :param env: environment variables dictionary
@@ -56,37 +51,38 @@ def get_repository(path, repo_type, project,
 
     repo_lower = repo_type.lower()
 
-    logger.debug("Constructing repo object for path {}".format(path))
+    logger.debug("Constructing repository object of type '{}' for path '{}'".
+                 format(repo_type, path))
 
     if not commands:
         commands = {}
 
     if repo_lower in ["mercurial", "hg"]:
-        return MercurialRepository(logger, path, project,
+        return MercurialRepository(repo_type, logger, path, project,
                                    commands.get("hg"),
                                    env, hooks, timeout)
     elif repo_lower in ["teamware", "sccs"]:
-        return TeamwareRepository(logger, path, project,
+        return TeamwareRepository(repo_type, logger, path, project,
                                   commands.get("teamware"),
                                   env, hooks, timeout)
     elif repo_lower == "cvs":
-        return CVSRepository(logger, path, project,
+        return CVSRepository(repo_type, logger, path, project,
                              commands.get("cvs"),
                              env, hooks, timeout)
     elif repo_lower in ["svn", "subversion"]:
-        return SubversionRepository(logger, path, project,
+        return SubversionRepository(repo_type, logger, path, project,
                                     commands.get("svn"),
                                     env, hooks, timeout)
     elif repo_lower == "git":
-        return GitRepository(logger, path, project,
+        return GitRepository(repo_type, logger, path, project,
                              commands.get("git"),
                              env, hooks, timeout)
     elif repo_lower == "perforce":
-        return PerforceRepository(logger, path, project,
+        return PerforceRepository(repo_type, logger, path, project,
                                   commands.get("perforce"),
                                   env, hooks, timeout)
     elif repo_lower == "repo":
-        return RepoRepository(logger, path, project,
+        return RepoRepository(repo_type, logger, path, project,
                               commands.get("repo"),
                               env, hooks, timeout)
     else:

--- a/tools/src/main/python/opengrok_tools/scm/svn.py
+++ b/tools/src/main/python/opengrok_tools/scm/svn.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -28,8 +28,8 @@ from .repository import Repository, RepositoryException
 
 
 class SubversionRepository(Repository):
-    def __init__(self, logger, path, project, command, env, hooks, timeout):
-        super().__init__(logger, path, project, command, env, hooks, timeout)
+    def __init__(self, name, logger, path, project, command, env, hooks, timeout):
+        super().__init__(name, logger, path, project, command, env, hooks, timeout)
 
         self.command = self._repository_command(command, default=lambda: which('svn'))
 

--- a/tools/src/main/python/opengrok_tools/scm/teamware.py
+++ b/tools/src/main/python/opengrok_tools/scm/teamware.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -28,8 +28,8 @@ from .repository import Repository, RepositoryException
 
 
 class TeamwareRepository(Repository):
-    def __init__(self, logger, path, project, command, env, hooks, timeout):
-        super().__init__(logger, path, project, command, env, hooks, timeout)
+    def __init__(self, name, logger, path, project, command, env, hooks, timeout):
+        super().__init__(name, logger, path, project, command, env, hooks, timeout)
 
         #
         # Teamware is different than the rest of the repositories.
@@ -39,7 +39,7 @@ class TeamwareRepository(Repository):
         # argument contains the path to the directory that contains
         # the binaries.
         #
-        command = self._repository_command(command)
+        self.command = self._repository_command(command)
         if command:
             if not os.path.isdir(command):
                 raise RepositoryException("Cannot construct Teamware "
@@ -67,3 +67,15 @@ class TeamwareRepository(Repository):
             return 0
 
         return self._run_custom_sync_command(['bringover'])
+
+    def _check_command(self):
+        #
+        # The default implementation checks file existence. Teamware needs
+        # a directory.
+        #
+        if not os.path.isdir(self.command):
+            self.logger.error("path for '{}' is not a directory: {}".
+                              format(self.name, self.command))
+            return False
+
+        return True


### PR DESCRIPTION
This change fixes `opengrok-mirror` configuration check for overridden commands. I decided not to check the validity of the overridden commands.