### PR TITLE
handle requests exceptions gracefully

### DIFF
--- a/tools/src/main/python/opengrok_tools/utils/commandsequence.py
+++ b/tools/src/main/python/opengrok_tools/utils/commandsequence.py
@@ -23,7 +23,7 @@
 
 import logging
 
-from requests.exceptions import HTTPError
+from requests.exceptions import RequestException
 
 from .command import Command
 from .utils import is_web_uri
@@ -169,7 +169,7 @@ class CommandSequence(CommandSequenceBase):
                     call_rest_api(command, {PROJECT_SUBST: self.name,
                                             URL_SUBST: self.url},
                                   self.http_headers, self.api_timeout)
-                except HTTPError as e:
+                except RequestException as e:
                     self.logger.error("RESTful command {} failed: {}".
                                       format(command, e))
                     self.failed = True
@@ -227,7 +227,7 @@ class CommandSequence(CommandSequenceBase):
                     call_rest_api(cleanup_cmd, {PROJECT_SUBST: self.name,
                                                 URL_SUBST: self.url},
                                   self.http_headers, self.api_timeout)
-                except HTTPError as e:
+                except RequestException as e:
                     self.logger.error("RESTful command {} failed: {}".
                                       format(cleanup_cmd, e))
             else:

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -29,7 +29,7 @@ import logging
 import urllib
 from tempfile import gettempdir
 
-from requests.exceptions import HTTPError
+from requests.exceptions import RequestException
 
 from .exitvals import (
     FAILURE_EXITVAL,
@@ -297,7 +297,7 @@ def process_changes(repos, project_name, uri, headers=None):
         logger.error('Unable to parse project \'{}\' indexed flag: {}'
                      .format(project_name, e))
         return FAILURE_EXITVAL
-    except HTTPError as e:
+    except RequestException as e:
         logger.error('Unable to determine project \'{}\' indexed flag: {}'
                      .format(project_name, e))
         return FAILURE_EXITVAL
@@ -366,7 +366,7 @@ def handle_disabled_project(config, project_name, disabled_msg, headers=None,
             try:
                 call_rest_api(disabled_command, {PROJECT_SUBST: project_name},
                               http_headers=headers, timeout=timeout)
-            except HTTPError as e:
+            except RequestException as e:
                 logger.error("API call failed for disabled command of "
                              "project '{}': {}".
                              format(project_name, e))

--- a/tools/src/main/python/opengrok_tools/utils/opengrok.py
+++ b/tools/src/main/python/opengrok_tools/utils/opengrok.py
@@ -22,6 +22,7 @@
 #
 
 import urllib.parse
+from requests.exceptions import RequestException
 from .webutil import get_uri
 from .restful import do_api_call
 
@@ -42,7 +43,7 @@ def get_repos(logger, project, uri, headers=None, timeout=None):
                                          urllib.parse.quote_plus(project),
                                          'repositories'),
                           headers=headers, timeout=timeout)
-    except Exception as exception:
+    except RequestException as exception:
         logger.error("could not get repositories for project '{}': {}".
                      format(project, exception))
         return None
@@ -64,7 +65,7 @@ def get_config_value(logger, name, uri, headers=None, timeout=None):
         res = do_api_call('GET', get_uri(uri, 'api', 'v1', 'configuration',
                                          urllib.parse.quote_plus(name)),
                           headers=headers, timeout=timeout)
-    except Exception as exception:
+    except RequestException as exception:
         logger.error("Cannot get the '{}' config value from the web "
                      "application: {}".format(name, exception))
         return None
@@ -90,7 +91,7 @@ def set_config_value(logger, name, value, uri, headers=None, timeout=None):
         local_headers['Content-type'] = 'application/text'
         do_api_call('PUT', get_uri(uri, 'api', 'v1', 'configuration', name),
                     data=value, headers=local_headers, timeout=timeout)
-    except Exception as exception:
+    except RequestException as exception:
         logger.error("Cannot set the '{}' config field to '{}' in the web "
                      "application: {}".format(name, value, exception))
         return False
