### PR TITLE
suppress 'Use try-with-resources or close' Sonar warning

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1782,6 +1782,7 @@ public final class RuntimeEnvironment {
      * @return SearcherManager for given project
      * @throws IOException I/O exception
      */
+    @SuppressWarnings("java:S2095")
     public SuperIndexSearcher getIndexSearcher(String projectName) throws IOException {
         SearcherManager mgr = searcherManagerMap.get(projectName);
         SuperIndexSearcher searcher;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1603,6 +1603,7 @@ public class IndexDatabase {
      * @return The index database where the file should be located or null if it
      * cannot be located.
      */
+    @SuppressWarnings("java:S2095")
     public static IndexReader getIndexReader(String path) {
         IndexReader ret = null;
 

--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
@@ -288,6 +288,7 @@ class SuggesterProjectData implements Closeable {
         }
     }
 
+    @SuppressWarnings("java:S2095")
     private void initSearchCountMap() throws IOException {
         searchCountMaps.values().forEach(PopularityMap::close);
         searchCountMaps.clear();

--- a/suggester/src/main/java/org/opengrok/suggest/popular/impl/chronicle/ChronicleMapAdapter.java
+++ b/suggester/src/main/java/org/opengrok/suggest/popular/impl/chronicle/ChronicleMapAdapter.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest.popular.impl.chronicle;
 
@@ -110,6 +110,7 @@ public class ChronicleMapAdapter implements PopularityMap {
      * @param newMapAvgKey new average key size
      * @throws IOException if some error occurred
      */
+    @SuppressWarnings("java:S2095")
     public void resize(final int newMapSize, final double newMapAvgKey) throws IOException {
         if (newMapSize < 0) {
             throw new IllegalArgumentException("Cannot resize chronicle map to negative size");


### PR DESCRIPTION
Sonar reports some closeable resources as not closed in multiple code blocks. I believe these are all false positives and the resources should not be closed as they are part of a structure/object. This change suppresses these warnings.