### PR TITLE
convert API call configuration to dictionary

### DIFF
--- a/docker/sync.yml
+++ b/docker/sync.yml
@@ -1,8 +1,9 @@
 commands:
-- command:
-  - '%URL%api/v1/messages'
-  - POST
-  - messageLevel: warning
+- call:
+  uri: '%URL%api/v1/messages'
+  method: POST
+  data:
+    messageLevel: warning
     duration: PT1H
     tags: ['%PROJECT%']
     text: resync + reindex in progress
@@ -12,14 +13,16 @@ commands:
     -r, dirbased, -G, -m, '256', --leadingWildCards, 'on',
     -c, /usr/local/bin/ctags, -U, '%URL%', -H, '%PROJECT%']
   limits: {RLIMIT_NOFILE: 1024}
-- command:
-  - '%URL%api/v1/messages?tag=%PROJECT%'
-  - DELETE
-  - 'resync + reindex in progress'
-  - 'Content-type': 'text/plain'
+- call:
+  uri: '%URL%api/v1/messages?tag=%PROJECT%'
+  method: DELETE
+  data: 'resync + reindex in progress'
+  headers:
+    'Content-type': 'text/plain'
 cleanup:
-- command:
-  - '%URL%api/v1/messages?tag=%PROJECT%'
-  - DELETE
-  - 'resync + reindex in progress'
-  - 'Content-type': 'text/plain'
+- call:
+  uri: '%URL%api/v1/messages?tag=%PROJECT%'
+  method: DELETE
+  data: 'resync + reindex in progress'
+  headers:
+    'Content-type': 'text/plain'

--- a/docker/sync.yml
+++ b/docker/sync.yml
@@ -1,12 +1,12 @@
 commands:
 - call:
-  uri: '%URL%api/v1/messages'
-  method: POST
-  data:
-    messageLevel: warning
-    duration: PT1H
-    tags: ['%PROJECT%']
-    text: resync + reindex in progress
+    uri: '%URL%api/v1/messages'
+    method: POST
+    data:
+      messageLevel: warning
+      duration: PT1H
+      tags: ['%PROJECT%']
+      text: resync + reindex in progress
 - command: [opengrok-mirror, -c, '/opengrok/etc/mirror.yml', -I, -U, '%URL%', '%PROJECT%']
 - command: [opengrok-reindex-project, --printoutput,
     --jar, /opengrok/lib/opengrok.jar, -U, '%URL%', -P, '%PROJECT%', --,
@@ -14,15 +14,15 @@ commands:
     -c, /usr/local/bin/ctags, -U, '%URL%', -H, '%PROJECT%']
   limits: {RLIMIT_NOFILE: 1024}
 - call:
-  uri: '%URL%api/v1/messages?tag=%PROJECT%'
-  method: DELETE
-  data: 'resync + reindex in progress'
-  headers:
-    'Content-type': 'text/plain'
+    uri: '%URL%api/v1/messages?tag=%PROJECT%'
+    method: DELETE
+    data: 'resync + reindex in progress'
+    headers:
+      'Content-type': 'text/plain'
 cleanup:
 - call:
-  uri: '%URL%api/v1/messages?tag=%PROJECT%'
-  method: DELETE
-  data: 'resync + reindex in progress'
-  headers:
-    'Content-type': 'text/plain'
+    uri: '%URL%api/v1/messages?tag=%PROJECT%'
+    method: DELETE
+    data: 'resync + reindex in progress'
+    headers:
+      'Content-type': 'text/plain'

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -121,7 +121,7 @@ def main():
                         help='Set response timeout in seconds '
                              'for RESTful API calls')
     parser.add_argument('--async_api_timeout', type=int, default=300,
-                        help='Set timeout in seconds for asynchronous RESTful API calls')
+                        help='Set timeout in seconds for asynchronous REST API calls')
 
     try:
         args = parser.parse_args()

--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -49,7 +49,8 @@ from .utils.log import get_console_logger, get_class_basename, \
 from .utils.opengrok import get_config_value, list_indexed_projects
 from .utils.parsers import get_base_parser, add_http_headers, get_headers
 from .utils.readconfig import read_config
