### PR TITLE
check commands structure in CommandSequenceBase()

### DIFF
--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -275,8 +275,8 @@ def main():
                         ignore_errors, uri, args.workers,
                         driveon=args.driveon, http_headers=headers,
                         timeout=args.api_timeout)
-        except CommandConfigurationException:
-            logger.error("Invalid configuration")
+        except CommandConfigurationException as exc:
+            logger.error("Invalid configuration: {}".format(exc))
             return FAILURE_EXITVAL
     else:
         lock = FileLock(os.path.join(tempfile.gettempdir(),
@@ -289,8 +289,8 @@ def main():
                                 ignore_errors, uri, args.workers,
                                 driveon=args.driveon, http_headers=headers,
                                 timeout=args.api_timeout)
-                except CommandConfigurationException:
-                    logger.error("Invalid configuration")
+                except CommandConfigurationException as exc:
+                    logger.error("Invalid configuration: {}".format(exc))
                     return FAILURE_EXITVAL
         except Timeout:
             logger.warning("Already running")

--- a/tools/src/main/python/opengrok_tools/utils/commandsequence.py
+++ b/tools/src/main/python/opengrok_tools/utils/commandsequence.py
@@ -48,11 +48,11 @@ def check_command_property(command):
     :param command: command element
     """
     if not isinstance(command, dict):
-        raise CommandConfigurationException("command {} is not a dictionary".format(command))
+        raise CommandConfigurationException("command '{}' is not a dictionary".format(command))
 
     command_value = command.get(COMMAND_PROPERTY)
     if command_value is None:
-        raise CommandConfigurationException("command dictionary has no {} key: {}".
+        raise CommandConfigurationException("command dictionary has no '{}' key: {}".
                                             format(COMMAND_PROPERTY, command))
 
     if not isinstance(command_value, list):

--- a/tools/src/main/python/opengrok_tools/utils/readconfig.py
+++ b/tools/src/main/python/opengrok_tools/utils/readconfig.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 
 import logging
@@ -33,17 +33,17 @@ except ImportError:
     JSONDecodeError = ValueError
 
 
-def read_config(logger, inputfile):
+def read_config(logger, input_file):
     """
-    Try to interpret inputfile as either JSON or YAML file,
+    Try to interpret input_file as either JSON or YAML file,
     parse it and return an object representing its contents.
 
     If neither is valid, return None.
     """
-    logging.debug("reading in {}".format(inputfile))
+    logging.debug("reading in {}".format(input_file))
     cfg = None
     try:
-        with open(inputfile) as data_file:
+        with open(input_file) as data_file:
             data = data_file.read()
 
             try:
@@ -67,6 +67,6 @@ def read_config(logger, inputfile):
 
                 return cfg
     except IOError as e:
-        logger.error("cannot open '{}': {}".format(inputfile, e.strerror))
+        logger.error("cannot open '{}': {}".format(input_file, e.strerror))
 
     return cfg

--- a/tools/src/test/python/test_command_sequence.py
+++ b/tools/src/test/python/test_command_sequence.py
@@ -62,7 +62,7 @@ def test_invalid_configuration_commands_no_command():
         CommandSequence(CommandSequenceBase("foo", [{"command": ['foo']},
                                                     {"foo": "bar"}]))
 
-    assert str(exc_info.value).startswith("command dictionary has no {} key".
+    assert str(exc_info.value).startswith("command dictionary has no '{}' key".
                                           format(COMMAND_PROPERTY))
 
 


### PR DESCRIPTION
This change should catch more invalid configurations of `opengrok-sync`. It introduces the `CommandConfigurationException`.

Looks like this:
```
$ opengrok-sync -c sync-invalid.yml 
Assuming directory: /var/opengrok/src
Invalid configuration: command 'foo' is not a dictionary
```