### PR TITLE
suppress Sonar warnings about auto-closeable DefinitionsTokenStream

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzer.java
@@ -200,6 +200,7 @@ public class PlainAnalyzer extends TextAnalyzer {
         }
     }
 
+    // DefinitionsTokenStream should not be used in try-with-resources
     @SuppressWarnings("java:S2095")
     private void tryAddingDefs(Document doc, Definitions defs, StreamSource src) throws IOException {
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzer.java
@@ -200,8 +200,8 @@ public class PlainAnalyzer extends TextAnalyzer {
         }
     }
 
-    private void tryAddingDefs(Document doc, Definitions defs, StreamSource src)
-            throws IOException {
+    @SuppressWarnings("java:S2095")
+    private void tryAddingDefs(Document doc, Definitions defs, StreamSource src) throws IOException {
 
         DefinitionsTokenStream defstream = new DefinitionsTokenStream();
         defstream.initialize(defs, src, this::wrapReader);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/plain/DefinitionsTokenStreamTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/plain/DefinitionsTokenStreamTest.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.plain;
@@ -97,6 +98,7 @@ public class DefinitionsTokenStreamTest {
             null);
     }
 
+    @SuppressWarnings("java:S2095")
     private void testDefinitionsVsContent(
             boolean expandTabs,
             String sourceResource,

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/plain/DefinitionsTokenStreamTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/plain/DefinitionsTokenStreamTest.java
@@ -98,6 +98,7 @@ public class DefinitionsTokenStreamTest {
             null);
     }
 
+    // DefinitionsTokenStream should not be used in try-with-resources
     @SuppressWarnings("java:S2095")
     private void testDefinitionsVsContent(
             boolean expandTabs,


### PR DESCRIPTION
As identified in #3782, the `DefinitionsTokenStream` should not be used with try-with-resources. This change attempts to suppress the Sonar warnings.