### PR TITLE
reduce field visibility in SearchHelper

### DIFF
--- a/dev/checkstyle/suppressions.xml
+++ b/dev/checkstyle/suppressions.xml
@@ -40,7 +40,8 @@ Portions Copyright (c) 2018-2020, Chris Fraire <cfraire@me.com>.
 
     <suppress checks="ParameterNumber" files="CtagsReader\.java|Definitions\.java|
         |JFlexXrefUtils\.java|FileAnalyzerFactory\.java|SearchController\.java|
-        |Context\.java|HistoryContext\.java|Suggester\.java|ProjectHelperTestBase\.java" />
+        |Context\.java|HistoryContext\.java|Suggester\.java|
+	|ProjectHelperTestBase\.java|SearchHelper\.java" />
 
     <suppress checks="FileLength" files="RuntimeEnvironment\.java" />
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Prefix.java
@@ -63,7 +63,7 @@ public enum Prefix {
     DOWNLOAD_P("/download"),
     /** Raw file display (link prefix). */
     RAW_P("/raw"),
-    /** Full blown search from main page or top bar (link prefix). */
+    /** Full-blown search from main page or top bar (link prefix). */
     SEARCH_P("/search"),
     /** Search from cross reference, can lead to direct match (which opens
      * directly) or to a matches Summary page. */

--- a/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/StatisticsFilter.java
@@ -82,7 +82,7 @@ public class StatisticsFilter implements Filter {
         SearchHelper helper = (SearchHelper) config.getRequestAttribute(SearchHelper.REQUEST_ATTR);
         MeterRegistry registry = Metrics.getRegistry();
         if (helper != null && registry != null) {
-            if (helper.hits == null || helper.hits.length == 0) {
+            if (helper.getHits() == null || helper.getHits().length == 0) {
                 Timer.builder("search.latency").
                         tags("category", "ui", "outcome", "empty").
                         register(registry).

--- a/opengrok-web/src/main/webapp/history.jsp
+++ b/opengrok-web/src/main/webapp/history.jsp
@@ -45,6 +45,8 @@ org.opengrok.indexer.web.QueryParameters,
 org.opengrok.indexer.web.SearchHelper,
 org.opengrok.indexer.web.Util"
 %>
+<%@ page import="jakarta.servlet.http.HttpServletResponse" %>
+<%@ page import="org.opengrok.indexer.web.SortOrder" %>
 <%/* ---------------------- history.jsp start --------------------- */
 {
     final Logger LOGGER = LoggerFactory.getLogger(getClass());
@@ -61,7 +63,7 @@ org.opengrok.indexer.web.Util"
         String primePath = path;
         Project project = cfg.getProject();
         if (project != null) {
-            SearchHelper searchHelper = cfg.prepareInternalSearch();
+            SearchHelper searchHelper = cfg.prepareInternalSearch(SortOrder.RELEVANCY);
             /*
              * N.b. searchHelper.destroy() is called via
              * WebappListener.requestDestroyed() on presence of the following

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -53,6 +53,8 @@ org.opengrok.web.DirectoryListing,
 org.opengrok.indexer.web.SearchHelper"
 %>
 <%@ page import="static org.opengrok.web.PageConfig.DUMMY_REVISION" %>
+<%@ page import="org.opengrok.indexer.web.SortOrder" %>
+<%@ page import="jakarta.servlet.http.Cookie" %>
 <%
 {
     // need to set it here since requesting parameters
@@ -159,7 +161,7 @@ document.pageReady.push(function() { pageReadyList();});
         List<String> files = cfg.getResourceFileList();
         if (!files.isEmpty()) {
             List<NullableNumLinesLOC> extras = null;
-            SearchHelper searchHelper = cfg.prepareInternalSearch();
+            SearchHelper searchHelper = cfg.prepareInternalSearch(SortOrder.RELEVANCY);
             /*
              * N.b. searchHelper.destroy() is called via
              * WebappListener.requestDestroyed() on presence of the following
@@ -173,7 +175,7 @@ document.pageReady.push(function() { pageReadyList();});
                 searchHelper.prepareExec(new TreeSet<String>());
             }
 
-            if (searchHelper.searcher != null) {
+            if (searchHelper.getSearcher() != null) {
                 DirectoryExtraReader extraReader = new DirectoryExtraReader();
                 String primePath = path;
                 try {
@@ -182,7 +184,7 @@ document.pageReady.push(function() { pageReadyList();});
                     LOGGER.log(Level.WARNING, String.format(
                             "Error getting prime relative for %s", path), ex);
                 }
-                extras = extraReader.search(searchHelper.searcher, primePath);
+                extras = extraReader.search(searchHelper.getSearcher(), primePath);
             }
 
             FileExtraZipper zipper = new FileExtraZipper();

--- a/opengrok-web/src/main/webapp/more.jsp
+++ b/opengrok-web/src/main/webapp/more.jsp
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 
@@ -37,6 +37,7 @@ org.opengrok.indexer.logger.LoggerFactory,
 org.opengrok.indexer.util.IOUtils,
 org.opengrok.indexer.web.SearchHelper"
 %>
+<%@ page import="org.opengrok.indexer.web.SortOrder" %>
 <%
 {
     PageConfig cfg = PageConfig.get(request);
@@ -63,7 +64,7 @@ file="mast.jsp"
     if (activeProject == null) {
         qbuilder = cfg.getQueryBuilder();
     } else {
-        searchHelper = cfg.prepareInternalSearch();
+        searchHelper = cfg.prepareInternalSearch(SortOrder.RELEVANCY);
         /*
          * N.b. searchHelper.destroy() is called via
          * WebappListener.requestDestroyed() on presence of the following
@@ -71,9 +72,9 @@ file="mast.jsp"
          */
         request.setAttribute(SearchHelper.REQUEST_ATTR, searchHelper);
         searchHelper.prepareExec(activeProject);
-        if (searchHelper.searcher != null) {
+        if (searchHelper.getSearcher() != null) {
             docId = searchHelper.searchSingle(resourceFile);
-            qbuilder = searchHelper.builder;
+            qbuilder = searchHelper.getBuilder();
             searchHelper.prepareSummary();
             tabSize = searchHelper.getTabSize(activeProject);
         }
@@ -88,8 +89,8 @@ file="mast.jsp"
             String xrefPrefix = request.getContextPath() + Prefix.XREF_P;
             boolean didPresentNew = false;
             if (docId >= 0) {
-                didPresentNew = searchHelper.sourceContext.getContext2(env,
-                    searchHelper.searcher, docId, out, xrefPrefix, null, false,
+                didPresentNew = searchHelper.getSourceContext().getContext2(env,
+                    searchHelper.getSearcher(), docId, out, xrefPrefix, null, false,
                     tabSize);
             }
             if (!didPresentNew) {

--- a/opengrok-web/src/main/webapp/search.jsp
+++ b/opengrok-web/src/main/webapp/search.jsp
@@ -49,11 +49,11 @@ include file="projects.jspf"
 %><%!
     private StringBuilder createUrl(HttpServletRequest request, SearchHelper sh, boolean menu) {
         StringBuilder url = new StringBuilder(64);
-        QueryBuilder qb = sh.builder;
+        QueryBuilder qb = sh.getBuilder();
         if (menu) {
             url.append("search?");
         } else {
-            Util.appendQuery(url, QueryParameters.SORT_PARAM, sh.order.toString());
+            Util.appendQuery(url, QueryParameters.SORT_PARAM, sh.getOrder().toString());
         }
         if (qb != null) {
             Util.appendQuery(url, QueryParameters.FULL_SEARCH_PARAM, qb.getFreetext());
@@ -63,7 +63,7 @@ include file="projects.jspf"
             Util.appendQuery(url, QueryParameters.HIST_SEARCH_PARAM, qb.getHist());
             Util.appendQuery(url, QueryParameters.TYPE_SEARCH_PARAM, qb.getType());
         }
-        if (sh.projects != null && !sh.projects.isEmpty()) {
+        if (sh.getProjects() != null && !sh.getProjects().isEmpty()) {
             if (Boolean.parseBoolean(request.getParameter(QueryParameters.ALL_PROJECT_SEARCH))) {
                 Util.appendQuery(url, QueryParameters.ALL_PROJECT_SEARCH, Boolean.TRUE.toString());
             } else {
@@ -85,12 +85,13 @@ include file="projects.jspf"
     request.setAttribute(SearchHelper.REQUEST_ATTR, searchHelper);
     searchHelper.prepareExec(cfg.getRequestedProjects()).executeQuery().prepareSummary();
     // notify suggester that query was searched
-    SuggesterServiceFactory.getDefault().onSearch(cfg.getRequestedProjects(), searchHelper.query);
-    if (searchHelper.redirect != null) {
-        response.sendRedirect(searchHelper.redirect);
+    SuggesterServiceFactory.getDefault().onSearch(cfg.getRequestedProjects(), searchHelper.getQuery());
+    String redirect = searchHelper.getRedirect();
+    if (redirect != null) {
+        response.sendRedirect(redirect);
         return;
     }
-    if (searchHelper.errorMsg != null) {
+    if (searchHelper.getErrorMsg() != null) {
         cfg.setTitle("Search Error");
         // Set status to Internal error. This should help to avoid caching
         // the page by some proxies.
@@ -98,7 +99,8 @@ include file="projects.jspf"
     } else {
         cfg.setTitle(cfg.getSearchTitle());
     }
-    response.addCookie(new Cookie("OpenGrokSorting", URLEncoder.encode(searchHelper.order.toString(), StandardCharsets.UTF_8)));
+    response.addCookie(new Cookie("OpenGrokSorting",
+            URLEncoder.encode(searchHelper.getOrder().toString(), StandardCharsets.UTF_8)));
 }
 %><%@
 
@@ -121,7 +123,7 @@ include file="httpheader.jspf"
             append(QueryParameters.SORT_PARAM_EQ);
     int ordcnt = 0;
     for (SortOrder o : SortOrder.values()) {
-        if (searchHelper.order == o) {
+        if (searchHelper.getOrder() == o) {
                     %><span class="active"><%= o.getDesc() %></span><%
         } else {
                     %><a href="<%= url %><%= o %>"><%= o.getDesc() %></a><%
@@ -151,22 +153,22 @@ include file="menu.jspf"
     SearchHelper searchHelper = (SearchHelper) request.getAttribute(SearchHelper.REQUEST_ATTR);
     // TODO spellchecking cycle below is not that great and we only create
     // suggest links for every token in query, not for a query as whole
-    if (searchHelper.errorMsg != null) {
+    String errorMsg = searchHelper.getErrorMsg();
+    if (errorMsg != null) {
         %><h3>Error</h3><p class="pagetitle"><%
-        if (searchHelper.errorMsg.startsWith((SearchHelper.PARSE_ERROR_MSG))) {
+        if (searchHelper.getErrorMsg().startsWith((SearchHelper.PARSE_ERROR_MSG))) {
             %><%= Util.htmlize(SearchHelper.PARSE_ERROR_MSG) %>
             <br/>You might try to enclose your search term in quotes,
             <a href="help.jsp#escaping">escape special characters</a>
             with <b>\</b>, or read the <a href="help.jsp">Help</a>
             on the query language. Error message from parser:<br/>
-            <%= Util.htmlize(searchHelper.errorMsg.substring(
-                        SearchHelper.PARSE_ERROR_MSG.length())) %><%
+            <%= Util.htmlize(errorMsg.substring(SearchHelper.PARSE_ERROR_MSG.length())) %><%
         } else {
-            %><%= Util.htmlize(searchHelper.errorMsg) %><%
+            %><%= Util.htmlize(errorMsg) %><%
         }%></p><%
-    } else if (searchHelper.hits == null) {
+    } else if (searchHelper.getHits() == null) {
         %><p class="pagetitle">No hits</p><%
-    } else if (searchHelper.hits.length == 0) {
+    } else if (searchHelper.getHits().length == 0) {
         List<Suggestion> hints = searchHelper.getSuggestions();
         for (Suggestion hint : hints) {
         %><p class="suggestions"><font color="#cc0000">Did you mean (for <%= hint.name %>)</font>:<%
@@ -195,7 +197,7 @@ include file="menu.jspf"
         }
         %>
         <p class="pagetitle"> Your search <b><%
-            Util.htmlize(searchHelper.query.toString(), out); %></b>
+            Util.htmlize(searchHelper.getQuery().toString(), out); %></b>
             did not match any files.
             <br/> Suggestions:<br/>
         </p>
@@ -207,18 +209,18 @@ include file="menu.jspf"
         </ul>
 	<%
     } else {
-        int start = searchHelper.start;
-        int max = searchHelper.maxItems;
-        long totalHits = searchHelper.totalHits;
+        int start = searchHelper.getStart();
+        int max = searchHelper.getMaxItems();
+        long totalHits = searchHelper.getTotalHits();
         long thispage = Math.min(totalHits - start, max);  // number of items to display on the current page
         // We have a lots of results to show: create a slider for
         String slider = Util.createSlider(start, max, totalHits, request);
         %>
         <p class="pagetitle">Searched <b><%
-            Util.htmlize(searchHelper.query.toString(), out);
+            Util.htmlize(searchHelper.getQuery().toString(), out);
             %></b> (Results <b> <%= start + 1 %> – <%= thispage + start
             %></b> of <b><%= totalHits %></b>) sorted by <%=
-            searchHelper.order.getDesc() %></p><%
+            searchHelper.getOrder().getDesc() %></p><%
         if (slider.length() > 0) {
         %>
         <p class="slider"><%= slider %></p><%


### PR DESCRIPTION
This change converts `SearchHelper` into proper class, by reducing field visibility to `private` and introducing non-default constructor and getters/setters as necessary.