### PR TITLE
Fix header overflow

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/Scripts.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/Scripts.java
@@ -114,7 +114,7 @@ public class Scripts implements Iterable<Scripts.Script> {
         putFromWebJar("jquery-tablesorter", "jquery.tablesorter.min.js", 12);
         putjs("tablesorter-parsers", "js/tablesorter-parsers-0.0.3", 13, true);
         putjs("searchable-option-list", "js/searchable-option-list-2.0.15", 14, true);
-        putjs("utils", "js/utils-0.0.42", 15, true);
+        putjs("utils", "js/utils-0.0.43", 15, true);
         putjs("repos", "js/repos-0.0.3", 20, true);
         putjs("diff", "js/diff-0.0.5", 20, true);
         putjs("jquery-caret", "js/jquery.caret-1.5.2", 25);

--- a/opengrok-web/src/main/webapp/js/utils-0.0.43.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.43.js
@@ -1657,11 +1657,6 @@ function domReadyMast() {
         const h = getParameter("h");
         if (h && h !== "") {
             window.location.hash = h;
-        } else {
-            $("#content").
-                    attr("tabindex", 1).
-                    focus().
-                    css('outline', 'none');
         }
     }
     if (document.annotate) {


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->

When opening pages with a mast the header was covering part of the content. Example:
http://demo.opengrok.org/xref/OpenGrok/pom.xml?r=5ec8ffa7
http://demo.opengrok.org/xref/OpenGrok/
<img width="634" alt="Screen Shot 2021-09-17 at 21 36 45" src="https://user-images.githubusercontent.com/12401160/133872863-656a68f1-6d58-479d-b3ce-8f033dade950.png">

Based on https://github.com/oracle/opengrok/pull/1194 it seems the change was done to allow scrolling with space or arrow keys. It's still possible even without the explicit focus (tested in Chrome and Safari). And the scrollbar stays on the same position when page is refreshed (which is in my opinion an added bonus).

Thanks!