### PR TITLE
use history cache when getting last revision of a file

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -205,7 +205,7 @@ public final class Configuration {
      * Set to false if we want to disable fetching history of individual files
      * (by running appropriate SCM command) when the history is not found
      * in history cache for repositories capable of fetching history for
-     * directories. This option affects file based history cache only.
+     * directories.
      */
     private boolean fetchHistoryWhenNotInCache;
     /*

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -638,6 +638,14 @@ class FileHistoryCache implements HistoryCache {
     @Override
     public History get(File file, Repository repository, boolean withFiles)
             throws HistoryException, ForbiddenSymlinkException {
+
+        return get(file, repository, withFiles, env.isFetchHistoryWhenNotInCache());
+    }
+
+    @Override
+    public History get(File file, Repository repository, boolean withFiles, boolean fallback)
+            throws HistoryException, ForbiddenSymlinkException {
+
         File cacheFile = getCachedFile(file);
         if (isUpToDate(file, cacheFile)) {
             try {
@@ -661,9 +669,8 @@ class FileHistoryCache implements HistoryCache {
          * since the history of all files in this repository should have been
          * fetched in the first phase of indexing.
          */
-        if (isHistoryIndexDone() && repository.isHistoryEnabled() &&
-                repository.hasHistoryForDirectories() &&
-                !env.isFetchHistoryWhenNotInCache()) {
+        if (isHistoryIndexDone() && repository.isHistoryEnabled() && repository.hasHistoryForDirectories() &&
+                !fallback) {
             return null;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -198,8 +198,7 @@ class FileHistoryCache implements HistoryCache {
      * @param file the file to find the cache for
      * @return file that might contain cached history for <code>file</code>
      */
-    private static File getCachedFile(File file) throws HistoryException,
-            ForbiddenSymlinkException {
+    private static File getCachedFile(File file) throws HistoryException, ForbiddenSymlinkException {
 
         StringBuilder sb = new StringBuilder();
         sb.append(env.getDataRootPath());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -469,7 +469,7 @@ public class GitRepository extends RepositoryWithPerPartesHistory {
     @Override
     public HistoryEntry getLastHistoryEntry(File file, boolean ui) throws HistoryException {
         History hist = getHistory(file, null, null, 1);
-        return getLastHistoryEntry(hist);
+        return hist.getLastHistoryEntry();
     }
 
     public History getHistory(File file, String sinceRevision, String tillRevision) throws HistoryException {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
@@ -23,6 +23,8 @@
  */
 package org.opengrok.indexer.history;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -177,6 +179,18 @@ public class History implements Serializable {
         }
 
         tags.clear();
+    }
+
+    /**
+     * @return last (newest) history entry or null
+     */
+    public @Nullable HistoryEntry getLastHistoryEntry() {
+        List<HistoryEntry> historyEntries = getHistoryEntries();
+        if (historyEntries == null || historyEntries.isEmpty()) {
+            return null;
+        }
+
+        return historyEntries.get(0);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
@@ -18,13 +18,15 @@
  */
 
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
 import java.io.File;
 import java.util.Date;
 import java.util.Map;
+
+import org.jetbrains.annotations.Nullable;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
 
 interface HistoryCache {
@@ -51,17 +53,23 @@ interface HistoryCache {
      * parsing the history information in the repository.
      *
      * @param file The file to retrieve history for
-     * @param repository The external repository to read the history from (can
-     * be <code>null</code>)
-     * @param withFiles A flag saying whether or not the returned history
-     * should include a list of files touched by each changeset. If false,
-     * the implementation is allowed to skip the file list, but it doesn't
-     * have to.
+     * @param repository The external repository to read the history from (can be <code>null</code>)
+     * @param withFiles A flag saying whether the returned history should include a list of files
+     *                  touched by each changeset. If false, the implementation is allowed to skip the file list,
+     *                  but it doesn't have to.
+     * @param fallback whether to fall back to {@link Repository#getHistory(File)}
+     *                 if the history cannot be retrieved from the cache
      * @throws HistoryException if the history cannot be fetched
      * @throws ForbiddenSymlinkException if symbolic-link checking encounters
      * an ineligible link
      */
-    History get(File file, Repository repository, boolean withFiles)
+    History get(File file, @Nullable Repository repository, boolean withFiles, boolean fallback)
+            throws HistoryException, ForbiddenSymlinkException;
+
+    /**
+     * Usually a wrapper of {@link HistoryCache#get(File, Repository, boolean, boolean)}.
+     */
+    History get(File file, @Nullable Repository repository, boolean withFiles)
             throws HistoryException, ForbiddenSymlinkException;
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -241,11 +241,11 @@ public final class HistoryGuru {
     }
 
     @Nullable
-    private History getHistoryFromCache(File file, Repository repository, boolean withFiles, boolean ui)
+    private History getHistoryFromCache(File file, Repository repository, boolean withFiles, boolean fallback)
             throws HistoryException, ForbiddenSymlinkException {
 
         if (useCache() && historyCache.supportsRepository(repository)) {
-            return historyCache.get(file, repository, withFiles);
+            return historyCache.get(file, repository, withFiles, fallback);
         }
 
         return null;
@@ -268,7 +268,7 @@ public final class HistoryGuru {
 
         History history;
         try {
-            history = getHistoryFromCache(file, repository, false, ui);
+            history = getHistoryFromCache(file, repository, false, false);
             if (history != null) {
                 HistoryEntry lastHistoryEntry = history.getLastHistoryEntry();
                 if (lastHistoryEntry != null) {
@@ -306,7 +306,7 @@ public final class HistoryGuru {
 
         History history;
         try {
-            history = getHistoryFromCache(file, repository, withFiles, ui);
+            history = getHistoryFromCache(file, repository, withFiles, true);
             if (history != null) {
                 return history;
             }
@@ -315,7 +315,7 @@ public final class HistoryGuru {
             return null;
         }
 
-        return repository.getHistory(file);
+        return null;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -156,6 +156,7 @@ public final class HistoryGuru {
      * <code>HistoryParser</code> does not support annotation
      * @throws IOException if I/O exception occurs
      */
+    @Nullable
     public Annotation annotate(File file, String rev) throws IOException {
         Annotation annotation = null;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -229,7 +229,7 @@ public final class HistoryGuru {
         return getHistory(file, true, true);
     }
 
-    private boolean isRepoHistoryEligible(Repository repo, File file, boolean ui) {
+    boolean isRepoHistoryEligible(Repository repo, File file, boolean ui) {
         RemoteSCM rscm = env.getRemoteScmSupported();
         boolean doRemote = (ui && (rscm == RemoteSCM.UIONLY))
                 || (rscm == RemoteSCM.ON)
@@ -775,7 +775,7 @@ public final class HistoryGuru {
         return repos;
     }
 
-    private Repository getRepository(File file) {
+    Repository getRepository(File file) {
         return repositoryLookup.getRepository(file.toPath(), repositoryRoots.keySet(), repositories,
                 PathUtils::getRelativeToCanonical);
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -571,9 +571,10 @@ public class MercurialRepository extends RepositoryWithPerPartesHistory {
     @Override
     public HistoryEntry getLastHistoryEntry(File file, boolean ui) throws HistoryException {
         History hist = getHistory(file, null, null, 1);
-        return getLastHistoryEntry(hist);
+        return hist.getLastHistoryEntry();
     }
 
+    @Override
     History getHistory(File file, String sinceRevision) throws HistoryException {
         return getHistory(file, sinceRevision, null);
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -49,8 +49,6 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
 import org.opengrok.indexer.util.Executor;
-
-import org.jetbrains.annotations.NotNull;
 
 /**
  * An interface for an external repository.
@@ -96,7 +94,6 @@ public abstract class Repository extends RepositoryInfo {
      *
      * @return {@code true} if the repository can get history for directories
      */
-    @NotNull
     abstract boolean hasHistoryForDirectories();
 
     public String toString() {
@@ -132,19 +129,6 @@ public abstract class Repository extends RepositoryInfo {
      */
     abstract History getHistory(File file) throws HistoryException;
 
-    HistoryEntry getLastHistoryEntry(History hist) {
-        if (hist == null) {
-            return null;
-        }
-
-        List<HistoryEntry> hlist = hist.getHistoryEntries();
-        if (hlist == null || hlist.isEmpty()) {
-            return null;
-        }
-
-        return hlist.get(0);
-    }
-
     /**
      * This is generic implementation that retrieves the full history of given file
      * and returns the latest history entry. This is obviously very inefficient, both in terms of memory and I/O.
@@ -154,15 +138,19 @@ public abstract class Repository extends RepositoryInfo {
      * @throws HistoryException on error
      */
     public HistoryEntry getLastHistoryEntry(File file, boolean ui) throws HistoryException {
-        History hist;
+        History history;
         try {
-            hist = HistoryGuru.getInstance().getHistory(file, false, ui);
+            history = HistoryGuru.getInstance().getHistory(file, false, ui);
         } catch (HistoryException ex) {
             LOGGER.log(Level.WARNING, "failed to get history for {0}", file);
             return null;
         }
 
-        return getLastHistoryEntry(hist);
+        if (history != null) {
+            return history.getLastHistoryEntry();
+        } else {
+            return null;
+        }
     }
 
     public Repository() {
@@ -519,7 +507,7 @@ public abstract class Repository extends RepositoryInfo {
     /**
      * Determine and return the current version of the repository.
      *
-     * This operation is consider "heavy" so this function should not be
+     * This operation is considered "heavy" so this function should not be
      * called on every web request.
      *
      * @param cmdType command timeout type

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryLookup.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryLookup.java
@@ -60,7 +60,7 @@ public interface RepositoryLookup {
     /**
      * Find enclosing repository for a given path.
      *
-     * @param path path to find encolsing repository for
+     * @param path path to find enclosing repository for
      * @param repoParentDirs Set of repository parent dirs (parents of repository roots)
      * @param repositories Map of repository root to Repository
      * @param canonicalizer PathCanonicalizer reference
@@ -77,7 +77,7 @@ public interface RepositoryLookup {
     /**
      * Lifecycle method to invalidate any cache entries that point to given repositories that are being removed.
      *
-     * @param removedRepos
+     * @param removedRepos collection of repositories
      */
     void repositoriesRemoved(Collection<Repository> removedRepos);
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.util;
@@ -63,7 +63,7 @@ public class Executor {
     private final File workingDirectory;
     private byte[] stdout;
     private byte[] stderr;
-    private int timeout; // in seconds, 0 means no timeout
+    private int timeout; // in milliseconds, 0 means no timeout
 
     /**
      * Create a new instance of the Executor.
@@ -83,14 +83,18 @@ public class Executor {
 
     /**
      * Create a new instance of the Executor with default command timeout value.
+     * The timeout value will be based on the running context (indexer or web application).
      * @param cmdList A list containing the command to execute
      * @param workingDirectory The directory the process should have as the
      *                         working directory
      */
     public Executor(List<String> cmdList, File workingDirectory) {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        int timeoutSec = env.isIndexer() ? env.getIndexerCommandTimeout() : env.getInteractiveCommandTimeout();
+
         this.cmdList = cmdList;
         this.workingDirectory = workingDirectory;
-        this.timeout = RuntimeEnvironment.getInstance().getIndexerCommandTimeout() * 1000;
+        this.timeout = timeoutSec * 1000;
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -887,9 +887,9 @@ class FileHistoryCacheTest {
                 updatedHistory.getHistoryEntries(), false);
     }
 
-    private void checkNoHistoryFetchRepo(String reponame, String filename, boolean hasHistory) throws Exception {
+    private void checkNoHistoryFetchRepo(String repoName, String filename, boolean hasHistory) throws Exception {
 
-        File reposRoot = new File(repositories.getSourceRoot(), reponame);
+        File reposRoot = new File(repositories.getSourceRoot(), repoName);
         Repository repo = RepositoryFactory.getRepository(reposRoot);
 
         // Make sure the file exists in the repository.
@@ -897,8 +897,7 @@ class FileHistoryCacheTest {
         assertTrue(repoFile.exists());
 
         // Try to fetch the history for given file. With default setting of
-        // FetchHistoryWhenNotInCache this should create corresponding file
-        // in history cache.
+        // FetchHistoryWhenNotInCache this should get the history even if not in cache.
         History retrievedHistory = cache.get(repoFile, repo, true);
         assertEquals(hasHistory, retrievedHistory != null);
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -107,7 +107,7 @@ public class HistoryGuruTest {
     }
 
     @Test
-    public void testGetRevision() throws HistoryException, IOException {
+    void testGetRevision() throws HistoryException, IOException {
         HistoryGuru instance = HistoryGuru.getInstance();
 
         for (File f : FILES) {
@@ -127,7 +127,7 @@ public class HistoryGuruTest {
 
     @Test
     @EnabledForRepository(SUBVERSION)
-    public void testBug16465() throws HistoryException, IOException {
+    void testBug16465() throws HistoryException, IOException {
         HistoryGuru instance = HistoryGuru.getInstance();
         for (File f : FILES) {
             if (f.getName().equals("bugreport16465@")) {
@@ -138,7 +138,7 @@ public class HistoryGuruTest {
     }
 
     @Test
-    public void annotation() throws Exception {
+    void annotation() throws Exception {
         HistoryGuru instance = HistoryGuru.getInstance();
         for (File f : FILES) {
             if (instance.hasAnnotation(f)) {
@@ -148,14 +148,14 @@ public class HistoryGuruTest {
     }
 
     @Test
-    public void getCacheInfo() throws HistoryException {
+    void getCacheInfo() throws HistoryException {
         // FileHistoryCache is used by default
         assertEquals("FileHistoryCache",
                 HistoryGuru.getInstance().getCacheInfo());
     }
 
     @Test
-    public void testAddRemoveRepositories() {
+    void testAddRemoveRepositories() {
         HistoryGuru instance = HistoryGuru.getInstance();
         final int numReposOrig = instance.getRepositories().size();
 
@@ -180,7 +180,7 @@ public class HistoryGuruTest {
 
     @Test
     @EnabledForRepository(CVS)
-    public void testAddSubRepositoryNotNestable() {
+    void testAddSubRepositoryNotNestable() {
         HistoryGuru instance = HistoryGuru.getInstance();
 
         // Check out CVS underneath a Git repository.
@@ -201,7 +201,7 @@ public class HistoryGuruTest {
 
     @Test
     @EnabledForRepository(MERCURIAL)
-    public void testAddSubRepository() {
+    void testAddSubRepository() {
         HistoryGuru instance = HistoryGuru.getInstance();
 
         // Clone a Mercurial repository underneath a Mercurial repository.
@@ -218,7 +218,7 @@ public class HistoryGuruTest {
     }
 
     @Test
-    public void testNestingMaximum() throws IOException {
+    void testNestingMaximum() throws IOException {
         // Just fake a nesting of Repo -> Git -> Git.
         File repoRoot = new File(repository.getSourceRoot(), "repoRoot");
         certainlyMkdirs(repoRoot);
@@ -253,7 +253,7 @@ public class HistoryGuruTest {
     }
 
     @Test
-    public void testScanningDepth() throws IOException {
+    void testScanningDepth() throws IOException {
         String topLevelDirName = "scanDepthTest";
         File repoRoot = new File(repository.getSourceRoot(), topLevelDirName);
         certainlyMkdirs(repoRoot);
@@ -293,7 +293,7 @@ public class HistoryGuruTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void testGetLastHistoryEntry(boolean isIndexerParam) throws HistoryException {
+    void testGetLastHistoryEntryVsIndexer(boolean isIndexerParam) throws HistoryException {
         boolean isIndexer = env.isIndexer();
         env.setIndexer(isIndexerParam);
         boolean isTagsEnabled = env.isTagsEnabled();
@@ -308,5 +308,17 @@ public class HistoryGuruTest {
         }
         env.setIndexer(isIndexer);
         env.setTagsEnabled(isTagsEnabled);
+    }
+
+    @Test
+    void testGetLastHistoryEntryRepoHistoryDisabled() throws HistoryException {
+        File file = new File(repository.getSourceRoot(), "git");
+        assertTrue(file.exists());
+        HistoryGuru instance = HistoryGuru.getInstance();
+        Repository repository = instance.getRepository(file);
+        assertNotNull(repository);
+        repository.setHistoryEnabled(false);
+        assertNull(instance.getLastHistoryEntry(file, false));
+        repository.setHistoryEnabled(true);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -111,11 +111,9 @@ public class HistoryGuruTest {
 
         for (File f : FILES) {
             if (f.isFile() && instance.hasHistory(f)) {
-                for (HistoryEntry entry
-                        : instance.getHistory(f).getHistoryEntries()) {
+                for (HistoryEntry entry : instance.getHistory(f).getHistoryEntries()) {
                     String revision = entry.getRevision();
-                    try (InputStream in = instance.getRevision(
-                            f.getParent(), f.getName(), revision)) {
+                    try (InputStream in = instance.getRevision(f.getParent(), f.getName(), revision)) {
                         assertNotNull(in, "Failed to get revision " + revision
                                 + " of " + f.getAbsolutePath());
                     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -75,8 +75,7 @@ public class HistoryGuruTest {
         repository = new TestRepository();
         repository.create(HistoryGuru.class.getResource("/repositories"));
         RepositoryFactory.initializeIgnoredNames(env);
-        FileUtilities.getAllFiles(new File(repository.getSourceRoot()),
-                FILES, true);
+        FileUtilities.getAllFiles(new File(repository.getSourceRoot()), FILES, true);
         assertNotEquals(0, FILES.size());
 
         HistoryGuru histGuru = HistoryGuru.getInstance();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -35,9 +35,10 @@ import java.util.TreeMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class HistoryTest {
+class HistoryTest {
     private final List<HistoryEntry> entries = List.of(
             new HistoryEntry("84599b3c", new Date(1485438707000L),
                     "Kryštof Tulinger <krystof.tulinger@oracle.com>", null,
@@ -49,7 +50,7 @@ public class HistoryTest {
                     Set.of(File.separator + Paths.get("git", "moved", "renamed2.c"))));
 
     @Test
-    public void testEqualsRenamed() {
+    void testEqualsRenamed() {
         History history = new History(entries,
                 List.of(Paths.get("moved", "renamed2.c").toString(),
                         Paths.get("moved2", "renamed2.c").toString(),
@@ -59,7 +60,7 @@ public class HistoryTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         History history = new History(entries);
         assertEquals(2, history.getHistoryEntries().size());
         History historySmaller = new History(entries.subList(1, 2));
@@ -114,5 +115,17 @@ public class HistoryTest {
         history1.setTags(Map.of("foo", "bar", "Bar", "foo"));
         history2.setTags(Map.of("foo", "bar", "bar", "foo"));
         assertNotEquals(history1, history2);
+    }
+
+    @Test
+    void testGetLastHistoryEntryEmpty() {
+        History history = new History();
+        assertNull(history.getLastHistoryEntry());
+    }
+
+    @Test
+    void testGetLastHistoryEntry() {
+        History history = new History(entries);
+        assertEquals(entries.get(0), history.getLastHistoryEntry());
     }
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2011, Jens Elkner.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
@@ -1288,17 +1288,20 @@ public final class PageConfig {
     /**
      * @return last revision string for {@code file} or null
      */
+    @Nullable
     public String getLatestRevision() {
         if (!getEnv().isHistoryEnabled()) {
             return null;
         }
 
+        // Try getting the history revision from the index first.
         String lastRev = getLastRevFromIndex();
         if (lastRev != null) {
             return lastRev;
         }
 
-        // fallback
+        // If this is older index, fallback to the history (either fetch from history cache or retrieve from
+        // the repository directly).
         try {
             return getLastRevFromHistory();
         } catch (HistoryException e) {
@@ -1309,8 +1312,8 @@ public final class PageConfig {
 
     @Nullable
     private String getLastRevFromHistory() throws HistoryException {
-        HistoryEntry he = HistoryGuru.getInstance().
-                getLastHistoryEntry(new File(getEnv().getSourceRootFile(), getPath()), true);
+        File file = new File(getEnv().getSourceRootFile(), getPath());
+        HistoryEntry he = HistoryGuru.getInstance().getLastHistoryEntry(file, true);
         if (he != null) {
             return he.getRevision();
         }


### PR DESCRIPTION
When browsing FreeBSD project (`main` branch from https://github.com/freebsd/freebsd-src) on internal OpenGrok instance, I noticed that getting xrefs takes way too long - usually bunch of seconds. When looking at what the web app is doing, I noticed CPU load spikes and `jstack` revealed that the web app actually retrieved the revision string by getting the history via repository specific code:
```
"http-nio-8080-exec-5982" #237111 daemon prio=5 os_prio=64 cpu=3475.16ms elapsed=49069.29s tid=0x000000001359a800 nid=0x3aef1 runnable  [0x00007ff2e0556000]
   java.lang.Thread.State: RUNNABLE
        at java.util.zip.Inflater.inflateBytesBytes(java.base@11.0.7-internal/Native Method)
        at java.util.zip.Inflater.inflate(java.base@11.0.7-internal/Inflater.java:385)
        - locked <0x00007ff851064fd0> (a java.util.zip.Inflater$InflaterZStreamRef)
        at org.eclipse.jgit.internal.storage.file.WindowCursor.inflate(WindowCursor.java:284)
        at org.eclipse.jgit.internal.storage.file.Pack.decompress(Pack.java:370)
        at org.eclipse.jgit.internal.storage.file.Pack.load(Pack.java:805)
        at org.eclipse.jgit.internal.storage.file.Pack.get(Pack.java:274)
        at org.eclipse.jgit.internal.storage.file.PackDirectory.open(PackDirectory.java:211)
        at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openPackedObject(ObjectDirectory.java:390)
        at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openPackedFromSelfOrAlternate(ObjectDirectory.java:354)
        at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openObjectWithoutRestoring(ObjectDirectory.java:345)
        at org.eclipse.jgit.internal.storage.file.ObjectDirectory.openObject(ObjectDirectory.java:330)
        at org.eclipse.jgit.internal.storage.file.WindowCursor.open(WindowCursor.java:132)
        at org.eclipse.jgit.revwalk.RevWalk.getCachedBytes(RevWalk.java:1109)
        at org.eclipse.jgit.revwalk.RevCommit.parseHeaders(RevCommit.java:126)
        at org.eclipse.jgit.revwalk.TreeRevFilter.include(TreeRevFilter.java:113)
        at org.eclipse.jgit.revwalk.PendingGenerator.next(PendingGenerator.java:108)
        at org.eclipse.jgit.revwalk.BlockRevQueue.<init>(BlockRevQueue.java:40)
        at org.eclipse.jgit.revwalk.FIFORevQueue.<init>(FIFORevQueue.java:37)
        at org.eclipse.jgit.revwalk.StartGenerator.next(StartGenerator.java:133)
        at org.eclipse.jgit.revwalk.RevWalk.next(RevWalk.java:591)
        at org.eclipse.jgit.revwalk.RevWalk.nextForIterator(RevWalk.java:1526)
        at org.eclipse.jgit.revwalk.RevWalk.iterator(RevWalk.java:1550)
        at org.opengrok.indexer.history.GitRepository.getHistory(GitRepository.java:520)
        at org.opengrok.indexer.history.GitRepository.getLastHistoryEntry(GitRepository.java:471)
        at org.opengrok.indexer.history.HistoryGuru.getLastHistoryEntry(HistoryGuru.java:234)
        at org.opengrok.web.PageConfig.getLastRevFromHistory(PageConfig.java:1313)
        at org.opengrok.web.PageConfig.getLatestRevision(PageConfig.java:1303)
        at org.apache.jsp.list_jsp._jspService(list_jsp.java:292)
        at org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:71)
        at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:770)
```
Given that the FreeBSD Git repository is on the heavier side, this action takes a bit of time.

Looking at the code of `PageConfig#getLastRevFromHistory()` and `HistoryGuru#getLastHistoryEntry()` I realized that history cache is avoided. This change fixes that.