### PR TITLE
DiffData cleanup

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -348,7 +348,7 @@ public final class Util {
      *
      * @param urlPrefix prefix to add to each url
      * @param path path to crack
-     * @return HTML markup fro the breadcrumb or the path itself.
+     * @return HTML markup for the breadcrumb or the path itself.
      *
      * @see #breadcrumbPath(String, String, char)
      */
@@ -905,9 +905,8 @@ public final class Util {
     /**
      * Wrapper around UTF-8 URL encoding of a string.
      *
-     * @param q query to be encoded. If {@code null}, an empty string will be
-     * used instead.
-     * @return null if fail, otherwise the encoded string
+     * @param q query to be encoded. If {@code null}, an empty string will be used instead.
+     * @return null if failed, otherwise the encoded string
      * @see URLEncoder#encode(String, String)
      */
     public static String URIEncode(String q) {

--- a/opengrok-web/src/main/java/org/opengrok/web/DiffData.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/DiffData.java
@@ -35,9 +35,9 @@ import org.suigeneris.jrcs.diff.Revision;
  */
 public class DiffData {
     /** the directory which contains the given file wrt. to the source root directory. */
-    String path;
+    private final String path;
     /** the HTML escaped filename used. */
-    String filename;
+    private final String filename;
     /** the genre of the requested diff. */
     AbstractAnalyzer.Genre genre;
     /** the original and new revision container. */
@@ -57,6 +57,15 @@ public class DiffData {
     boolean full;
     /** How should the data be displayed (request parameter {@code format}. */
     DiffType type;
+
+    public DiffData(String path, String filename) {
+        this.path = path;
+        this.filename = filename;
+
+        this.rev = new String[2];
+        this.file = new String[2][];
+        this.param = new String[2];
+    }
 
     public String getPath() {
         return path;

--- a/opengrok-web/src/main/java/org/opengrok/web/DiffData.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/DiffData.java
@@ -19,43 +19,82 @@
 
 /*
  * Copyright (c) 2009, 2011, Jens Elkner.
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
-package org.opengrok.indexer.web;
+package org.opengrok.web;
 
 import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.suigeneris.jrcs.diff.Revision;
 
 /**
- * A simple container to store the data required to generated a view of diffs
+ * A simple container to store the data required to generate a view of diffs
  * for a certain versioned file.
  *
  * @author  Jens Elkner
- * @version $Revision$
  */
 public class DiffData {
-
     /** the directory which contains the given file wrt. to the source root directory. */
-    public String path;
+    String path;
     /** the HTML escaped filename used. */
-    public String filename;
+    String filename;
     /** the genre of the requested diff. */
-    public AbstractAnalyzer.Genre genre;
+    AbstractAnalyzer.Genre genre;
     /** the original and new revision container. */
-    public Revision revision;
-    /** the URI encoded parameter values of the request. {@code param[0]}
-     * belongs to {@code r1}, {@code param[1]} to {@code r2}. */
-    public String[] param;
+    Revision revision;
+    /**
+     * the URI encoded parameter values of the request. {@code param[0]}
+     * belongs to {@code r1}, {@code param[1]} to {@code r2}.
+     */
+    String[] param;
     /** the revision names extracted from {@link #param}. */
-    public String[] rev;
-    /** the content of the original and new file line-by-line corresponding
-     * with {@link #rev}. */
-    public String[][] file;
+    String[] rev;
+    /** the content of the original and new file line-by-line corresponding with {@link #rev}. */
+    String[][] file;
     /** error message to show, if diffs are not available. */
-    public String errorMsg;
+    String errorMsg;
     /** If {@code true} a full diff is desired. */
-    public boolean full;
+    boolean full;
     /** How should the data be displayed (request parameter {@code format}. */
-    public DiffType type;
+    DiffType type;
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public AbstractAnalyzer.Genre getGenre() {
+        return genre;
+    }
+
+    public Revision getRevision() {
+        return revision;
+    }
+
+    public String getParam(int index) {
+        return param[index];
+    }
+
+    public String getRev(int index) {
+        return rev[index];
+    }
+
+    public String[] getFile(int index) {
+        return file[index];
+    }
+
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+
+    public boolean isFull() {
+        return full;
+    }
+
+    public DiffType getType() {
+        return type;
+    }
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/DiffType.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/DiffType.java
@@ -21,13 +21,12 @@
  * Copyright (c) 2009, 2011, Jens Elkner.
  * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  */
-package org.opengrok.indexer.web;
+package org.opengrok.web;
 
 /**
  * Known diff display types.
  *
  * @author  Jens Elkner
- * @version $Revision$
  */
 public enum DiffType {
 

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1092,8 +1092,8 @@ public final class PageConfig {
 
     /**
      * Get the canonical path of the related resource relative to the source
-     * root directory (used file separators are all {@link org.opengrok.indexer.index.Indexer#PATH_SEPARATOR}). No check is made,
-     * whether the obtained path is really an accessible resource on disk.
+     * root directory (used file separators are all {@link org.opengrok.indexer.index.Indexer#PATH_SEPARATOR}).
+     * No check is made, whether the obtained path is really an accessible resource on disk.
      *
      * @see HttpServletRequest#getPathInfo()
      * @return a possible empty String (denotes the source root directory) but
@@ -1111,7 +1111,7 @@ public final class PageConfig {
     }
 
     /**
-     * @return true if file/directory corrsponding to the request path exists however is unreadable, false otherwise
+     * @return true if file/directory corresponding to the request path exists however is unreadable, false otherwise
      */
     public boolean isUnreadable() {
         File f = new File(getSourceRootPath(), getPath());
@@ -1122,7 +1122,7 @@ public final class PageConfig {
      * Get the on disk file for the given path.
      *
      * NOTE: If a repository contains hard or symbolic links, the returned file
-     * may finally point to a file outside of the source root directory.
+     * may finally point to a file outside the source root directory.
      *
      * @param path the path to the file relatively to the source root
      * @return null if the related file or directory is not
@@ -1143,11 +1143,11 @@ public final class PageConfig {
      * Get the on disk file to the request related file or directory.
      *
      * NOTE: If a repository contains hard or symbolic links, the returned file
-     * may finally point to a file outside of the source root directory.
+     * may finally point to a file outside the source root directory.
      *
-     * @return {@code new File({@link org.opengrok.indexer.index.Indexer#PATH_SEPARATOR_STRING })} if the related file or directory is not
-     * available (can not be find below the source root directory), the readable
-     * file or directory otherwise.
+     * @return {@code new File({@link org.opengrok.indexer.index.Indexer#PATH_SEPARATOR_STRING })}
+     * if the related file or directory is not available (can not be find below the source root directory),
+     * the readable file or directory otherwise.
      * @see #getSourceRootPath()
      * @see #getPath()
      */
@@ -1165,8 +1165,8 @@ public final class PageConfig {
      * Get the canonical on disk path to the request related file or directory
      * with all file separators replaced by a {@link org.opengrok.indexer.index.Indexer#PATH_SEPARATOR}.
      *
-     * @return {@link org.opengrok.indexer.index.Indexer#PATH_SEPARATOR_STRING} if the evaluated path is invalid or outside the source root
-     * directory), otherwise the path to the readable file or directory.
+     * @return {@link org.opengrok.indexer.index.Indexer#PATH_SEPARATOR_STRING} if the evaluated path is invalid
+     * or outside the source root directory, otherwise the path to the readable file or directory.
      * @see #getResourceFile()
      */
     public String getResourcePath() {
@@ -1181,8 +1181,7 @@ public final class PageConfig {
      * directory below the source root directory and whether it matches an
      * ignored pattern.
      *
-     * @return {@code true} if the related resource does not exists or should be
-     * ignored.
+     * @return {@code true} if the related resource does not exist or should be ignored.
      * @see #getIgnoredNames()
      * @see #getResourcePath()
      */
@@ -1350,7 +1349,7 @@ public final class PageConfig {
                 }
                 Date fileDate = new Date(getResourceFile().lastModified());
                 if (docDate.compareTo(fileDate) < 0) {
-                    LOGGER.log(Level.FINER, "document for '{0}' is out of sync", getResourceFile());
+                    LOGGER.log(Level.FINER, "document for ''{0}'' is out of sync", getResourceFile());
                     return null;
                 }
             }

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -276,7 +276,6 @@ public final class PageConfig {
             InputStream[] in = new InputStream[2];
             try {
                 // Get input stream for both older and newer file.
-                ExecutorService executor = this.executor;
                 Future<?>[] future = new Future<?>[2];
                 for (int i = 0; i < 2; i++) {
                     File f = new File(srcRoot + filepath[i]);

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -555,7 +555,7 @@ public final class PageConfig {
                     ret = x;
                 }
             } catch (NumberFormatException e) {
-                LOGGER.log(Level.INFO, "Failed to parse " + name + " integer " + s, e);
+                LOGGER.log(Level.INFO, String.format("Failed to parse %s integer %s", name, s), e);
             }
         }
         return ret;
@@ -597,14 +597,14 @@ public final class PageConfig {
 
     /**
      * Get sort orders from the request parameter {@code sort} and if this list
-     * would be empty from the cookie {@code OpenGrokorting}.
+     * would be empty from the cookie {@code OpenGrokSorting}.
      *
      * @return a possible empty list which contains the sort order values in the
      * same order supplied by the request parameter or cookie(s).
      */
     public List<SortOrder> getSortOrder() {
         List<SortOrder> sort = new ArrayList<>();
-        List<String> vals = getParamVals(QueryParameters.SORT_PARAM);
+        List<String> vals = getParameterValues(QueryParameters.SORT_PARAM);
         for (String s : vals) {
             SortOrder so = SortOrder.get(s);
             if (so != null) {
@@ -646,7 +646,7 @@ public final class PageConfig {
     }
 
     /**
-     * Get the eftar reader for the data directory. If it has been already
+     * Get the <i>Eftar</i> reader for the data directory. If it has been already
      * opened and not closed, this instance gets returned. One should not close
      * it once used: {@link #cleanup(ServletRequest)} takes care to close it.
      *
@@ -682,7 +682,6 @@ public final class PageConfig {
         if (eftarReader != null) {
             try {
                 dtag = eftarReader.get(getPath());
-                // cfg.getPrefix() != Prefix.XREF_S) {
             } catch (IOException e) {
                 LOGGER.log(Level.INFO, "Failed to get entry from eftar reader: ", e);
             }
@@ -770,12 +769,11 @@ public final class PageConfig {
     }
 
     /**
-     * Get the {@code path} parameter and display value for "Search only in"
-     * option.
+     * Get the {@code path} parameter and display value for "Search only in" option.
      *
      * @return always an array of 3 fields, whereby field[0] contains the path
-     * value to use (starts and ends always with a {@link org.opengrok.indexer.index.Indexer#PATH_SEPARATOR}). Field[1] the contains
-     * string to show in the UI. field[2] is set to {@code disabled=""} if the
+     * value to use (starts and ends always with a {@link org.opengrok.indexer.index.Indexer#PATH_SEPARATOR}).
+     * Field[1] the contains string to show in the UI. field[2] is set to {@code disabled=""} if the
      * current path is the "/" directory, otherwise set to an empty string.
      */
     public String[] getSearchOnlyIn() {
@@ -896,12 +894,12 @@ public final class PageConfig {
      * @param paramName name of the parameter.
      * @return a possible empty list.
      */
-    private List<String> getParamVals(String paramName) {
-        String[] vals = req.getParameterValues(paramName);
+    private List<String> getParameterValues(String paramName) {
+        String[] parameterValues = req.getParameterValues(paramName);
         List<String> res = new ArrayList<>();
-        if (vals != null) {
-            for (int i = vals.length - 1; i >= 0; i--) {
-                splitByComma(vals[i], res);
+        if (parameterValues != null) {
+            for (int i = parameterValues.length - 1; i >= 0; i--) {
+                splitByComma(parameterValues[i], res);
             }
         }
         return res;
@@ -952,7 +950,7 @@ public final class PageConfig {
         }
 
         // Add all projects which match the project parameter name values/
-        List<String> names = getParamVals(projectParamName);
+        List<String> names = getParameterValues(projectParamName);
         for (String projectName : names) {
             Project project = Project.getByName(projectName);
             if (project != null && project.isIndexed() && authFramework.isAllowed(req, project)) {
@@ -961,7 +959,7 @@ public final class PageConfig {
         }
 
         // Add all projects which are part of a group that matches the group parameter name.
-        names = getParamVals(groupParamName);
+        names = getParameterValues(groupParamName);
         for (String groupName : names) {
             Group group = Group.getByName(groupName);
             if (group != null) {
@@ -1246,7 +1244,7 @@ public final class PageConfig {
 
     /**
      * Find the files with the given names in the {@link #getPath()} directory
-     * relative to the crossfile directory of the opengrok data directory. It is
+     * relative to the cross-file directory of the opengrok data directory. It is
      * tried to find the compressed file first by appending the file extension
      * ".gz" to the filename. If that fails or an uncompressed version of the
      * file is younger than its compressed version, the uncompressed file gets
@@ -1275,7 +1273,7 @@ public final class PageConfig {
     }
 
     /**
-     * Lookup the file {@link #getPath()} relative to the crossfile directory of
+     * Lookup the file {@link #getPath()} relative to the cross-file directory of
      * the opengrok data directory. It is tried to find the compressed file
      * first by appending the file extension ".gz" to the filename. If that
      * fails or an uncompressed version of the file is younger than its
@@ -1368,7 +1366,7 @@ public final class PageConfig {
     }
 
     /**
-     * Get the location of cross reference for given file containing the given revision.
+     * Get the location of cross-reference for given file containing the given revision.
      * @param revStr defined revision string
      * @return location to redirect to
      */

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -276,8 +276,9 @@ public final class PageConfig {
         String context = req.getContextPath();
         String[] filepath = new String[2];
 
-        if (!getFileRevision(data, context, filepath))
+        if (!getFileRevision(data, context, filepath)) {
             return data;
+        }
 
         data.genre = AnalyzerGuru.getGenre(getResourceFile().getName());
         if (data.genre == null || txtGenres.contains(data.genre)) {

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -86,8 +86,6 @@ import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.IOUtils;
 import org.opengrok.indexer.util.LineBreaker;
 import org.opengrok.indexer.util.TandemPath;
-import org.opengrok.indexer.web.DiffData;
-import org.opengrok.indexer.web.DiffType;
 import org.opengrok.indexer.web.EftarFileReader;
 import org.opengrok.indexer.web.Laundromat;
 import org.opengrok.indexer.web.Prefix;
@@ -108,7 +106,7 @@ import org.suigeneris.jrcs.diff.DifferentiationFailedException;
  * Purpose is to decouple implementation details from web design, so that the
  * JSP developer does not need to know every implementation detail and normally
  * has to deal with this class/wrapper, only (so some people may like to call
- * this class a bean with request scope ;-)). Furthermore it helps to keep the
+ * this class a bean with request scope ;-)). Furthermore, it helps to keep the
  * pages (how content gets generated) consistent and to document the request
  * parameters used.
  * <p>
@@ -128,8 +126,8 @@ public final class PageConfig {
     public static final String DUMMY_REVISION = "unknown";
 
     // query parameters
-    protected static final String PROJECT_PARAM_NAME = "project";
-    protected static final String GROUP_PARAM_NAME = "group";
+    static final String PROJECT_PARAM_NAME = "project";
+    static final String GROUP_PARAM_NAME = "group";
     private static final String DEBUG_PARAM_NAME = "debug";
 
     // TODO if still used, get it from the app context
@@ -343,8 +341,7 @@ public final class PageConfig {
             try {
                 data.revision = Diff.diff(data.file[0], data.file[1]);
             } catch (DifferentiationFailedException e) {
-                data.errorMsg = "Unable to get diffs: "
-                        + Util.htmlize(e.getMessage());
+                data.errorMsg = "Unable to get diffs: " + Util.htmlize(e.getMessage());
             }
             for (int i = 0; i < 2; i++) {
                 try {

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1416,9 +1416,7 @@ public final class PageConfig {
     public String getDirectoryRedirect() {
         if (isDir()) {
             getPrefix();
-            /**
-             * Redirect /xref -> /xref/
-             */
+            // Redirect /xref -> /xref/
             if (prefix == Prefix.XREF_P
                     && getUriEncodedPath().isEmpty()
                     && !req.getRequestURI().endsWith("/")) {
@@ -1448,8 +1446,7 @@ public final class PageConfig {
      * Get the URI encoded canonical path to the related file or directory (the
      * URI part between the servlet path and the start of the query string).
      *
-     * @return an URI encoded path which might be an empty string but not
-     * {@code null}.
+     * @return a URI encoded path which might be an empty string but not {@code null}.
      * @see #getPath()
      */
     public String getUriEncodedPath() {
@@ -1488,7 +1485,7 @@ public final class PageConfig {
     }
 
     /**
-     * Get opengrok's configured dataroot directory. It is verified, that the
+     * Get opengrok's configured data root directory. It is verified, that the
      * used environment has a valid opengrok data root set and that it is an
      * accessible directory.
      *
@@ -1723,14 +1720,13 @@ public final class PageConfig {
      */
     public String getHistoryTitle() {
         String path = getPath();
-        return Util.htmlize(getShortPath(path) +
-                " - OpenGrok history log for " + path);
+        return Util.htmlize(getShortPath(path) + " - OpenGrok history log for " + path);
     }
 
     public String getPathTitle() {
         String path = getPath();
         String title = getShortPath(path);
-        if (getRequestedRevision() != null && !getRequestedRevision().isEmpty()) {
+        if (!getRequestedRevision().isEmpty()) {
             title += " (revision " + getRequestedRevision() + ")";
         }
         title += " - OpenGrok cross reference for " + (path.isEmpty() ? "/" : path);
@@ -1744,13 +1740,16 @@ public final class PageConfig {
         }
         File sourceRootPathFile = RuntimeEnvironment.getInstance().getSourceRootFile();
         if (!sourceRootPathFile.exists()) {
-            throw new FileNotFoundException(String.format("Source root path \"%s\" does not exist", sourceRootPathFile.getAbsolutePath()));
+            throw new FileNotFoundException(String.format("Source root path \"%s\" does not exist",
+                    sourceRootPathFile.getAbsolutePath()));
         }
         if (!sourceRootPathFile.isDirectory()) {
-            throw new FileNotFoundException(String.format("Source root path \"%s\" is not a directory", sourceRootPathFile.getAbsolutePath()));
+            throw new FileNotFoundException(String.format("Source root path \"%s\" is not a directory",
+                    sourceRootPathFile.getAbsolutePath()));
         }
         if (!sourceRootPathFile.canRead()) {
-            throw new IOException(String.format("Source root path \"%s\" is not readable", sourceRootPathFile.getAbsolutePath()));
+            throw new IOException(String.format("Source root path \"%s\" is not readable",
+                    sourceRootPathFile.getAbsolutePath()));
         }
     }
 
@@ -1762,7 +1761,7 @@ public final class PageConfig {
      * <li>Messages with tag = project's groups names</li>
      * </ol>
      *
-     * @return the sorted set of messages according to the accept time
+     * @return the sorted set of messages according to accept time
      * @see org.opengrok.indexer.web.messages.MessagesContainer#MESSAGES_MAIN_PAGE_TAG
      */
     private SortedSet<AcceptedMessage> getProjectMessages() {
@@ -1841,8 +1840,7 @@ public final class PageConfig {
      * Determines whether a match offset from a search result has been
      * indicated, and if so tries to calculate a translated xref fragment
      * identifier.
-     * @return {@code true} if an xref fragment identifier was calculated by
-     * the call to this method
+     * @return {@code true} if a xref fragment identifier was calculated by the call to this method
      */
     public boolean evaluateMatchOffset() {
         if (fragmentIdentifier == null) {
@@ -1861,8 +1859,8 @@ public final class PageConfig {
                             return true;
                         }
                     } catch (IOException e) {
-                        LOGGER.log(Level.WARNING, "Failed to evaluate match offset for " +
-                                resourceFile, e);
+                        LOGGER.log(Level.WARNING, String.format("Failed to evaluate match offset for %s",
+                                resourceFile), e);
                     }
                 }
             }

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -226,15 +226,13 @@ public final class PageConfig {
     }
 
     /**
-     * Get all data required to create a diff view w.r.t. to this request in one
-     * go.
+     * Get all data required to create a diff view w.r.t. to this request in one go.
      *
-     * @return an instance with just enough information to render a sufficient
-     * view. If not all required parameters were given either they are
-     * supplemented with reasonable defaults if possible, otherwise the related
-     * field(s) are {@code null}. {@link DiffData#errorMsg}
-     *  {@code != null} indicates, that an error occured and one should not try
-     * to render a view.
+     * @return an instance with just enough information to render a sufficient view.
+     * If not all required parameters were given either they are supplemented
+     * with reasonable defaults if possible, otherwise the related field(s) are {@code null}.
+     * {@link DiffData#errorMsg}
+     * {@code != null} indicates that an error occurred and one should not try to render a view.
      */
     public DiffData getDiffData() {
         DiffData data = new DiffData();

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -233,17 +233,12 @@ public final class PageConfig {
      * {@code != null} indicates that an error occurred and one should not try to render a view.
      */
     public DiffData getDiffData() {
-        DiffData data = new DiffData();
-        data.path = getPath().substring(0, getPath().lastIndexOf(PATH_SEPARATOR));
-        data.filename = Util.htmlize(getResourceFile().getName());
+        DiffData data = new DiffData(getPath().substring(0, getPath().lastIndexOf(PATH_SEPARATOR)),
+                Util.htmlize(getResourceFile().getName()));
 
         String srcRoot = getSourceRootPath();
         String context = req.getContextPath();
-
         String[] filepath = new String[2];
-        data.rev = new String[2];
-        data.file = new String[2][];
-        data.param = new String[2];
 
         /*
          * Basically the request URI looks like this:

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -227,7 +227,7 @@ public final class PageConfig {
      * Extract file path and revision strings from the URL.
      * @param data DiffData object
      * @param context context path
-     * @param filepath file path
+     * @param filepath file path array (output parameter)
      * @return true if the extraction was successful, false otherwise
      * (in which case {@link DiffData#errorMsg} will be set)
      */

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -459,12 +459,12 @@ public final class PageConfig {
                 List<String> listOfFiles = getSortedFiles(files);
 
                 if (env.hasProjects() && getPath().isEmpty()) {
-                    /**
+                    /*
                      * This denotes the source root directory, we need to filter
                      * projects which aren't allowed by the authorization
                      * because otherwise the main xref page expose the names of
                      * all projects in OpenGrok even those which aren't allowed
-                     * for the particular user. E. g. remove all which aren't
+                     * for the particular user. E.g. remove all which aren't
                      * among the filtered set of projects.
                      *
                      * The authorization check is made in

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -114,7 +114,6 @@ import org.suigeneris.jrcs.diff.DifferentiationFailedException;
  * method of this class changes neither the request nor the response.
  *
  * @author Jens Elkner
- * @version $Revision$
  */
 public final class PageConfig {
 

--- a/opengrok-web/src/test/java/org/opengrok/web/DiffTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/DiffTest.java
@@ -1,0 +1,125 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.history.HistoryGuru;
+import org.opengrok.indexer.history.RepositoryFactory;
+import org.opengrok.indexer.index.Indexer;
+import org.opengrok.indexer.util.TestRepository;
+import org.opengrok.indexer.web.QueryParameters;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DiffTest {
+
+    private static final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+    private static TestRepository repository;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        repository = new TestRepository();
+        repository.create(HistoryGuru.class.getResourceAsStream("repositories.zip"));
+
+        env.setSourceRoot(repository.getSourceRoot());
+        env.setDataRoot(repository.getDataRoot());
+        env.setProjectsEnabled(true);
+        env.setHistoryEnabled(true);
+        RepositoryFactory.initializeIgnoredNames(env);
+
+        Indexer.getInstance().prepareIndexer(
+                env,
+                true, // search for repositories
+                true, // scan and add projects
+                false, // don't create dictionary
+                null, // subFiles - needed when refreshing history partially
+                null); // repositories - needed when refreshing history partially
+    }
+
+    @AfterAll
+    static void tearDown() {
+        repository.destroy();
+    }
+
+    @Test
+    void testGetDiffDataNoParams() {
+        final HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getPathInfo()).thenReturn("foo/bar");
+        when(req.getContextPath()).thenReturn("/source");
+
+        PageConfig pageConfig = PageConfig.get(req);
+        DiffData diffData = pageConfig.getDiffData();
+        assertNotNull(diffData);
+        assertNotNull(diffData.getErrorMsg());
+        assertTrue(diffData.getErrorMsg().startsWith("Please pick"));
+    }
+
+    @Test
+    void testGetDiffDataInvalidRevision() {
+        final HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getPathInfo()).thenReturn("git/main.c");
+        when(req.getContextPath()).thenReturn("/source");
+        when(req.getParameter(QueryParameters.REVISION_PARAM + "1")).thenReturn("main.c@abc");
+        when(req.getParameter(QueryParameters.REVISION_PARAM + "2")).thenReturn("main.c@xyz");
+
+        PageConfig pageConfig = PageConfig.get(req);
+        DiffData diffData = pageConfig.getDiffData();
+        assertNotNull(diffData);
+        assertNotNull(diffData.getErrorMsg());
+        assertTrue(diffData.getErrorMsg().startsWith("Unable to get revision"));
+    }
+
+    @Test
+    void testGetDiffData() {
+        final HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getPathInfo()).thenReturn("/git/main.c");
+        when(req.getContextPath()).thenReturn("/source");
+        final String rev1 = "bb74b7e";
+        final String rev2 = "aa35c25";
+        when(req.getParameter(QueryParameters.REVISION_PARAM + "1")).
+                thenReturn("/git/main.c@" + rev1);
+        when(req.getParameter(QueryParameters.REVISION_PARAM + "2")).
+                thenReturn("/git/main.c@" + rev2);
+
+        PageConfig pageConfig = PageConfig.get(req);
+        DiffData diffData = pageConfig.getDiffData();
+        assertNotNull(diffData);
+        assertNull(diffData.getErrorMsg());
+        assertAll(() -> assertEquals(rev1, diffData.getRev(0)),
+                () -> assertEquals(rev2, diffData.getRev(1)),
+                () -> assertTrue(diffData.getFile(0).length > 0),
+                () -> assertTrue(diffData.getFile(1).length > 0)
+        );
+    }
+}


### PR DESCRIPTION
This change is half-hearted attempt to address Sonar issues found in `DiffData` and push it away from being a dumb container class. I moved it (along with `DiffType`) to the `org.opengrok.web` package which allows to access the now package-private fields from `PageConfig` and introduced bunch of getters to make `diff.jsp` work.