### PR TITLE
make the message more explanatory

### DIFF
--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -286,7 +286,7 @@ def process_changes(repos, project_name, uri, headers=None):
         if not bool(r.json()):
             changes_detected = True
             logger.info('Project {} has not been indexed yet, '
-                        'overridding incoming check'
+                        'overriding incoming check'
                         .format(project_name))
     except ValueError as e:
         logger.error('Unable to parse project \'{}\' indexed flag: {}'


### PR DESCRIPTION
When `opengrok-mirror` is run with `-I` and the project has not been indexed yet, the incoming check is overridden. I find the current message unsatisfactory, hence the change.