### PR TITLE
Cleanup file locks in opengrok python tools

### DIFF
--- a/tools/src/main/python/opengrok_tools/indexer.py
+++ b/tools/src/main/python/opengrok_tools/indexer.py
@@ -27,6 +27,7 @@ import argparse
 import os
 import sys
 import tempfile
+from os import path
 
 from .utils.indexer import FindCtags, Indexer
 from .utils.log import get_console_logger, get_class_basename, fatal
@@ -116,6 +117,8 @@ def main():
     except Timeout:
         logger.warning("Already running, exiting.")
         return FAILURE_EXITVAL
+    finally:
+        if path.exists(lock.lock_file): os.remove(lock.lock_file)
 
 
 if __name__ == '__main__':

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -36,6 +36,7 @@ import os
 import sys
 import tempfile
 from multiprocessing import Pool, cpu_count
+from os import path
 
 from filelock import Timeout, FileLock
 
@@ -224,6 +225,8 @@ def main():
     except Timeout:
         logger.warning("Already running, exiting.")
         return FAILURE_EXITVAL
+    finally:
+            if path.exists(lock.lock_file): os.remove(lock.lock_file)
 
     logging.shutdown()
     return ret

--- a/tools/src/main/python/opengrok_tools/projadm.py
+++ b/tools/src/main/python/opengrok_tools/projadm.py
@@ -28,6 +28,7 @@
 
 import argparse
 import io
+import os
 import shutil
 import sys
 import tempfile
@@ -399,6 +400,9 @@ def main():
     except Timeout:
         logger.warning("Already running, exiting.")
         sys.exit(FAILURE_EXITVAL)
+    finally:
+        # cleanup lock file
+        if path.exists(lock.lock_file): os.remove(lock.lock_file)
 
 
 if __name__ == '__main__':

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -287,6 +287,8 @@ def main():
         except Timeout:
             logger.warning("Already running")
             return FAILURE_EXITVAL
+        finally:
+            if path.exists(lock.lock_file): os.remove(lock.lock_file)
 
     return r
 


### PR DESCRIPTION
This patch ensures that lock files created by FileLock are always
eventually cleaned up. FileLock does not delete lock files itself, which
usually isn't an issue, but it can lead to permission problems if a tool
finds a file lock left over from a previous (finished) run and can't overwrite it.