-from .utils.utils import get_int, is_web_uri
+from .utils.utils import get_int
+from .utils.webutil import is_web_uri
 from .utils.mirror import check_configuration, LOGDIR_PROPERTY, \
     mirror_project, HOOKDIR_PROPERTY, CMD_TIMEOUT_PROPERTY, \
     HOOK_TIMEOUT_PROPERTY
@@ -58,7 +59,7 @@ major_version = sys.version_info[0]
 if major_version < 3:
     fatal("Need Python 3, you are running {}".format(major_version))
 
-__version__ = "1.2"
+__version__ = "1.3"
 
 OPENGROK_NO_MIRROR_ENV = "OPENGROK_NO_MIRROR"
 

--- a/tools/src/main/python/opengrok_tools/projadm.py
+++ b/tools/src/main/python/opengrok_tools/projadm.py
@@ -42,7 +42,8 @@ from .utils.log import get_console_logger, get_class_basename, \
 from .utils.opengrok import get_configuration, set_configuration, \
     add_project, delete_project, get_config_value, get_repos
 from .utils.parsers import get_base_parser, get_headers, add_http_headers
-from .utils.utils import get_command, is_web_uri
+from .utils.utils import get_command
+from .utils.webutil import is_web_uri
 from .utils.exitvals import (
     FAILURE_EXITVAL,
     SUCCESS_EXITVAL

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -41,7 +41,7 @@ from .utils.log import get_console_logger, get_class_basename, fatal
 from .utils.opengrok import list_indexed_projects, get_config_value
 from .utils.parsers import get_base_parser, add_http_headers, get_headers
 from .utils.readconfig import read_config
-from .utils.utils import is_web_uri
+from .utils.webutil import is_web_uri
 from .utils.exitvals import (
     FAILURE_EXITVAL,
     SUCCESS_EXITVAL
@@ -52,7 +52,7 @@ if (major_version < 3):
     print("Need Python 3, you are running {}".format(major_version))
     sys.exit(1)
 
-__version__ = "1.3"
+__version__ = "1.4"
 
 
 def worker(base):

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -96,7 +96,8 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
                                        cleanup=cleanup,
                                        driveon=driveon, url=uri,
                                        http_headers=http_headers,
-                                       api_timeout=timeout)
+                                       api_timeout=timeout,
+                                       async_api_timeout=api_timeout)
         cmds_base.append(cmd_base)
 
     # Map the commands into pool of workers, so they can be processed.

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -69,7 +69,7 @@ def worker(base):
 
 def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
             uri, numworkers, driveon=False, print_output=False, logger=None,
-            http_headers=None, timeout=None):
+            http_headers=None, timeout=None, api_timeout=None):
     """
     Process the list of directories in parallel.
     :param logger: logger to be used in this function
@@ -86,6 +86,7 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
     :param logger: optional logger
     :param http_headers: optional dictionary of HTTP headers
     :param timeout: optional timeout in seconds for API call response
+    :param api_timeout: optional timeout in seconds for async API call duration
     :return SUCCESS_EXITVAL on success, FAILURE_EXITVAL on error
     """
 
@@ -156,6 +157,8 @@ def main():
     parser.add_argument('--api_timeout', type=int, default=3,
                         help='Set response timeout in seconds'
                         'for RESTful API calls')
+    parser.add_argument('--async_api_timeout', type=int, default=300,
+                        help='Set timeout in seconds for asynchronous REST API calls')
     add_http_headers(parser)
 
     try:
@@ -275,7 +278,8 @@ def main():
                         dirs_to_process,
                         ignore_errors, uri, args.workers,
                         driveon=args.driveon, http_headers=headers,
-                        timeout=args.api_timeout)
+                        timeout=args.api_timeout,
+                        api_timeout=args.async_api_timeout)
         except CommandConfigurationException as exc:
             logger.error("Invalid configuration: {}".format(exc))
             return FAILURE_EXITVAL
@@ -289,7 +293,8 @@ def main():
                                 dirs_to_process,
                                 ignore_errors, uri, args.workers,
                                 driveon=args.driveon, http_headers=headers,
