### PR TITLE
cleanup timeout handling in tools

### DIFF
--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -110,7 +110,7 @@ def main():
     parser.add_argument('-w', '--workers', default=cpu_count(), type=int,
                         help='Number of worker processes')
     add_http_headers(parser)
-    parser.add_argument('--api_timeout', type=int,
+    parser.add_argument('--api_timeout', type=int, default=3,
                         help='Set response timeout in seconds '
                              'for RESTful API calls')
 

--- a/tools/src/main/python/opengrok_tools/projadm.py
+++ b/tools/src/main/python/opengrok_tools/projadm.py
@@ -266,9 +266,9 @@ def main():
                         default=False, help='Do not delete source code when '
                                             'deleting a project')
     add_http_headers(parser)
-    parser.add_argument('--api_timeout', type=int,
+    parser.add_argument('--api_timeout', type=int, default=3,
                         help='Set response timeout in seconds for RESTful API calls')
-    parser.add_argument('--async_api_timeout', type=int,
+    parser.add_argument('--async_api_timeout', type=int, default=300,
                         help='Set timeout in seconds for asynchronous RESTful API calls')
 
     group = parser.add_mutually_exclusive_group()

--- a/tools/src/main/python/opengrok_tools/reindex_project.py
+++ b/tools/src/main/python/opengrok_tools/reindex_project.py
@@ -18,7 +18,7 @@
 # CDDL HEADER END
 
 #
-# Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 
 
@@ -43,7 +43,7 @@ from .utils.exitvals import (
 """
 
 
-def get_logprop_file(logger, template, pattern, project):
+def get_logprop_file(template, pattern, project):
     """
     Return the filename of file with logging properties specific for given
     project.
@@ -93,7 +93,7 @@ def main():
                         help='URI of the webapp with context path')
     parser.add_argument('--printoutput', action='store_true', default=False)
     add_http_headers(parser)
-    parser.add_argument('--api_timeout', type=int,
+    parser.add_argument('--api_timeout', type=int, default=3,
                         help='Set response timeout in seconds for RESTful API calls')
 
     cmd_args = sys.argv[1:]
@@ -105,18 +105,17 @@ def main():
     logger = get_console_logger(get_class_basename(), args.loglevel)
 
     # Make sure the log directory exists.
-    if args.directory:
-        if not os.path.isdir(args.directory):
-            os.makedirs(args.directory)
+    if args.directory and not os.path.isdir(args.directory):
+        os.makedirs(args.directory)
 
     # Get files needed for per-project reindex.
     headers = get_headers(args.header)
-    conf_file = get_config_file(logger, args.uri, headers=headers)
+    conf_file = get_config_file(logger, args.uri, headers=headers, timeout=args.api_timeout)
     if conf_file is None:
         fatal("could not get config file to run the indexer")
     logprop_file = None
     if args.template and args.pattern:
-        logprop_file = get_logprop_file(logger, args.template, args.pattern,
+        logprop_file = get_logprop_file(args.template, args.pattern,
                                         args.project)
 
     # Reindex with the modified logging.properties file and read-only config.

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -19,7 +19,7 @@
 #
 
 #
-# Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 
 """

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -80,6 +80,7 @@ def get_repos_for_project(project_name, uri, source_root,
                   variables
     :param command_timeout: command timeout value in seconds
     :param headers: optional HTTP headers dictionary
+    :param timeout: connect timeout for API calls
     :return: list of Repository objects
     """
 

--- a/tools/src/main/python/opengrok_tools/utils/opengrok.py
+++ b/tools/src/main/python/opengrok_tools/utils/opengrok.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 
 import urllib.parse
@@ -191,7 +191,7 @@ def delete_project(logger, project, uri, headers=None, timeout=None, api_timeout
         r = do_api_call('DELETE', get_uri(uri, 'api', 'v1', 'projects',
                                           urllib.parse.quote_plus(project)),
                         headers=headers, timeout=timeout, api_timeout=api_timeout)
-        if r is None or r.status != 204:
+        if r is None or r.status_code != 204:
             logger.error(f"could not delete project '{project}' in web application")
             return False
     except Exception as exception:

--- a/tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/tools/src/main/python/opengrok_tools/utils/restful.py
@@ -141,7 +141,7 @@ def subst(src, substitutions):
     return src
 
 
-def call_rest_api(command, substitutions=None, http_headers=None, timeout=None):
+def call_rest_api(command, substitutions=None, http_headers=None, timeout=None, api_timeout=None):
     """
     Make RESTful API call. Occurrence of the pattern in the URI
     (first part of the command) or data payload will be replaced by the name.
@@ -154,6 +154,7 @@ def call_rest_api(command, substitutions=None, http_headers=None, timeout=None):
                           data substitution
     :param http_headers: optional dictionary of HTTP headers to be appended
     :param timeout: optional timeout in seconds for API call response
+    :param api_timeout: optional timeout in seconds for asynchronous API call
     :return value from given requests method
     """
 
@@ -200,4 +201,4 @@ def call_rest_api(command, substitutions=None, http_headers=None, timeout=None):
         data = subst(data, substitutions)
         logger.debug("entity data: {}".format(data))
 
-    return do_api_call(verb, uri, headers=headers, data=data, timeout=timeout)
+    return do_api_call(verb, uri, headers=headers, data=data, timeout=timeout, api_timeout=api_timeout)

--- a/tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/tools/src/main/python/opengrok_tools/utils/restful.py
@@ -71,7 +71,7 @@ def wait_for_async_api(response, api_timeout, headers=None, timeout=None):
     return response
 
 
-def do_api_call(verb, uri, params=None, headers=None, data=None, timeout=60, api_timeout=300):
+def do_api_call(verb, uri, params=None, headers=None, data=None, timeout=None, api_timeout=None):
     """
     Perform an API call. Will raise an exception if the request fails.
     :param verb: string holding HTTP verb
@@ -91,6 +91,12 @@ def do_api_call(verb, uri, params=None, headers=None, data=None, timeout=60, api
     handler = getattr(requests, verb.lower())
     if handler is None or not callable(handler):
         raise Exception('Unknown HTTP verb: {}'.format(verb))
+
+    if timeout is None:
+        timeout = 60
+
+    if api_timeout is None:
+        api_timeout = 300
 
     logger.debug("{} API call: {} with data '{}', connect timeout {} seconds, API timeout {} seconds and headers: {}".
                  format(verb, uri, data, timeout, api_timeout, headers))

--- a/tools/src/test/python/test_restful.py
+++ b/tools/src/test/python/test_restful.py
@@ -20,7 +20,7 @@
 #
 
 #
-# Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 
 import pytest
@@ -130,8 +130,8 @@ def test_headers_timeout(monkeypatch):
 def test_headers_timeout_requests():
     """
     Test that headers and timeout parameters from do_call_api() are passed
-    to the appropriate function in the requests module.
-    Currently done for the GET HTTP verb only.
+    to the appropriate function in the 'requests' module.
+    Currently, this is done for the GET HTTP verb only.
     """
 
     uri = "http://foo:8080"


### PR DESCRIPTION
This change addresses a problem with checking response status:
```
could not delete project 'foo' in web application: 'Response' object has no attribute 'status'
```
and also moves the timeout defaults to the programs.