### PR TITLE
rename displayRepositories getter to match the return type

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -1177,7 +1177,7 @@ public final class Configuration {
         this.currentIndexedCollapseThreshold = currentIndexedCollapseThreshold;
     }
 
-    public boolean getDisplayRepositories() {
+    public boolean isDisplayRepositories() {
         return this.displayRepositories;
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1328,8 +1328,8 @@ public final class RuntimeEnvironment {
         syncWriteConfiguration(historyEnabled, Configuration::setHistoryEnabled);
     }
 
-    public boolean getDisplayRepositories() {
-        return syncReadConfiguration(Configuration::getDisplayRepositories);
+    public boolean isDisplayRepositories() {
+        return syncReadConfiguration(Configuration::isDisplayRepositories);
     }
 
     public void setDisplayRepositories(boolean displayRepositories) {

--- a/opengrok-web/src/main/webapp/index.jsp
+++ b/opengrok-web/src/main/webapp/index.jsp
@@ -55,7 +55,7 @@ include file="menu.jspf"
         </header>
         <div id="results">
             <%= PageConfig.get(request).getEnv().getIncludeFiles().getBodyIncludeFileContent(false) %>
-            <% if (PageConfig.get(request).getEnv().getDisplayRepositories()) { %><%@
+            <% if (PageConfig.get(request).getEnv().isDisplayRepositories()) { %><%@
 
 include file="repos.jspf"
 


### PR DESCRIPTION
The methods for checking whether to display repositories/projects on the index page should be called `isDisplayRepositories()` to match the boolean.