### PR TITLE
asynchronous API

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -8,6 +8,10 @@ Besides `/suggester`, `/search` and `/metrics` endpoints, everything is accessib
 unless authentication bearer tokens are configured in the web application and used via the 'Authorization' HTTP header
 (within HTTPS connection).
 
+Some of the APIs are asynchronous. They return status code 202 (Accepted) and a Location header that contains the URL
+for the status endpoint to check for the result of the API call. Once the status API returns result other than 202,
+the client should issue DELETE request to this URL to clean up server resources.
+
 ## Annotation [/annotation{?path}]
 
 ### Get annotation for a file [GET]
@@ -37,6 +41,8 @@ unless authentication bearer tokens are configured in the web application and us
 
 ### reloads authorization framework [POST]
 
+This is asynchronous API endpoint.
+
 + Request (application/text)
 
 + Response 204
@@ -61,6 +67,8 @@ unless authentication bearer tokens are configured in the web application and us
 
 ### sets configuration from XML representation [PUT]
 
+This is asynchronous API endpoint.
+
 + Request (application/xml)
   + Body
 
@@ -84,6 +92,8 @@ unless authentication bearer tokens are configured in the web application and us
 + Response 200 (application/json)
 
 ### sets specific configuration field [PUT]
+
+This is asynchronous API endpoint.
 
 + Parameters
   + reindex (boolean) - specifies if the underlying data were also reindexed (refreshes some searchers and additional data structures)
@@ -577,3 +587,22 @@ This kicks off suggester data rebuild in the background, i.e. the rebuild will v
   + project - project name
 
 + Response 204
