### PR TITLE
log merged/written revisions in FileHistoryCache

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -659,7 +659,7 @@ public final class RuntimeEnvironment {
     /**
      * Get the max time a SCM operation may use to avoid being cached.
      *
-     * @return the max time
+     * @return the maximum time in milliseconds
      */
     public int getHistoryReaderTimeLimit() {
         return syncReadConfiguration(Configuration::getHistoryCacheTime);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -676,15 +676,20 @@ class FileHistoryCache implements HistoryCache {
             return null;
         }
 
-        // Either the cache is stale or retrieving the history took too long, cache it!
-        if (!file.isDirectory() && (cacheFile.exists() || (time > env.getHistoryReaderTimeLimit()))) {
-            // Also, don't cache history-information for directories, since the
-            // history information on the directory may change if a file in
-            // a sub-directory change. This will cause us to present a stale
-            // history log until the current directory is updated and
-            // invalidates the cache entry.
-            LOGGER.log(Level.FINEST, "getting history for ''{0}'' took longer than {1} ms, caching it [{2}]",
-                    new Object[]{file, env.getHistoryReaderTimeLimit(), history.getRevisionList()});
+        // Don't cache history-information for directories, since the
+        // history information on the directory may change if a file in
+        // a sub-directory change. This will cause us to present a stale
+        // history log until the current directory is updated and
+        // invalidates the cache entry.
+        if (!file.isDirectory()) {
+            // Either the cache is stale or retrieving the history took too long, cache it!
+            if (cacheFile.exists()) {
+                LOGGER.log(Level.FINEST, "refreshing history for ''{0}'': {1}",
+                        new Object[]{file, history.getRevisionList()});
+            } else if (time > env.getHistoryReaderTimeLimit()) {
+                LOGGER.log(Level.FINEST, "getting history for ''{0}'' took longer than {1} ms, caching it: {2}",
+                        new Object[]{file, env.getHistoryReaderTimeLimit(), history.getRevisionList()});
+            }
             storeFile(history, file, repository);
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -692,13 +692,14 @@ class FileHistoryCache implements HistoryCache {
                     LOGGER.log(Level.FINEST, "refreshing history for ''{0}'': {1}",
                             new Object[]{file, history.getRevisionList()});
                 }
+                storeFile(history, file, repository);
             } else if (time > env.getHistoryReaderTimeLimit()) {
                 if (LOGGER.isLoggable(Level.FINEST)) {
                     LOGGER.log(Level.FINEST, "getting history for ''{0}'' took longer than {1} ms, caching it: {2}",
                             new Object[]{file, env.getHistoryReaderTimeLimit(), history.getRevisionList()});
                 }
+                storeFile(history, file, repository);
             }
-            storeFile(history, file, repository);
         }
 
         return history;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -392,7 +392,7 @@ class FileHistoryCache implements HistoryCache {
             // create confusion (once it starts working again).
             LOGGER.log(Level.WARNING,
                 "Could not store history for repository {0}: {1} is not a directory",
-                new Object[]{repository.getDirectoryName(), histDir});
+                new Object[]{repository, histDir});
         } else {
             storeLatestCachedRevision(repository, latestRev);
         }
@@ -505,7 +505,7 @@ class FileHistoryCache implements HistoryCache {
          * The renamed files will be handled separately.
          */
         LOGGER.log(Level.FINE, "Storing history for {0} regular files in repository ''{1}'' till {2}",
-                new Object[]{regularFiles.size(), repository.getDirectoryName(), getRevisionString(tillRevision)});
+                new Object[]{regularFiles.size(), repository, getRevisionString(tillRevision)});
         final File root = env.getSourceRootFile();
 
         final CountDownLatch latch = new CountDownLatch(regularFiles.size());
@@ -536,7 +536,7 @@ class FileHistoryCache implements HistoryCache {
                 LOGGER.log(Level.SEVERE, "latch exception", ex);
             }
             LOGGER.log(Level.FINE, "Stored history for {0} regular files in repository ''{1}''",
-                    new Object[]{fileHistoryCount, repository.getDirectoryName()});
+                    new Object[]{fileHistoryCount, repository});
         }
 
         if (!handleRenamedFiles) {
@@ -564,7 +564,7 @@ class FileHistoryCache implements HistoryCache {
         renamedFiles = renamedFiles.stream().filter(f -> new File(env.getSourceRootPath() + f).exists()).
                 collect(Collectors.toSet());
         LOGGER.log(Level.FINE, "Storing history for {0} renamed files in repository ''{1}'' till {2}",
-                new Object[]{renamedFiles.size(), repository.getDirectoryName(), getRevisionString(tillRevision)});
+                new Object[]{renamedFiles.size(), repository, getRevisionString(tillRevision)});
 
         createDirectoriesForFiles(renamedFiles, repository, "renamed files for history " +
                 getRevisionString(tillRevision));
@@ -602,7 +602,7 @@ class FileHistoryCache implements HistoryCache {
             }
         }
         LOGGER.log(Level.FINE, "Stored history for {0} renamed files in repository ''{1}''",
-                new Object[]{renamedFileHistoryCount.intValue(), repository.getDirectoryName()});
+                new Object[]{renamedFileHistoryCount.intValue(), repository});
     }
 
     private void createDirectoriesForFiles(Set<String> files, Repository repository, String label)
