### PR TITLE
--strip-outgoing option for opengrok-mirror

### DIFF
--- a/docker/sync.yml
+++ b/docker/sync.yml
@@ -6,7 +6,8 @@ commands:
     duration: PT1H
     tags: ['%PROJECT%']
     text: resync + reindex in progress
-- command: [opengrok-mirror, -c, '/opengrok/etc/mirror.yml', -I, -U, '%URL%', '%PROJECT%']
+- command: [opengrok-mirror, -c, '/opengrok/etc/mirror.yml',
+    --strip-outgoing, --check-changes, -U, '%URL%', '%PROJECT%']
 - command: [opengrok-reindex-project, --printoutput,
     --jar, /opengrok/lib/opengrok.jar, -U, '%URL%', -P, '%PROJECT%', --,
     -r, dirbased, -G, -m, '256', --leadingWildCards, 'on',

--- a/docker/sync.yml
+++ b/docker/sync.yml
@@ -6,8 +6,7 @@ commands:
     duration: PT1H
     tags: ['%PROJECT%']
     text: resync + reindex in progress
-- command: [opengrok-mirror, -c, '/opengrok/etc/mirror.yml',
-    --strip-outgoing, --check-changes, -U, '%URL%', '%PROJECT%']
+- command: [opengrok-mirror, -c, '/opengrok/etc/mirror.yml', -I, -U, '%URL%', '%PROJECT%']
 - command: [opengrok-reindex-project, --printoutput,
     --jar, /opengrok/lib/opengrok.jar, -U, '%URL%', -P, '%PROJECT%', --,
     -r, dirbased, -G, -m, '256', --leadingWildCards, 'on',

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -231,7 +231,8 @@ public class ProjectsController {
                         () -> {
                             deleteProjectDataWorkHorse(projectName);
                             return null;
-                        }));
+                        },
+                        Response.Status.NO_CONTENT));
     }
 
     private void deleteProjectDataWorkHorse(String projectName) {

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -108,7 +108,7 @@ def main():
                              ' repositories,'
                              ' terminate the processing'
                              ' if no change is found.')
-    parser.add_argument('--strip_outgoing', type=bool, default=False,
+    parser.add_argument('--strip_outgoing', action='store_true', default=False,
                         help='check outgoing changes for each repository of a project,'
                         'strip any such changes and remove all project data so that'
                         'it can be reindexed from scratch')

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -108,7 +108,7 @@ def main():
                              ' repositories,'
                              ' terminate the processing'
                              ' if no change is found.')
-    parser.add_argument('--strip_outgoing', action='store_true', default=False,
+    parser.add_argument('--strip-outgoing', action='store_true', default=False,
                         help='check outgoing changes for each repository of a project,'
                         'strip any such changes and remove all project data so that'
                         'it can be reindexed from scratch')

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -111,7 +111,7 @@ def main():
     parser.add_argument('--strip-outgoing', action='store_true', default=False,
                         help='check outgoing changes for each repository of a project,'
                         'strip any such changes and remove all project data so that'
-                        'it can be reindexed from scratch')
+                        'it can be reindexed from scratch. Supported: Git')
     parser.add_argument('-w', '--workers', default=cpu_count(), type=int,
                         help='Number of worker processes')
     add_http_headers(parser)

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -64,7 +64,7 @@ OPENGROK_NO_MIRROR_ENV = "OPENGROK_NO_MIRROR"
 
 
 def worker(args):
-    project_name, logdir, loglevel, backup_count, config, check_changes, check_outgoing, uri, \
+    project_name, logdir, loglevel, backup_count, config, check_changes, strip_outgoing, uri, \
         source_root, batch, headers, timeout, api_timeout = args
 
     if batch:
@@ -74,7 +74,7 @@ def worker(args):
                          get_class_basename())
 
     return mirror_project(config, project_name,
-                          check_changes, check_outgoing,
+                          check_changes, strip_outgoing,
                           uri, source_root, headers=headers,
                           timeout=timeout,
                           api_timeout=api_timeout)

--- a/tools/src/main/python/opengrok_tools/scm/git.py
+++ b/tools/src/main/python/opengrok_tools/scm/git.py
@@ -60,9 +60,13 @@ class GitRepository(Repository):
         status, out = self._run_command([self.command, 'log',
                                         '--pretty=tformat:%H', '--reverse', 'origin..'])
         if status == 0:
