### PR TITLE
move bold style into CSS

### DIFF
--- a/opengrok-web/src/main/webapp/default/style-1.0.4.css
+++ b/opengrok-web/src/main/webapp/default/style-1.0.4.css
@@ -65,6 +65,10 @@ tbody:not(.search-result) tr:nth-child(EVEN) {
     background-color: #e8e8f0;
 }
 
+.bold {
+    font-weight: bold;
+}
+
 .btn {
     padding-left: 7px;
     padding-right: 7px;

--- a/opengrok-web/src/main/webapp/history.jsp
+++ b/opengrok-web/src/main/webapp/history.jsp
@@ -148,8 +148,8 @@ include file="httpheader.jspf"
 %>
         <div id="Masthead">History log of 
         <%= Util.breadcrumbPath(context + Prefix.XREF_P, path,'/',"",true,cfg.isDir()) %>
-        (Results <b> <%= totalHits != 0 ? start + 1 : 0 %> – <%= thispage + start
-            %></b> of <b><%= totalHits %></b>)
+        (Results <span class="bold"> <%= totalHits != 0 ? start + 1 : 0 %> – <%= thispage + start
+            %></span> of <span class="bold"><%= totalHits %></span>)
         </div>
 <%
     }
@@ -271,7 +271,7 @@ document.domReady.push(function() {domReadyHistory();});
                     %>
         <tr class="revtags-hidden">
             <td colspan="<%= colspan %>" class="revtags">
-                <b>Revision tags:</b> <%= tags %>
+                <span class="bold">Revision tags:</span> <%= tags %>
             </td>
         </tr><tr style="display: none;"></tr><%
                 }
@@ -432,7 +432,7 @@ document.domReady.push(function() {domReadyHistory();});
 
 </form><%
             if (striked) {
-%><p><b>Note:</b> No associated file changes are available for
+%><p><span class="bold">Note:</span> No associated file changes are available for
 revisions with strike-through numbers (eg. <del>1.45</del>)</p><%
             }
 %>

--- a/opengrok-web/src/main/webapp/more.jsp
+++ b/opengrok-web/src/main/webapp/more.jsp
@@ -83,7 +83,7 @@ file="mast.jsp"
     try {
         Query tquery = qbuilder.build();
         if (tquery != null) {
-%><p><span class="pagetitle">Lines Matching <b><%= tquery %></b></span></p>
+%><p><span class="pagetitle">Lines Matching <span class="bold"><%= tquery %></span></span></p>
 <div id="more" style="line-height:1.5em;">
     <pre><%
             String xrefPrefix = request.getContextPath() + Prefix.XREF_P;

--- a/opengrok-web/src/main/webapp/search.jsp
+++ b/opengrok-web/src/main/webapp/search.jsp
@@ -160,7 +160,7 @@ include file="menu.jspf"
             %><%= Util.htmlize(SearchHelper.PARSE_ERROR_MSG) %>
             <br/>You might try to enclose your search term in quotes,
             <a href="help.jsp#escaping">escape special characters</a>
-            with <b>\</b>, or read the <a href="help.jsp">Help</a>
+            with <code>\</code>, or read the <a href="help.jsp">Help</a>
             on the query language. Error message from parser:<br/>
             <%= Util.htmlize(errorMsg.substring(SearchHelper.PARSE_ERROR_MSG.length())) %><%
         } else {
@@ -196,8 +196,8 @@ include file="menu.jspf"
         %></p><%
         }
         %>
-        <p class="pagetitle"> Your search <b><%
-            Util.htmlize(searchHelper.getQuery().toString(), out); %></b>
+        <p class="pagetitle"> Your search <span class="bold"><%
+            Util.htmlize(searchHelper.getQuery().toString(), out); %></span>
             did not match any files.
             <br/> Suggestions:<br/>
         </p>
@@ -216,10 +216,10 @@ include file="menu.jspf"
         // We have a lots of results to show: create a slider for
         String slider = Util.createSlider(start, max, totalHits, request);
         %>
-        <p class="pagetitle">Searched <b><%
+        <p class="pagetitle">Searched <span class="bold"><%
             Util.htmlize(searchHelper.getQuery().toString(), out);
-            %></b> (Results <b> <%= start + 1 %> – <%= thispage + start
-            %></b> of <b><%= totalHits %></b>) sorted by <%=
+            %></span> (Results <span class="bold"> <%= start + 1 %> – <%= thispage + start
+            %></span> of <span class="bold"><%= totalHits %></span>) sorted by <%=
             searchHelper.getOrder().getDesc() %></p><%
         if (slider.length() > 0) {
         %>


### PR DESCRIPTION
This change addresses Sonar reported issue by moving the `<b>` style into CSS. I did not bother with bumping CSS version as there has been no release since the last version change.