### PR TITLE
suppress path injection error

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/util/FileUtil.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/util/FileUtil.java
@@ -46,6 +46,7 @@ public class FileUtil {
      * leads outside source root
      * @throws NoPathParameterException if the {@code path} parameter is null
      */
+    @SuppressWarnings("lgtm[java/path-injection]")
     public static File toFile(String path) throws NoPathParameterException, IOException {
         if (path == null) {
             throw new NoPathParameterException("Missing path parameter");


### PR DESCRIPTION
This change silences the LGTM warning for uncontrolled path in `toFile()`.

This was reported as false positive: https://github.com/github/codeql/issues/7277