@@ -110,7 +111,7 @@ def get_repo_type(logger, repository, uri, headers=None, timeout=None):
         res = do_api_call('GET', get_uri(uri, 'api', 'v1', 'repositories',
                                          'property', 'type'), params=payload,
                           headers=headers, timeout=timeout)
-    except Exception as exception:
+    except RequestException as exception:
         logger.error("could not get repository type for '{}' from web"
                      "application: {}".format(repository, exception))
         return None
@@ -125,7 +126,7 @@ def get_configuration(logger, uri, headers=None, timeout=None):
     try:
         res = do_api_call('GET', get_uri(uri, 'api', 'v1', 'configuration'),
                           headers=headers, timeout=timeout)
-    except Exception as exception:
+    except RequestException as exception:
         logger.error('could not get configuration from web application: {}'.
                      format(exception))
         return None
@@ -140,7 +141,7 @@ def set_configuration(logger, configuration, uri, headers=None, timeout=None, ap
         if r is None or r.status_code != 201:
             logger.error('could not set configuration to web application')
             return False
-    except Exception as exception:
+    except RequestException as exception:
         logger.error('could not set configuration to web application: {}'.
                      format(exception))
         return False
@@ -153,7 +154,7 @@ def list_projects(logger, uri, headers=None, timeout=None):
         res = do_api_call('GET',
                           get_uri(uri, 'api', 'v1', 'projects'),
                           headers=headers, timeout=timeout)
-    except Exception as exception:
+    except RequestException as exception:
         logger.error("could not list projects from web application: {}".
                      format(exception))
         return None
@@ -166,7 +167,7 @@ def list_indexed_projects(logger, uri, headers=None, timeout=None):
         res = do_api_call('GET',
                           get_uri(uri, 'api', 'v1', 'projects', 'indexed'),
                           headers=headers, timeout=timeout)
-    except Exception as exception:
+    except RequestException as exception:
         logger.error("could not list indexed projects from web application: {}".
                      format(exception))
         return None
@@ -181,7 +182,7 @@ def add_project(logger, project, uri, headers=None, timeout=None, api_timeout=No
         if r is None or r.status_code != 201:
             logger.error(f"could not add project '{project}' in web application")
             return False
-    except Exception as exception:
+    except RequestException as exception:
         logger.error("could not add project '{}' to web application: {}".
                      format(project, exception))
         return False
@@ -197,7 +198,7 @@ def delete_project(logger, project, uri, headers=None, timeout=None, api_timeout
         if r is None or r.status_code != 204:
             logger.error(f"could not delete project '{project}' in web application")
             return False
-    except Exception as exception:
+    except RequestException as exception:
         logger.error("could not delete project '{}' in web application: {}".
                      format(project, exception))
         return False


### PR DESCRIPTION
Instead of catching specific exceptions (like `HTTPError` or `ReadTimeout` or `Timeout`), I chose to catch `RequestException` which encompasses all exceptions coming from `requests.exceptions`. Tested with `toxiproxy`:
```
$ toxiproxy-server
INFO[0000] API HTTP server starting                      host=localhost port=8474 version=2.1.4
...

$ toxiproxy-cli create tomcat -l localhost:33333 -u localhost:8080
Created new proxy tomcat
$ toxiproxy-cli toxic add tomcat --toxicName latency_downstream -t latency -a latency=5000
Added downstream latency toxic 'latency_downstream' on proxy 'tomcat'
$ toxiproxy-cli list
Name			Listen		Upstream		Enabled		Toxics
======================================================================================
tomcat			127.0.0.1:33333	localhost:8080		enabled		1

Hint: inspect toxics with `toxiproxy-cli inspect <proxyName>`
$ cd tools
$ . ./env/bin/activate
$ python setup.py install
$ python3
>>> from opengrok_tools.utils.opengrok import get_configuration
>>> import logging
>>> logger = logging.getLogger(__name__)
>>> get_configuration(logger, "http://localhost:33333/source/", timeout=1)
could not get configuration from web application: HTTPConnectionPool(host='localhost', port=33333): Read timed out. (read timeout=1)
```