### PR TITLE
Optionally show surrounding context during search

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
@@ -141,13 +141,13 @@ public final class Results {
     /**
      * Prints out results in html form. The following search helper fields are
      * required to be properly initialized: <ul>
-     * <li>{@link SearchHelper#dataRoot}</li>
-     * <li>{@link SearchHelper#contextPath}</li>
-     * <li>{@link SearchHelper#searcher}</li> <li>{@link SearchHelper#hits}</li>
-     * <li>{@link SearchHelper#historyContext} (ignored if {@code null})</li>
-     * <li>{@link SearchHelper#sourceContext} (ignored if {@code null})</li>
-     * <li>{@link SearchHelper#summarizer} (if sourceContext is not
-     * {@code null})</li> <li>{@link SearchHelper#sourceRoot} (if
+     * <li>{@link SearchHelper#getDataRoot()}</li>
+     * <li>{@link SearchHelper#getContextPath()}</li>
+     * <li>{@link SearchHelper#getSearcher()}</li> <li>{@link SearchHelper#getHits()}</li>
+     * <li>{@link SearchHelper#getHistoryContext()} (ignored if {@code null})</li>
+     * <li>{@link SearchHelper#getSourceContext()} (ignored if {@code null})</li>
+     * <li>{@link SearchHelper#getSummarizer()} (if sourceContext is not
+     * {@code null})</li> <li>{@link SearchHelper#getSourceRoot()} (if
      * sourceContext or historyContext is not {@code null})</li> </ul>
      *
      * @param out write destination
@@ -271,9 +271,9 @@ public final class Results {
 
         fargs.shelp.getSourceContext().toggleAlt();
 
-        boolean didPresentNew = fargs.shelp.getSourceContext().getContext2(fargs.env,
+        boolean didPresentNew = fargs.shelp.getSourceContext().getContext2(
             fargs.shelp.getSearcher(), docId, fargs.out, fargs.xrefPrefix,
-            fargs.morePrefix, true, fargs.tabSize);
+            fargs.morePrefix, fargs.shelp.getLimitedContextArgs(), fargs.tabSize);
 
         if (!didPresentNew) {
             /*

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/ContextArgs.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/ContextArgs.java
@@ -27,6 +27,13 @@ package org.opengrok.indexer.search.context;
  * to producing context presentations.
  */
 public class ContextArgs {
+    /**
+     * The maximum number of lines of surrounding context in a single direction
+     * to allow during a search. If there is sufficient content both preceding
+     * and following a hit, then the total context might be twice this value.
+     */
+    public static final short MAX_CONTEXT_SURROUND = 4;
+
     /** Not Lucene-related, so {@code int} does fine. */
     private static final int CONTEXT_WIDTH = 100;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/QueryParameters.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/QueryParameters.java
@@ -37,6 +37,16 @@ public class QueryParameters {
     public static final String ANNOTATION_PARAM_EQ_TRUE = ANNOTATION_PARAM + "=true";
 
     /**
+     * Parameter name to specify a number of context lines.
+     */
+    public static final String CONTEXT_SURROUND_PARAM = "x";
+
+    /**
+     * {@link #CONTEXT_SURROUND_PARAM} concatenated with {@code "=" }.
+     */
+    public static final String CONTEXT_SURROUND_PARAM_EQ = CONTEXT_SURROUND_PARAM + "=";
+
+    /**
      * Parameter name to specify a count value.
      */
     public static final String COUNT_PARAM = "n";

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -78,6 +78,7 @@ import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.search.SettingsHelper;
 import org.opengrok.indexer.search.Summarizer;
 import org.opengrok.indexer.search.context.Context;
+import org.opengrok.indexer.search.context.ContextArgs;
 import org.opengrok.indexer.search.context.HistoryContext;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
 import org.opengrok.indexer.util.IOUtils;
@@ -133,6 +134,10 @@ public class SearchHelper {
      * max. number of result items to show
      */
     private final int maxItems;
+    /**
+     * args to use when context is limited.
+     */
+    private final ContextArgs limitedContextArgs;
     /**
      * The QueryBuilder used to create the query.
      */
@@ -235,6 +240,7 @@ public class SearchHelper {
 
     public SearchHelper(int start, SortOrder sortOrder, File dataRoot, File sourceRoot, int maxItems,
                         EftarFileReader eftarFileReader, QueryBuilder queryBuilder, boolean crossRefSearch,
+                        ContextArgs limitedContextArgs,
                         String contextPath, boolean guiSearch, boolean noRedirect) {
         this.start = start;
         this.order = sortOrder;
@@ -244,6 +250,7 @@ public class SearchHelper {
         this.desc = eftarFileReader;
         this.builder = queryBuilder;
         this.crossRefSearch = crossRefSearch;
+        this.limitedContextArgs = limitedContextArgs;
         this.contextPath = contextPath;
         this.guiSearch = guiSearch;
         this.noRedirect = noRedirect;
@@ -263,6 +270,10 @@ public class SearchHelper {
 
     public QueryBuilder getBuilder() {
         return builder;
+    }
+
+    public ContextArgs getLimitedContextArgs() {
+        return limitedContextArgs;
     }
 
     public String getContextPath() {
@@ -516,6 +527,10 @@ public class SearchHelper {
             errorMsg = e.getMessage();
         }
         return this;
+    }
+
+    public ContextArgs getUnlimitedContextArgs() {
+        return new ContextArgs(limitedContextArgs.getContextSurround(), Short.MAX_VALUE);
     }
 
     private void maybeRedirectToDefinition(int docID, TermQuery termQuery)

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/JFlexXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/JFlexXrefTest.java
@@ -230,8 +230,8 @@ public class JFlexXrefTest {
         StringWriter output = new StringWriter();
         xref.write(output);
 
-        assertLinesEqual("xref " + xrefClass.getSimpleName(),
-            FIRST_LINE_PREAMBLE + expectedOutput, output.toString());
+        assertLinesEqual(FIRST_LINE_PREAMBLE + expectedOutput, output.toString(), "xref " +
+                xrefClass.getSimpleName());
     }
 
     /**
@@ -248,9 +248,8 @@ public class JFlexXrefTest {
             new StringReader(ECHO_QUOT_XYZ)));
         StringWriter out = new StringWriter();
         xref.write(out);
-        assertLinesEqual("Unterminated string:\n" + ECHO_QUOT_XYZ,
-            FIRST_LINE_PREAMBLE +
-            "<b>echo</b> <span class=\"s\">&quot;xyz</span>", out.toString());
+        assertLinesEqual(FIRST_LINE_PREAMBLE + "<b>echo</b> <span class=\"s\">&quot;xyz</span>",
+                out.toString(), "Unterminated string:\n" + ECHO_QUOT_XYZ);
 
         // Reuse the xref and verify that the broken syntax in the previous
         // file doesn't cause broken highlighting in the next file
@@ -259,10 +258,8 @@ public class JFlexXrefTest {
         xref.setReader(new StringReader(new String(contents.toCharArray())));
         xref.reset();
         xref.write(out);
-        assertLinesEqual("reused ShXref after broken syntax",
-            FIRST_LINE_PREAMBLE +
-            "<b>echo</b> <span class=\"s\">&quot;hello&quot;</span>",
-            out.toString());
+        assertLinesEqual(FIRST_LINE_PREAMBLE + "<b>echo</b> <span class=\"s\">&quot;hello&quot;</span>",
+                out.toString(), "reused ShXref after broken syntax");
     }
 
     /**
@@ -413,13 +410,12 @@ public class JFlexXrefTest {
         StringWriter out = new StringWriter();
         xref.write(out);
 
-        assertLinesEqual("UuencodeXref truncated",
-                "<a class=\"l\" name=\"1\" href=\"#1\">1</a>"
-                + "<strong>begin</strong> <em>644</em> "
-                + "<a href=\"/source/s?full=test.txt\">test.txt</a>"
-                + "<span class=\"c\">\n"
-                + "<a class=\"l\" name=\"2\" href=\"#2\">2</a></span>",
-                out.toString());
+        assertLinesEqual("<a class=\"l\" name=\"1\" href=\"#1\">1</a>" +
+                "<strong>begin</strong> <em>644</em> " +
+                "<a href=\"/source/s?full=test.txt\">test.txt</a>" +
+                "<span class=\"c\">\n" +
+                "<a class=\"l\" name=\"2\" href=\"#2\">2</a></span>", out.toString(),
+                "UuencodeXref truncated");
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/XrefTestBase.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/XrefTestBase.java
@@ -86,7 +86,7 @@ public abstract class XrefTestBase {
         String[] expected = expStr.split("\n");
 
         String messagePrefix = factory.getClass().getName();
-        assertLinesEqual(messagePrefix + " xref", expected, gotten);
+        assertLinesEqual(expected, gotten, messagePrefix + " xref");
         assertEquals(expectedLOC, actLOC, messagePrefix + " LOC");
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/haskell/HaskellXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/haskell/HaskellXrefTest.java
@@ -61,12 +61,10 @@ public class HaskellXrefTest {
         AbstractAnalyzer analyzer = fac.getAnalyzer();
         WriteXrefArgs xargs = new WriteXrefArgs(new StringReader(s), w);
         Xrefer xref = analyzer.writeXref(xargs);
-        assertLinesEqual("Haskell basicTest",
-            "<a class=\"l\" name=\"1\" href=\"#1\">1</a>" +
-            "<a href=\"/source/s?defs=putStrLn\" class=\"intelliWindow-symbol\"" +
-            " data-definition-place=\"undefined-in-file\">putStrLn</a>" +
-            " <span class=\"s\">&quot;Hello, world!&quot;</span>\n",
-                w.toString());
+        assertLinesEqual("<a class=\"l\" name=\"1\" href=\"#1\">1</a>" +
+                "<a href=\"/source/s?defs=putStrLn\" class=\"intelliWindow-symbol\"" +
+                " data-definition-place=\"undefined-in-file\">putStrLn</a>" +
+                " <span class=\"s\">&quot;Hello, world!&quot;</span>\n", w.toString(), "Haskell basicTest");
         assertEquals(1, xref.getLOC(), "Haskell LOC");
     }
 
@@ -125,7 +123,7 @@ public class HaskellXrefTest {
 
         String[] actual = new String(sampleOutputStream.toByteArray(), StandardCharsets.UTF_8).split("\\r?\\n");
         String[] expected = new String(expectedOutputSteam.toByteArray(), StandardCharsets.UTF_8).split("\\r?\\n");
-        assertLinesEqual("Haskell sampleTest()", expected, actual);
+        assertLinesEqual(expected, actual, "Haskell sampleTest()");
         assertEquals(3, actLOC, "Haskell LOC");
     }
 
@@ -167,7 +165,7 @@ public class HaskellXrefTest {
         String estr = new String(expbytes, StandardCharsets.UTF_8);
         String[] expected = estr.split("\n");
 
-        assertLinesEqual("Haskell xref", expected, gotten);
+        assertLinesEqual(expected, gotten, "Haskell xref");
         assertEquals(expLOC, actLOC, "Haskell LOC");
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/php/PhpXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/php/PhpXrefTest.java
@@ -78,20 +78,19 @@ public class PhpXrefTest {
         AbstractAnalyzer analyzer = fac.getAnalyzer();
         WriteXrefArgs xargs = new WriteXrefArgs(new StringReader(s), w);
         Xrefer xref = analyzer.writeXref(xargs);
-        assertLinesEqual("PHP quoting",
-                "<a class=\"l\" name=\"1\" href=\"#1\">1</a><strong>&lt;?php</strong> "
-                        + "<a href=\"/source/s?defs=define\" class=\"intelliWindow-symbol\" "
-                        + "data-definition-place=\"undefined-in-file\">define</a>(<span class=\"s\">&quot;FOO&quot;</span>,"
-                        + " <span class=\"s\">&apos;BAR<strong>\\&apos;</strong>&quot;&apos;</span>); "
-                        + "$<a href=\"/source/s?defs=foo\" class=\"intelliWindow-symbol\" "
-                        + "data-definition-place=\"undefined-in-file\">foo</a>=<span class=\"s\">&apos;bar&apos;</span>; "
-                        + "$<a href=\"/source/s?defs=hola\" class=\"intelliWindow-symbol\" "
-                        + "data-definition-place=\"undefined-in-file\">hola</a>=<span class=\"s\">&quot;ls&quot;</span>; "
-                        + "$<a href=\"/source/s?defs=hola\" class=\"intelliWindow-symbol\" "
-                        + "data-definition-place=\"undefined-in-file\">hola</a>=<span class=\"s\">&apos;&apos;</span>; "
-                        + "$<a href=\"/source/s?defs=hola\" class=\"intelliWindow-symbol\" "
-                        + "data-definition-place=\"undefined-in-file\">hola</a>=<span class=\"s\">&quot;&quot;</span>;",
-                w.toString());
+        assertLinesEqual("<a class=\"l\" name=\"1\" href=\"#1\">1</a><strong>&lt;?php</strong> " +
+                "<a href=\"/source/s?defs=define\" class=\"intelliWindow-symbol\" " +
+                "data-definition-place=\"undefined-in-file\">define</a>(<span class=\"s\">&quot;FOO&quot;</span>, " +
+                "<span class=\"s\">&apos;BAR<strong>\\&apos;</strong>&quot;&apos;</span>); " +
+                "$<a href=\"/source/s?defs=foo\" class=\"intelliWindow-symbol\" " +
+                "data-definition-place=\"undefined-in-file\">foo</a>=<span class=\"s\">&apos;bar&apos;</span>; " +
+                "$<a href=\"/source/s?defs=hola\" class=\"intelliWindow-symbol\" " +
+                "data-definition-place=\"undefined-in-file\">hola</a>=<span class=\"s\">&quot;ls&quot;</span>; " +
+                "$<a href=\"/source/s?defs=hola\" class=\"intelliWindow-symbol\" " +
+                "data-definition-place=\"undefined-in-file\">hola</a>=<span class=\"s\">&apos;&apos;</span>; " +
+                "$<a href=\"/source/s?defs=hola\" class=\"intelliWindow-symbol\" " +
+                "data-definition-place=\"undefined-in-file\">hola</a>=<span class=\"s\">&quot;&quot;</span>;",
+                w.toString(), "PHP quoting");
         assertEquals(1, xref.getLOC(), "PHP LOC");
     }
 
@@ -146,7 +145,7 @@ public class PhpXrefTest {
 
         String[] gotten = new String(baos.toByteArray(), StandardCharsets.UTF_8).split("\\r?\\n");
         String[] expected = new String(expbytes, StandardCharsets.UTF_8).split("\n");
-        assertLinesEqual("PHP xref", expected, gotten);
+        assertLinesEqual(expected, gotten, "PHP xref");
         assertEquals(29, actLOC, "PHP LOC");
 
         assertEquals(expected.length, gotten.length);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ruby/RubyXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/ruby/RubyXrefTest.java
@@ -66,7 +66,7 @@ public class RubyXrefTest extends XrefTestBase {
                 + "data-definition-place=\"undefined-in-file\">logfn</a>"
                 + "<span class=\"s\">}:&quot;</span>\n" +
             "<a class=\"l\" name=\"2\" href=\"#2\">2</a>\n";
-        assertLinesEqual("Ruby colon-quote", xexpected, xout);
+        assertLinesEqual(xexpected, xout, "Ruby colon-quote");
         assertEquals(1, actLOC, "Ruby colon-quote LOC");
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/ContextFormatterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/ContextFormatterTest.java
@@ -47,7 +47,10 @@ public class ContextFormatterTest {
             " Aenean dignissim ipsum eu rhoncus ultricies.\n" +
             "\n" +
             "    Fusce pretium hendrerit dictum. Pellentesque habitant\n" +
-            "morbi tristique senectus et netus.";
+            "morbi tristique senectus et netus.\n" +
+            "Nam scelerisque odio at justo fringilla, eu aliquet sem commodo.\n" +
+            "Duis aliquet non magna ac gravida. Aliquam erat volutpat. Proin\n" +
+            "nec iaculis mauris.";
 
     private static final String DOC2 = "abc\n" +
             "def\n" +
@@ -74,10 +77,10 @@ public class ContextFormatterTest {
 
         final String DOCCTX_0 =
                 "<a class=\"s\" href=\"http://example.com#3\"><span class=\"l\">" +
-                        "3</span> Mauris diam nisl, tincidunt nec <b>gravida</b> sit" +
-                        " amet, efficitur vitae</a><br/>\n";
+                "3</span> Mauris diam nisl, tincidunt nec <b>gravida</b> sit " +
+                "amet, efficitur vitae</a><br/>\n";
         String ctx = res.toString();
-        assertLinesEqual("format().toString()", DOCCTX_0, ctx);
+        assertLinesEqual(DOCCTX_0, ctx, "format().toString()");
 
         // Second, test with contextCount==1
         args = new ContextArgs((short) 1, (short) 10);
@@ -86,16 +89,17 @@ public class ContextFormatterTest {
         res = fmt.format(new Passage[] {p}, DOC);
         assertNotNull(res, "format() result");
 
-        final String DOCCTX_1 = "<a class=\"s\" href=\"http://example.com#2\"><span class=\"l\">" +
+        final String DOCCTX_1 =
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#2\"><span class=\"l\">" +
                 "2</span> Mauris vel tortor vel nisl efficitur fermentum nec vel" +
-                " erat.</a><br/>" +
-                "<a class=\"s\" href=\"http://example.com#3\"><span class=\"l\">" +
+                " erat.</a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#3\"><span class=\"l\">" +
                 "3</span> Mauris diam nisl, tincidunt nec <b>gravida</b> sit" +
-                " amet, efficitur vitae</a><br/>" +
-                "<a class=\"s\" href=\"http://example.com#4\"><span class=\"l\">" +
-                "4</span> est. Sed aliquam non mi vel mattis:</a><br/>";
+                " amet, efficitur vitae</a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#4\"><span class=\"l\">" +
+                "4</span> est. Sed aliquam non mi vel mattis:</a><br/></span>";
         ctx = res.toString();
-        assertLinesEqual("format().toString()", DOCCTX_1, ctx);
+        assertLinesEqual(DOCCTX_1, ctx, "format().toString()");
     }
 
     @Test
@@ -106,7 +110,7 @@ public class ContextFormatterTest {
         p.addMatch(0, p.getEndOffset(), new BytesRef(DOC2), 1);
         assertEquals(1, p.getNumMatches(), "getNumMatches()");
 
-        /**
+        /*
          * We're using the entire document, but see how it behaves with
          * contextCount==1
          */
@@ -117,14 +121,14 @@ public class ContextFormatterTest {
         assertNotNull(res, "format() result");
 
         final String DOC2CTX =
-                "<a class=\"s\" href=\"http://example.com#1\"><span class=\"l\">" +
-                        "1</span> <b>abc</b></a><br/>" +
-                        "<a class=\"s\" href=\"http://example.com#2\"><span class=\"l\">" +
-                        "2</span> <b>def</b></a><br/>" +
-                        "<a class=\"s\" href=\"http://example.com#3\"><span class=\"l\">" +
-                        "3</span> <b>ghi</b></a><br/>";
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#1\"><span class=\"l\">" +
+                "1</span> <b>abc</b></a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#2\"><span class=\"l\">" +
+                "2</span> <b>def</b></a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#3\"><span class=\"l\">" +
+                "3</span> <b>ghi</b></a><br/></span>";
         String ctx = res.toString();
-        assertLinesEqual("format().toString()", DOC2CTX, ctx);
+        assertLinesEqual(DOC2CTX, ctx, "format().toString()");
     }
 
     @Test
@@ -151,7 +155,7 @@ public class ContextFormatterTest {
                 " non ornare egestas. Aenean <b>dignissim</b> ipsum eu" +
                 " rhoncus&hellip;</a><br/>\n";
         String ctx = res.toString();
-        assertLinesEqual("format().toString()", DOCCTX_0, ctx);
+        assertLinesEqual(DOCCTX_0, ctx, "format().toString()");
 
         // Second, test with contextCount==1
         args = new ContextArgs((short) 1, (short) 10);
@@ -160,35 +164,36 @@ public class ContextFormatterTest {
         res = fmt.format(new Passage[] {p}, DOC);
         assertNotNull(res, "format() result");
 
-        final String DOCCTX_1 = "<a class=\"s\" href=\"http://example.com#5\"><span class=\"l\">" +
-                "5</span> </a><br/>" +
-                "<a class=\"s\" href=\"http://example.com#6\"><span class=\"l\">" +
+        final String DOCCTX_1 =
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#5\"><span class=\"l\">" +
+                "5</span> </a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#6\"><span class=\"l\">" +
                 "6</span> &hellip;putate ipsum sed laoreet. Nam maximus libero" +
                 " non ornare egestas. Aenean <b>dignissim</b> ipsum eu" +
-                " rhoncus&hellip;</a><br/>" +
-                "<a class=\"s\" href=\"http://example.com#7\"><span class=\"l\">" +
-                "7</span> </a><br/>";
+                " rhoncus&hellip;</a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#7\"><span class=\"l\">" +
+                "7</span> </a><br/></span>";
         ctx = res.toString();
-        assertLinesEqual("format().toString()", DOCCTX_1, ctx);
+        assertLinesEqual(DOCCTX_1, ctx, "format().toString()");
 
         // Third, test with contextCount==1 and a line limit
-        args = new ContextArgs((short) 1, (short) 10);
+        args = new ContextArgs((short) 1, (short) 2);
         fmt = new ContextFormatter(args);
         fmt.setUrl("http://example.com");
-        fmt.setMoreLimit(2);
         fmt.setMoreUrl("http://example.com/more");
         res = fmt.format(new Passage[] {p}, DOC);
         assertNotNull(res, "format() result");
 
-        final String DOCCTX_2M = "<a class=\"s\" href=\"http://example.com#5\"><span class=\"l\">" +
-                "5</span> </a><br/>" +
-                "<a class=\"s\" href=\"http://example.com#6\"><span class=\"l\">" +
+        final String DOCCTX_2M =
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#5\"><span class=\"l\">" +
+                "5</span> </a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#6\"><span class=\"l\">" +
                 "6</span> &hellip;putate ipsum sed laoreet. Nam maximus libero" +
                 " non ornare egestas. Aenean <b>dignissim</b> ipsum eu" +
-                " rhoncus&hellip;</a><br/>" +
+                " rhoncus&hellip;</a><br/></span>" +
                 "<a href=\"http://example.com/more\">[all &hellip;]</a><br/>";
         ctx = res.toString();
-        assertLinesEqual("format().toString()", DOCCTX_2M, ctx);
+        assertLinesEqual(DOCCTX_2M, ctx, "format().toString()");
     }
 
     @Test
@@ -212,12 +217,12 @@ public class ContextFormatterTest {
 
         final String DOCCTX_0 =
                 "<a class=\"s\" href=\"http://example.com#6\"><span " +
-                        "class=\"l\">6</span> &hellip;um sed laoreet. Nam " +
-                        "maximus libero non ornare egestas. Aenean " +
-                        "dignissim ipsum eu rhoncus <b>ultricies</b>.</a>" +
-                        "<br/>";
+                "class=\"l\">6</span> &hellip;um sed laoreet. Nam " +
+                "maximus libero non ornare egestas. Aenean " +
+                "dignissim ipsum eu rhoncus <b>ultricies</b>.</a>" +
+                "<br/>";
         String ctx = res.toString();
-        assertLinesEqual("format().toString()", DOCCTX_0, ctx);
+        assertLinesEqual(DOCCTX_0, ctx, "format().toString()");
 
         // Second, test with contextCount==1
         args = new ContextArgs((short) 1, (short) 10);
@@ -227,37 +232,38 @@ public class ContextFormatterTest {
         assertNotNull(res, "format() result");
 
         final String DOCCTX_1 =
-                "<a class=\"s\" href=\"http://example.com#5\"><span " +
-                        "class=\"l\">5</span> </a><br/>" +
-                        "<a class=\"s\" href=\"http://example.com#6\"><span " +
-                        "class=\"l\">6</span> &hellip;um sed laoreet. Nam " +
-                        "maximus libero non ornare egestas. Aenean " +
-                        "dignissim ipsum eu rhoncus <b>ultricies</b>.</a>" +
-                        "<br/>" +
-                        "<a class=\"s\" href=\"http://example.com#7\"><span " +
-                        "class=\"l\">7</span> </a><br/>";
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#5\"><span " +
+                "class=\"l\">5</span> </a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#6\"><span " +
+                "class=\"l\">6</span> &hellip;um sed laoreet. Nam " +
+                "maximus libero non ornare egestas. Aenean " +
+                "dignissim ipsum eu rhoncus <b>ultricies</b>.</a>" +
+                "<br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#7\"><span " +
+                "class=\"l\">7</span> </a><br/></span>";
         ctx = res.toString();
-        assertLinesEqual("format().toString()", DOCCTX_1, ctx);
+        assertLinesEqual(DOCCTX_1, ctx, "format().toString()");
 
         // Third, test with contextCount==1 and a line limit
-        args = new ContextArgs((short) 1, (short) 10);
+        args = new ContextArgs((short) 1, (short) 2);
         fmt = new ContextFormatter(args);
         fmt.setUrl("http://example.com");
-        fmt.setMoreLimit(2);
         fmt.setMoreUrl("http://example.com/more");
         res = fmt.format(new Passage[] {p}, DOC);
         assertNotNull(res, "format() result");
 
-        final String DOCCTX_2M = "<a class=\"s\" href=\"http://example.com#5\">" +
-                "<span class=\"l\">5</span> </a><br/>" +
-                "<a class=\"s\" href=\"http://example.com#6\"><span " +
+        final String DOCCTX_2M =
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#5\">" +
+                "<span class=\"l\">5</span> </a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#6\"><span " +
                 "class=\"l\">6</span> &hellip;um sed laoreet. Nam " +
                 "maximus libero non ornare egestas. Aenean " +
                 "dignissim ipsum eu rhoncus <b>ultricies</b>.</a>" +
-                "<br/><a href=\"http://example.com/more\">[all " +
+                "<br/></span>" +
+                "<a href=\"http://example.com/more\">[all " +
                 "&hellip;]</a><br/>";
         ctx = res.toString();
-        assertLinesEqual("format().toString()", DOCCTX_2M, ctx);
+        assertLinesEqual(DOCCTX_2M, ctx, "format().toString()");
     }
 
     @Test
@@ -284,7 +290,7 @@ public class ContextFormatterTest {
                 "lacus velit varius vulputate ipsum sed laoreet. " +
                 "Nam maximus libero non ornare eg&hellip;</a><br/>";
         String ctx = res.toString();
-        assertLinesEqual("format().toString()", DOCCTX_0, ctx);
+        assertLinesEqual(DOCCTX_0, ctx, "format().toString()");
 
         // Second, test with contextCount==1
         args = new ContextArgs((short) 1, (short) 10);
@@ -294,36 +300,36 @@ public class ContextFormatterTest {
         assertNotNull(res, "format() result");
 
         final String DOCCTX_1 =
-                "<a class=\"s\" href=\"http://example.com#5\"><span " +
-                        "class=\"l\">5</span> </a><br/>" +
-                        "<a class=\"s\" href=\"http://example.com#6\"><span " +
-                        "class=\"l\">6</span> ----<b>Maecenas</b> vitae " +
-                        "lacus velit varius vulputate ipsum sed laoreet. " +
-                        "Nam maximus libero non ornare eg&hellip;</a><br/>" +
-                        "<a class=\"s\" href=\"http://example.com#7\"><span " +
-                        "class=\"l\">7</span> </a><br/>";
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#5\"><span " +
+                "class=\"l\">5</span> </a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#6\"><span " +
+                "class=\"l\">6</span> ----<b>Maecenas</b> vitae " +
+                "lacus velit varius vulputate ipsum sed laoreet. " +
+                "Nam maximus libero non ornare eg&hellip;</a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#7\"><span " +
+                "class=\"l\">7</span> </a><br/></span>";
         ctx = res.toString();
-        assertLinesEqual("format().toString()", DOCCTX_1, ctx);
+        assertLinesEqual(DOCCTX_1, ctx, "format().toString()");
 
         // Third, test with contextCount==1 and a line limit
-        args = new ContextArgs((short) 1, (short) 10);
+        args = new ContextArgs((short) 1, (short) 2);
         fmt = new ContextFormatter(args);
         fmt.setUrl("http://example.com");
-        fmt.setMoreLimit(2);
         fmt.setMoreUrl("http://example.com/more");
         res = fmt.format(new Passage[] {p}, DOC);
         assertNotNull(res, "format() result");
 
-        final String DOCCTX_2M = "<a class=\"s\" href=\"http://example.com#5\"><span " +
-                "class=\"l\">5</span> </a><br/>" +
-                "<a class=\"s\" href=\"http://example.com#6\"><span " +
+        final String DOCCTX_2M =
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#5\"><span " +
+                "class=\"l\">5</span> </a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#6\"><span " +
                 "class=\"l\">6</span> ----<b>Maecenas</b> vitae " +
                 "lacus velit varius vulputate ipsum sed laoreet. " +
-                "Nam maximus libero non ornare eg&hellip;</a><br/>" +
+                "Nam maximus libero non ornare eg&hellip;</a><br/></span>" +
                 "<a href=\"http://example.com/more\">[all " +
                 "&hellip;]</a><br/>\n";
         ctx = res.toString();
-        assertLinesEqual("format().toString()", DOCCTX_2M, ctx);
+        assertLinesEqual(DOCCTX_2M, ctx, "format().toString()");
     }
 
     @Test
@@ -354,6 +360,61 @@ public class ContextFormatterTest {
                 "3</span> Mauris diam nisl, tincidunt nec gravida sit" +
                 " amet, <b>efficitur vitae</b></a><br/>\n";
         String ctx = res.toString();
-        assertLinesEqual("format().toString()", DOC_CTX_0, ctx);
+        assertLinesEqual(DOC_CTX_0, ctx, "format().toString()");
+    }
+
+    @Test
+    public void testRecalculatedContextLimit() {
+        final String PHRASE1 = "efficitur fermentum";
+        final String PHRASE2 = "varius vulputate";
+        final String PHRASE3 = "justo fringilla";
+
+        Passage passage1 = new Passage();
+        int phraseOff1 = DOC.indexOf(PHRASE1);
+        passage1.setStartOffset(phraseOff1);
+        passage1.setEndOffset(phraseOff1 + PHRASE1.length());
+        assertTrue(passage1.getStartOffset() >= 0 && passage1.getEndOffset() >
+                passage1.getStartOffset(), "passage1 offsets are positive");
+        passage1.addMatch(passage1.getStartOffset(), passage1.getEndOffset(), new BytesRef(PHRASE1), 1);
+
+        Passage passage2 = new Passage();
+        int phraseOff2 = DOC.indexOf(PHRASE2);
+        passage2.setStartOffset(phraseOff2);
+        passage2.setEndOffset(phraseOff2 + PHRASE2.length());
+        assertTrue(passage2.getStartOffset() >= 0 && passage2.getEndOffset() >
+                passage2.getStartOffset(), "passage2 offsets are positive");
+        passage2.addMatch(passage2.getStartOffset(), passage2.getEndOffset(), new BytesRef(PHRASE2), 1);
+
+        Passage passage3 = new Passage();
+        int phraseOff3 = DOC.indexOf(PHRASE3);
+        passage3.setStartOffset(phraseOff3);
+        passage3.setEndOffset(phraseOff3 + PHRASE3.length());
+        assertTrue(passage3.getStartOffset() >= 0 && passage3.getEndOffset() >
+                passage3.getStartOffset(), "passage3 offsets are positive");
+        passage3.addMatch(passage3.getStartOffset(), passage3.getEndOffset(), new BytesRef(PHRASE3), 1);
+
+        // Test with non-zero context limit.
+        ContextArgs args = new ContextArgs((short) 1, (short) 7);
+        ContextFormatter fmt = new ContextFormatter(args);
+        fmt.setUrl("http://example.com");
+        Object formatted = fmt.format(new Passage[] {passage1, passage2, passage3}, DOC);
+        assertNotNull(formatted, "format() result");
+
+        final String DOC_CTX_0 = "<span class=\"xovl\">" +
+                "<a class=\"s\" href=\"http://example.com#1\"><span class=\"l\">1</span>" +
+                "     Lorem ipsum dolor sit amet, consectetur adipiscing elit.</a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#2\">" +
+                "<span class=\"l\">2</span> Mauris vel tortor vel nisl " +
+                "<b>efficitur fermentum</b> nec vel erat.</a><br/></span><span class=\"xovl\">" +
+                "<a class=\"s\" href=\"http://example.com#3\"><span class=\"l\">3</span> " +
+                "Mauris diam nisl, tincidunt nec gravida sit amet, efficitur vitae</a><br/></span>" +
+                "<span class=\"ovl\"><a class=\"s\" href=\"http://example.com#5\">" +
+                "<span class=\"l\">5</span> </a><br/></span><span class=\"xovl\">" +
+                "<a class=\"s\" href=\"http://example.com#6\"><span class=\"l\">6</span> " +
+                "----Maecenas vitae lacus velit <b>varius vulputate</b> ipsum sed laoreet. " +
+                "Nam maximus libero non ornare eg&hellip;</a><br/></span>" +
+                "<span class=\"xovl\"><a class=\"s\" href=\"http://example.com#7\">" +
+                "<span class=\"l\">7</span> </a><br/></span>";
+        assertLinesEqual(DOC_CTX_0, formatted.toString(), "format().toString()");
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/CustomAssertions.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/CustomAssertions.java
@@ -51,25 +51,25 @@ public class CustomAssertions {
     /**
      * Asserts the specified strings have equal contents, comparing line-wise
      * after splitting on LFs.
-     * @param messagePrefix a message prefixed to line-specific or length-
-     * specific errors
      * @param expected the expected content
      * @param actual the actual content
+     * @param messagePrefix a message prefixed to line-specific or length-
+     * specific errors
      */
-    public static void assertLinesEqual(String messagePrefix, String expected, String actual) {
+    public static void assertLinesEqual(String expected, String actual, String messagePrefix) {
         String[] expecteds = expected.split("\n");
         String[] gotten = actual.split("\n");
-        assertLinesEqual(messagePrefix, expecteds, gotten);
+        assertLinesEqual(expecteds, gotten, messagePrefix);
     }
 
     /**
      * Asserts the specified lines arrays have equal contents.
-     * @param messagePrefix a message prefixed to line-specific or length-
-     * specific errors
      * @param expecteds the expected content of lines
      * @param actuals the actual content of lines
+     * @param messagePrefix a message prefixed to line-specific or length-
+     * specific errors
      */
-    public static void assertLinesEqual(String messagePrefix, String[] expecteds, String[] actuals) {
+    public static void assertLinesEqual(String[] expecteds, String[] actuals, String messagePrefix) {
 
         List<Integer> diffLines = new ArrayList<>();
 
@@ -137,7 +137,7 @@ public class CustomAssertions {
 
         count = 0;
         for (String token : tokens) {
-            // 1-based offset to accord with line #
+            // 1-based index to accord with line #
             if (count >= expectedTokens.size()) {
                 printTokens(tokens);
                 assertTrue(count < expectedTokens.size(), "too many tokens at term" + (1 + count) + ": " + token);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
@@ -82,7 +82,7 @@ class SearchHelperTest {
                 env.getDataRootFile(), env.getSourceRootFile(),
                 env.getHitsPerPage(), null,
                 new QueryBuilder().setFreetext(searchTerm), false,
-                env.getUrlPrefix(), false, false);
+                null, env.getUrlPrefix(), false, false);
 
         assertNotSame(0, sh.getBuilder().getSize());
         return sh;
@@ -93,7 +93,7 @@ class SearchHelperTest {
                 env.getDataRootFile(), env.getSourceRootFile(),
                 env.getHitsPerPage(), null,
                 new QueryBuilder().setPath(searchTerm), false,
-                env.getUrlPrefix(), false, false);
+                null, env.getUrlPrefix(), false, false);
 
         assertNotSame(0, sh.getBuilder().getSize());
         return sh;

--- a/opengrok-web/src/main/webapp/default/print-1.1.0.css
+++ b/opengrok-web/src/main/webapp/default/print-1.1.0.css
@@ -187,13 +187,12 @@ input.submit { /* start search button */
 }
 /* ############### end of header ############## */
 
-
 /* ############### start of content ############## */
+
 #content {
     position: static;
     overflow-x: hidden;
 }
-
 
 /* *** help page *** */
 #help h4 {
@@ -216,13 +215,22 @@ input.submit { /* start search button */
 
 /* *** more page ***/
 #more {
-    line-height: 1.25em;
+    line-height: 1.5em;
 }
 
 #more b { /* highlight matches */
     background-color: #e5e5e5;
 }
 
+#more .ovl, #results .ovl {
+    /*
+     * overline non-consecutive, contextual, "more" line contents or search-
+     * result line contents
+     */
+    border-style: dotted none none none;
+    border-width: 1px;
+    display: block;
+}
 
 /* *** history page *** */
 table#revisions {
@@ -257,6 +265,10 @@ table#revisions {
 #revisions tbody td:nth-child(4) { /* author column */
     padding: 0 1ex;
     text-align: center;
+}
+
+.rev-message-hidden {
+    display: none;
 }
 
 .rssbadge { /* RSS/XML Feed on history page */
@@ -320,19 +332,41 @@ table#dirlist { /* the "Name" column */
     border-collapse: collapse;
 }
 
+table#dirlist thead tr:nth-child(1) {
+    height: 22px;
+}
+
 #dirlist .r, #dirlist .p {
     padding: 0;
     margin: 0 0 0 1em;
 }
 
-#dirlist td:nth-child(n+2) { /* all but the first column */
+#dirlist td:nth-child(n+3) { /* all but the first 2 columns */
     padding-right: 1em;
 }
 
-#dirlist tbody td:nth-child(4) {
+#dirlist tbody td:nth-child(5) {
     text-align: right; /* CSS3 may allow " " (single space char) */
 }
 
+#dirlist td.q { /* 2nd column: H A D */
+    white-space: nowrap;
+    font-size: small;
+    padding-left: 16px;
+    width: 3em;
+}
+
+#dirlist td.numlines { /* 5th column: #Lines */
+    text-align: right; /* CSS3 may allow " " (single space char) */
+}
+
+#dirlist td.loc { /* 6th column: LOC */
+    text-align: right; /* CSS3 may allow " " (single space char) */
+}
+
+span.simplified-path {
+    color: #888;
+}
 
 /* file display */
 #src {
@@ -365,12 +399,22 @@ table#dirlist { /* the "Name" column */
     color: #000;
 }
 
+/* highlight line number with anchor */
+#src a.l:target, #src a.hl:target {
+    background: orange;
+    color:yellow;
+}
+
 .blame .r { /* revision number "column" (annotation) */
     text-align: right;
 }
 
 .blame .a { /* author name "column" (annotation) */
     text-align: center;
+}
+
+.most_recent_revision {
+    font-weight: bold;
 }
 
 /* source code highlighting - see org/opengrok/analysis/$lang/*Xref.lex */
@@ -504,10 +548,6 @@ a.xsr    { /* subroutine */         color: #00f; font-weight: bold;             
 }
 /* ############### end of footer ############## */
 
-.important-note {
-    display: none;
-}
-
 /* *** scopes *** */
 
 span.scope-head {
@@ -535,5 +575,9 @@ span.scope-signature {
 }
 
 div#scope {
+    display: none;
+}
+
+.important-note {
     display: none;
 }

--- a/opengrok-web/src/main/webapp/default/style-1.1.0.css
+++ b/opengrok-web/src/main/webapp/default/style-1.1.0.css
@@ -104,6 +104,11 @@ button:hover, button:active, .btn:hover, .btn:active {
 label {
 }
 
+label.sch {
+    /* Surrounding context chooser */
+    font-size: small;
+}
+
 .pre { /* the diff content */
     white-space: pre-wrap;
     font-family: monospace;
@@ -500,13 +505,40 @@ html.history #content{
 
 /* *** more page ***/
 #more {
-    line-height: 1.25em;
+    line-height: 1.5em;
 }
 
 #more b { /* highlight matches */
     background-color: #ffff99;
 }
 
+#more .ovl, #results .ovl {
+    /*
+     * overline non-consecutive, contextual, "more" line contents or search-
+     * result line contents.
+     */
+    border-style: dotted none none none;
+    border-width: 1px;
+    display: block;
+    white-space: pre;
+    /* Safari work-around re word-wrap when white-space: pre is used. */
+    word-wrap: normal;
+}
+
+#more .xovl, #results .xovl {
+    /*
+     * Applies for contextual search result line contents that are not #ovl.
+     * Technically #more is already in a <pre> but avoiding a missing style.
+     */
+    white-space: pre;
+    /* Safari work-around re word-wrap when white-space: pre is used. */
+    word-wrap: normal;
+}
+
+#more .ovl b, #results .ovl b, #more .xovl b, #results .xovl b {
+    /* highlight matches when surrounding context is shown. */
+    background-color: #ffff99;
+}
 
 /* *** history page *** */
 table#revisions {

--- a/opengrok-web/src/main/webapp/httpheader.jspf
+++ b/opengrok-web/src/main/webapp/httpheader.jspf
@@ -45,8 +45,8 @@ org.opengrok.web.Scripts"
     PageConfig cfg = PageConfig.get(request);
     String styleDir = cfg.getCssDir();
     String ctxPath = request.getContextPath();
-    String dstyle = styleDir + '/' + "style-1.0.4.min.css";
-    String pstyle = styleDir + '/' + "print-1.0.2.min.css";
+    String dstyle = styleDir + '/' + "style-1.1.0.min.css";
+    String pstyle = styleDir + '/' + "print-1.1.0.min.css";
     String mstyle = styleDir + '/' + "mandoc-1.0.0.min.css";
 %><!DOCTYPE html>
 <html lang="en"

--- a/opengrok-web/src/main/webapp/menu.jspf
+++ b/opengrok-web/src/main/webapp/menu.jspf
@@ -29,6 +29,7 @@ java.util.TreeSet,
 
 org.opengrok.indexer.configuration.Group,
 org.opengrok.indexer.configuration.Project,
+org.opengrok.indexer.search.context.ContextArgs,
 org.opengrok.indexer.search.QueryBuilder,
 org.opengrok.web.PageConfig,
 org.opengrok.web.ProjectHelper,
@@ -69,7 +70,7 @@ document.domReady.push(function() { domReadyMenu(); });
     <label for="<%= QueryParameters.PROJECT_SEARCH_PARAM %>">Project(s)</label>
     </td>
     <td colspan="2">
-    <select tabindex="8" class="q" id="<%= QueryParameters.PROJECT_SEARCH_PARAM %>"
+    <select tabindex="0" class="q" id="<%= QueryParameters.PROJECT_SEARCH_PARAM %>"
         name="<%= QueryParameters.PROJECT_SEARCH_PARAM %>" multiple="multiple" size="<%=
         Math.min(15, projectsSize) %>"><%
         SortedSet<String> pRequested = new TreeSet<>(cfg.getRequestedProjects());
@@ -126,15 +127,15 @@ document.domReady.push(function() { domReadyMenu(); });
     </tr>
     <tr>
     <td colspan="3" >
-    <button tabindex="6" type="button"
+    <button tabindex="0" type="button"
         onclick="selectAllProjects(); return false;"
         >select all</button>
     &nbsp;
-    <button tabindex="7" type="button"
+    <button tabindex="0" type="button"
         onclick="invertAllProjects(); return false;"
         >invert selection</button>
     &nbsp;
-    <button tabindex="8" type="button"
+    <button tabindex="0" type="button"
         onclick="deselectAllProjects(); return false;"
         >clear</button>
     </td>
@@ -148,7 +149,7 @@ document.domReady.push(function() { domReadyMenu(); });
         <td><label for="<%= QueryParameters.FULL_SEARCH_PARAM %>"
               title="Text token(s) or other fields to be found (Lucene query--this is not full text)">
             Full&nbsp;Search</label></td>
-        <td colspan="2"><input tabindex="1" class="q"
+        <td colspan="2"><input tabindex="0" class="q"
                 name="<%= QueryParameters.FULL_SEARCH_PARAM %>"
                 id="<%= QueryParameters.FULL_SEARCH_PARAM %>" type="text" value="<%=
                 Util.formQuoteEscape(queryParams.getFreetext()) %>"/></td>
@@ -156,7 +157,7 @@ document.domReady.push(function() { domReadyMenu(); });
     <tr>
         <td><label for="<%= QueryParameters.DEFS_SEARCH_PARAM %>"
               title="Definitions of function/variable/class">Definition</label></td>
-        <td colspan="2"><input class="q" tabindex="2"
+        <td colspan="2"><input class="q" tabindex="0"
             name="<%= QueryParameters.DEFS_SEARCH_PARAM %>"
             id="<%= QueryParameters.DEFS_SEARCH_PARAM %>" type="text" value="<%=
             Util.formQuoteEscape(queryParams.getDefs()) %>"/></td>
@@ -164,7 +165,7 @@ document.domReady.push(function() { domReadyMenu(); });
     <tr>
         <td><label for="<%= QueryParameters.REFS_SEARCH_PARAM %>"
               title="Usage of function/variable/class">Symbol</label></td>
-        <td colspan="2"><input class="q" tabindex="3"
+        <td colspan="2"><input class="q" tabindex="0"
             name="<%= QueryParameters.REFS_SEARCH_PARAM %>"
             id="<%= QueryParameters.REFS_SEARCH_PARAM %>" type="text" value="<%=
             Util.formQuoteEscape(queryParams.getRefs()) %>"/></td>
@@ -172,7 +173,7 @@ document.domReady.push(function() { domReadyMenu(); });
     <tr>
         <td><label for="<%= QueryParameters.PATH_SEARCH_PARAM %>"
               title="Path or parts of it (no need to use separators)">File&nbsp;Path</label></td>
-        <td colspan="2"><input class="q" tabindex="4"
+        <td colspan="2"><input class="q" tabindex="0"
             name="<%= QueryParameters.PATH_SEARCH_PARAM %>"
             id="<%= QueryParameters.PATH_SEARCH_PARAM %>" type="text" value="<%=
             Util.formQuoteEscape(queryParams.getPath()) %>"/></td>
@@ -183,7 +184,7 @@ document.domReady.push(function() { domReadyMenu(); });
     <tr>
         <td><label for="<%= QueryParameters.HIST_SEARCH_PARAM %>"
               title="Search in project(s) repository log messages">History</label></td>
-        <td colspan="2"><input class="q" tabindex="5"
+        <td colspan="2"><input class="q" tabindex="0"
             name="<%= QueryParameters.HIST_SEARCH_PARAM %>"
             id="<%= QueryParameters.HIST_SEARCH_PARAM %>" type="text" value="<%=
             Util.formQuoteEscape(queryParams.getHist()) %>"/></td>
@@ -193,7 +194,7 @@ document.domReady.push(function() { domReadyMenu(); });
     %>
     <tr>
         <td id="typeLabelTd"><label for="<%= QueryParameters.TYPE_SEARCH_PARAM %>">Type</label></td>
-        <td><select class="q" tabindex="6" name="<%= QueryParameters.TYPE_SEARCH_PARAM %>"
+        <td><select class="q" tabindex="0" name="<%= QueryParameters.TYPE_SEARCH_PARAM %>"
                 id="<%= QueryParameters.TYPE_SEARCH_PARAM %>"><%
                 String selection = queryParams.getType();
                 %>
@@ -216,18 +217,25 @@ document.domReady.push(function() { domReadyMenu(); });
     </tbody>
 </table>
 <div id="form-controls">
-    <input tabindex="9" class="submit btn" onclick="$('#xrd').val(''); $('#sbox').submit()"
+    <input tabindex="0" class="submit btn" onclick="$('#xrd').val(''); $('#sbox').submit()"
            type="submit" value="Search"/>
-    <input tabindex="10" class="submit btn" onclick="clearSearchFrom();"
+    <input tabindex="0" class="submit btn" onclick="clearSearchFrom();"
            type="button" value="Clear"/>
-    <input tabindex="11" class="submit btn" onclick="window.open('help.jsp', '_blank');"
+    <input tabindex="0" class="submit btn" onclick="window.open('help.jsp', '_blank');"
            type="button" value="Help"/>
-    <input tabindex="12" class="submit btn" onclick="window.open('settings.jsp', '_self');"
+    <input tabindex="0" class="submit btn" onclick="window.open('settings.jsp', '_self');"
            type="button" value="Settings"/>
+    <label for="<%= QueryParameters.CONTEXT_SURROUND_PARAM %>" class="sch">
+      <input type="number" name="<%= QueryParameters.CONTEXT_SURROUND_PARAM %>"
+             id="<%= QueryParameters.CONTEXT_SURROUND_PARAM %>" min="0"
+             max="<%= ContextArgs.MAX_CONTEXT_SURROUND %>" step="1"
+             value="<%= cfg.getLimitedContextArgs().getContextSurround() %>">
+        context &nbsp;
+    </label>
 </div>
 </div>
 <div id="ltbl">
-    <!-- filled with javascript -->
+    <%-- filled with javascript --%>
 </div>
 <input type="hidden" id="<%= QueryParameters.NO_REDIRECT_PARAM %>"
        name="<%= QueryParameters.NO_REDIRECT_PARAM %>" value=""/>

--- a/opengrok-web/src/main/webapp/minisearch.jspf
+++ b/opengrok-web/src/main/webapp/minisearch.jspf
@@ -21,10 +21,12 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
 --%>
 <%@ page session="false" errorPage="error.jsp" import="
 org.opengrok.indexer.configuration.Project,
+org.opengrok.indexer.search.context.ContextArgs,
 org.opengrok.web.PageConfig,
 org.opengrok.indexer.web.Prefix,
 org.opengrok.indexer.web.QueryParameters,
-org.opengrok.indexer.web.Util"%><%
+org.opengrok.indexer.web.Util"%>
+<%
     /* ---------------------- minisearch.jspf start --------------------- */
 {
         PageConfig cfg = PageConfig.get(request);
@@ -98,10 +100,20 @@ org.opengrok.indexer.web.Util"%><%
     }
         %><li><input type="text" id="search" name="<%= QueryParameters.FULL_SEARCH_PARAM %>"
                   class="q" aria-label="Search"/></li>
-            <li><input type="submit" value="Search" class="submit" /></li><%
+        <li><input type="submit" value="Search" class="submit" /></li>
+        <li>
+            <label for="<%= QueryParameters.CONTEXT_SURROUND_PARAM %>" class="sch">
+            <input type="number" name="<%= QueryParameters.CONTEXT_SURROUND_PARAM %>"
+                   id="<%= QueryParameters.CONTEXT_SURROUND_PARAM %>" min="0"
+                   max="<%= ContextArgs.MAX_CONTEXT_SURROUND %>" step="1"
+                   value="<%= cfg.getLimitedContextArgs().getContextSurround() %>">
+            context &nbsp;
+        </label></li><%
     Project proj = cfg.getProject();
     String[] vals = cfg.getSearchOnlyIn();
-        %><li><label><input id="minisearch-path" type="checkbox"
+        %><li>
+            <label for="<%= QueryParameters.PATH_SEARCH_PARAM %>" class="sch">
+            <input id="minisearch-path" type="checkbox"
                   name="<%= QueryParameters.PATH_SEARCH_PARAM %>" value='"<%= vals[0]
             %>"' <%= vals[2] %>/> current directory</label></li>
     </ul><%

--- a/opengrok-web/src/main/webapp/more.jsp
+++ b/opengrok-web/src/main/webapp/more.jsp
@@ -1,6 +1,4 @@
 <%--
-$Id$
-
 CDDL HEADER START
 
 The contents of this file are subject to the terms of the
@@ -84,14 +82,14 @@ file="mast.jsp"
         Query tquery = qbuilder.build();
         if (tquery != null) {
 %><p><span class="pagetitle">Lines Matching <span class="bold"><%= tquery %></span></span></p>
-<div id="more" style="line-height:1.5em;">
+<div id="more">
     <pre><%
             String xrefPrefix = request.getContextPath() + Prefix.XREF_P;
             boolean didPresentNew = false;
             if (docId >= 0) {
-                didPresentNew = searchHelper.getSourceContext().getContext2(env,
-                    searchHelper.getSearcher(), docId, out, xrefPrefix, null, false,
-                    tabSize);
+                didPresentNew = searchHelper.getSourceContext().getContext2(
+                        searchHelper.getSearcher(), docId, out, xrefPrefix, null,
+                        searchHelper.getUnlimitedContextArgs(), tabSize);
             }
             if (!didPresentNew) {
                 /**

--- a/opengrok-web/src/main/webapp/search.jsp
+++ b/opengrok-web/src/main/webapp/search.jsp
@@ -19,10 +19,8 @@ CDDL HEADER END
 Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
-
 --%>
 <%@page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@page import="jakarta.servlet.http.HttpServletResponse"%>
 <%@page session="false" errorPage="error.jsp" import="
 org.apache.lucene.queryparser.classic.QueryParser,
 org.opengrok.indexer.search.Results,
@@ -32,11 +30,12 @@ org.opengrok.indexer.web.SearchHelper,
 org.opengrok.indexer.web.SortOrder,
 org.opengrok.indexer.web.Suggestion,
 
-java.util.List"
+java.nio.charset.StandardCharsets,
+java.util.List,
+jakarta.servlet.http.Cookie,
+jakarta.servlet.http.HttpServletRequest,
+jakarta.servlet.http.HttpServletResponse"
 %>
-<%@ page import="jakarta.servlet.http.HttpServletRequest" %>
-<%@ page import="jakarta.servlet.http.Cookie" %>
-<%@ page import="java.nio.charset.StandardCharsets" %>
 <%
 {
     PageConfig cfg = PageConfig.get(request);


### PR DESCRIPTION
Resolves #1767 

Also:
* Use tabindex="0" for Accessibility
* Fix up print.css
* Scale moreLimit with additional context but limited
* Don't re-report scopes when showing surrounding context
* Highlight match when showing surrounding context

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
