### PR TITLE
set default for API response timeout in opengrok-sync

### DIFF
--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -152,7 +152,7 @@ def main():
     parser.add_argument('--nolock', action='store_false', default=True,
                         help='do not acquire lock that prevents multiple '
                         'instances from running')
-    parser.add_argument('--api_timeout', type=int,
+    parser.add_argument('--api_timeout', type=int, default=3,
                         help='Set response timeout in seconds'
                         'for RESTful API calls')
     add_http_headers(parser)


### PR DESCRIPTION
Forgot to set the default for `opengrok-sync` in PR #3866.