-            cset = out.get(0)
-            if cset:
-                self.logger.debug("Resetting the repository {} to parent of changeset {}".
+            lines = out.split('\n')
+            if len(lines) == 0:
+                return False
+
+            cset = lines[0]
+            if len(cset) > 0:
+                self.logger.debug("Resetting the repository {} to parent of changeset '{}'".
                                   format(self, cset))
                 status, out = self._run_command([self.command, 'reset', '--hard',
                                                  cset + '^'])
@@ -71,8 +75,8 @@ class GitRepository(Repository):
                                               format(self, cset, out))
                 else:
                     return True
-            else:
-                return False
+        else:
+            raise RepositoryException("failed to check for outgoing changes in {}: {}".
+                                      format(self, status))
 
-        raise RepositoryException("failed to check for outgoing changes in {}: {}".
-                                  format(self, status))
+        return False

--- a/tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/tools/src/main/python/opengrok_tools/scm/repository.py
@@ -105,12 +105,22 @@ class Repository:
     def incoming_check(self):
         """
         Check if there are any incoming changes.
-        Normally this method definition is overriden, unless the repository
+        Normally this method definition is overridden, unless the repository
         type has no way how to check for incoming changes.
 
-        Return True if so, False otherwise.
+        :return True if so, False otherwise.
         """
         return True
+
+    def strip_outgoing(self):
+        """
+        Strip any outgoing changes.
+        Normally this method definition is overridden, unless the repository
+        type has no way how to check for outgoing changes or cannot strip them.
+
+        :return True if any changes were stripped, False otherwise.
+        """
+        return False
 
     def _run_custom_sync_command(self, command):
         """
@@ -152,7 +162,7 @@ class Repository:
                                env_vars=self.env, logger=self.logger)
         cmd.execute()
         if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
-            cmd.log_error("failed to perform command")
+            cmd.log_error("failed to perform command {}".format(command))
             status = cmd.getretcode()
             if status == 0 and cmd.getstate() != Command.FINISHED:
                 status = 1

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -410,32 +410,17 @@ def process_outgoing(repos, project_name):
     """
 
     logger = logging.getLogger(__name__)
+    logger.info("Checking outgoing changes for project {}".format(project_name))
 
     ret = False
     for repo in repos:
+        logger.debug("Checking outgoing changes for repository {}", repo)
         if repo.strip_outgoing():
             logger.debug('Repository {} in project {} had outgoing changes stripped'.
                          format(repo, project_name))
             ret = True
 
     return ret
