### PR TITLE
deal with exceptions in asynchronous API tasks

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
@@ -185,15 +185,13 @@ public class ApiTask {
                 throw new IllegalStateException(String.format("API task %s already submitted", this));
             }
 
-            return new Callable<>() {
-                public Object call() throws Exception {
-                    LOGGER.log(Level.FINE, "API task {0} started", this);
-                    setSubmitted();
-                    Object ret = callable.call();
-                    setCompleted();
-                    LOGGER.log(Level.FINE, "API task {0} done", this);
-                    return ret;
-                }
+            return () -> {
+                LOGGER.log(Level.FINE, "API task {0} started", this);
+                setSubmitted();
+                Object ret = callable.call();
+                setCompleted();
+                LOGGER.log(Level.FINE, "API task {0} done", this);
+                return ret;
             };
         }
     }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
@@ -166,10 +166,10 @@ public class ApiTask {
                 public Object call() throws Exception {
                     LOGGER.log(Level.FINE, "API task {0} started", this);
                     setSubmitted();
-                    callable.call();
+                    Object ret = callable.call();
                     setCompleted();
                     LOGGER.log(Level.FINE, "API task {0} done", this);
-                    return null;
+                    return ret;
                 }
             };
         }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
@@ -145,6 +145,12 @@ public class ApiTask {
         }
     }
 
+    /**
+     * Provides simple Exception to status code mapping. The Exception match is exact, i.e. exception class hierarchy
+     * is not considered.
+     * @param exception Exception
+     * @return Response status
+     */
     private Response.Status mapExceptionToStatus(ExecutionException exception) {
         return exceptionStatusMap.getOrDefault(exception.getCause().getClass(), Response.Status.INTERNAL_SERVER_ERROR);
     }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
