### PR TITLE
Allow '.' in symbol tokens

### DIFF
--- a/opengrok-indexer/src/main/jflex/analysis/plain/PlainSymbolTokenizer.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/plain/PlainSymbolTokenizer.lex
@@ -36,7 +36,7 @@ import org.opengrok.indexer.analysis.JFlexSymbolMatcher;
 %char
 
 %%
-[a-zA-Z_] [a-zA-Z0-9_]* {
+[a-zA-Z_] [a-zA-Z0-9_.]* {
     onSymbolMatched(yytext(), yychar);
     return yystate();
 }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
Suggester suggests OpenGrok's package names as single tokens for search; however, the search will split the text by `.` into multiple tokens and the final result is empty.

Example:
![Screen Shot 2021-11-25 at 17 02 09](https://user-images.githubusercontent.com/12401160/143503390-25d79df5-a4ac-4e2d-893c-c5e9d76cb962.png)

http://demo.opengrok.org/search?project=OpenGrok&full=&defs=org.opengrok.indexer.history&refs=&path=&hist=&type=&xrd=&nn=1

This change fixes the problem as now the search is successful:
![Screen Shot 2021-11-25 at 17 04 55](https://user-images.githubusercontent.com/12401160/143503496-4d930f57-5f1f-43a5-b362-4de390239eb3.png)

However, the xref is still wrong, e.g.: http://demo.opengrok.org/xref/OpenGrok/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceHistoryParser.java?r=51e20d51#26

I'm not sure if this can have an adverse effect on other thing and if we should rather try to split the defs terms by `.` -> but then they do not represent the whole definition (in this instance the package).

@vladak, what do you think?