### PR TITLE
add tunable for concurrency level of repository invalidation 

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -192,6 +192,7 @@ public final class Configuration {
     private boolean compressXref;
     private boolean indexVersionedFilesOnly;
     private int indexingParallelism;
+    private int repositoryInvalidationParallelism;
     private int historyParallelism;
     private int historyFileParallelism;
     private boolean tagsEnabled;
@@ -1166,6 +1167,14 @@ public final class Configuration {
 
     public void setIndexingParallelism(int value) {
         this.indexingParallelism = Math.max(value, 0);
+    }
+
+    public int getRepositoryInvalidationParallelism() {
+        return repositoryInvalidationParallelism;
+    }
+
+    public void setRepositoryInvalidationParallelism(int value) {
+        this.repositoryInvalidationParallelism = Math.max(value, 0);
     }
 
     public int getHistoryParallelism() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1115,6 +1115,16 @@ public final class RuntimeEnvironment {
     }
 
     /**
+     * Gets the value of {@link Configuration#getRepositoryInvalidationParallelism()} -- or
+     * if zero, then as a default gets the number of available processors halved.
+     * @return a natural number &gt;= 1
+     */
+    public int getRepositoryInvalidationParallelism() {
+        int parallelism = syncReadConfiguration(Configuration::getRepositoryInvalidationParallelism);
+        return parallelism < 1 ? (Runtime.getRuntime().availableProcessors() / 2) : parallelism;
+    }
+
+    /**
      * Gets the value of {@link Configuration#getHistoryParallelism()} -- or
      * if zero, then as a default gets the number of available processors.
      * @return a natural number &gt;= 1

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -817,7 +817,7 @@ public final class HistoryGuru {
         final CountDownLatch latch = new CountDownLatch(repos.size());
         int parallelismLevel;
         // Both indexer and web app startup should be as quick as possible.
-        if (cmdType.equals(CommandTimeoutType.INDEXER) || cmdType.equals(CommandTimeoutType.WEBAPP_START)) {
+        if (cmdType == CommandTimeoutType.INDEXER || cmdType == CommandTimeoutType.WEBAPP_START) {
             parallelismLevel = env.getIndexingParallelism();
         } else {
             parallelismLevel = env.getRepositoryInvalidationParallelism();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
@@ -245,7 +245,7 @@ public final class RepositoryFactory {
 
                 // If this repository displays tags only for files changed by tagged
                 // revision, we need to prepare list of all tags in advance.
-                if (env.isTagsEnabled() && repo.hasFileBasedTags()) {
+                if (cmdType.equals(CommandTimeoutType.INDEXER) && env.isTagsEnabled() && repo.hasFileBasedTags()) {
                     repo.buildTagList(file, cmdType);
                 }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -59,7 +59,7 @@ public class ConfigurationController {
     @PUT
     @Consumes(MediaType.APPLICATION_XML)
     public void set(final String body, @QueryParam("reindex") final boolean reindex) {
-        env.applyConfig(body, reindex, reindex ? CommandTimeoutType.INDEXER : CommandTimeoutType.RESTFUL);
+        env.applyConfig(body, reindex, CommandTimeoutType.RESTFUL);
         suggesterService.refresh();
     }
 


### PR DESCRIPTION
This change lowers the pressure on the system imposed by `HistoryGuru#invalidateRepositories()` by changing the concurrency level (the web app uses _parallelism_ which is not technically correct, I think) for the web app and avoiding repository tag construction in that code path. This is mainly targeting setting the configuration in the web app.

https://github.com/oracle/opengrok/wiki/Webapp-configuration will have to be updated.