### PR TITLE
outgoing check needs to take current branch into account

### DIFF
--- a/tools/src/main/python/opengrok_tools/scm/git.py
+++ b/tools/src/main/python/opengrok_tools/scm/git.py
@@ -55,10 +55,20 @@ class GitRepository(Repository):
         self._configure_git_pull()
         return self._run_custom_incoming_command([self.command, 'pull', '--dry-run'])
 
+    def get_branch(self):
+        status, out = self._run_command([self.command, 'branch', '--show-current'])
+        if status != 0:
+            raise RepositoryException("cannot get branch of {}: {}".format(self, out))
+
+        branch = out.split('\n')[0]
+
+        return branch
+
     def strip_outgoing(self):
         self._configure_git_pull()
+        branch = self.get_branch()
         status, out = self._run_command([self.command, 'log',
-                                        '--pretty=tformat:%H', '--reverse', 'origin..'])
+                                        '--pretty=tformat:%H', '--reverse', 'origin/' + branch + '..'])
         if status == 0:
             lines = out.split('\n')
             if len(lines) == 0:

--- a/tools/src/main/python/opengrok_tools/scm/git.py
+++ b/tools/src/main/python/opengrok_tools/scm/git.py
@@ -64,8 +64,18 @@ class GitRepository(Repository):
 
         return branch
 
+    def fetch(self):
+        status, out = self._run_command([self.command, 'fetch'])
+        if status != 0:
+            raise RepositoryException("cannot fetch {}: {}".format(self, out))
+
     def strip_outgoing(self):
+        """
+        Check for outgoing changes and if found, strip them.
+        :return: True if there were any changes stripped, False otherwise.
+        """
         self._configure_git_pull()
+        self.fetch()
         branch = self.get_branch()
         status, out = self._run_command([self.command, 'log',
                                         '--pretty=tformat:%H', '--reverse', 'origin/' + branch + '..'])


### PR DESCRIPTION
When testing the outgoing changes handling with internal Linux UEK repository, a changeset that had no parent was wrongly detected as outgoing. This change fixes that.

Also, I realized that `git fetch` is needed before checking the outgoing changes.