### PR TITLE
fix repo repository mirroring

### DIFF
--- a/tools/src/main/python/opengrok_tools/scm/repo.py
+++ b/tools/src/main/python/opengrok_tools/scm/repo.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -29,7 +29,7 @@ from .repository import Repository, RepositoryException
 
 class RepoRepository(Repository):
     def __init__(self, name, logger, path, project, command, env, hooks, timeout):
-        super().__init__(logger, name, path, project, command, env, hooks, timeout)
+        super().__init__(name, logger, path, project, command, env, hooks, timeout)
 
         self.command = self._repository_command(command, default=lambda: which('repo'))
 

--- a/tools/src/main/python/opengrok_tools/scm/repo.py
+++ b/tools/src/main/python/opengrok_tools/scm/repo.py
@@ -36,6 +36,13 @@ class RepoRepository(Repository):
         if not self.command:
             raise RepositoryException("Cannot get repo command")
 
+    def top_level(self):
+        """
+        It is not desired to descend into sub-repositories when syncing.
+        :return:
+        """
+        return True
+
     def reposync(self):
         return self._run_custom_sync_command([self.command, 'sync', '-cf'])
 

--- a/tools/src/main/python/opengrok_tools/scm/repo.py
+++ b/tools/src/main/python/opengrok_tools/scm/repo.py
@@ -44,7 +44,7 @@ class RepoRepository(Repository):
         return True
 
     def reposync(self):
-        return self._run_custom_sync_command([self.command, 'sync', '-cf'])
+        return self._run_custom_sync_command([self.command, 'sync', '-c'])
 
     def incoming_check(self):
         return self._run_custom_incoming_command([self.command, 'sync', '-n'])

--- a/tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/tools/src/main/python/opengrok_tools/scm/repository.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 

--- a/tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/tools/src/main/python/opengrok_tools/scm/repository.py
@@ -234,7 +234,6 @@ class Repository:
 
     def top_level(self):
         """
-
-        :return:
+        :return: Whether to terminate the synchronization processing at the top level.
         """
         return False

--- a/tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/tools/src/main/python/opengrok_tools/scm/repository.py
@@ -199,7 +199,7 @@ class Repository:
 
     def _check_command(self):
         """
-        Could be overriden in given repository class to provide different check.
+        Could be overridden in given repository class to provide different check.
         :return: True if self.command is a file, False otherwise.
         """
         if self.command and not os.path.isfile(self.command):
@@ -212,7 +212,7 @@ class Repository:
     def check_command(self):
         """
         Check the validity of the command. Does not check the command if
-        the sync/incoming is overriden.
+        the sync/incoming is overridden.
         :return: True if self.command is valid, False otherwise.
         """
 
@@ -231,3 +231,10 @@ class Repository:
             return False
 
         return self._check_command()
+
+    def top_level(self):
+        """
+
+        :return:
+        """
+        return False

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -495,7 +495,7 @@ def mirror_project(config, project_name, check_changes, uri,
             ret = FAILURE_EXITVAL
 
         if repo.top_level():
-            logger.info("Repository {} is top level, breaking".format(repo))
+            logger.debug("Repository {} is top level, breaking".format(repo))
             break
 
     if not process_hook(HOOK_POST_PROPERTY, posthook, source_root, project_name,

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -19,7 +19,7 @@
 #
 
 #
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 
 import re

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -462,7 +462,7 @@ def test_get_repos_for_project_first_repo(monkeypatch):
     repository matching the project.
     """
     project_name = 'foo'
-    test_repo = "/" + project_name
+    test_repo = os.path.sep + project_name
 
     def mock_get_repos(*args, **kwargs):
         return [test_repo + os.path.sep + "x", test_repo, test_repo + os.path.sep + "y"]

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -465,7 +465,7 @@ def test_get_repos_for_project_first_repo(monkeypatch):
     test_repo = "/" + project_name
 
     def mock_get_repos(*args, **kwargs):
-        return [test_repo + "/x", test_repo, test_repo + "/y"]
+        return [test_repo + os.path.sep + "x", test_repo, test_repo + os.path.sep + "y"]
 
     def mock_get_repo_type(*args, **kwargs):
         return "Git"


### PR DESCRIPTION
While playing with `repo` for #3872, I discovered the support for it is broken in `opengrok-mirror`. Firstly, the `RepoRepository`  init function has wrong order or arguments, secondly the `repo` synchronization should not descend into sub-repositories.