### PR TITLE
Annotate with history cache

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -165,8 +165,7 @@ public final class HistoryGuru {
             try {
                 hist = getHistory(file);
             } catch (HistoryException ex) {
-                LOGGER.log(Level.FINEST,
-                        "Cannot get messages for tooltip: ", ex);
+                LOGGER.log(Level.FINEST, "Cannot get messages for tooltip: ", ex);
             }
             if (hist != null && annotation != null) {
                 Set<String> revs = annotation.getRevisions();


### PR DESCRIPTION
When I started working on #3685, I noticed that `getAnnotation()` needlessly reaches to the repository object to get the history of given file. In most cases this will lead to a SCM command being executed. Using history cache should be generally faster. If the history cache is disabled, this will fall back to the repository method.