-                                timeout=args.api_timeout)
+                                timeout=args.api_timeout,
+                                api_timeout=args.async_api_timeout)
                 except CommandConfigurationException as exc:
                     logger.error("Invalid configuration: {}".format(exc))
                     return FAILURE_EXITVAL

--- a/tools/src/main/python/opengrok_tools/utils/commandsequence.py
+++ b/tools/src/main/python/opengrok_tools/utils/commandsequence.py
@@ -72,7 +72,7 @@ class CommandSequenceBase:
 
     def __init__(self, name, commands, loglevel=logging.INFO, cleanup=None,
                  driveon=False, url=None, env=None, http_headers=None,
-                 api_timeout=None):
+                 api_timeout=None, async_api_timeout=None):
         self.name = name
 
         if commands is None:
@@ -99,6 +99,7 @@ class CommandSequenceBase:
         self.env = env
         self.http_headers = http_headers
         self.api_timeout = api_timeout
+        self.async_api_timeout = async_api_timeout
 
         self.url = url
 
@@ -132,7 +133,8 @@ class CommandSequence(CommandSequenceBase):
                          cleanup=base.cleanup, driveon=base.driveon,
                          url=base.url, env=base.env,
                          http_headers=base.http_headers,
-                         api_timeout=base.api_timeout)
+                         api_timeout=base.api_timeout,
+                         async_api_timeout=base.async_api_timeout)
 
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(base.loglevel)
@@ -169,7 +171,9 @@ class CommandSequence(CommandSequenceBase):
                     call_rest_api(command.get(CALL_PROPERTY),
                                   {PROJECT_SUBST: self.name,
                                    URL_SUBST: self.url},
-                                  self.http_headers, self.api_timeout)
+                                  self.http_headers,
+                                  self.api_timeout,
+                                  self.async_api_timeout)
                 except RequestException as e:
                     self.logger.error("REST API call {} failed: {}".
                                       format(command, e))
@@ -229,7 +233,9 @@ class CommandSequence(CommandSequenceBase):
                     call_rest_api(cleanup_cmd.get(CALL_PROPERTY),
                                   {PROJECT_SUBST: self.name,
                                    URL_SUBST: self.url},
-                                  self.http_headers, self.api_timeout)
+                                  self.http_headers,
+                                  self.api_timeout,
+                                  self.async_api_timeout)
                 except RequestException as e:
                     self.logger.error("API call {} failed: {}".
                                       format(cleanup_cmd, e))

--- a/tools/src/main/python/opengrok_tools/utils/commandsequence.py
+++ b/tools/src/main/python/opengrok_tools/utils/commandsequence.py
@@ -159,7 +159,7 @@ class CommandSequence(CommandSequenceBase):
         by project name, otherwise project name will be appended to the
         argument list of the command.
 
-        Any command entry that is a URI, will be used to submit RESTful API
+        Any command entry that is a URI, will be used to submit REST API
         request.
         """
 

--- a/tools/src/main/python/opengrok_tools/utils/patterns.py
+++ b/tools/src/main/python/opengrok_tools/utils/patterns.py
@@ -18,9 +18,10 @@
 #
 
 #
-# Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 
 PROJECT_SUBST = '%PROJECT%'
 URL_SUBST = '%URL%'
 COMMAND_PROPERTY = "command"
+CALL_PROPERTY = "call"

--- a/tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/tools/src/main/python/opengrok_tools/utils/restful.py
@@ -189,8 +189,8 @@ def call_rest_api(call, substitutions=None, http_headers=None, timeout=None, api
     :param substitutions: dictionary of pattern:value for command and/or
                           data substitution
     :param http_headers: optional dictionary of HTTP headers to be appended
-    :param timeout: optional timeout in seconds for API call response
-    :param api_timeout: optional timeout in seconds for asynchronous API call
+    :param timeout: optional connect/read timeout in seconds for API call
+    :param api_timeout: optional timeout in seconds for total duration of asynchronous API call
     :return value from given requests method
     """
 
