### PR TITLE
sanitize class paths

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
@@ -278,14 +278,14 @@ public abstract class PluginFramework<PluginType> {
      * delegates the loading to the custom class loader
      * {@link #loadClass(String)}.
      *
-     * @param jarfiles list of jar files containing java classes
+     * @param fileList list of jar files containing java classes
      * @see #handleLoadClass(String)
      * @see #loadClass(String)
      */
-    private void loadJarFiles(List<File> jarfiles) {
+    private void loadJarFiles(List<File> fileList) {
         PluginType pf;
 
-        for (File file : jarfiles) {
+        for (File file : fileList) {
             try (JarFile jar = new JarFile(file)) {
                 Enumeration<JarEntry> entries = jar.entries();
                 while (entries.hasMoreElements()) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
@@ -306,12 +306,12 @@ public abstract class PluginFramework<PluginType> {
     }
 
     @Nullable
-    private String getClassName(File f) {
-        if (!f.getName().endsWith(CLASS_SUFFIX)) {
+    private String getClassName(File file) {
+        if (!file.getName().endsWith(CLASS_SUFFIX)) {
             return null;
         }
 
-        String classname = f.getAbsolutePath().substring(pluginDirectory.getAbsolutePath().length() + 1);
+        String classname = file.getAbsolutePath().substring(pluginDirectory.getAbsolutePath().length() + 1);
         classname = classname.replace(File.separatorChar, '.'); // convert to package name
         // no need to check for the index from lastIndexOf because we're in a branch
         // where we expect the .class suffix
@@ -320,8 +320,8 @@ public abstract class PluginFramework<PluginType> {
     }
 
     @Nullable
-    private String getClassName(JarEntry f) {
-        final String filePath = f.getName();
+    private String getClassName(JarEntry jarEntry) {
+        final String filePath = jarEntry.getName();
         if (!filePath.endsWith(CLASS_SUFFIX)) {
             return null;
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
@@ -328,7 +328,7 @@ public abstract class PluginFramework<PluginType> {
 
         File file = new File(pluginDirectory.getAbsolutePath(), filePath);
         try {
-            if (!file.getCanonicalPath().startsWith(pluginDirectory.getCanonicalPath())) {
+            if (!file.getCanonicalPath().startsWith(pluginDirectory.getCanonicalPath() + File.separator)) {
                 return null;
             }
         } catch (IOException e) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
@@ -252,14 +252,14 @@ public abstract class PluginFramework<PluginType> {
      * delegates the loading to the custom class loader
      * {@link #loadClass(String)}.
      *
-     * @param classfiles list of files which possibly contain a java class
+     * @param fileList list of files which possibly contain a java class
      * @see #handleLoadClass(String)
      * @see #loadClass(String)
      */
-    private void loadClassFiles(List<File> classfiles) {
+    private void loadClassFiles(List<File> fileList) {
         PluginType plugin;
 
-        for (File file : classfiles) {
+        for (File file : fileList) {
             String classname = getClassName(file);
             if (classname == null || classname.isEmpty()) {
                 continue;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
@@ -329,9 +329,11 @@ public abstract class PluginFramework<PluginType> {
         File file = new File(pluginDirectory.getAbsolutePath(), filePath);
         try {
             if (!file.getCanonicalPath().startsWith(pluginDirectory.getCanonicalPath() + File.separator)) {
+                LOGGER.log(Level.WARNING, "canonical path for jar entry {0} leads outside the origin", filePath);
                 return null;
             }
         } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "failed to get canonical path for {0}", file);
             return null;
         }
 


### PR DESCRIPTION
This change should fix the "zip slip" issue in plugin framework reported by Sonar. Normally the plugin archives are considered trusted however a bit of sanitization does not hurt.