### PR TITLE
avoid variable shadowing in LdapAttrPlugin + nits

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin;
 
@@ -172,10 +172,10 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
             ldapUser.setAttribute(ldapAttr, attributeValues);
         }
 
-        boolean sessionAllowed = attributeValues.stream().anyMatch(whitelist::contains);
+        boolean isAttrInWhitelist = attributeValues.stream().anyMatch(whitelist::contains);
         LOGGER.log(Level.FINEST, "LDAP user {0} {1} against {2}",
-                new Object[]{ldapUser, sessionAllowed ? "allowed" : "denied", filePath});
-        updateSession(req, sessionAllowed);
+                new Object[]{ldapUser, isAttrInWhitelist ? "allowed" : "denied", filePath});
+        updateSession(req, isAttrInWhitelist);
     }
 
     /**

--- a/plugins/src/main/java/opengrok/auth/plugin/entity/User.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/entity/User.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin.entity;
 
@@ -44,8 +44,8 @@ public class User {
      * @param id user ID
      */
     public User(String username, String id) {
-        this.id = id;
         this.username = username;
+        this.id = id;
     }
 
     /**
@@ -56,8 +56,7 @@ public class User {
      * @param timeouted is the user timed out
      */
     public User(String username, String id, Date cookieTimestamp, boolean timeouted) {
-        this.id = id;
-        this.username = username;
+        this(username, id);
         this.cookieTimestamp = cookieTimestamp;
         this.timeouted = timeouted;
     }

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin;
 
@@ -92,7 +92,6 @@ public class LdapAttrPluginTest {
         plugin.load(parameters, new FakeLdapFacade());
     }
 
-    @SuppressWarnings("unchecked")
     private void prepareRequest(String username, String mail, String... ous) {
         dummyRequest = new DummyHttpServletRequestLdap();
         dummyRequest.setAttribute(UserPlugin.REQUEST_ATTR,
@@ -124,7 +123,7 @@ public class LdapAttrPluginTest {
      * Test of {@code isAllowed} method.
      */
     @Test
-    public void testIsAllowed() {
+    void testIsAllowed() {
         /*
          * whitelist[mail] => [james@bond.com, random@email.com, just_a_text]
          */
@@ -165,7 +164,7 @@ public class LdapAttrPluginTest {
      * </ul>
      */
     @Test
-    public void testAttrLookup() throws LdapException {
+    void testAttrLookup() throws LdapException {
         String attr_to_get = "mail";
         String instance_num = "42";
         String mail_attr_value = "james@bond.com";

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
@@ -78,7 +78,7 @@ public class LdapAttrPluginTest {
 
     @AfterAll
     public static void afterClass() {
-        whitelistFile.delete();
+        whitelistFile.deleteOnExit();
     }
 
     @BeforeEach

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
@@ -170,7 +170,7 @@ public class LdapAttrPluginTest {
         String mail_attr_value = "james@bond.com";
 
         // Create mock LDAP provider, simulating the work of LdapUserPlugin.
-        AbstractLdapProvider mockprovider = mock(LdapFacade.class);
+        AbstractLdapProvider mockProvider = mock(LdapFacade.class);
         Map<String, Set<String>> attrs = new HashMap<>();
         attrs.put(attr_to_get, Collections.singleton(mail_attr_value));
         final String dn = "cn=FOO_BAR,L=EMEA,DC=FOO,DC=COM";
@@ -178,7 +178,7 @@ public class LdapAttrPluginTest {
                 new AbstractLdapProvider.LdapSearchResult<>(dn, attrs);
         assertNotNull(result);
         // TODO use Mockito Argument captor ?
-        when(mockprovider.lookupLdapContent(anyString(), any(String[].class))).
+        when(mockProvider.lookupLdapContent(anyString(), any(String[].class))).
                 thenReturn(result);
 
         // Load the LdapAttrPlugin using the mock LDAP provider.
@@ -187,7 +187,7 @@ public class LdapAttrPluginTest {
         parameters.put(LdapAttrPlugin.FILE_PARAM, whitelistFile.getAbsolutePath());
         parameters.put(LdapAttrPlugin.ATTR_PARAM, attr_to_get);
         parameters.put(LdapAttrPlugin.INSTANCE_PARAM, instance_num);
-        plugin.load(parameters, mockprovider);
+        plugin.load(parameters, mockProvider);
 
         LdapUser ldapUser = new LdapUser(dn, null);
         HttpServletRequest request = new DummyHttpServletRequestLdap();

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
@@ -177,7 +177,6 @@ public class LdapAttrPluginTest {
         AbstractLdapProvider.LdapSearchResult<Map<String, Set<String>>> result =
                 new AbstractLdapProvider.LdapSearchResult<>(dn, attrs);
         assertNotNull(result);
-        // TODO use Mockito Argument captor ?
         when(mockProvider.lookupLdapContent(anyString(), any(String[].class))).thenReturn(result);
 
         // Load the LdapAttrPlugin using the mock LDAP provider.

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
@@ -189,7 +189,6 @@ public class LdapAttrPluginTest {
         parameters.put(LdapAttrPlugin.INSTANCE_PARAM, instance_num);
         plugin.load(parameters, mockprovider);
 
-        // TODO prepareRequest() ?
         LdapUser ldapUser = new LdapUser(dn, null);
         HttpServletRequest request = new DummyHttpServletRequestLdap();
         request.getSession().setAttribute(LdapUserPlugin.SESSION_ATTR + instance_num, ldapUser);

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
@@ -169,7 +169,7 @@ public class LdapAttrPluginTest {
         String instance_num = "42";
         String mail_attr_value = "james@bond.com";
 
-        // Create mock LDAP provider, simulating the work of LdapUserPlugin.
+        // Create mock LDAP provider, simulating the work of LDAP server for LdapAttrPlugin#fillSession().
         AbstractLdapProvider mockProvider = mock(LdapFacade.class);
         Map<String, Set<String>> attrs = new HashMap<>();
         attrs.put(attr_to_get, Collections.singleton(mail_attr_value));

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
@@ -192,7 +192,7 @@ public class LdapAttrPluginTest {
         request.getSession().setAttribute(LdapUserPlugin.SESSION_ATTR + instance_num, ldapUser);
 
         // Here it comes all together.
-        User user = new User("foo@bar.cz", "id");
+        User user = new User("jbond", "007");
         plugin.fillSession(request, user);
 
         // See if LdapAttrPlugin set its own session attribute based on the mocked query.

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapAttrPluginTest.java
@@ -178,8 +178,7 @@ public class LdapAttrPluginTest {
                 new AbstractLdapProvider.LdapSearchResult<>(dn, attrs);
         assertNotNull(result);
         // TODO use Mockito Argument captor ?
-        when(mockProvider.lookupLdapContent(anyString(), any(String[].class))).
-                thenReturn(result);
+        when(mockProvider.lookupLdapContent(anyString(), any(String[].class))).thenReturn(result);
 
         // Load the LdapAttrPlugin using the mock LDAP provider.
         LdapAttrPlugin plugin = new LdapAttrPlugin();


### PR DESCRIPTION
This change fixes a small problem in `LdapAttrPlugin` by avoiding variable shadowing, that could make it harder to follow the code.