### PR TITLE
remove /system/refresh API endpoint

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -209,17 +209,6 @@ The time is in the ISO 8601 format in UTC time zone.
 
             "2021-02-15T16:39:16.409+00:00"
 
-## Index searchers refresh [/system/refresh]
-
-### refreshes index searchers for specified project [PUT]
-
-+ Request (text/plain)
-  + Body
-
-            project name to refresh
-
-+ Response 204
-
 ## Messages [/messages{?tag}]
 
 ### adds message to a system [POST]

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1486,34 +1486,6 @@ public final class RuntimeEnvironment {
     }
 
     /**
-     * Send message to webapp to refresh SearcherManagers for given projects.
-     * This is used for partial reindex.
-     *
-     * @param subFiles list of directories to refresh corresponding SearcherManagers
-     * @param host the host address to receive the configuration
-     */
-    public void signalTorefreshSearcherManagers(List<String> subFiles, String host) {
-        // subFile entries start with path separator so get basename
-        // to convert them to project names.
-
-        subFiles.stream().map(proj -> new File(proj).getName()).forEach(project -> {
-            Response r = ClientBuilder.newClient()
-                    .target(host)
-                    .path("api")
-                    .path("v1")
-                    .path("system")
-                    .path("refresh")
-                    .request()
-                    .headers(getWebAppHeaders())
-                    .put(Entity.text(project));
-
-            if (r.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
-                LOGGER.log(Level.WARNING, "Could not refresh search manager for {0}", project);
-            }
-        });
-    }
-
-    /**
      * Generate a TreeMap of projects with corresponding repository information.
      * <p>
      * Project with some repository information is considered as a repository

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -385,14 +385,9 @@ public final class Indexer {
 
             writeConfigToFile(env, configFilename);
 
-            // Finally, ping webapp to refresh indexes in the case of partial reindex
-            // or send new configuration to the web application in the case of full reindex.
-            if (webappURI != null) {
-                if (!subFiles.isEmpty()) {
-                    getInstance().refreshSearcherManagers(env, subFiles, webappURI);
-                } else {
-                    getInstance().sendToConfigHost(env, webappURI);
-                }
+            // Finally, send new configuration to the web application in the case of full reindex.
+            if (webappURI != null && subFiles.isEmpty()) {
+                getInstance().sendToConfigHost(env, webappURI);
             }
 
             env.getIndexerParallelizer().bounce();
@@ -1156,12 +1151,6 @@ public final class Indexer {
         elapsed.report(LOGGER, "Done indexing data of all repositories", "indexer.repository.indexing");
 
         CtagsUtil.deleteTempFiles();
-    }
-
-    public void refreshSearcherManagers(RuntimeEnvironment env, List<String> projects, String host) {
-        LOGGER.log(Level.INFO, "Refreshing searcher managers to: {0}", host);
-
-        env.signalTorefreshSearcherManagers(projects, host);
     }
 
     public void sendToConfigHost(RuntimeEnvironment env, String host) {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
@@ -59,14 +59,6 @@ public class SystemController {
     private SuggesterService suggester;
 
     @PUT
-    @Path("/refresh")
-    @Consumes(MediaType.TEXT_PLAIN)
-    public void refresh(final String project) {
-        env.maybeRefreshIndexSearchers(Collections.singleton(project));
-        CompletableFuture.runAsync(() -> suggester.rebuild(project));
-    }
-
-    @PUT
     @Path("/includes/reload")
     public void reloadIncludes() {
         env.getIncludeFiles().reloadIncludeFiles();

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.controller;
 import jakarta.inject.Inject;
@@ -41,10 +41,8 @@ import org.opengrok.indexer.web.PathDescription;
 import org.opengrok.web.api.v1.suggester.provider.service.SuggesterService;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 


### PR DESCRIPTION
The API endpoint is redundant and causes suggester to be rebuilt twice in case of per project handling.