### PR TITLE
make markIndexed() asynchronous

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -363,6 +363,8 @@ This entry point is used by the Indexer once it finishes indexing given project.
 
 ### marks project as indexed [PUT]
 
+This is asynchronous API endpoint.
+
 + Request (text/plain)
   + Body
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;
@@ -53,7 +53,6 @@ import java.util.stream.Collectors;
 
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiReader;
@@ -62,7 +61,6 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.NamedThreadFactory;
-import org.jetbrains.annotations.NotNull;
 import org.opengrok.indexer.authorization.AuthorizationFramework;
 import org.opengrok.indexer.authorization.AuthorizationStack;
 import org.opengrok.indexer.history.HistoryGuru;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/ApiUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/ApiUtils.java
@@ -1,0 +1,90 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.web;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import org.jetbrains.annotations.NotNull;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.logger.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ApiUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiUtils.class);
+
+    private ApiUtils() {
+        // utility class
+    }
+
+    /**
+     * Busy waits for API call to complete by repeatedly querying the status API endpoint passed
+     * in the {@code Location} header in the response parameter. The overall time is governed
+     * by the {@link RuntimeEnvironment#getApiTimeout()}, however each individual status check
+     * uses {@link RuntimeEnvironment#getConnectTimeout()} so in the worst case the total time can be
+     * {@code getApiTimeout() * getConnectTimeout()}.
+     * @param response response returned from the server upon asynchronous API request
+     * @return response from the status API call
+     * @throws InterruptedException on sleep interruption
+     * @throws IllegalArgumentException on invalid request (no {@code Location} header)
+     */
+    public static @NotNull Response waitForAsyncApi(@NotNull Response response)
+            throws InterruptedException, IllegalArgumentException {
+
+        String location = response.getHeaderString(HttpHeaders.LOCATION);
+        if (location == null) {
+            throw new IllegalArgumentException(String.format("no %s header in %s", HttpHeaders.LOCATION, response));
+        }
+
+        LOGGER.log(Level.FINER, "checking asynchronous API result on {0}", location);
+        for (int i = 0; i < RuntimeEnvironment.getInstance().getApiTimeout(); i++) {
+            response = ClientBuilder.newBuilder().
+                    connectTimeout(RuntimeEnvironment.getInstance().getConnectTimeout(), TimeUnit.SECONDS).build().
+                    target(location).request().get();
+            if (response.getStatus() == Response.Status.ACCEPTED.getStatusCode()) {
+                Thread.sleep(1000);
+            } else {
+                break;
+            }
+        }
+
+        if (response.getStatus() == Response.Status.ACCEPTED.getStatusCode()) {
+            LOGGER.log(Level.WARNING, "API request still not completed: {0}", response);
+            return response;
+        }
+
+        LOGGER.log(Level.FINER, "making DELETE API request to {0}", location);
+        Response deleteResponse = ClientBuilder.newBuilder().connectTimeout(3, TimeUnit.SECONDS).build().
+                target(location).request().delete();
+        if (deleteResponse.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+            LOGGER.log(Level.WARNING, "DELETE API call to {0} failed with HTTP error {1}",
+                    new Object[]{location, response.getStatusInfo()});
+        }
+
+        return response;
+    }
+}

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -27,7 +27,6 @@ import static org.opengrok.indexer.history.RepositoryFactory.getRepository;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ApiUtils.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ApiUtils.java
@@ -41,7 +41,7 @@ public class ApiUtils {
 
     /**
      * Busy-waits the status of asynchronous API call, mimicking
-     * {@link org.opengrok.indexer.configuration.RuntimeEnvironment#waitForAsyncApi(Response)},
+     * {@link org.opengrok.indexer.web.ApiUtils#waitForAsyncApi(Response)},
      * however side-steps status API check by going to the {@link ApiTaskManager} directly in order to avoid
      * going through the {@link StatusController} as it might not be deployed in the unit tests.
      * The method will return right away if the status of the response object parameter is not

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
@@ -393,8 +393,8 @@ class ProjectsControllerTest extends OGKJerseyTest {
         // Test that the project's indexed flag becomes true only after
         // the message is applied.
 
-        markIndexed(projectName);
 
+        assertEquals(markIndexed(projectName).getStatusInfo().getFamily(), Response.Status.Family.SUCCESSFUL);
         assertTrue(env.getProjects().get(projectName).isIndexed(), "indexed flag should be set to true");
 
         // Test that the "indexed" message triggers refresh of current version
@@ -406,18 +406,19 @@ class ProjectsControllerTest extends OGKJerseyTest {
         assertTrue(ri.getCurrentVersion().contains("c78fa757c524"), "current version should be refreshed");
     }
 
-    private void markIndexed(final String project) {
-        target("projects")
+    private Response markIndexed(final String project) {
+        Response response = target("projects")
                 .path(project)
                 .path("indexed")
                 .request()
                 .put(Entity.text(""));
+        return waitForTask(response);
     }
 
     @Test
     void testList() {
         addProject("mercurial");
-        markIndexed("mercurial");
+        assertEquals(markIndexed("mercurial").getStatusInfo().getFamily(), Response.Status.Family.SUCCESSFUL);
 
         // Add another project.
         addProject("git");


### PR DESCRIPTION
This change makes the `/projects/{project}/indexed` API endpoint asynchronous. I decided to leave the suggester rebuild in a separate thread.