@@ -731,11 +731,10 @@ class FileHistoryCache implements HistoryCache {
         String repoDirBasename;
 
         try {
-            repoDirBasename = env.getPathRelativeToSourceRoot(
-                    new File(repository.getDirectoryName()));
+            repoDirBasename = env.getPathRelativeToSourceRoot(new File(repository.getDirectoryName()));
         } catch (IOException ex) {
-            LOGGER.log(Level.WARNING, "Could not resolve " +
-                repository.getDirectoryName() + " relative to source root", ex);
+            LOGGER.log(Level.WARNING,
+                    String.format("Could not resolve repository %s relative to source root", repository), ex);
             return null;
         } catch (ForbiddenSymlinkException ex) {
             LOGGER.log(Level.FINER, ex.getMessage());
@@ -768,8 +767,8 @@ class FileHistoryCache implements HistoryCache {
                   new FileOutputStream(getRepositoryCachedRevPath(repository))));
             writer.write(rev);
         } catch (IOException ex) {
-            LOGGER.log(Level.WARNING, "Cannot write latest cached revision to file for " + repository.getDirectoryName(),
-                ex);
+            LOGGER.log(Level.WARNING,
+                    String.format("Cannot write latest cached revision to file for repository %s", repository), ex);
         } finally {
            try {
                if (writer != null) {
@@ -788,8 +787,7 @@ class FileHistoryCache implements HistoryCache {
 
         String revPath = getRepositoryCachedRevPath(repository);
         if (revPath == null) {
-            LOGGER.log(Level.WARNING, "no rev path for {0}",
-                repository.getDirectoryName());
+            LOGGER.log(Level.WARNING, "no rev path for repository {0}", repository);
             return null;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -246,8 +246,10 @@ class FileHistoryCache implements HistoryCache {
      */
     private void writeHistoryToFile(File dir, History history, File cacheFile) throws HistoryException {
 
-        LOGGER.log(Level.FINEST, "writing history entries to ''{0}'': {1}",
-                new Object[]{cacheFile, history.getRevisionList()});
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, "writing history entries to ''{0}'': {1}",
+                    new Object[]{cacheFile, history.getRevisionList()});
+        }
 
         // We have a problem that multiple threads may access the cache layer
         // at the same time. Since I would like to avoid read-locking, I just
@@ -309,8 +311,10 @@ class FileHistoryCache implements HistoryCache {
             // Merge old history with the new history.
             List<HistoryEntry> listOld = histOld.getHistoryEntries();
             if (!listOld.isEmpty()) {
-                LOGGER.log(Level.FINEST, "for ''{0}'' merging old history {1} with new history {2}",
-                        new Object[]{cacheFile, histOld.getRevisionList(), histNew.getRevisionList()});
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST, "for ''{0}'' merging old history {1} with new history {2}",
+                            new Object[]{cacheFile, histOld.getRevisionList(), histNew.getRevisionList()});
+                }
                 List<HistoryEntry> listNew = histNew.getHistoryEntries();
                 ListIterator<HistoryEntry> li = listNew.listIterator(listNew.size());
                 while (li.hasPrevious()) {
@@ -684,11 +688,15 @@ class FileHistoryCache implements HistoryCache {
         if (!file.isDirectory()) {
             // Either the cache is stale or retrieving the history took too long, cache it!
             if (cacheFile.exists()) {
-                LOGGER.log(Level.FINEST, "refreshing history for ''{0}'': {1}",
-                        new Object[]{file, history.getRevisionList()});
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST, "refreshing history for ''{0}'': {1}",
+                            new Object[]{file, history.getRevisionList()});
+                }
             } else if (time > env.getHistoryReaderTimeLimit()) {
-                LOGGER.log(Level.FINEST, "getting history for ''{0}'' took longer than {1} ms, caching it: {2}",
-                        new Object[]{file, env.getHistoryReaderTimeLimit(), history.getRevisionList()});
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST, "getting history for ''{0}'' took longer than {1} ms, caching it: {2}",
+                            new Object[]{file, env.getHistoryReaderTimeLimit(), history.getRevisionList()});
+                }
             }
             storeFile(history, file, repository);
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -676,7 +676,7 @@ class FileHistoryCache implements HistoryCache {
             return null;
         }
 
-        if (!file.isDirectory() && cacheFile.exists() && (time > env.getHistoryReaderTimeLimit())) {
+        if (!file.isDirectory() && (cacheFile.exists() || (time > env.getHistoryReaderTimeLimit()))) {
             // Retrieving the history took too long, cache it!
             // Also, don't cache history-information for directories, since the
             // history information on the directory may change if a file in

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -309,7 +309,7 @@ class FileHistoryCache implements HistoryCache {
             // Merge old history with the new history.
             List<HistoryEntry> listOld = histOld.getHistoryEntries();
             if (!listOld.isEmpty()) {
-                LOGGER.log(Level.FINEST, "for ''{0}'' merging old history [{1}] with new history [{2}]",
+                LOGGER.log(Level.FINEST, "for ''{0}'' merging old history {1} with new history {2}",
                         new Object[]{cacheFile, histOld.getRevisionList(), histNew.getRevisionList()});
                 List<HistoryEntry> listNew = histNew.getHistoryEntries();
                 ListIterator<HistoryEntry> li = listNew.listIterator(listNew.size());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -676,8 +676,8 @@ class FileHistoryCache implements HistoryCache {
             return null;
         }
 
+        // Either the cache is stale or retrieving the history took too long, cache it!
         if (!file.isDirectory() && (cacheFile.exists() || (time > env.getHistoryReaderTimeLimit()))) {
-            // Retrieving the history took too long, cache it!
             // Also, don't cache history-information for directories, since the
             // history information on the directory may change if a file in
             // a sub-directory change. This will cause us to present a stale

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Class representing the history of a file.
@@ -156,6 +157,14 @@ public class History implements Serializable {
 
     public Set<String> getRenamedFiles() {
         return renamedFiles;
+    }
+
+    /**
+     * @return list of revisions
+     */
+    public List<String> getRevisionList() {
+        return getHistoryEntries().stream().
+                map(HistoryEntry::getRevision).collect(Collectors.toList());
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -100,7 +100,26 @@ public abstract class Repository extends RepositoryInfo {
     abstract boolean hasHistoryForDirectories();
 
     public String toString() {
-        return this.getDirectoryName();
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("{");
+        stringBuilder.append("dir=");
+        stringBuilder.append(this.getDirectoryName());
+        stringBuilder.append(",");
+        stringBuilder.append("type=");
+        stringBuilder.append(getType());
+        stringBuilder.append(",");
+
+        if (!isHistoryEnabled()) {
+            stringBuilder.append("history=off");
+        } else {
+            stringBuilder.append("renamed=");
+            stringBuilder.append(this.isHandleRenamedFiles());
+            stringBuilder.append(",");
+            stringBuilder.append("merge=");
+            stringBuilder.append(this.isMergeCommitsEnabled());
+        }
+        stringBuilder.append("}");
+        return stringBuilder.toString();
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -96,6 +96,9 @@ public class RepositoryInfo implements Serializable {
         this.parent = orig.parent;
         this.branch = orig.branch;
         this.currentVersion = orig.currentVersion;
+        this.historyEnabled = orig.historyEnabled;
+        this.handleRenamedFiles = orig.handleRenamedFiles;
+        this.mergeCommitsEnabled = orig.mergeCommitsEnabled;
     }
 
     /**


### PR DESCRIPTION
This change is aimed at aiding debugging of #1114. I suspect there is either something fishy in the history merging process or the forced history cache refresh in `get()`. Having the debug log capability in the release allows me to use in on our production instance.

I fixed some minor issues in the (neighboring) code and augmented the `Repositoryinfo` copy constructor (which might be actually relevant to the issue), otherwise the semantics should be retained.

Both the indexer and webapp would have to run with `FINEST` log level in order to get as much data about the problem as possible.