### PR TITLE
make kwd protected in Consts

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ada/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ada/Consts.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.ada;
@@ -30,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         kwd.add("abort");
         kwd.add("abs");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/asm/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/asm/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.asm;
 
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
 
     static {
         // CPP

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.c;
 
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
 
     static {
         // CPP

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/clojure/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/clojure/Consts.java
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         kwd.add("nil");
         kwd.add("*");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/csharp/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/csharp/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.csharp;
 
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         // C# Keywords
         kwd.add("abstract");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/eiffel/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/eiffel/Consts.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.eiffel;
@@ -30,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
 
     static {
         /*

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/erlang/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/erlang/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.erlang;
@@ -31,8 +31,8 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
-    public static final Set<String> modules_kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> modules_kwd = new HashSet<>();
     static {
         kwd.add("after"); // Ref. 9.1 "1.5 Reserved Words"
         kwd.add("and"); // Ref. 9.1 "1.5 Reserved Words"

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/fortran/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/fortran/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.fortran;
 
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
 
     static {
         // multi-word keywords, such as "DOUBLE PRECISION", etc. are for

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/golang/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/golang/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.golang;
@@ -32,7 +32,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         // Go Programming Language Specification 2015
         kwd.add("break");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/haskell/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/haskell/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.haskell;
@@ -32,7 +32,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         // Haskell 2010 Language Report, Chapter 2.4
         kwd.add("case");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/hcl/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/hcl/Consts.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.hcl;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.java;
 
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         kwd.add("abstract");
         kwd.add("assert");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/json/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/json/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.json;
 
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
 
     static {
         kwd.add("true");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/kotlin/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/kotlin/Consts.java
@@ -17,8 +17,8 @@
  * CDDL HEADER END
  */
 
- /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+/*
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.kotlin;
 
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
 
     static {
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lisp/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lisp/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.lisp;
 
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         kwd.add("and");
         kwd.add("assert");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lua/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lua/Consts.java
@@ -17,8 +17,8 @@
  * CDDL HEADER END
  */
 
- /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+/*
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.lua;
 
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         // Lua 5.3 Reference Manual, Chapter 3.1
         // http://www.lua.org/manual/5.3/manual.html

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.pascal;
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         kwd.add("abstract");
         kwd.add("and");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/perl/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/perl/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.perl;
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         // Note that keywords with 1 letter will be ignored for historical
         // reasons, as the {Identifier} used to require 2 characters in

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/php/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/php/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.php;
 
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         //Keywords
         kwd.add("abstract"); //As of PHP5

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/powershell/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/powershell/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.powershell;
 
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> poshkwd = new HashSet<>();
+    protected static final Set<String> poshkwd = new HashSet<>();
     static {
         // Powershell keywords
         poshkwd.add("begin");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/python/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/python/Consts.java
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         kwd.add("and");
         kwd.add("as"); //2.5 , 2.6

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/r/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/r/Consts.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.r;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/Consts.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.ruby;
@@ -30,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         kwd.add("false");
         kwd.add("FALSE");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/rust/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/rust/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2016, Nikolay Denev.
  */
 package org.opengrok.indexer.analysis.rust;
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         kwd.add("abstract");
         kwd.add("alignof");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/scala/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/scala/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.scala;
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         kwd.add("abstract");
         kwd.add("case");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sh/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sh/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.sh;
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> shkwd = new HashSet<>();
+    protected static final Set<String> shkwd = new HashSet<>();
     static {
         // Built-in shell commands mentioned in shell_builtins(1)
         shkwd.add(":");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.swift;
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
 
     static {
         kwd.add("associatedtype");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/tcl/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/tcl/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.tcl;
 
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
     static {
         // Tcl cmds
         kwd.add("after");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/terraform/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/terraform/Consts.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.terraform;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/verilog/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/verilog/Consts.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.verilog;
@@ -30,7 +31,7 @@ import java.util.Set;
  */
 public class Consts {
 
-    public static final Set<String> kwd = new HashSet<>();
+    protected static final Set<String> kwd = new HashSet<>();
 
     static {
         kwd.add("accept_on"); // IEEE 1800-2017


### PR DESCRIPTION
Seems like the `kwd` can be made protected in the various `Consts` since they are used in the lexers that belong to the same package. This addresses bunch of issues reported by Sonar.