@@ -96,7 +96,7 @@ public class ApiTask {
     /**
      * @return response status
      */
-    public Response.Status getResponseStatus() {
+    Response.Status getResponseStatus() {
         return responseStatus;
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
@@ -67,6 +67,11 @@ public class ApiTask {
         this(path, callable, Response.Status.OK);
     }
 
+    /**
+     * @param path request path (for identification)
+     * @param callable Callable object
+     * @param status request status to return after the runnable is done
+     */
     public ApiTask(String path, Callable<Object> callable, Response.Status status) {
         this(path, callable, status, null);
     }
@@ -89,6 +94,10 @@ public class ApiTask {
         }
     }
 
+    /**
+     * The UUID is randomly generated in the constructor.
+     * @return UUID
+     */
     public UUID getUuid() {
         return uuid;
     }
@@ -107,6 +116,9 @@ public class ApiTask {
         state = ApiTaskState.SUBMITTED;
     }
 
+    /**
+     * @return whether the API task successfully completed
+     */
     public boolean isCompleted() {
         return state.equals(ApiTaskState.COMPLETED);
     }
@@ -115,10 +127,16 @@ public class ApiTask {
         state = ApiTaskState.COMPLETED;
     }
 
+    /**
+     * @param future Future object used for tracking the progress of the API task
+     */
     public void setFuture(Future<Object> future) {
         this.future = future;
     }
 
+    /**
+     * @return whether the task is finished (normally or with exception)
+     */
     public boolean isDone() {
         if (future != null) {
             return future.isDone();
@@ -131,6 +149,11 @@ public class ApiTask {
         return exceptionStatusMap.getOrDefault(exception.getCause().getClass(), Response.Status.INTERNAL_SERVER_ERROR);
     }
 
+    /**
+     * This method assumes that the API task is finished.
+     * @return response object corresponding to the state of the API task
+     * @throws IllegalStateException if the API task is not finished
+     */
     public Response getResponse() {
         // Avoid thread being blocked in future.get() below.
         if (!isDone()) {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
@@ -57,7 +57,7 @@ public class ApiTask {
 
     private Future<Object> future;
 
-    private final Map<Class<?>,Response.Status> exceptionStatusMap = new HashMap<>();
+    private final Map<Class<?>, Response.Status> exceptionStatusMap = new HashMap<>();
 
     /**
      * @param path request path (for identification)

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
@@ -111,7 +111,7 @@ public class ApiTask {
         return state.equals(ApiTaskState.COMPLETED);
     }
 
-    public void setCompleted() {
+    void setCompleted() {
         state = ApiTaskState.COMPLETED;
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
@@ -103,7 +103,7 @@ public class ApiTask {
     /**
      * Set status as submitted.
      */
-    public void setSubmitted() {
+    void setSubmitted() {
         state = ApiTaskState.SUBMITTED;
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
@@ -103,7 +103,7 @@ public class ApiTask {
     }
 
     /**
-     * @return response status
+     * @return response status to be used when the task was successfully completed
      */
     Response.Status getResponseStatus() {
         return responseStatus;

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTask.java
@@ -130,7 +130,7 @@ public class ApiTask {
     /**
      * @param future Future object used for tracking the progress of the API task
      */
-    public void setFuture(Future<Object> future) {
+    void setFuture(Future<Object> future) {
         this.future = future;
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTaskManager.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTaskManager.java
@@ -92,7 +92,7 @@ public final class ApiTaskManager {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
 
-        queues.get(queueName).submit(apiTask.getRunnable());
+        apiTask.setFuture(queues.get(queueName).submit(apiTask.getCallable()));
         apiTasks.put(apiTask.getUuid(), apiTask);
 
         return Response.status(Response.Status.ACCEPTED).

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
@@ -68,6 +68,7 @@ public class ConfigurationController {
 
     @PUT
     @Consumes(MediaType.APPLICATION_XML)
+    @Produces("text/plain")
     public Response set(@Context HttpServletRequest request,
                         @QueryParam("reindex") final boolean reindex) throws IOException {
 
@@ -80,6 +81,7 @@ public class ConfigurationController {
                 new ApiTask(request.getRequestURI(), () -> {
                     env.applyConfig(body, reindex, CommandTimeoutType.RESTFUL);
                     suggesterService.refresh();
+                    return null;
                 }));
     }
 
@@ -92,6 +94,7 @@ public class ConfigurationController {
 
     @PUT
     @Path("/{field}")
+    @Produces("text/plain")
     public Response setField(@Context HttpServletRequest request,
                              @PathParam("field") final String field, final String value) {
 
@@ -102,15 +105,18 @@ public class ConfigurationController {
                     // apply the configuration - let the environment reload the configuration if necessary
                     env.applyConfig(false, CommandTimeoutType.RESTFUL);
                     suggesterService.refresh();
+                    return null;
                 }));
     }
 
     @POST
     @Path("/authorization/reload")
+    @Produces("text/plain")
     public Response reloadAuthorization(@Context HttpServletRequest request) {
         return ApiTaskManager.getInstance().submitApiTask("authorization",
                 new ApiTask(request.getRequestURI(),
-                        () -> env.getAuthorizationFramework().reload(), Response.Status.NO_CONTENT));
+                        () -> { env.getAuthorizationFramework().reload(); return null; },
+                        Response.Status.NO_CONTENT));
     }
 
     private Object getConfigurationValueException(String fieldName) throws WebApplicationException {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
@@ -115,7 +115,10 @@ public class ConfigurationController {
     public Response reloadAuthorization(@Context HttpServletRequest request) {
         return ApiTaskManager.getInstance().submitApiTask("authorization",
                 new ApiTask(request.getRequestURI(),
-                        () -> { env.getAuthorizationFramework().reload(); return null; },
+                        () -> {
+                            env.getAuthorizationFramework().reload();
+                            return null;
+                        },
                         Response.Status.NO_CONTENT));
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
@@ -68,7 +68,6 @@ public class ConfigurationController {
 
     @PUT
     @Consumes(MediaType.APPLICATION_XML)
-    @Produces("text/plain")
     public Response set(@Context HttpServletRequest request,
                         @QueryParam("reindex") final boolean reindex) throws IOException {
 
@@ -94,7 +93,6 @@ public class ConfigurationController {
 
     @PUT
     @Path("/{field}")
-    @Produces("text/plain")
     public Response setField(@Context HttpServletRequest request,
                              @PathParam("field") final String field, final String value) {
 
@@ -111,7 +109,6 @@ public class ConfigurationController {
 
     @POST
     @Path("/authorization/reload")
-    @Produces("text/plain")
     public Response reloadAuthorization(@Context HttpServletRequest request) {
         return ApiTaskManager.getInstance().submitApiTask("authorization",
                 new ApiTask(request.getRequestURI(),

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -167,6 +167,7 @@ public class ProjectsController {
 
     @DELETE
     @Path("/{project}")
+    @Produces("text/plain")
     public Response deleteProject(@Context HttpServletRequest request, @PathParam("project") String projectNameParam) {
         // Avoid classification as a taint bug.
         final String projectName = Laundromat.launderInput(projectNameParam);
@@ -176,7 +177,8 @@ public class ProjectsController {
 
         return ApiTaskManager.getInstance().submitApiTask(PROJECTS_PATH,
                 new ApiTask(request.getRequestURI(),
-                        () -> deleteProjectWorkHorse(projectName, project), Response.Status.NO_CONTENT));
+                        () -> { deleteProjectWorkHorse(projectName, project); return null; },
+                        Response.Status.NO_CONTENT));
     }
 
     private void deleteProjectWorkHorse(String projectName, Project project) {
@@ -206,6 +208,7 @@ public class ProjectsController {
 
     @DELETE
     @Path("/{project}/data")
+    @Produces("text/plain")
     public Response deleteProjectData(@Context HttpServletRequest request,
                                       @PathParam("project") String projectNameParam) {
         // Avoid classification as a taint bug.
@@ -214,7 +217,7 @@ public class ProjectsController {
         disableProject(projectName);
 
         return ApiTaskManager.getInstance().submitApiTask(PROJECTS_PATH,
-                new ApiTask(request.getRequestURI(), () -> deleteProjectDataWorkHorse(projectName)));
+                new ApiTask(request.getRequestURI(), () -> { deleteProjectDataWorkHorse(projectName); return null; }));
     }
 
     private void deleteProjectDataWorkHorse(String projectName) {
@@ -238,6 +241,7 @@ public class ProjectsController {
 
     @DELETE
     @Path("/{project}/historycache")
+    @Produces("text/plain")
     public Response deleteHistoryCache(@Context HttpServletRequest request,
                                        @PathParam("project") String projectNameParam) {
 
@@ -249,7 +253,7 @@ public class ProjectsController {
         final String projectName = Laundromat.launderInput(projectNameParam);
 
         return ApiTaskManager.getInstance().submitApiTask(PROJECTS_PATH,
-                new ApiTask(request.getRequestURI(), () -> deleteHistoryCacheWorkHorse(projectName)));
+                new ApiTask(request.getRequestURI(), () -> { deleteHistoryCacheWorkHorse(projectName); return null; }));
     }
 
     private void deleteHistoryCacheWorkHorse(String projectName) {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -167,7 +167,6 @@ public class ProjectsController {
 
     @DELETE
     @Path("/{project}")
-    @Produces("text/plain")
     public Response deleteProject(@Context HttpServletRequest request, @PathParam("project") String projectNameParam) {
         // Avoid classification as a taint bug.
         final String projectName = Laundromat.launderInput(projectNameParam);
@@ -211,7 +210,6 @@ public class ProjectsController {
 
     @DELETE
     @Path("/{project}/data")
-    @Produces("text/plain")
     public Response deleteProjectData(@Context HttpServletRequest request,
                                       @PathParam("project") String projectNameParam) {
         // Avoid classification as a taint bug.
@@ -248,7 +246,6 @@ public class ProjectsController {
 
     @DELETE
     @Path("/{project}/historycache")
-    @Produces("text/plain")
     public Response deleteHistoryCache(@Context HttpServletRequest request,
                                        @PathParam("project") String projectNameParam) {
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -177,7 +177,10 @@ public class ProjectsController {
 
         return ApiTaskManager.getInstance().submitApiTask(PROJECTS_PATH,
                 new ApiTask(request.getRequestURI(),
-                        () -> { deleteProjectWorkHorse(projectName, project); return null; },
+                        () -> {
+                            deleteProjectWorkHorse(projectName, project);
+                            return null;
+                        },
                         Response.Status.NO_CONTENT));
     }
 
@@ -217,7 +220,11 @@ public class ProjectsController {
         disableProject(projectName);
 
         return ApiTaskManager.getInstance().submitApiTask(PROJECTS_PATH,
-                new ApiTask(request.getRequestURI(), () -> { deleteProjectDataWorkHorse(projectName); return null; }));
+                new ApiTask(request.getRequestURI(),
+                        () -> {
+                            deleteProjectDataWorkHorse(projectName);
+                            return null;
+                        }));
     }
 
     private void deleteProjectDataWorkHorse(String projectName) {
@@ -253,7 +260,11 @@ public class ProjectsController {
         final String projectName = Laundromat.launderInput(projectNameParam);
 
         return ApiTaskManager.getInstance().submitApiTask(PROJECTS_PATH,
-                new ApiTask(request.getRequestURI(), () -> { deleteHistoryCacheWorkHorse(projectName); return null; }));
+                new ApiTask(request.getRequestURI(),
+                        () -> {
+                            deleteHistoryCacheWorkHorse(projectName);
+                            return null;
+                        }));
     }
 
     private void deleteHistoryCacheWorkHorse(String projectName) {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/StatusController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/StatusController.java
@@ -55,8 +55,8 @@ public class StatusController {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 
-        if (apiTask.isCompleted()) {
-            return Response.status(apiTask.getResponseStatus()).build();
+        if (apiTask.isDone()) {
+            return apiTask.getResponse();
         } else {
             return Response.status(Response.Status.ACCEPTED).build();
         }
@@ -70,8 +70,8 @@ public class StatusController {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 
-        if (!apiTask.isCompleted()) {
-            LOGGER.log(Level.WARNING, "API task {0} not yet completed", apiTask);
+        if (!apiTask.isDone()) {
+            LOGGER.log(Level.WARNING, "API task {0} not yet done", apiTask);
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskManagerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskManagerTest.java
@@ -86,7 +86,10 @@ class ApiTaskManagerTest {
         ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
         String name = "exception";
         apiTaskManager.addPool(name, 1);
-        ApiTask apiTask = new ApiTask("foo", () -> { throw new Exception("foo"); });
+        ApiTask apiTask = new ApiTask("foo",
+                () -> {
+                    throw new Exception("foo");
+                });
         apiTaskManager.submitApiTask(name, apiTask);
         await().atMost(3, TimeUnit.SECONDS).until(apiTask::isDone);
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), apiTask.getResponse().getStatus());
@@ -98,7 +101,10 @@ class ApiTaskManagerTest {
         String name = "exceptionMap";
         apiTaskManager.addPool(name, 1);
         final String exceptionText = "exception text";
-        ApiTask apiTask = new ApiTask("foo", () -> { throw new IllegalStateException(exceptionText); },
+        ApiTask apiTask = new ApiTask("foo",
+                () -> {
+                    throw new IllegalStateException(exceptionText);
+                },
                 Response.Status.NO_CONTENT,
                 Map.of(IllegalStateException.class, Response.Status.NOT_ACCEPTABLE));
         apiTaskManager.submitApiTask(name, apiTask);

--- a/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskManagerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskManagerTest.java
@@ -26,8 +26,11 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -49,7 +52,8 @@ class ApiTaskManagerTest {
         assertEquals(name.substring(1), ApiTaskManager.getQueueName(name));
     }
 
-    private void doNothing() {
+    private Object doNothing() {
+        return null;
     }
 
     @Test
@@ -76,6 +80,33 @@ class ApiTaskManagerTest {
         apiTaskManager.deleteApiTask(uuidString);
         assertNull(apiTaskManager.getApiTask(uuidString));
     }
+
+    @Test
+    void taskSubmitCallableWithException() {
+        ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
+        String name = "exception";
+        apiTaskManager.addPool(name, 1);
+        ApiTask apiTask = new ApiTask("foo", () -> { throw new Exception("foo"); });
+        apiTaskManager.submitApiTask(name, apiTask);
+        await().atMost(3, TimeUnit.SECONDS).until(apiTask::isDone);
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), apiTask.getResponse().getStatus());
+    }
+
+    @Test
+    void taskSubmitCallableWithExceptionMapping() {
+        ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
+        String name = "exceptionMap";
+        apiTaskManager.addPool(name, 1);
+        ApiTask apiTask = new ApiTask("foo", () -> { throw new IllegalStateException("foo"); },
+                Response.Status.NO_CONTENT,
+                Map.of(IllegalStateException.class, Response.Status.NOT_ACCEPTABLE));
+        apiTaskManager.submitApiTask(name, apiTask);
+        await().atMost(3, TimeUnit.SECONDS).until(apiTask::isDone);
+        assertEquals(Response.Status.NOT_ACCEPTABLE.getStatusCode(), apiTask.getResponse().getStatus());
+    }
+
+    // TODO: test payload with exception
+    // TODO: test payload with data returned from callable
 
     @Test
     void testTaskInvalidUuid() {

--- a/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskTest.java
@@ -69,7 +69,11 @@ class ApiTaskTest {
     void testCallable() throws Exception {
         Task task = new Task();
         int newValue = task.getValue() ^ 1;
-        ApiTask apiTask = new ApiTask("foo", () -> { task.setValue(newValue); return newValue; });
+        ApiTask apiTask = new ApiTask("foo",
+                () -> {
+                    task.setValue(newValue);
+                    return newValue;
+                });
         assertFalse(apiTask.isCompleted());
         assertFalse(apiTask.isDone());
         apiTask.getCallable().call();

--- a/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskTest.java
@@ -32,7 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ApiTaskTest {
 
-    private void doNothing() {
+    private Object doNothing() {
+        return null;
     }
 
     @Test
@@ -65,20 +66,27 @@ class ApiTaskTest {
     }
 
     @Test
-    void testRunnable() {
+    void testCallable() throws Exception {
         Task task = new Task();
         int newValue = task.getValue() ^ 1;
-        ApiTask apiTask = new ApiTask("foo", () -> task.setValue(newValue));
+        ApiTask apiTask = new ApiTask("foo", () -> { task.setValue(newValue); return newValue; });
         assertFalse(apiTask.isCompleted());
-        apiTask.getRunnable().run();
+        assertFalse(apiTask.isDone());
+        apiTask.getCallable().call();
         assertEquals(newValue, task.getValue());
         assertTrue(apiTask.isCompleted());
+    }
+
+    @Test
+    void testEarlyGetResponse() {
+        ApiTask apiTask = new ApiTask("early", () -> null);
+        assertThrows(IllegalStateException.class, apiTask::getResponse);
     }
 
     @Test
     void testAlreadySubmitted() {
         ApiTask apiTask = new ApiTask("foo", this::doNothing);
         apiTask.setSubmitted();
-        assertThrows(IllegalStateException.class, apiTask::getRunnable);
+        assertThrows(IllegalStateException.class, apiTask::getCallable);
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ApiUtils.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ApiUtils.java
@@ -63,7 +63,7 @@ public class ApiUtils {
         String uuid = locationUri.substring(idx + apiPrefix.length());
         ApiTask apiTask = ApiTaskManager.getInstance().getApiTask(uuid);
         assertNotNull(apiTask);
-        await().atMost(16, TimeUnit.SECONDS).until(apiTask::isCompleted);
+        await().atMost(16, TimeUnit.SECONDS).until(apiTask::isDone);
 
         if (!apiTask.isDone()) {
             return response;

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ApiUtils.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ApiUtils.java
@@ -65,10 +65,10 @@ public class ApiUtils {
         assertNotNull(apiTask);
         await().atMost(16, TimeUnit.SECONDS).until(apiTask::isCompleted);
 
-        if (!apiTask.isCompleted()) {
+        if (!apiTask.isDone()) {
             return response;
         } else {
-            return Response.status(apiTask.getResponseStatus()).build();
+            return apiTask.getResponse();
         }
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatusControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatusControllerTest.java
@@ -55,7 +55,8 @@ class StatusControllerTest extends OGKJerseyTest {
         ApiTaskManager.getInstance().shutdown();
     }
 
-    private void doNothing() {
+    private Object doNothing() {
+        return null;
     }
 
     @Test
@@ -85,6 +86,7 @@ class StatusControllerTest extends OGKJerseyTest {
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
+            return null;
         }, Response.Status.CREATED);
         String uuidString = apiTask.getUuid().toString();
         ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();
@@ -114,6 +116,7 @@ class StatusControllerTest extends OGKJerseyTest {
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
+            return null;
         });
         String uuidString = apiTask.getUuid().toString();
         ApiTaskManager apiTaskManager = ApiTaskManager.getInstance();


### PR DESCRIPTION
This change is follow up to the asynchronous API introduction in #3853. It adds the possibility to set payload in the final response. Either to the string representation of an exception (if one was thrown) or the string representation of object returned from the `Callable`.