### PR TITLE
lower the visibility of the constructor in AnalyzerFactory

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AbstractAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AbstractAnalyzer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved. Use is subject to license terms.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
@@ -49,7 +49,7 @@ public abstract class AbstractAnalyzer extends Analyzer {
     protected boolean scopesEnabled;
     protected boolean foldingEnabled;
 
-    public AbstractAnalyzer(ReuseStrategy reuseStrategy) {
+    protected AbstractAnalyzer(ReuseStrategy reuseStrategy) {
         super(reuseStrategy);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
@@ -65,7 +65,7 @@ public abstract class AnalyzerFactory {
      */
     protected AbstractAnalyzer.Genre genre;
 
-    public AnalyzerFactory(FileAnalyzerFactory.Matcher matcher, String contentType) {
+    protected AnalyzerFactory(FileAnalyzerFactory.Matcher matcher, String contentType) {
         cachedAnalyzer = new ThreadLocal<>();
         if (matcher == null) {
             this.matchers = Collections.emptyList();


### PR DESCRIPTION
Sonar says: 
> Constructors of abstract classes can only be called in constructors of their subclasses.