### PR TITLE
replace X-Forwarded-Host with configuration value

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -300,6 +300,8 @@ public final class Configuration {
     private int historyChunkCount;
     private boolean historyCachePerPartesEnabled = true;
 
+    private String serverName;  // for reverse proxy environment
+
     /*
      * types of handling history for remote SCM repositories:
      *  ON - index history and display it in webapp
@@ -1401,6 +1403,14 @@ public final class Configuration {
 
     public void setHistoryCachePerPartesEnabled(boolean historyCachePerPartesEnabled) {
         this.historyCachePerPartesEnabled = historyCachePerPartesEnabled;
+    }
+
+    public String getServerName() {
+        return serverName;
+    }
+
+    public void setServerName(String serverName) {
+        this.serverName = serverName;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1410,6 +1410,14 @@ public final class RuntimeEnvironment {
         syncWriteConfiguration(disabledRepositories, Configuration::setDisabledRepositories);
     }
 
+    public String getServerName() {
+        return syncReadConfiguration(Configuration::getServerName);
+    }
+
+    public void setServerName(String serverName) {
+        syncWriteConfiguration(serverName, Configuration::setServerName);
+    }
+
     /**
      * Read an configuration file and set it as the current configuration.
      *

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1509,6 +1509,21 @@ public final class PageConfig {
     }
 
     /**
+     * Play nice in reverse proxy environment by using pre-configured hostname
+     * request to construct the URLs.
+     * Will not work well if the scheme or port is different for proxied server
+     * and original server.
+     * @return server name
+     */
+    public String getServerName() {
+        if (env.getServerName() != null) {
+            return env.getServerName();
+        } else {
+            return req.getServerName();
+        }
+    }
+
+    /**
      * Prepare a search helper with all required information, ready to execute
      * the query implied by the related request parameters and cookies.
      * <p>

--- a/opengrok-web/src/main/webapp/opensearch.jsp
+++ b/opengrok-web/src/main/webapp/opensearch.jsp
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 
@@ -45,30 +45,20 @@ include file="projects.jspf"
 
     // Optimize for URLs up to 128 characters. 
     StringBuilder url = new StringBuilder(128);
-    String ForwardedHost = request.getHeader("X-Forwarded-Host");
     String scheme = request.getScheme();
     int port = request.getServerPort();
 
     url.append(scheme).append("://");
 
-    // Play nice in proxy environment by using hostname from the original
-    // request to construct the URLs.
-    // Will not work well if the scheme or port is different for proxied server
-    // and original server. Unfortunately the X-Forwarded-Host does not seem to
-    // contain the port number so there is no way around it.
-    if (ForwardedHost != null) {
-        url.append(ForwardedHost);
-    } else {
-        url.append(request.getServerName());
+    String serverName = cfg.getServerName();
+    url.append(serverName);
 
-        // Append port if needed.
-        if ((port != 80 && scheme.equals("http")) ||
-                   (port != 443 && scheme.equals("https"))) {
-            url.append(':').append(port);
-        }
+    // Append port if needed.
+    if ((port != 80 && scheme.equals("http")) || (port != 443 && scheme.equals("https"))) {
+        url.append(':').append(port);
     }
 
-    String imgurl = url +  cfg.getCssDir() + "/img/icon.png";
+    String imgUrl = url + cfg.getCssDir() + "/img/icon.png";
 
     /* TODO  Bug 11749 ??? */
     StringBuilder text = new StringBuilder();
@@ -86,7 +76,7 @@ include file="projects.jspf"
     <ShortName>OpenGrok <%= text.toString() %></ShortName>
     <Description>Search in OpenGrok <%= text.toString() %></Description>
     <InputEncoding>UTF-8</InputEncoding>
-    <Image height="16" width="16" type="image/png"><%= imgurl %></Image>
+    <Image height="16" width="16" type="image/png"><%= imgUrl %></Image>
 <%-- <Url type="application/x-suggestions+json" template="suggestionURL"/>--%>
     <Url template="<%= url.toString() %>&amp;<%= QueryParameters.FULL_SEARCH_PARAM_EQ %>{searchTerms}"
         type="text/html"/>

--- a/opengrok-web/src/main/webapp/rss.jsp
+++ b/opengrok-web/src/main/webapp/rss.jsp
@@ -18,12 +18,10 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
-
+Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 
 --%><%@page import="
-java.io.File,
 java.text.SimpleDateFormat,
 java.util.Set,
 
@@ -34,7 +32,9 @@ org.opengrok.indexer.history.HistoryGuru,
 org.opengrok.indexer.web.Util,
 org.opengrok.indexer.web.Prefix,
 org.opengrok.web.PageConfig"
-%><%@ page session="false" errorPage="error.jsp"%><%
+%>
+<%@ page import="jakarta.servlet.http.HttpServletResponse" %>
+<%@ page session="false" errorPage="error.jsp"%><%
 /* ---------------------- rss.jsp start --------------------- */
 {
     PageConfig cfg = PageConfig.get(request);
@@ -51,7 +51,6 @@ org.opengrok.web.PageConfig"
     }
     String path = cfg.getPath();
     String dtag = cfg.getDefineTagsIndex();
-    String ForwardedHost = request.getHeader("X-Forwarded-Host");
     response.setContentType("text/xml");
 %><?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="<%= request.getContextPath()
@@ -90,21 +89,14 @@ org.opengrok.web.PageConfig"
             String replaced = entry.getMessage().split("\n")[0];
         %><%= Util.htmlize(entry.getRevision()) %> - <%= Util.htmlize(replaced) %></title>
         <link><%
-            // Play nice in proxy environment by using hostname from the original
-            // request to construct the URLs.
-            // Will not work well if the scheme or port is different for proxied server
-            // and original server. Unfortunately the X-Forwarded-Host does not seem to
-            // contain the port number so there is no way around it.
             String requestURL = request.getScheme() + "://";
-            if (ForwardedHost != null) {
-                requestURL += ForwardedHost;
-            } else {
-                requestURL += request.getServerName();
-                String port = Integer.toString(request.getLocalPort());
-                if (!port.isEmpty()) {
-                    requestURL += ":" + port;
-                }
+            String serverName = cfg.getServerName();
+            requestURL += serverName;
+            String port = Integer.toString(request.getLocalPort());
+            if (!port.isEmpty()) {
+                requestURL += ":" + port;
             }
+
             requestURL += request.getContextPath();
             requestURL += Prefix.HIST_L + cfg.getPath() + "#" + entry.getRevision();
         %><%= Util.htmlize(requestURL) %></link>


### PR DESCRIPTION
In opensearch and rss JSPs the `X-Forwarded-Host` request header is used to construct URLs which Sonar finds inappropriate. Rather than sanitizing I think it would be more prudent to supply the value from the configuration.

https://github.com/oracle/opengrok/wiki/Webapp-configuration#configuration-tunables will need to be updated.