@@ -208,9 +208,14 @@ def call_rest_api(call, substitutions=None, http_headers=None, timeout=None, api
     uri = subst(uri, substitutions)
     logger.debug(f"URI after the substitutions: {uri}")
 
+    call_timeout = call.get("timeout")
+    if call_timeout:
+        logger.debug(f"Setting connect/read API timeout based on the call to {call_timeout}")
+        timeout = call_timeout
+
     call_api_timeout = call.get("api_timeout")
     if call_api_timeout:
-        logger.debug(f"Setting API timeout based on the call to {call_api_timeout}")
+        logger.debug(f"Setting async API timeout based on the call to {call_api_timeout}")
         api_timeout = call_api_timeout
 
     if data:

--- a/tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/tools/src/main/python/opengrok_tools/utils/restful.py
@@ -122,6 +122,7 @@ def do_api_call(method, uri, params=None, headers=None, data=None, timeout=None,
         proxies=get_proxies(uri),
         timeout=timeout
     )
+    logger.debug(f"API call result: {r}")
 
     if r is None:
         raise Exception("API call failed")

--- a/tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/tools/src/main/python/opengrok_tools/utils/restful.py
@@ -208,12 +208,12 @@ def call_rest_api(call, substitutions=None, http_headers=None, timeout=None, api
     uri = subst(uri, substitutions)
     logger.debug(f"URI after the substitutions: {uri}")
 
-    call_timeout = call.get("timeout")
+    call_timeout = call.get("api_timeout")
     if call_timeout:
         logger.debug(f"Setting connect/read API timeout based on the call to {call_timeout}")
         timeout = call_timeout
 
-    call_api_timeout = call.get("api_timeout")
+    call_api_timeout = call.get("async_api_timeout")
     if call_api_timeout:
         logger.debug(f"Setting async API timeout based on the call to {call_api_timeout}")
         api_timeout = call_api_timeout

--- a/tools/src/main/python/opengrok_tools/utils/utils.py
+++ b/tools/src/main/python/opengrok_tools/utils/utils.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 
 import os
@@ -26,7 +26,6 @@ from shutil import which
 from logging import log
 import logging
 import sys
-from urllib.parse import urlparse
 from distutils import util
 from .exitvals import (
     FAILURE_EXITVAL,
@@ -114,11 +113,3 @@ def get_bool(logger, name, value):
     except ValueError:
         logger.error("'{}' is not a number: {}".format(name, value))
         return None
-
-
-def is_web_uri(url):
-    """
-    Check if given string is web URL.
-    """
-    o = urlparse(url)
-    return o.scheme in ['http', 'https']

--- a/tools/src/main/python/opengrok_tools/utils/webutil.py
+++ b/tools/src/main/python/opengrok_tools/utils/webutil.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018-2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
 #
 
 from urllib.parse import urlparse
@@ -45,3 +45,11 @@ def get_proxies(url):
         return {'http': None, 'https': None}
     else:
         return None
+
+
+def is_web_uri(url):
+    """
+    Check if given string is web URL.
+    """
+    o = urlparse(url)
+    return o.scheme in ['http', 'https']

--- a/tools/src/test/python/test_command_sequence.py
+++ b/tools/src/test/python/test_command_sequence.py
@@ -33,7 +33,7 @@ from requests.exceptions import HTTPError
 
 from opengrok_tools.utils.commandsequence import CommandSequence, \
     CommandSequenceBase, CommandConfigurationException
-from opengrok_tools.utils.patterns import PROJECT_SUBST, COMMAND_PROPERTY
+from opengrok_tools.utils.patterns import PROJECT_SUBST, CALL_PROPERTY
 
 
 def test_str():
@@ -62,8 +62,7 @@ def test_invalid_configuration_commands_no_command():
         CommandSequence(CommandSequenceBase("foo", [{"command": ['foo']},
                                                     {"foo": "bar"}]))
 
-    assert str(exc_info.value).startswith("command dictionary has no '{}' key".
-                                          format(COMMAND_PROPERTY))
+    assert str(exc_info.value).startswith("command dictionary has unknown key")
 
 
 def test_invalid_configuration_commands_no_list():
@@ -212,7 +211,7 @@ def test_restful_fail(monkeypatch):
 
     commands = CommandSequence(
         CommandSequenceBase("test-cleanup-list",
-                            [{'command': ['http://foo', 'PUT', 'data']}]))
+                            [{CALL_PROPERTY: {"uri": 'http://foo', "method": 'PUT', "data": 'data'}}]))
     assert commands is not None
     with monkeypatch.context() as m:
         m.setattr("requests.put", mock_response)
@@ -225,13 +224,15 @@ def test_headers_init():
 
     # First verify that header parameter of a command does not impact class member.
     commands = CommandSequence(CommandSequenceBase("opengrok-master",
-                                                   [{'command': ['http://foo', 'PUT', 'data', headers]}]))
+                                                   [{CALL_PROPERTY: {"uri": 'http://foo', "method": 'PUT',
+                                                                     "data": 'data', "headers": headers}}]))
 
     assert commands.http_headers is None
 
     # Second, verify that init function propagates the headers.
     commands = CommandSequence(CommandSequenceBase("opengrok-master",
-                                                   [{'command': ['http://foo', 'PUT', 'data']}],
+                                                   [{CALL_PROPERTY: {"uri": 'http://foo',
+                                                                     "method": 'PUT', "data": 'data'}}],
                                                    http_headers=headers))
 
     assert commands.http_headers == headers

