### PR TITLE
make sure Suggester#init() does not receive duplicate entries

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.suggester.provider.service.impl;
 
@@ -331,7 +331,7 @@ public class SuggesterServiceImpl implements SuggesterService {
             return env.getProjectList().stream()
                     .filter(Project::isIndexed)
                     .map(this::getNamedIndexDir)
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toSet());
         } else {
             Path indexDir = Paths.get(env.getDataRootPath(), IndexDatabase.INDEX_DIR);
             return Collections.singleton(new NamedIndexDir("", indexDir));

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest;
 
@@ -35,6 +35,7 @@ import org.apache.lucene.util.BytesRef;
 import org.opengrok.suggest.query.SuggesterPrefixQuery;
 import org.opengrok.suggest.query.SuggesterQuery;
 
+import javax.print.attribute.standard.MediaSize;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -48,6 +49,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -744,6 +746,25 @@ public final class Suggester implements Closeable {
         @Override
         public String toString() {
             return name;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+
+            if (!(obj instanceof NamedIndexDir)) {
+                return false;
+            }
+
+            NamedIndexDir that = (NamedIndexDir) obj;
+            return (this.name.equals(that.name) && this.path.equals(that.path));
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.name, this,path);
         }
     }
 

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -35,7 +35,6 @@ import org.apache.lucene.util.BytesRef;
 import org.opengrok.suggest.query.SuggesterPrefixQuery;
 import org.opengrok.suggest.query.SuggesterQuery;
 
-import javax.print.attribute.standard.MediaSize;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -764,7 +763,7 @@ public final class Suggester implements Closeable {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.name, this,path);
+            return Objects.hash(this.name, this.path);
         }
     }
 

--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest;
 
@@ -60,11 +60,12 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SuggesterTest {
+class SuggesterTest {
 
     private final MeterRegistry registry = new SimpleMeterRegistry();
 
@@ -101,13 +102,13 @@ public class SuggesterTest {
     }
 
     @Test
-    public void testNullSuggesterDir() {
+    void testNullSuggesterDir() {
         assertThrows(IllegalArgumentException.class,
                 () -> new Suggester(null, 10, Duration.ofMinutes(5), false, true, null, Integer.MAX_VALUE, 1, registry));
     }
 
     @Test
-    public void testNullDuration() {
+    void testNullDuration() {
         assertThrows(IllegalArgumentException.class, () -> {
             Path tempFile = Files.createTempFile("opengrok", "test");
             try {
@@ -119,7 +120,7 @@ public class SuggesterTest {
     }
 
     @Test
-    public void testNegativeDuration() {
+    void testNegativeDuration() {
         assertThrows(IllegalArgumentException.class, () -> {
             Path tempFile = Files.createTempFile("opengrok", "test");
             try {
@@ -172,7 +173,7 @@ public class SuggesterTest {
     }
 
     @Test
-    public void testSimpleSuggestions() throws IOException {
+    void testSimpleSuggestions() throws IOException {
         SuggesterTestData t = initSuggester();
 
         Suggester.NamedIndexReader ir = t.getNamedIndexReader();
@@ -187,7 +188,7 @@ public class SuggesterTest {
     }
 
     @Test
-    public void testRefresh() throws IOException {
+    void testRefresh() throws IOException {
         SuggesterTestData t = initSuggester();
 
         addText(t.getIndexDirectory(), "a1 a2");
@@ -206,7 +207,7 @@ public class SuggesterTest {
     }
 
     @Test
-    public void testIndexChangedWhileOffline() throws IOException {
+    void testIndexChangedWhileOffline() throws IOException {
         SuggesterTestData t = initSuggester();
 
         t.s.close();
@@ -233,7 +234,7 @@ public class SuggesterTest {
     }
 
     @Test
-    public void testRemove() throws IOException {
+    void testRemove() throws IOException {
         SuggesterTestData t = initSuggester();
 
         t.s.remove(Collections.singleton("test"));
@@ -245,7 +246,7 @@ public class SuggesterTest {
     }
 
     @Test
-    public void testComplexQuerySearch() throws IOException {
+    void testComplexQuerySearch() throws IOException {
         SuggesterTestData t = initSuggester();
 
         List<LookupResultItem> res = t.s.search(Collections.singletonList(t.getNamedIndexReader()),
@@ -259,7 +260,7 @@ public class SuggesterTest {
 
     @Test
     @SuppressWarnings("unchecked") // for contains()
-    public void testOnSearch() throws IOException {
+    void testOnSearch() throws IOException {
         SuggesterTestData t = initSuggester();
 
         Query q = new BooleanQuery.Builder()
@@ -278,7 +279,7 @@ public class SuggesterTest {
     }
 
     @Test
-    public void testGetSearchCountsForUnknown() throws IOException {
+    void testGetSearchCountsForUnknown() throws IOException {
         SuggesterTestData t = initSuggester();
 
         assertTrue(t.s.getSearchCounts("unknown", "unknown", 0, 10).isEmpty());
@@ -288,7 +289,7 @@ public class SuggesterTest {
 
     @Test
     @SuppressWarnings("unchecked") // for contains()
-    public void testIncreaseSearchCount() throws IOException {
+    void testIncreaseSearchCount() throws IOException {
         SuggesterTestData t = initSuggester();
 
         t.s.increaseSearchCount("test", new Term("test", "term2"), 100, true);
@@ -300,4 +301,10 @@ public class SuggesterTest {
         t.close();
     }
 
+    @Test
+    void testNamedIndexDirEquals() {
+        Suggester.NamedIndexDir namedIndexDir1 = new Suggester.NamedIndexDir("foo", Path.of("/foo"));
+        Suggester.NamedIndexDir namedIndexDir2 = new Suggester.NamedIndexDir("foo", Path.of("/foo"));
+        assertEquals(namedIndexDir1, namedIndexDir2);
+    }
 }

--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
@@ -62,6 +62,7 @@ import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInA
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -306,5 +307,19 @@ class SuggesterTest {
         Suggester.NamedIndexDir namedIndexDir1 = new Suggester.NamedIndexDir("foo", Path.of("/foo"));
         Suggester.NamedIndexDir namedIndexDir2 = new Suggester.NamedIndexDir("foo", Path.of("/foo"));
         assertEquals(namedIndexDir1, namedIndexDir2);
+    }
+
+    @Test
+    void testNamedIndexDirNotEqualsName() {
+        Suggester.NamedIndexDir namedIndexDir1 = new Suggester.NamedIndexDir("foo", Path.of("/foo"));
+        Suggester.NamedIndexDir namedIndexDir2 = new Suggester.NamedIndexDir("bar", Path.of("/foo"));
+        assertNotEquals(namedIndexDir1, namedIndexDir2);
+    }
+
+    @Test
+    void testNamedIndexDirNotEqualsPath() {
+        Suggester.NamedIndexDir namedIndexDir1 = new Suggester.NamedIndexDir("foo", Path.of("/foo"));
+        Suggester.NamedIndexDir namedIndexDir2 = new Suggester.NamedIndexDir("foo", Path.of("/bar"));
+        assertNotEquals(namedIndexDir1, namedIndexDir2);
     }
 }


### PR DESCRIPTION
When writing https://github.com/oracle/opengrok/discussions/3928#discussioncomment-2530471 I realized it would not hurt to be more careful with the collection passed to `Suggester#init()`.