### PR TITLE
fix getAuthors() in SCCSRepository

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
@@ -91,6 +91,14 @@ public class Annotation {
         return ret;
     }
 
+    Set<String> getAuthors() {
+        Set<String> ret = new HashSet<>();
+        for (Line ln : this.lines) {
+            ret.add(ln.author);
+        }
+        return ret;
+    }
+
     /**
      * Gets the author who last modified the specified line.
      *

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
@@ -94,11 +94,7 @@ public class Annotation {
 
     @TestOnly
     Set<String> getAuthors() {
-        Set<String> ret = new HashSet<>();
-        for (Line ln : this.lines) {
-            ret.add(ln.author);
-        }
-        return ret;
+        return lines.stream().map(ln -> ln.author).collect(Collectors.toSet());
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
@@ -24,6 +24,7 @@
  */
 package org.opengrok.indexer.history;
 
+import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.Color;
 import org.opengrok.indexer.util.LazilyInstantiate;
@@ -91,6 +92,7 @@ public class Annotation {
         return ret;
     }
 
+    @VisibleForTesting
     Set<String> getAuthors() {
         Set<String> ret = new HashSet<>();
         for (Line ln : this.lines) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
@@ -24,7 +24,7 @@
  */
 package org.opengrok.indexer.history;
 
-import org.jetbrains.annotations.VisibleForTesting;
+import org.jetbrains.annotations.TestOnly;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.Color;
 import org.opengrok.indexer.util.LazilyInstantiate;
@@ -92,7 +92,7 @@ public class Annotation {
         return ret;
     }
 
-    @VisibleForTesting
+    @TestOnly
     Set<String> getAuthors() {
         Set<String> ret = new HashSet<>();
         for (Line ln : this.lines) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSRepository.java
@@ -100,8 +100,7 @@ public class SCCSRepository extends Repository {
         argv.add(RepoCommand);
         argv.add("prs");
         argv.add("-e");
-        argv.add("-d");
-        argv.add(":I: :P:");
+        argv.add("-d:I: :P:");
         argv.add(file.getCanonicalPath());
 
         Executor executor = new Executor(argv, file.getCanonicalFile().getParentFile(),

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSRepositoryAuthorParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSRepositoryAuthorParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -46,8 +46,7 @@ public class SCCSRepositoryAuthorParser implements Executor.StreamHandler {
     /**
      * Pattern used to extract revision from the {@code sccs get} command.
      */
-    private static final Pattern AUTHOR_PATTERN
-            = Pattern.compile("^([\\d.]+)\\s+(\\S+)");
+    private static final Pattern AUTHOR_PATTERN = Pattern.compile("^([\\d.]+)\\s+(\\S+)");
 
     @Override
     public void processStream(InputStream input) throws IOException {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/SCCSRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/SCCSRepositoryTest.java
@@ -127,6 +127,7 @@ class SCCSRepositoryTest {
         assertNotNull(annotation);
         Set<String> revSet = Set.of("1.2", "1.1");
         assertEquals(revSet, annotation.getRevisions());
+        assertEquals(Set.of("trond"), annotation.getAuthors());
     }
 
     @Test


### PR DESCRIPTION
Looking at the output from the `SCCSRepositoryTest#testAnnotation()` I can see a warning:
```
WARNING: Non-zero exit status 1 from command [sccs prs -e -d $':I: :P:' /tmp/source11618603591071727860/teamware/main.c] in directory /tmp/source11618603591071727860/teamware: prs: Cannot open SCCS file SCCS/s.:I: :P: for reading : No such file or directory
```
and also looking at the test it does not assert the authors in the `Annotation` object which is why this went uncovered.

The problem is that the 'cssc' implementation of SCCS requires the `-d` and its optarg to be single argument (as opposed to the SCCS implementation on Solaris):
```
$ sccs -V
sccs from GNU CSSC 1.4.1
$Id: sccs.c,v 1.44 2007/12/19 00:21:14 jay Exp $
SccsPath = 'SCCS'
SccsDir = ''
Default prefix for SCCS subcommands is '/usr/lib/x86_64-linux-gnu/cssc/'
$ sccs prs -e -d ':I: :P:' main.c
prs: Cannot open SCCS file SCCS/s.:I: :P: for reading : No such file or directory



$ sccs prs -e -d':I: :P:' main.c
1.2 trond
1.1 trond
```