--- a/tools/src/test/python/test_command_sequence.py
+++ b/tools/src/test/python/test_command_sequence.py
@@ -81,6 +81,20 @@ def test_invalid_configuration_commands_no_dict():
     assert str(exc_info.value).find("is not a dictionary") != -1
 
 
+def test_timeout_propagation():
+    """
+    Make sure the timeouts propagate from CommandSequenceBase to CommandSequence.
+    """
+    expected_timeout = 11
+    expected_api_timeout = 22
+    cmd_seq_base = CommandSequenceBase("foo", [{"command": ['foo']}],
+                                       api_timeout=expected_timeout,
+                                       async_api_timeout=expected_api_timeout)
+    cmd_seq = CommandSequence(cmd_seq_base)
+    assert cmd_seq.api_timeout == expected_timeout
+    assert cmd_seq.async_api_timeout == expected_api_timeout
+
+
 @pytest.mark.skipif(not os.path.exists('/bin/sh')
                     or not os.path.exists('/bin/echo'),
                     reason="requires Unix")

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -49,7 +49,7 @@ from opengrok_tools.utils.mirror import check_project_configuration, \
     CMD_TIMEOUT_PROPERTY, HOOK_TIMEOUT_PROPERTY, DISABLED_REASON_PROPERTY, \
     INCOMING_PROPERTY, IGNORE_ERR_PROPERTY, HOOK_PRE_PROPERTY, \
     HOOKDIR_PROPERTY, HOOK_POST_PROPERTY, COMMANDS_PROPERTY
-from opengrok_tools.utils.patterns import COMMAND_PROPERTY, PROJECT_SUBST
+from opengrok_tools.utils.patterns import COMMAND_PROPERTY, PROJECT_SUBST, CALL_PROPERTY
 
 
 def test_empty_project_configuration():
