### PR TITLE
revert to filelock < 3.3.0

### DIFF
--- a/tools/setup.py
+++ b/tools/setup.py
@@ -35,7 +35,7 @@ setup(
         'pyyaml',
         'requests>=2.20.0',
         'resource',
-        'filelock',
+        'filelock<3.3.0',
         'setuptools>=36.7.2',
     ],
     setup_requires=[


### PR DESCRIPTION
This change avoids pylint errors when using the latest filelock package.