### PR TITLE
suppress unsafe deserialization error in Configuration

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -1441,6 +1441,7 @@ public final class Configuration {
         return ret;
     }
 
+    @SuppressWarnings("lgtm[java/unsafe-deserialization]")
     private static Configuration decodeObject(InputStream in) throws IOException {
         final Object ret;
         final LinkedList<Exception> exceptions = new LinkedList<>();
@@ -1457,7 +1458,7 @@ public final class Configuration {
 
         if (!exceptions.isEmpty()) {
             // There was an exception during parsing.
-            // see {@code addGroup}
+            // see addGroup()
             if (exceptions.getFirst() instanceof IOException) {
                 throw (IOException) exceptions.getFirst();
             }
@@ -1466,7 +1467,7 @@ public final class Configuration {
 
         Configuration conf = ((Configuration) ret);
 
-        // Removes all non root groups.
+        // Removes all non-root groups.
         // This ensures that when the configuration is reloaded then the set
         // contains only root groups. Subgroups are discovered again
         // as follows below


### PR DESCRIPTION
LGTM reports `Configuration#decodeObject()` as unsafe deserialization (in particular when accepting data from `ConfigurationController` which is authorized or localhost only - via `IncomingFilter`), however `ConfigurationClassLoader` contains set of allowed classes. This change should suppress this warning.