### PR TITLE
update dependency-check-maven to 6.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>6.2.2</version>
+                <version>6.5.1</version>
                 <configuration>
                     <skipSystemScope>true</skipSystemScope>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 
 -->


### PR DESCRIPTION
The `dependency-check-maven` plugin has started failing quite a lot on macOS recently due to connection timeouts. While this may not fix this, it is good to update.