### PR TITLE
suppress warning about lack of sanitization

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
@@ -319,6 +319,8 @@ public abstract class PluginFramework<PluginType> {
         return classname;
     }
 
+    // The filePath is checked not to point outside the "target" directory in the code below.
+    @SuppressWarnings("javasecurity:S6096")
     @Nullable
     private String getClassName(JarEntry jarEntry) {
         final String filePath = jarEntry.getName();


### PR DESCRIPTION
Looks like the change to sanitize paths from the archive did not help w.r.t. Sonar warnings so this change adds error suppression.