### PR TITLE
handle delete failure in FileHistoryCache

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -815,7 +815,11 @@ class FileHistoryCache implements HistoryCache {
             // remove the file cached last revision (done separately in case
             // it gets ever moved outside of the hierarchy)
             File cachedRevFile = new File(revPath);
-            cachedRevFile.delete();
+            try {
+                Files.delete(cachedRevFile.toPath());
+            } catch (IOException e) {
+                LOGGER.log(Level.WARNING, String.format("failed to delete '%s'", cachedRevFile), e);
+            }
         }
 
         String histDir = getRepositoryHistDataDirname(repository);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -813,7 +813,7 @@ class FileHistoryCache implements HistoryCache {
         String revPath = getRepositoryCachedRevPath(repository);
         if (revPath != null) {
             // remove the file cached last revision (done separately in case
-            // it gets ever moved outside of the hierarchy)
+            // it gets ever moved outside the hierarchy)
             File cachedRevFile = new File(revPath);
             try {
                 Files.delete(cachedRevFile.toPath());


### PR DESCRIPTION
This change adds file delete failure handing for the file containing the last revision for given repository. 