### PR TITLE
Add additional printable chars to full index

### DIFF
--- a/opengrok-indexer/src/main/jflex/analysis/plain/PlainFullTokenizer.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/plain/PlainFullTokenizer.lex
@@ -41,7 +41,7 @@ import org.opengrok.indexer.analysis.JFlexSymbolMatcher;
 Identifier = [a-zA-Z\p{Letter}_] [a-zA-Z\p{Letter}0-9\p{Number}_]*
 Number = [0-9]+|[0-9]+\.[0-9]+| "0[xX]" [0-9a-fA-F]+
 // No letters in the following, so no toLowerCase(Locale.ROOT) needed.
-Printable = [\@\$\%\^\&\-+=\?\.\:]
+Printable = [\@\$\%\^\&\-+=\?\.\:!\[\]\{\}*\/\|#\<\>\(\),;~]
 
 %%
 {Identifier}|{Number}|{Printable} {


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
This change adds additional chars to the list of printable characters that is being recognized by full tokenizer.

This change will be especially useful for `""` queries that could now return proper results even for the following:
- `!= null`
- `new int[0]`
- `#!/bin/`
- `/**`


Thanks to @Aldarrion for the suggestion.
