### PR TITLE
negative cache for LdapUserPlugin 

### DIFF
--- a/plugins/src/main/java/opengrok/auth/entity/LdapUser.java
+++ b/plugins/src/main/java/opengrok/auth/entity/LdapUser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.entity;
 
@@ -46,7 +46,6 @@ public class LdapUser implements Serializable {
 
     public LdapUser(String dn, Map<String, Set<String>> attrs) {
         this.dn = dn;
-
         this.attributes = Objects.requireNonNullElseGet(attrs, HashMap::new);
     }
 

--- a/plugins/src/main/java/opengrok/auth/plugin/AbstractLdapPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/AbstractLdapPlugin.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin;
 
@@ -264,9 +264,7 @@ public abstract class AbstractLdapPlugin implements IAuthorizationPlugin {
      * @param username new username
      * @param established new value for established
      */
-    protected void updateSession(HttpServletRequest req,
-            String username,
-            boolean established) {
+    protected void updateSession(HttpServletRequest req, String username, boolean established) {
         setSessionEstablished(req, established);
         setSessionUsername(req, username);
     }

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapUserPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapUserPlugin.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin;
 
@@ -57,9 +57,11 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
      * List of configuration names.
      * <ul>
      * <li><code>filter</code> is LDAP filter used for searching (optional)</li>
-     * <li><code>useDN</code> boolean value indicating if User.username should be treated as Distinguished Name (optional, default is false)</li>
+     * <li><code>useDN</code> boolean value indicating if User.username should be treated as Distinguished Name
+     * (optional, default is false)</li>
      * <li><code>attributes</code> is comma separated list of LDAP attributes to be produced (mandatory)</li>
-     * <li><code>instance</code> integer that can be used to identify instance of this plugin by other LDAP plugins (optional, default empty)</li>
+     * <li><code>instance</code> integer that can be used to identify instance of this plugin by other LDAP plugins
+     * (optional, default empty)</li>
      * </ul>
      */
     static final String LDAP_FILTER = "filter";
@@ -89,8 +91,7 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
     private void init(Map<String, Object> parameters) {
         String attributesVal;
         if ((attributesVal = (String) parameters.get(ATTRIBUTES)) == null) {
-            throw new NullPointerException("Missing configuration parameter [" + ATTRIBUTES +
-                    "] in the setup");
+            throw new NullPointerException("Missing configuration parameter [" + ATTRIBUTES + "] in the setup");
         }
         attrSet = new HashSet<>(Arrays.asList(attributesVal.split(",")));
 
@@ -119,8 +120,7 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
      */
     @Override
     protected boolean sessionExists(HttpServletRequest req) {
-        return super.sessionExists(req)
-                && req.getSession().getAttribute(getSessionAttrName()) != null;
+        return super.sessionExists(req) && req.getSession().getAttribute(getSessionAttrName()) != null;
     }
 
     /**
@@ -157,8 +157,7 @@ public class LdapUserPlugin extends AbstractLdapPlugin {
         String dn = null;
         if (Boolean.TRUE.equals(useDN)) {
             dn = user.getUsername();
-            LOGGER.log(Level.FINEST, "using DN ''{0}'' for user {1}",
-                    new Object[]{dn, user});
+            LOGGER.log(Level.FINEST, "using DN ''{0}'' for user {1}", new Object[]{dn, user});
         }
 
         String expandedFilter = null;

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapUserPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapUserPluginTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin;
 
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static opengrok.auth.plugin.LdapUserPlugin.SESSION_ATTR;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -50,7 +51,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Vladimir Kotal
  */
-public class LdapUserPluginTest {
+class LdapUserPluginTest {
 
     private LdapUserPlugin plugin;
 
@@ -68,37 +69,37 @@ public class LdapUserPluginTest {
     }
 
     @Test
-    public void loadTestNegative1() {
+    void loadTestNegative1() {
         Map<String, Object> params = getParamsMap();
         params.put("foo", "bar");
         assertThrows(NullPointerException.class, () -> plugin.load(params));
     }
 
     @Test
-    public void loadTestPositive() {
+    void loadTestPositive() {
         Map<String, Object> params = getParamsMap();
         params.put(LdapUserPlugin.ATTRIBUTES, "mail");
         plugin.load(params);
     }
 
     @Test
-    public void filterTest() {
+    void filterTest() {
         Map<String, Object> params = getParamsMap();
         params.put(LdapUserPlugin.LDAP_FILTER, "(&(objectclass=person)(mail=%username%))");
         params.put(LdapUserPlugin.ATTRIBUTES, "uid,mail");
         plugin.load(params);
 
-        User user = new User("foo@bar.cz", "id", null, false);
+        User user = new User("foo@example.com", "id", null, false);
         String filter = plugin.expandFilter(user);
-        assertEquals("(&(objectclass=person)(mail=foo@bar.cz))", filter);
+        assertEquals("(&(objectclass=person)(mail=foo@example.com))", filter);
     }
 
     @Test
-    public void testFillSessionWithDnOff() throws LdapException {
+    void testFillSessionWithDnOff() throws LdapException {
         AbstractLdapProvider mockprovider = mock(LdapFacade.class);
         Map<String, Set<String>> attrs = new HashMap<>();
-        attrs.put("mail", Collections.singleton("foo@bar.cz"));
-        final String dn = "cn=FOO_BAR,L=EMEA,DC=FOO,DC=COM";
+        attrs.put("mail", Collections.singleton("foo@example.com"));
+        final String dn = "cn=FOO_BAR,L=EMEA,DC=EXAMPLE,DC=COM";
         AbstractLdapProvider.LdapSearchResult<Map<String, Set<String>>> result =
                 new AbstractLdapProvider.LdapSearchResult<>(dn, attrs);
         assertNotNull(result);
@@ -113,7 +114,7 @@ public class LdapUserPluginTest {
         assertEquals(mockprovider, plugin.getLdapProvider());
 
         HttpServletRequest request = new DummyHttpServletRequestLdap();
-        User user = new User("foo@bar.cz", "id");
+        User user = new User("foo@example.com", "id");
         plugin.fillSession(request, user);
 
         assertNotNull(request.getSession().getAttribute(SESSION_ATTR));
@@ -121,7 +122,7 @@ public class LdapUserPluginTest {
     }
 
     @Test
-    public void testInstance() {
+    void testInstance() {
         Map<String, Object> params = getParamsMap();
         params.put(LdapUserPlugin.ATTRIBUTES, "mail");
         params.put(LdapUserPlugin.INSTANCE, "42");
@@ -134,7 +135,7 @@ public class LdapUserPluginTest {
     }
 
     @Test
-    public void testInvalidInstance() {
+    void testInvalidInstance() {
         Map<String, Object> params = getParamsMap();
         params.put(LdapUserPlugin.ATTRIBUTES, "mail");
         params.put(LdapUserPlugin.INSTANCE, "foobar");


### PR DESCRIPTION
I decided to store the negative "flag" in the `LdapUser` object itself as an attribute (as opposed to e.g. having the `attributes` field being `null` - this brings all kinds of trouble along the way). This also means that the negative cache is per session. In Tomcat the default session duration is 30 minutes however the authnz changes on the server/identity side are usually not fast either.