### PR TITLE
FileHistoryCache#get() should not modify history cache

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -108,11 +108,6 @@ public final class Configuration {
      */
     private boolean historyCache;
     /**
-     * The maximum time in milliseconds {@code HistoryCache.get()} can take
-     * before its result is cached.
-     */
-    private int historyCacheTime;
-    /**
      * flag to generate history. This is bigger hammer than @{code historyCache}
      * above. If set to false, no history query will be ever made and the webapp
      * will not display any history related links/allow any history queries.
@@ -543,7 +538,6 @@ public final class Configuration {
         setGroupsCollapseThreshold(4);
         setHandleHistoryOfRenamedFiles(false);
         setHistoryCache(true);
-        setHistoryCacheTime(30);
         setHistoryEnabled(true);
         setHitsPerPage(25);
         setIgnoredNames(new IgnoredNames());
@@ -805,28 +799,6 @@ public final class Configuration {
      */
     public void setHistoryCache(boolean historyCache) {
         this.historyCache = historyCache;
-    }
-
-    /**
-     * How long can a history request take before it's cached? If the time is
-     * exceeded, the result is cached. This setting only affects
-     * {@code FileHistoryCache}.
-     *
-     * @return the maximum time in milliseconds a history request can take
-     * before it's cached
-     */
-    public int getHistoryCacheTime() {
-        return historyCacheTime;
-    }
-
-    /**
-     * Set the maximum time a history request can take before it's cached. This
-     * setting is only respected if {@code FileHistoryCache} is used.
-     *
-     * @param historyCacheTime maximum time in milliseconds
-     */
-    public void setHistoryCacheTime(int historyCacheTime) {
-        this.historyCacheTime = historyCacheTime;
     }
 
     public boolean isFetchHistoryWhenNotInCache() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -657,25 +657,6 @@ public final class RuntimeEnvironment {
     }
 
     /**
-     * Get the max time a SCM operation may use to avoid being cached.
-     *
-     * @return the maximum time in milliseconds
-     */
-    public int getHistoryReaderTimeLimit() {
-        return syncReadConfiguration(Configuration::getHistoryCacheTime);
-    }
-
-    /**
-     * Specify the maximum time a SCM operation should take before it will be
-     * cached (in ms).
-     *
-     * @param historyCacheTime the max time in ms before it is cached
-     */
-    public void setHistoryReaderTimeLimit(int historyCacheTime) {
-        syncWriteConfiguration(historyCacheTime, Configuration::setHistoryCacheTime);
-    }
-
-    /**
      * Is history cache currently enabled?
      *
      * @return true if history cache is enabled

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -177,6 +177,10 @@ class FileHistoryCache implements HistoryCache {
         }
     }
 
+    double getFileHistoryCacheHits() {
+        return fileHistoryCacheHits.count();
+    }
+
     @Override
     public void optimize() {
         // nothing to do
@@ -669,37 +673,12 @@ class FileHistoryCache implements HistoryCache {
         }
 
         final History history;
-        long time;
         try {
-            time = System.currentTimeMillis();
             history = repository.getHistory(file);
-            time = System.currentTimeMillis() - time;
         } catch (UnsupportedOperationException e) {
             // In this case, we've found a file for which the SCM has no history
             // An example is a non-SCCS file somewhere in an SCCS-controlled workspace.
             return null;
-        }
-
-        // Don't cache history-information for directories, since the
-        // history information on the directory may change if a file in
-        // a sub-directory change. This will cause us to present a stale
-        // history log until the current directory is updated and
-        // invalidates the cache entry.
-        if (!file.isDirectory()) {
-            // Either the cache is stale or retrieving the history took too long, cache it!
-            if (cacheFile.exists()) {
-                if (LOGGER.isLoggable(Level.FINEST)) {
-                    LOGGER.log(Level.FINEST, "refreshing history for ''{0}'': {1}",
-                            new Object[]{file, history.getRevisionList()});
-                }
-                storeFile(history, file, repository);
-            } else if (time > env.getHistoryReaderTimeLimit()) {
-                if (LOGGER.isLoggable(Level.FINEST)) {
-                    LOGGER.log(Level.FINEST, "getting history for ''{0}'' took longer than {1} ms, caching it: {2}",
-                            new Object[]{file, env.getHistoryReaderTimeLimit(), history.getRevisionList()});
-                }
-                storeFile(history, file, repository);
-            }
         }
 
         return history;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ConfigMergeTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ConfigMergeTest.java
@@ -31,9 +31,9 @@ import static org.opengrok.indexer.configuration.ConfigMerge.merge;
  *
  * @author vkotal
  */
-public class ConfigMergeTest {
+class ConfigMergeTest {
     @Test
-    public void basicTest() throws Exception {
+    void basicTest() throws Exception {
 
         String srcRoot = "/foo";
         String dataRoot = "/bar";

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
@@ -216,14 +216,6 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testHistoryReaderTimeLimit() {
-        RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
-        assertEquals(30, instance.getHistoryReaderTimeLimit());
-        instance.setHistoryReaderTimeLimit(50);
-        assertEquals(50, instance.getHistoryReaderTimeLimit());
-    }
-
-    @Test
     public void testFetchHistoryWhenNotInCache() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertTrue(instance.isFetchHistoryWhenNotInCache());


### PR DESCRIPTION
This change removes the ability of `FileHistoryCache#get()` to modify the history cache as this can lead to cache corruption. I find this approach more robust than trying to add detection. This solves the problem described in https://github.com/oracle/opengrok/issues/1114#issuecomment-985059373