### PR TITLE
do not throw IllegalStateException in web app

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -319,7 +319,11 @@ public abstract class Repository extends RepositoryInfo {
         }
 
         if (this.getTagList() == null) {
-            throw new IllegalStateException("getTagList() is null");
+            if (RuntimeEnvironment.getInstance().isIndexer()) {
+                throw new IllegalStateException("getTagList() is null");
+            } else {
+                return;
+            }
         }
 
         Iterator<TagEntry> it = this.getTagList().descendingIterator();


### PR DESCRIPTION
This is a follow-up to #3775 to prevent:
```
java.lang.IllegalStateException: getTagList() is null
	at org.opengrok.indexer.history.Repository.assignTagsInHistory(Repository.java:322)
	at org.opengrok.indexer.history.GitRepository.getHistory(GitRepository.java:558)
	at org.opengrok.indexer.history.GitRepository.getLastHistoryEntry(GitRepository.java:476)
	at org.opengrok.indexer.history.HistoryGuru.getLastHistoryEntry(HistoryGuru.java:240)
	at org.opengrok.web.PageConfig.getLastRevFromHistory(PageConfig.java:1312)
	at org.opengrok.web.PageConfig.getLatestRevision(PageConfig.java:1302)
	at org.apache.jsp.list_jsp._jspService(list_jsp.java:288)
```