### PR TITLE
Fix terraform definitions regex

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -455,8 +455,8 @@ public class Ctags implements Resettable {
          */
         command.add("--kinddef-terraform=s,struct,Resource\\ names");
         command.add("--regex-terraform=" +
-                "/[[:<:]]resource[[:space:]]*\"([[:alpha:]][-_[:alpha:]]*)\"[[:space:]]*" +
-                "\"([[:alpha:]][-_[:alpha:]]*)\"[[:space:]]*\\{/" +
+                "/^[[:space:]]*resource[[:space:]]*\\\"([[:alpha:]][-_[:alpha:]]*)\\\"[[:space:]]*" +
+                "\\\"([[:alpha:]][-_[:alpha:]]*)\\\"[[:space:]]*\\{/" +
                 "\\1.\\2/s/");
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opengrok.indexer.util.TestRepository;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -135,5 +136,14 @@ public class CtagsTest {
             }
         }
         assertEquals(names.length, count, "function count");
+    }
+
+    @Test
+    void testTfTags() throws Exception {
+        var defs = getDefs("terraform/test.tf");
+        assertAll(
+                () -> assertEquals(1, defs.getTags().size()),
+                () -> assertEquals("oci_core_vcn.test_vcn", defs.getTags().get(0).symbol)
+        );
     }
 }

--- a/opengrok-indexer/src/test/resources/sources/terraform/test.tf
+++ b/opengrok-indexer/src/test/resources/sources/terraform/test.tf
@@ -1,0 +1,13 @@
+resource "oci_core_vcn" "test_vcn" {
+  #Required
+  compartment_id = var.compartment_id
+
+  #Optional
+  cidr_block = var.vcn_cidr_block
+  cidr_blocks = var.vcn_cidr_blocks
+  defined_tags = {"Operations.CostCenter"= "42"}
+  display_name = var.vcn_display_name
+  dns_label = var.vcn_dns_label
+  freeform_tags = {"Department"= "Finance"}
+  is_ipv6enabled = var.vcn_is_ipv6enabled
+}


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
There is a warning during indexing:
```
WARNING: Error from ctags: ctags: Warning: regcomp [[:<:]]resource[[:space:]]*"([[:alpha:]][-_[:alpha:]]*)"[[:space:]]*"([[:alpha:]][-_[:alpha:]]*)"[[:space:]]*\{: Invalid character class name
```
which causes no tf definitions to be recognized.

Thanks!