-
-
-def wipe_project_data(project_name, uri, headers=None, timeout=None, api_timeout=None):
-    """
-    Remove data for the project and mark it as not indexed.
-    :param project_name: name of the project
-    :param uri: URI of the webapp
-    :param headers: HTTP headers
-    :param timeout: connect timeout
-    :param api_timeout: asynchronous API timeout
-    """
-
-    logger = logging.getLogger(__name__)
-
-    logger.info("removing data for project {}".format(project_name))
-    delete_project_data(logger, project_name, uri,
-                        headers=headers, timeout=timeout, api_timeout=api_timeout)
 
 
 def mirror_project(config, project_name, check_changes, check_outgoing, uri,
@@ -539,8 +524,11 @@ def mirror_project(config, project_name, check_changes, check_outgoing, uri,
                          'a repository in project {}: {}'.format(project_name, exc))
             return get_mirror_retcode(ignore_errors, FAILURE_EXITVAL)
         if r:
-            wipe_project_data(project_name, uri, headers=headers,
-                              timeout=timeout, api_timeout=api_timeout)
+            logger.info("removing data for project {}".format(project_name))
+            r = delete_project_data(logger, project_name, uri,
+                                    headers=headers, timeout=timeout, api_timeout=api_timeout)
+            if not r:
+                return get_mirror_retcode(ignore_errors, FAILURE_EXITVAL)
 
     # Check if the project or any of its repositories have changed.
     if check_changes:

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -526,7 +526,8 @@ def mirror_project(config, project_name, check_changes, strip_outgoing, uri,
                          'a repository in project {}: {}'.format(project_name, exc))
             return get_mirror_retcode(ignore_errors, FAILURE_EXITVAL)
         if r:
-            logger.info("removing data for project {}".format(project_name))
+            logger.info("Found outgoing changesets, removing data for project {}".
+                        format(project_name))
             r = delete_project_data(logger, project_name, uri,
                                     headers=headers, timeout=timeout, api_timeout=api_timeout)
             if not r:

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -516,6 +516,8 @@ def mirror_project(config, project_name, check_changes, check_outgoing, uri,
     if check_outgoing_config is not None:
         check_outgoing = check_outgoing_config
 
+    # Check outgoing changes first. If there are any, such changes will be stripped
+    # and the subsequent incoming check will do the right thing.
     if check_outgoing:
         try:
             r = process_outgoing(repos, project_name)

--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -414,7 +414,7 @@ def process_outgoing(repos, project_name):
 
     ret = False
     for repo in repos:
-        logger.debug("Checking outgoing changes for repository {}", repo)
+        logger.debug("Checking outgoing changes for repository {}".format(repo))
         if repo.strip_outgoing():
             logger.debug('Repository {} in project {} had outgoing changes stripped'.
                          format(repo, project_name))

--- a/tools/src/main/python/opengrok_tools/utils/opengrok.py
+++ b/tools/src/main/python/opengrok_tools/utils/opengrok.py
@@ -139,7 +139,7 @@ def set_configuration(logger, configuration, uri, headers=None, timeout=None, ap
         r = do_api_call('PUT', get_uri(uri, 'api', 'v1', 'configuration'),
                         data=configuration, headers=headers, timeout=timeout, api_timeout=api_timeout)
         if r is None or r.status_code != 201:
-            logger.error('could not set configuration to web application')
+            logger.error(f'could not set configuration to web application {r}')
             return False
     except RequestException as exception:
         logger.error('could not set configuration to web application: {}'.
@@ -180,7 +180,7 @@ def add_project(logger, project, uri, headers=None, timeout=None, api_timeout=No
         r = do_api_call('POST', get_uri(uri, 'api', 'v1', 'projects'),
                         data=project, headers=headers, timeout=timeout, api_timeout=api_timeout)
         if r is None or r.status_code != 201:
-            logger.error(f"could not add project '{project}' in web application")
+            logger.error(f"could not add project '{project}' in web application: {r}")
             return False
     except RequestException as exception:
         logger.error("could not add project '{}' to web application: {}".
@@ -195,7 +195,7 @@ def _delete_project(logger, project, uri, headers=None, timeout=None, api_timeou
         r = do_api_call('DELETE', uri,
                         headers=headers, timeout=timeout, api_timeout=api_timeout)
         if r is None or r.status_code != 204:
-            logger.error(f"could not delete project '{project}' in web application")
+            logger.error(f"could not delete project '{project}' in web application: {r}")
             return False
     except RequestException as exception:
         logger.error("could not delete project '{}' in web application: {}".

--- a/tools/src/main/python/opengrok_tools/utils/opengrok.py
+++ b/tools/src/main/python/opengrok_tools/utils/opengrok.py
@@ -190,10 +190,9 @@ def add_project(logger, project, uri, headers=None, timeout=None, api_timeout=No
     return True
 
 
-def delete_project(logger, project, uri, headers=None, timeout=None, api_timeout=None):
+def _delete_project(logger, project, uri, headers=None, timeout=None, api_timeout=None):
     try:
-        r = do_api_call('DELETE', get_uri(uri, 'api', 'v1', 'projects',
-                                          urllib.parse.quote_plus(project)),
+        r = do_api_call('DELETE', uri,
                         headers=headers, timeout=timeout, api_timeout=api_timeout)
         if r is None or r.status_code != 204:
             logger.error(f"could not delete project '{project}' in web application")
@@ -204,3 +203,17 @@ def delete_project(logger, project, uri, headers=None, timeout=None, api_timeout
         return False
 
     return True
+
+
+def delete_project(logger, project, uri, headers=None, timeout=None, api_timeout=None):
+    return _delete_project(logger, project, get_uri(uri, 'api', 'v1', 'projects',
+                                                    urllib.parse.quote_plus(project)),
+                           headers=headers,
+                           timeout=timeout, api_timeout=api_timeout)
+
+
+def delete_project_data(logger, project, uri, headers=None, timeout=None, api_timeout=None):
+    return _delete_project(logger, project, get_uri(uri, 'api', 'v1', 'projects',
+                                                    urllib.parse.quote_plus(project), 'data'),
+                           headers=headers,
+                           timeout=timeout, api_timeout=api_timeout)

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -210,7 +210,7 @@ def test_disabled_command_api():
     Test that mirror_project() calls call_rest_api() if API
     call is specified in the configuration for disabled project.
     """
-    def mock_call_rest_api(command, b, http_headers=None, timeout=None):
+    def mock_call_rest_api(command, b, http_headers=None, timeout=None, api_timeout=None):
         return mock(spec=requests.Response)
 
     with patch(opengrok_tools.utils.mirror.call_rest_api,
@@ -227,12 +227,12 @@ def test_disabled_command_api():
             }
         }
 
-        assert mirror_project(config, project_name, False,
+        assert mirror_project(config, project_name, False, False,
                               None, None) == CONTINUE_EXITVAL
         verify(opengrok_tools.utils.mirror). \
             call_rest_api(config.get(DISABLED_CMD_PROPERTY),
                           {PROJECT_SUBST: project_name},
-                          http_headers=None, timeout=None)
+                          http_headers=None, timeout=None, api_timeout=None)
 
 
 def test_disabled_command_api_text_append(monkeypatch):
@@ -242,7 +242,7 @@ def test_disabled_command_api_text_append(monkeypatch):
 
     text_to_append = "foo bar"
 
-    def mock_call_rest_api(command, b, http_headers=None, timeout=None):
+    def mock_call_rest_api(command, b, http_headers=None, timeout=None, api_timeout=None):
         disabled_command = config.get(DISABLED_CMD_PROPERTY)
         assert disabled_command
         command_args = disabled_command.get(COMMAND_PROPERTY)
@@ -277,7 +277,7 @@ def test_disabled_command_api_text_append(monkeypatch):
             }
         }
 
-        mirror_project(config, project_name, False, None, None)
+        mirror_project(config, project_name, False, False, None, None)
 
 
 def test_disabled_command_run():
@@ -295,7 +295,7 @@ def test_disabled_command_run():
         }
     }
 
-    assert mirror_project(config, project_name, False,
+    assert mirror_project(config, project_name, False, False,
                           None, None) == CONTINUE_EXITVAL
     verify(opengrok_tools.utils.mirror).run_command(ANY, project_name)
 
@@ -330,7 +330,7 @@ def test_ignore_errors_sync(monkeypatch, per_project):
                   mock_get_repos)
 
         src_root = "srcroot"
-        assert mirror_project(config, project_name, False,
+        assert mirror_project(config, project_name, False, False,
                               None, src_root) == SUCCESS_EXITVAL
 
 
@@ -371,7 +371,7 @@ def test_ignore_errors_hooks(monkeypatch, hook_type, per_project):
                   mock_get_repos)
 
         src_root = "srcroot"
-        assert mirror_project(config, project_name, False,
+        assert mirror_project(config, project_name, False, False,
                               None, src_root) == SUCCESS_EXITVAL
         verify(opengrok_tools.utils.mirror).\
             process_hook(hook_type, os.path.join(hook_dir, hook_name),
@@ -419,7 +419,7 @@ def test_mirror_project_timeout(monkeypatch):
         return False
 
     def test_mirror_project(config):
-        retval = mirror_project(config, project_name, False,
+        retval = mirror_project(config, project_name, False, False,
                                 "http://localhost:8080/source", "srcroot")
         assert retval == FAILURE_EXITVAL
 


### PR DESCRIPTION
This change adds the `--strip-outgoing` CLI option and `strip_outgoing` config option (both global and per project) to `opengrok-mirror`. When set to true, the outgoing changesets (in repositories where this option is in effect and where supported) will be stripped and project data will be deleted (not the source code, just index/xrefs/cache) so that the project can be reindexed from scratch. This is handy in situations when mirroring a repository that has its history frequently rewritten and not caring about the reindex time (the project will disappear from the UI after its data is deleted. It will reappear after reindex automatically). So far only Git is supported, although this should be possible to implement also for Mercurial and other changeset based SCMs.