### PR TITLE
report file history cache progress

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -549,18 +549,17 @@ public final class HistoryGuru {
         if (repository.isWorking()) {
             Statistics elapsed = new Statistics();
 
-            LOGGER.log(Level.INFO, "Creating historycache for {0} ({1}) {2} renamed file handling",
+            LOGGER.log(Level.INFO, "Creating history cache for {0} ({1}) {2} renamed file handling",
                     new Object[]{path, type, repository.isHandleRenamedFiles() ? "with" : "without"});
 
             try {
                 repository.createCache(historyCache, sinceRevision);
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING,
-                        "An error occurred while creating cache for " + path + " ("
-                        + type + ")", e);
+                        "An error occurred while creating cache for " + path + " (" + type + ")", e);
             }
 
-            elapsed.report(LOGGER, "Done historycache for " + path);
+            elapsed.report(LOGGER, "Done history cache for " + path);
         } else {
             LOGGER.log(Level.WARNING,
                     "Skipping creation of historycache of {0} repository in {1}: Missing SCM dependencies?",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -99,6 +99,10 @@ public abstract class Repository extends RepositoryInfo {
     @NotNull
     abstract boolean hasHistoryForDirectories();
 
+    public String toString() {
+        return this.getDirectoryName();
+    }
+
     /**
      * Get the history for the specified file or directory.
      * It is expected that {@link History#getRenamedFiles()} and {@link HistoryEntry#getFiles()} are empty for files.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryWithPerPartesHistory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryWithPerPartesHistory.java
@@ -88,7 +88,8 @@ public abstract class RepositoryWithPerPartesHistory extends Repository {
         int cnt = 0;
         for (String tillRevision: boundaryChangesetList) {
             Statistics stat = new Statistics();
-            LOGGER.log(Level.FINEST, "getting history for ({0}, {1})", new Object[]{sinceRevision, tillRevision});
+            LOGGER.log(Level.FINEST, "storing history cache for revision range ({0}, {1})",
+                    new Object[]{sinceRevision, tillRevision});
             finishCreateCache(cache, getHistory(directory, sinceRevision, tillRevision), tillRevision);
             sinceRevision = tillRevision;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
@@ -264,12 +264,20 @@ public class IndexerParallelizer implements AutoCloseable {
 
     private void createLazyHistoryExecutor() {
         lzHistoryExecutor = LazilyInstantiate.using(() ->
-                Executors.newFixedThreadPool(env.getHistoryParallelism()));
+                Executors.newFixedThreadPool(env.getHistoryParallelism(), runnable -> {
+                        Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+                        thread.setName("history-" + thread.getId());
+                        return thread;
+                }));
     }
 
     private void createLazyHistoryFileExecutor() {
         lzHistoryFileExecutor = LazilyInstantiate.using(() ->
-                Executors.newFixedThreadPool(env.getHistoryFileParallelism()));
+                Executors.newFixedThreadPool(env.getHistoryFileParallelism(), runnable -> {
+                    Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+                    thread.setName("history-file-" + thread.getId());
+                    return thread;
+                }));
     }
 
     private class CtagsObjectFactory implements ObjectFactory<Ctags> {


### PR DESCRIPTION
This change adds progress reporting for file history cache. For repositories that support per partes history cache creation an annotation of the terminal changeset is added.