### PR TITLE
print default values of options

### DIFF
--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -84,6 +84,7 @@ def main():
     ret = SUCCESS_EXITVAL
 
     parser = argparse.ArgumentParser(description='project mirroring',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      parents=[get_base_parser(
                                          tool_version=__version__)
                                      ])

--- a/tools/src/main/python/opengrok_tools/reindex_project.py
+++ b/tools/src/main/python/opengrok_tools/reindex_project.py
@@ -78,6 +78,7 @@ def get_config_file(logger, uri, headers=None, timeout=None):
 def main():
     parser = argparse.ArgumentParser(description='OpenGrok indexer wrapper '
                                                  'for indexing single project',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      parents=[get_java_parser()],
                                      prog=sys.argv[0])
     parser.add_argument('-t', '--template',

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -122,6 +122,7 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
 
 def main():
     parser = argparse.ArgumentParser(description='Manage parallel workers.',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      parents=[
                                          get_base_parser(
                                              tool_version=__version__)

--- a/tools/src/main/python/opengrok_tools/utils/log.py
+++ b/tools/src/main/python/opengrok_tools/utils/log.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 
 import logging
@@ -48,7 +48,7 @@ def fatal(msg, exit=True):
 def add_log_level_argument(parser):
     parser.add_argument('-l', '--loglevel', action=LogLevelAction,
                         help='Set log level (e.g. \"ERROR\")',
-                        default=logging.INFO)
+                        default="INFO")
 
 
 class LogLevelAction(argparse.Action):


### PR DESCRIPTION
This change adds formatter to some of the Python tools so that default values of options are printed in help, e.g.:
```
$ opengrok-mirror -h

...

  --api_timeout API_TIMEOUT
                        Set response timeout in seconds for RESTful API calls (default: 3)
  --async_api_timeout ASYNC_API_TIMEOUT
                        Set timeout in seconds for asynchronous RESTful API calls (default: 300)
```