+
+## Status [/status/{uuid}]
+
+### Check the state of API request [GET]
+
++ Parameters
+  + uuid
+
++ Response 202
+
+### Delete state associated with API request tracking [DELETE]
+
+This should be done only after the API request is completed, i.e. after the GET request for the API request state
+returns appropriate status code (e.g. 201).
+
++ Parameters
+  + uuid
+
++ Response 200

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -297,6 +297,9 @@ public final class Configuration {
 
     private String serverName;  // for reverse proxy environment
 
+    private int connectTimeout = -1;    // connect timeout in seconds
+    private int apiTimeout = -1;    // API timeout in seconds
+
     /*
      * types of handling history for remote SCM repositories:
      *  ON - index history and display it in webapp
@@ -577,6 +580,8 @@ public final class Configuration {
         setWebappLAF("default");
         // webappCtags is default(boolean)
         setXrefTimeout(30);
+        setApiTimeout(300); // 5 minutes
+        setConnectTimeout(3);
     }
 
     public String getRepoCmd(String clazzName) {
@@ -1383,6 +1388,28 @@ public final class Configuration {
 
     public void setServerName(String serverName) {
         this.serverName = serverName;
+    }
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(int connectTimeout) {
+        if (connectTimeout < 0) {
+            throw new IllegalArgumentException(String.format(NEGATIVE_NUMBER_ERROR, "connectTimeout", connectTimeout));
+        }
+        this.connectTimeout = connectTimeout;
+    }
+
+    public int getApiTimeout() {
+        return apiTimeout;
+    }
+
+    public void setApiTimeout(int apiTimeout) {
+        if (apiTimeout < 0) {
+            throw new IllegalArgumentException(String.format(NEGATIVE_NUMBER_ERROR, "apiTimeout", apiTimeout));
+        }
+        this.apiTimeout = apiTimeout;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -48,6 +48,7 @@ import java.util.TreeMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -378,7 +379,7 @@ public class IndexDatabase {
 
         Response r;
         try {
-            r = ClientBuilder.newClient()
+            r = ClientBuilder.newBuilder().connectTimeout(env.getConnectTimeout(), TimeUnit.SECONDS).build()
                     .target(env.getConfigURI())
                     .path("api")
                     .path("v1")

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -468,6 +468,12 @@ public final class Indexer {
                         }
             });
 
+            parser.on("--apiTimeout", "=number", Integer.class,
+                    "Set timeout for asynchronous API requests.").execute(v -> cfg.setApiTimeout((Integer) v));
+
+            parser.on("--connectTimeout", "=number", Integer.class,
+                    "Set connect timeout. Used for API requests.").execute(v -> cfg.setConnectTimeout((Integer) v));
+
             parser.on(
                 "-A (.ext|prefix.):(-|analyzer)", "--analyzer",
                     "/(\\.\\w+|\\w+\\.):(-|[a-zA-Z_0-9.]+)/",
@@ -1154,10 +1160,12 @@ public final class Indexer {
         LOGGER.log(Level.INFO, "Sending configuration to: {0}", host);
         try {
             env.writeConfiguration(host);
-        } catch (IOException ex) {
+        } catch (IOException | IllegalArgumentException ex) {
             LOGGER.log(Level.SEVERE, String.format(
                     "Failed to send configuration to %s "
                     + "(is web application server running with opengrok deployed?)", host), ex);
+        } catch (InterruptedException e) {
+            LOGGER.log(Level.WARNING, "interrupted while sending configuration");
         }
         LOGGER.info("Configuration update routine done, check log output for errors.");
     }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
@@ -1,0 +1,123 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.api;
+
+import jakarta.ws.rs.core.Response;
+import org.opengrok.indexer.logger.LoggerFactory;
+
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Represents task associated with asynchronous API request.
+ */
+public class ApiTask {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiTask.class);
+
+    private final Runnable runnable;
+
+    enum ApiTaskState {
+        INITIAL,
+        SUBMITTED,
+        COMPLETED,
+    }
+    private ApiTaskState state;
+
+    private final UUID uuid;
+    private final String path;
+
+    private final Response.Status responseStatus;
+
+    /**
+     * @param path request path (for identification)
+     * @param runnable Runnable object
+     */
+    public ApiTask(String path, Runnable runnable) {
+        this(path, runnable, Response.Status.OK);
+    }
+
+    /**
+     * @param path request path (for identification)
+     * @param runnable Runnable object
+     * @param status request status to return after the runnable is done
+     */
+    public ApiTask(String path, Runnable runnable, Response.Status status) {
+        this.runnable = runnable;
+        this.uuid = UUID.randomUUID();
+        this.responseStatus = status;
+        this.path = path;
+        this.state = ApiTaskState.INITIAL;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    /**
+     * @return response status
+     */
+    public Response.Status getResponseStatus() {
+        return responseStatus;
+    }
+
+    /**
+     * Set status as submitted.
+     */
+    public void setSubmitted() {
+        state = ApiTaskState.SUBMITTED;
+    }
+
+    public boolean isCompleted() {
+        return state.equals(ApiTaskState.COMPLETED);
+    }
+
+    public void setCompleted() {
+        state = ApiTaskState.COMPLETED;
+    }
+
+    /**
+     * @return Runnable object that contains the work that needs to be completed for this API request
+     */
+    public Runnable getRunnable() {
+        synchronized (this) {
+            if (state.equals(ApiTaskState.SUBMITTED)) {
+                throw new IllegalStateException(String.format("API task %s already submitted", this));
+            }
+
+            return () -> {
+                LOGGER.log(Level.FINE, "API task {0} started", this);
+                setSubmitted();
+                runnable.run();
+                setCompleted();
+                LOGGER.log(Level.FINE, "API task {0} done", this);
+            };
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "{uuid=" + uuid + ",path=" + path + ",state=" + state + ",responseStatus=" + responseStatus + "}";
+    }
+}

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTaskManager.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTaskManager.java
@@ -1,0 +1,143 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.api;
+
+import jakarta.ws.rs.core.Response;
+import org.apache.lucene.util.NamedThreadFactory;
+import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.web.api.v1.controller.StatusController;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Manages asynchronous API requests.
+ */
+public final class ApiTaskManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiTaskManager.class);
+
+    private final Map<String, ExecutorService> queues = new ConcurrentHashMap<>(); // queue name -> ExecutorService
+    private final Map<UUID, ApiTask> apiTasks = new ConcurrentHashMap<>(); // UUID -> ApiTask
+
+    private static final ApiTaskManager apiTaskManager = new ApiTaskManager();
+
+    private String contextPath;
+
+    private ApiTaskManager() {
+        // singleton
+    }
+
+    public static ApiTaskManager getInstance() {
+        return apiTaskManager;
+    }
+
+    /**
+     * @param uuid UUID
+     * @return ApiTask object or null
+     */
+    public ApiTask getApiTask(String uuid) {
+        return apiTasks.get(UUID.fromString(uuid));
+    }
+
+    /**
+     * Set context path. This is used to construct status URLs in {@link #submitApiTask(String, ApiTask)}
+     * @param path context path
+     */
+    public void setContextPath(String path) {
+        this.contextPath = path;
+    }
+
+    static String getQueueName(String name) {
+        return name.replaceAll("^/", "").replace("/", "-");
+    }
+
+    /**
+     * Submit an API task for processing.
+     * @param name name of the API endpoint
+     * @param apiTask ApiTask object
+     * @return Response status
+     */
+    public Response submitApiTask(String name, ApiTask apiTask) {
+        String queueName = getQueueName(name);
+        if (queues.get(queueName) == null) {
+            LOGGER.log(Level.WARNING, "cannot find queue ''{0}''", queueName);
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+
+        queues.get(queueName).submit(apiTask.getRunnable());
+        apiTasks.put(apiTask.getUuid(), apiTask);
+
+        return Response.status(Response.Status.ACCEPTED).
+                location(URI.create(contextPath + "/api/v1" + StatusController.PATH + "/" +
+                        apiTask.getUuid())).build();
+    }
+
+    /**
+     * Delete API task.
+     * @param uuid task UUID
+     */
+    public void deleteApiTask(String uuid) {
+        apiTasks.remove(UUID.fromString(uuid));
+    }
+
+    /**
+     * Add new thread pool.
+     * @param name name of the thread pool
+     * @param threadCount thread count
+     */
+    public void addPool(String name, int threadCount) {
+        String queueName = getQueueName(name);
+
+        if (queues.get(queueName) != null) {
+            throw new IllegalStateException(String.format("queue %s already present", queueName));
+        }
+
+        queues.put(queueName, Executors.newFixedThreadPool(threadCount,
+                new NamedThreadFactory(getQueueName(queueName))));
+    }
+
+    /**
+     * Shutdown all executor services and wait 60 seconds for pending tasks.
+     */
+    public synchronized void shutdown() throws InterruptedException {
+        for (ExecutorService executorService : queues.values()) {
+            executorService.shutdown();
+        }
+
+        for (Map.Entry<String, ExecutorService> entry : queues.entrySet()) {
+            boolean shutdownResult = entry.getValue().awaitTermination(60, TimeUnit.SECONDS);
+            if (!shutdownResult) {
+                LOGGER.log(Level.WARNING, "abnormal termination for executor service for queue ''{0}''",
+                        entry.getKey());
+            }
+        }
+    }
+}

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/StatusController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/StatusController.java
@@ -1,0 +1,82 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.api.v1.controller;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
+import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.web.api.ApiTask;
+import org.opengrok.web.api.ApiTaskManager;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.opengrok.web.api.v1.controller.StatusController.PATH;
+
+/**
+ * API endpoint to check status of asynchronous requests.
+ * Relies on {@link org.opengrok.web.api.v1.filter.IncomingFilter} to authorize the requests.
+ */
+@Path(PATH)
+public class StatusController {
+
+    public static final String PATH = "/status";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StatusController.class);
+
+    @GET
+    @Path("/{uuid}")
+    public Response getStatus(@PathParam("uuid") String uuid) {
+        ApiTask apiTask = ApiTaskManager.getInstance().getApiTask(uuid);
+        if (apiTask == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        if (apiTask.isCompleted()) {
+            return Response.status(apiTask.getResponseStatus()).build();
+        } else {
+            return Response.status(Response.Status.ACCEPTED).build();
+        }
+    }
+
+    @DELETE
+    @Path("/{uuid}")
+    public Response delete(@PathParam("uuid") String uuid) {
+        ApiTask apiTask = ApiTaskManager.getInstance().getApiTask(uuid);
+        if (apiTask == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        if (!apiTask.isCompleted()) {
+            LOGGER.log(Level.WARNING, "API task {0} not yet completed", apiTask);
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+
+        ApiTaskManager.getInstance().deleteApiTask(uuid);
+
+        return Response.ok().build();
+    }
+}

--- a/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskManagerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskManagerTest.java
@@ -1,0 +1,103 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.api;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApiTaskManagerTest {
+    @Test
+    void testSingleton() {
+        assertNotNull(ApiTaskManager.getInstance());
+    }
+
+    @Test
+    void testQueueName() {
+        String name = "foo";
+        assertEquals(name, ApiTaskManager.getQueueName(name));
+        name = "/foo";
+        assertEquals(name.substring(1), ApiTaskManager.getQueueName(name));
+    }
+
+    private void doNothing() {
+    }
+
+    @Test
+    void testTaskInvalidQueue() {
+        ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
+        ApiTask apiTask = new ApiTask("foo", this::doNothing);
+        assertEquals(Response.Status.BAD_REQUEST,
+                apiTaskManager.submitApiTask("/nonexistent", apiTask).getStatusInfo());
+    }
+
+    @Test
+    void testTaskSubmitDelete() {
+        ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
+        String name = "foo";
+        apiTaskManager.addPool(name, 1);
+        ApiTask apiTask = new ApiTask("foo", this::doNothing);
+        Response response = apiTaskManager.submitApiTask(name, apiTask);
+        assertEquals(Response.Status.ACCEPTED, response.getStatusInfo());
+        String location = response.getHeaderString(HttpHeaders.LOCATION);
+        assertNotNull(location);
+        String uuidString = apiTask.getUuid().toString();
+        assertTrue(location.contains(uuidString));
+        assertSame(apiTask, apiTaskManager.getApiTask(uuidString));
+        apiTaskManager.deleteApiTask(uuidString);
+        assertNull(apiTaskManager.getApiTask(uuidString));
+    }
+
+    @Test
+    void testTaskInvalidUuid() {
+        ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
+        assertThrows(IllegalArgumentException.class, () -> apiTaskManager.getApiTask("foo"));
+    }
+
+    @Test
+    void testDuplicateQueueAdd() {
+        ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
+        String name = "myQueue";
+        apiTaskManager.addPool(name, 1);
+        assertThrows(IllegalStateException.class, () -> apiTaskManager.addPool(name, 1));
+    }
+
+    @Test
+    void testShutdown() throws InterruptedException {
+        ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
+        String name = "bar";
+        apiTaskManager.addPool(name, 1);
+        apiTaskManager.shutdown();
+        ApiTask apiTask = new ApiTask("nada", this::doNothing);
+        assertThrows(RejectedExecutionException.class, () -> apiTaskManager.submitApiTask(name, apiTask));
+    }
+}

--- a/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskTest.java
@@ -1,0 +1,84 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.api;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApiTaskTest {
+
+    private void doNothing() {
+    }
+
+    @Test
+    void testConstructorBasic() {
+        ApiTask apiTask = new ApiTask("foo", this::doNothing);
+        assertFalse(apiTask.isCompleted());
+    }
+
+    @Test
+    void testConstructorResponseStatus() {
+        Response.Status status = Response.Status.INTERNAL_SERVER_ERROR;
+        ApiTask apiTask = new ApiTask("bar", this::doNothing, status);
+        assertEquals(status, apiTask.getResponseStatus());
+    }
+
+    private static class Task {
+        private int value;
+
+        Task() {
+            value = 1;
+        }
+
+        public void setValue(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    @Test
+    void testRunnable() {
+        Task task = new Task();
+        int newValue = task.getValue() ^ 1;
+        ApiTask apiTask = new ApiTask("foo", () -> task.setValue(newValue));
+        assertFalse(apiTask.isCompleted());
+        apiTask.getRunnable().run();
+        assertEquals(newValue, task.getValue());
+        assertTrue(apiTask.isCompleted());
+    }
+
+    @Test
+    void testAlreadySubmitted() {
+        ApiTask apiTask = new ApiTask("foo", this::doNothing);
+        apiTask.setSubmitted();
+        assertThrows(IllegalStateException.class, apiTask::getRunnable);
+    }
+}

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ApiUtils.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ApiUtils.java
@@ -1,0 +1,74 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.api.v1.controller;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import org.opengrok.web.api.ApiTask;
+import org.opengrok.web.api.ApiTaskManager;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ApiUtils {
+    private ApiUtils() {
+        // utility class
+    }
+
+    /**
+     * Busy-waits the status of asynchronous API call, mimicking
+     * {@link org.opengrok.indexer.configuration.RuntimeEnvironment#waitForAsyncApi(Response)},
+     * however side-steps status API check by going to the {@link ApiTaskManager} directly in order to avoid
+     * going through the {@link StatusController} as it might not be deployed in the unit tests.
+     * The method will return right away if the status of the response object parameter is not
+     * {@code Response.Status.ACCEPTED}.
+     * @param response API Response object
+     * @return the response object
+     */
+    protected static Response waitForTask(Response response) {
+        if (response.getStatus() != Response.Status.ACCEPTED.getStatusCode()) {
+            return response;
+        }
+
+        String location = response.getHeaderString(HttpHeaders.LOCATION);
+        String locationUri = URI.create(location).getPath();
+        final String apiPrefix = "api/v1/status/";
+        assertTrue(locationUri.contains(apiPrefix));
+        int idx = locationUri.indexOf(apiPrefix);
+        assertTrue(idx > 0);
+        String uuid = locationUri.substring(idx + apiPrefix.length());
+        ApiTask apiTask = ApiTaskManager.getInstance().getApiTask(uuid);
+        assertNotNull(apiTask);
+        await().atMost(16, TimeUnit.SECONDS).until(apiTask::isCompleted);
+
+        if (!apiTask.isCompleted()) {
+            return response;
+        } else {
+            return Response.status(apiTask.getResponseStatus()).build();
+        }
+    }
+}

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
@@ -18,12 +18,18 @@
  */
 
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
 
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -44,8 +50,13 @@ public class SearchControllerTest extends OGKJerseyTest {
     private static TestRepository repository;
 
     @Override
-    protected Application configure() {
-        return new RestApp();
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
+        return new GrizzlyWebTestContainerFactory();
     }
 
     @BeforeAll

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatusControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatusControllerTest.java
@@ -1,0 +1,145 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.api.v1.controller;
+
+import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.opengrok.web.api.ApiTask;
+import org.opengrok.web.api.ApiTaskManager;
+import org.opengrok.web.api.v1.RestApp;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StatusControllerTest extends OGKJerseyTest {
+    @Override
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
+        return new GrizzlyWebTestContainerFactory();
+    }
+
+    @AfterAll
+    static void cleanup() throws InterruptedException {
+        ApiTaskManager.getInstance().shutdown();
+    }
+
+    private void doNothing() {
+    }
+
+    @Test
+    void testGetNoUuid() {
+        Response response = target(StatusController.PATH)
+                .path(UUID.randomUUID().toString())
+                .request()
+                .get();
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void testDeleteNoUuid() {
+        Response response = target(StatusController.PATH)
+                .path(UUID.randomUUID().toString())
+                .request()
+                .delete();
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void testGet() throws InterruptedException {
+        int sleepTime = 3000;
+        ApiTask apiTask = new ApiTask("foo", () -> {
+            try {
+                Thread.sleep(sleepTime);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }, Response.Status.CREATED);
+        String uuidString = apiTask.getUuid().toString();
+        ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
+        String poolName = "foo";
+        apiTaskManager.addPool(poolName, 1);
+        apiTaskManager.submitApiTask(poolName, apiTask);
+        Response response = target(StatusController.PATH)
+                .path(uuidString)
+                .request()
+                .get();
+        assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
+
+        Thread.sleep(sleepTime);
+        response = target(StatusController.PATH)
+                .path(uuidString)
+                .request()
+                .get();
+        assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void testDeleteNotCompleted() {
+        int sleepTime = 3000;
+        ApiTask apiTask = new ApiTask("foo", () -> {
+            try {
+                Thread.sleep(sleepTime);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+        String uuidString = apiTask.getUuid().toString();
+        ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
+        String poolName = "deleteNotCompleted";
+        apiTaskManager.addPool(poolName, 1);
+        apiTaskManager.submitApiTask(poolName, apiTask);
+        Response response = target(StatusController.PATH)
+                .path(uuidString)
+                .request()
+                .delete();
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void testDelete() throws InterruptedException {
+        ApiTask apiTask = new ApiTask("foo", this::doNothing);
+        String uuidString = apiTask.getUuid().toString();
+        ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
+        String poolName = "deleteCompleted";
+        apiTaskManager.addPool(poolName, 1);
+        apiTaskManager.submitApiTask(poolName, apiTask);
+        Thread.sleep(1000);
+        Response response = target(StatusController.PATH)
+                .path(uuidString)
+                .request()
+                .delete();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+}

--- a/tools/src/main/python/opengrok_tools/projadm.py
+++ b/tools/src/main/python/opengrok_tools/projadm.py
@@ -184,7 +184,7 @@ def project_add(doit, logger, project, uri, headers=None, timeout=None):
 
 
 def project_delete(logger, project, uri, doit=True, deletesource=False,
-                   headers=None, timeout=None):
+                   headers=None, timeout=None, api_timeout=None):
     """
     Delete the project for configuration and all its data.
     Works in multiple steps:
@@ -201,7 +201,8 @@ def project_delete(logger, project, uri, doit=True, deletesource=False,
     logger.info("Deleting project {} and its index data".format(project))
 
     if doit:
-        delete_project(logger, project, uri, headers=headers, timeout=timeout)
+        delete_project(logger, project, uri, headers=headers, timeout=timeout,
+                       api_timeout=api_timeout)
 
     if deletesource:
         src_root = get_config_value(logger, 'sourceRoot', uri, headers=headers,
@@ -267,6 +268,8 @@ def main():
     add_http_headers(parser)
     parser.add_argument('--api_timeout', type=int,
                         help='Set response timeout in seconds for RESTful API calls')
+    parser.add_argument('--async_api_timeout', type=int,
+                        help='Set timeout in seconds for asynchronous RESTful API calls')
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-a', '--add', metavar='project', nargs='+',
@@ -371,7 +374,8 @@ def main():
                                    uri=uri, doit=doit,
                                    deletesource=not args.nosourcedelete,
                                    headers=headers,
-                                   timeout=args.api_timeout)
+                                   timeout=args.api_timeout,
+                                   api_timeout=args.async_api_timeout)
 
                 config_refresh(doit=doit, logger=logger,
                                basedir=args.base,
@@ -406,7 +410,8 @@ def main():
                             if not set_configuration(logger,
                                                      config_data, uri,
                                                      headers=headers,
-                                                     timeout=args.api_timeout):
+                                                     timeout=args.api_timeout,
+                                                     api_timeout=args.async_api_timeout):
                                 sys.exit(FAILURE_EXITVAL)
                 else:
                     logger.error("file {} does not exist".format(main_config))

--- a/tools/src/main/python/opengrok_tools/utils/opengrok.py
+++ b/tools/src/main/python/opengrok_tools/utils/opengrok.py
@@ -133,10 +133,13 @@ def get_configuration(logger, uri, headers=None, timeout=None):
     return res.text
 
 
-def set_configuration(logger, configuration, uri, headers=None, timeout=None):
+def set_configuration(logger, configuration, uri, headers=None, timeout=None, api_timeout=None):
     try:
-        do_api_call('PUT', get_uri(uri, 'api', 'v1', 'configuration'),
-                    data=configuration, headers=headers, timeout=timeout)
+        r = do_api_call('PUT', get_uri(uri, 'api', 'v1', 'configuration'),
+                        data=configuration, headers=headers, timeout=timeout, api_timeout=api_timeout)
+        if r is None or r.status_code != 201:
+            logger.error('could not set configuration to web application')
+            return False
     except Exception as exception:
         logger.error('could not set configuration to web application: {}'.
                      format(exception))
@@ -183,11 +186,14 @@ def add_project(logger, project, uri, headers=None, timeout=None):
     return True
 
 
-def delete_project(logger, project, uri, headers=None, timeout=None):
+def delete_project(logger, project, uri, headers=None, timeout=None, api_timeout=None):
     try:
-        do_api_call('DELETE', get_uri(uri, 'api', 'v1', 'projects',
-                                      urllib.parse.quote_plus(project)),
-                    headers=headers, timeout=timeout)
+        r = do_api_call('DELETE', get_uri(uri, 'api', 'v1', 'projects',
+                                          urllib.parse.quote_plus(project)),
+                        headers=headers, timeout=timeout, api_timeout=api_timeout)
+        if r is None or r.status != 204:
+            logger.error(f"could not delete project '{project}' in web application")
+            return False
     except Exception as exception:
         logger.error("could not delete project '{}' in web application: {}".
                      format(project, exception))


### PR DESCRIPTION
This change introduces very simple framework for asynchronous API requests and adapts some of the API endpoints to use it. I made some tradeoff decisions like:
  - there is no way how to pass output/result from an API task so far
  - the clients need to employ busy wait in order to await the final state of an API task
  - the cleanup of the resources associated with an API task is explicit (DELETE)

https://github.com/oracle/opengrok/wiki/Indexer-configuration#indexer-tunables will have to be updated with `connectTimeout` and `apiTimeout`.