@@ -218,9 +218,9 @@ def test_disabled_command_api():
         project_name = "foo"
         config = {
             DISABLED_CMD_PROPERTY: {
-                COMMAND_PROPERTY: [
-                    "http://localhost:8080/source/api/v1/foo",
-                    "POST", "data"]
+                CALL_PROPERTY: {
+                    "uri": "http://localhost:8080/source/api/v1/foo",
+                    "method": "POST", "data": "data"}
             },
             PROJECTS_PROPERTY: {
                 project_name: {DISABLED_PROPERTY: True}
@@ -230,7 +230,7 @@ def test_disabled_command_api():
         assert mirror_project(config, project_name, False, False,
                               None, None) == CONTINUE_EXITVAL
         verify(opengrok_tools.utils.mirror). \
-            call_rest_api(config.get(DISABLED_CMD_PROPERTY),
+            call_rest_api(config.get(DISABLED_CMD_PROPERTY).get(CALL_PROPERTY),
                           {PROJECT_SUBST: project_name},
                           http_headers=None, timeout=None, api_timeout=None)
 

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -230,7 +230,7 @@ def test_disabled_command_api():
         assert mirror_project(config, project_name, False, False,
                               None, None) == CONTINUE_EXITVAL
         verify(opengrok_tools.utils.mirror). \
-            call_rest_api(config.get(DISABLED_CMD_PROPERTY).get(CALL_PROPERTY),
+            call_rest_api(ANY,
                           {PROJECT_SUBST: project_name},
                           http_headers=None, timeout=None, api_timeout=None)
 
@@ -242,14 +242,10 @@ def test_disabled_command_api_text_append(monkeypatch):
 
     text_to_append = "foo bar"
 
-    def mock_call_rest_api(command, b, http_headers=None, timeout=None, api_timeout=None):
-        disabled_command = config.get(DISABLED_CMD_PROPERTY)
-        assert disabled_command
-        command_args = disabled_command.get(COMMAND_PROPERTY)
-        assert command_args
-        data = command_args[2]
+    def mock_call_rest_api(call, b, http_headers=None, timeout=None, api_timeout=None):
+        call_data = call.data
         assert data
-        text = data.get("text")
+        text = call_data.get("text")
         assert text
         assert text.find(text_to_append)
 
@@ -265,9 +261,9 @@ def test_disabled_command_api_text_append(monkeypatch):
                 'text': 'disabled project'}
         config = {
             DISABLED_CMD_PROPERTY: {
-                COMMAND_PROPERTY: [
-                    "http://localhost:8080/source/api/v1/foo",
-                    "POST", data]
+                CALL_PROPERTY: {
+                    "uri": "http://localhost:8080/source/api/v1/foo",
+                    "method": "POST", "data": data}
             },
             PROJECTS_PROPERTY: {
                 project_name: {

--- a/tools/src/test/python/test_restful.py
+++ b/tools/src/test/python/test_restful.py
@@ -131,6 +131,30 @@ def test_headers_timeout(monkeypatch):
                       api_timeout=expected_api_timeout)
 
 
+def test_api_call_timeout_override(monkeypatch):
+    """
+    Test that ApiCall object timeouts override timeouts passed as call_rest_api() arguments.
+    """
+    expected_timeout = 42
+    expected_api_timeout = 24
+
+    call = {"uri": "http://localhost:8080/source/api/v1/bar",
+            "method": "POST", "data": "data",
+            "api_timeout": expected_timeout,
+            "async_api_timeout": expected_api_timeout}
+
+    def mock_do_api_call(verb, uri, **kwargs):
+        assert kwargs['timeout'] == expected_timeout
+        assert kwargs['api_timeout'] == expected_api_timeout
+
+    with monkeypatch.context() as m:
+        m.setattr("opengrok_tools.utils.restful.do_api_call",
+                  mock_do_api_call)
+        call_rest_api(ApiCall(call),
+                      timeout=expected_timeout + 1,
+                      api_timeout=expected_api_timeout + 1)
+
+
 def test_headers_timeout_requests():
     """
     Test that headers and timeout parameters from do_call_api() are passed


### PR DESCRIPTION
Changes the structure of API call configuration for `opengrok-sync` and `opengrok-mirror` to dictionary.

Example configuration for `opengrok-sync`:
```yml
commands:
- call:
    uri: '%URL%/api/v1/messages'
    method: POST
    data:
      messageLevel: warning
      duration: PT1H
      tags: ['%PROJECT%']
      text: resync + reindex in progress
- command: ["/bin/sleep", "60"]
- call:
    uri: '%URL%/api/v1/messages?tag=%PROJECT%'
    method: DELETE
    data: 'resync + reindex in progress'
    headers:
      'Content-type': 'text/plain'
    api_timeout: 3
    async_api_timeout: 30
```

The `api_timeout`/`async_api_timeout` keys override the `--api_timeout`/`--async_api_timeout` options of `opengrok-sync`, respectively.

https://github.com/oracle/opengrok/wiki/Repository-synchronization will have to be updated.