### PR TITLE
be more robust in face of None

### DIFF
--- a/tools/src/main/python/opengrok_tools/projadm.py
+++ b/tools/src/main/python/opengrok_tools/projadm.py
@@ -223,8 +223,10 @@ def project_delete(logger, project, uri, doit=True, deletesource=False,
 
 def get_lock_file(args):
     project_list = list()
-    project_list.extend(args.add)
-    project_list.extend(args.delete)
+    if args.add is not None:
+        project_list.extend(args.add)
+    if args.delete is not None:
+        project_list.extend(args.delete)
     if len(project_list) == 0:
         name = "refresh"
     else:


### PR DESCRIPTION
When running `projadm -a` I ran into this:
```
Traceback (most recent call last):
  File "/opengrok/dist/bin/venv/bin/opengrok-projadm", line 11, in <module>
    load_entry_point('opengrok-tools==1.7.21', 'console_scripts', 'opengrok-projadm')()
  File "/opengrok/dist/bin/venv/lib/python3.7/site-packages/opengrok_tools/projadm.py", line 346, in main
    lock = FileLock(get_lock_file(args))
  File "/opengrok/dist/bin/venv/lib/python3.7/site-packages/opengrok_tools/projadm.py", line 227, in get_lock_file
    project_list.extend(args.delete)
TypeError: 'NoneType' object is not iterable
```
This change fixes that.