### PR TITLE
add alt attribute to images in xref

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1099,8 +1099,7 @@ public final class PageConfig {
      */
     public String getPath() {
         if (path == null) {
-            path = Util.getCanonicalPath(Laundromat.launderInput(
-                    req.getPathInfo()), PATH_SEPARATOR);
+            path = Util.getCanonicalPath(Laundromat.launderInput(req.getPathInfo()), PATH_SEPARATOR);
             if (PATH_SEPARATOR_STRING.equals(path)) {
                 path = "";
             }

--- a/opengrok-web/src/main/webapp/xref.jspf
+++ b/opengrok-web/src/main/webapp/xref.jspf
@@ -129,7 +129,7 @@ org.opengrok.indexer.web.QueryParameters"
                             defs, annotation, project);
                     } else if (g == AbstractAnalyzer.Genre.IMAGE) {
         %></pre>
-    <img src="<%= rawPath %>?<%= QueryParameters.REVISION_PARAM_EQ %><%= Util.URIEncode(rev) %>" alt="<%= path %>"/>
+    <img src="<%= rawPath %>?<%= QueryParameters.REVISION_PARAM_EQ %><%= Util.URIEncode(rev) %>" alt="Image from Source Repository"/>
     <pre><%
                     } else if (g == AbstractAnalyzer.Genre.HTML) {
                         /*

--- a/opengrok-web/src/main/webapp/xref.jspf
+++ b/opengrok-web/src/main/webapp/xref.jspf
@@ -129,7 +129,7 @@ org.opengrok.indexer.web.QueryParameters"
                             defs, annotation, project);
                     } else if (g == AbstractAnalyzer.Genre.IMAGE) {
         %></pre>
-    <img src="<%= rawPath %>?<%= QueryParameters.REVISION_PARAM_EQ %><%= Util.URIEncode(rev) %>"/>
+    <img src="<%= rawPath %>?<%= QueryParameters.REVISION_PARAM_EQ %><%= Util.URIEncode(rev) %>" alt="<%= path %>"/>
     <pre><%
                     } else if (g == AbstractAnalyzer.Genre.HTML) {
                         /*


### PR DESCRIPTION
This change should silence Sonar warning about missing the `alt` attribute in images in `xref.jspf`.