### PR TITLE
do not clear HistoryGuru structures on project data delete

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -729,7 +729,8 @@ public final class HistoryGuru {
 
     /**
      * Remove history data for a list of repositories. Those that are
-     * successfully cleared are removed from the internal list of repositories.
+     * successfully cleared may be removed from the internal list of repositories,
+     * depending on the {@code removeRepositories} parameter.
      *
      * @param repositories list of repository paths relative to source root
      * @param removeRepositories set true to also remove the repositories from internal structures

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -728,14 +728,6 @@ public final class HistoryGuru {
     }
 
     /**
-     * wrapper for {@link #removeCache(Collection, boolean)} with the {@code removeRepositories}
-     * parameter set to true.
-     */
-    public void removeCache(Collection<String> repositories) {
-        removeCache(repositories, true);
-    }
-
-    /**
      * Remove history data for a list of repositories. Those that are
      * successfully cleared are removed from the internal list of repositories.
      *

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -728,18 +728,29 @@ public final class HistoryGuru {
     }
 
     /**
+     * wrapper for {@link #removeCache(Collection, boolean)} with the {@code removeRepositories}
+     * parameter set to true.
+     */
+    public void removeCache(Collection<String> repositories) {
+        removeCache(repositories, true);
+    }
+
+    /**
      * Remove history data for a list of repositories. Those that are
      * successfully cleared are removed from the internal list of repositories.
      *
      * @param repositories list of repository paths relative to source root
+     * @param removeRepositories set true to also remove the repositories from internal structures
      */
-    public void removeCache(Collection<String> repositories) {
+    public void removeCache(Collection<String> repositories, boolean removeRepositories) {
         if (!useCache()) {
             return;
         }
 
         List<String> repos = clearCache(repositories);
-        removeRepositories(repos);
+        if (removeRepositories) {
+            removeRepositories(repos);
+        }
     }
 
     /**
@@ -797,7 +808,7 @@ public final class HistoryGuru {
         ccopy.forEach(this::putRepository);
     }
 
-    /**set
+    /**
      * Set list of known repositories which match the list of directories.
      * @param repos list of repositories
      * @param dirs list of directories that might correspond to the repositories

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -194,7 +194,7 @@ public class ProjectsController {
 
     private void deleteProjectWorkHorse(String projectName, Project project) {
         // Delete index data associated with the project.
-        deleteProjectDataWorkHorse(projectName);
+        deleteProjectDataWorkHorse(projectName, true);
 
         // Remove the project from its groups.
         for (Group group : project.getGroups()) {
@@ -229,13 +229,13 @@ public class ProjectsController {
         return ApiTaskManager.getInstance().submitApiTask(PROJECTS_PATH,
                 new ApiTask(request.getRequestURI(),
                         () -> {
-                            deleteProjectDataWorkHorse(projectName);
+                            deleteProjectDataWorkHorse(projectName, false);
                             return null;
                         },
                         Response.Status.NO_CONTENT));
     }
 
-    private void deleteProjectDataWorkHorse(String projectName) {
+    private void deleteProjectDataWorkHorse(String projectName, boolean clearHistoryGuru) {
         LOGGER.log(Level.INFO, "deleting data for project {0}", projectName);
 
         // Delete index and xrefs.
@@ -248,7 +248,7 @@ public class ProjectsController {
             }
         }
 
-        deleteHistoryCacheWorkHorse(projectName);
+        deleteHistoryCacheWorkHorse(projectName, clearHistoryGuru);
 
         // Delete suggester data.
         suggester.delete(projectName);
@@ -269,12 +269,12 @@ public class ProjectsController {
         return ApiTaskManager.getInstance().submitApiTask(PROJECTS_PATH,
                 new ApiTask(request.getRequestURI(),
                         () -> {
-                            deleteHistoryCacheWorkHorse(projectName);
+                            deleteHistoryCacheWorkHorse(projectName, false);
                             return null;
                         }));
     }
 
-    private void deleteHistoryCacheWorkHorse(String projectName) {
+    private void deleteHistoryCacheWorkHorse(String projectName, boolean clearHistoryGuru) {
         Project project = disableProject(projectName);
 
         LOGGER.log(Level.INFO, "deleting history cache for project {0}", projectName);
@@ -301,7 +301,7 @@ public class ProjectsController {
                         // {@code removeCache()} will return nothing.
                         return "";
                     }
-                }).filter(x -> !x.isEmpty()).collect(Collectors.toSet()));
+                }).filter(x -> !x.isEmpty()).collect(Collectors.toSet()), clearHistoryGuru);
     }
 
     @PUT


### PR DESCRIPTION
This change makes the project/history data deletion softer w.r.t. `HistoryGuru` structures - these operations leave them alone so a project can be reindexed without having to refresh the structures.

Specifically, it allows one to run `opengrok-projadm add` and then `opengrok-sync` with `opengrok-mirror` using `--strip-outgoing` without having the history view disappear after the outgoing changes are stripped (and project data deleted) and the project reindexed from scratch.