### PR TITLE
terminate the outgoing check for top level repository

### DIFF
--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -420,6 +420,11 @@ def process_outgoing(repos, project_name):
                          format(repo, project_name))
             ret = True
 
+        if repo.top_level():
+            logger.debug('Repository {} is top level, finishing outgoing changeset handling'.
+                         format(repo))
+            break
+
     return ret
 
 


### PR DESCRIPTION
When introducing the changes for outgoing check+strip I forgot to add handling for top level repositories, breaking AOSP mirroring. This change fixes that.