### PR TITLE
add --check_config to opengrok-sync

### DIFF
--- a/tools/src/main/python/opengrok_tools/mirror.py
+++ b/tools/src/main/python/opengrok_tools/mirror.py
@@ -143,7 +143,7 @@ def main():
         return 1
 
     if args.check_config:
-        logger.debug("Configuration check passed, exiting")
+        logger.info("Configuration check passed, exiting")
         return 0
 
     nomirror = os.environ.get(OPENGROK_NO_MIRROR_ENV)

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -103,6 +103,8 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
         cmds_base.append(cmd_base)
 
     if check_config:
+        if not logger:
+            logger = logging.getLogger(__name__)
         logger.info("Configuration check passed")
         return SUCCESS_EXITVAL
 

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -69,7 +69,7 @@ def worker(base):
 
 def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
             uri, numworkers, driveon=False, print_output=False, logger=None,
-            http_headers=None, timeout=None, api_timeout=None):
+            http_headers=None, timeout=None, api_timeout=None, check_config=False):
     """
     Process the list of directories in parallel.
     :param logger: logger to be used in this function
@@ -87,6 +87,7 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
     :param http_headers: optional dictionary of HTTP headers
     :param timeout: optional timeout in seconds for API call response
     :param api_timeout: optional timeout in seconds for async API call duration
+    :param check_config: check configuration and return
     :return SUCCESS_EXITVAL on success, FAILURE_EXITVAL on error
     """
 
@@ -99,6 +100,9 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
                                        api_timeout=timeout,
                                        async_api_timeout=api_timeout)
         cmds_base.append(cmd_base)
+
+    if check_config:
+        return SUCCESS_EXITVAL
 
     # Map the commands into pool of workers, so they can be processed.
     retval = SUCCESS_EXITVAL
@@ -160,6 +164,8 @@ def main():
                         'for RESTful API calls')
     parser.add_argument('--async_api_timeout', type=int, default=300,
                         help='Set timeout in seconds for asynchronous REST API calls')
+    parser.add_argument('--check_config', action='store_true',
+                        help='check configuration and exit')
     add_http_headers(parser)
 
     try:
@@ -280,7 +286,8 @@ def main():
                         ignore_errors, uri, args.workers,
                         driveon=args.driveon, http_headers=headers,
                         timeout=args.api_timeout,
-                        api_timeout=args.async_api_timeout)
+                        api_timeout=args.async_api_timeout,
+                        check_config=args.check_config)
         except CommandConfigurationException as exc:
             logger.error("Invalid configuration: {}".format(exc))
             return FAILURE_EXITVAL
@@ -295,7 +302,8 @@ def main():
                                 ignore_errors, uri, args.workers,
                                 driveon=args.driveon, http_headers=headers,
                                 timeout=args.api_timeout,
-                                api_timeout=args.async_api_timeout)
+                                api_timeout=args.async_api_timeout,
+                                check_config=args.check_config)
                 except CommandConfigurationException as exc:
                     logger.error("Invalid configuration: {}".format(exc))
                     return FAILURE_EXITVAL

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -27,6 +27,7 @@
 """
 
 import argparse
+import logging
 import multiprocessing
 import os
 import sys
@@ -91,6 +92,8 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
     :return SUCCESS_EXITVAL on success, FAILURE_EXITVAL on error
     """
 
+    logger = logging.getLogger(__name__)
+
     cmds_base = []
     for directory in dirs_to_process:
         cmd_base = CommandSequenceBase(directory, commands, loglevel=loglevel,
@@ -102,6 +105,7 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
         cmds_base.append(cmd_base)
 
     if check_config:
+        logger.info("Configuration check passed")
         return SUCCESS_EXITVAL
 
     # Map the commands into pool of workers, so they can be processed.

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -92,8 +92,6 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
     :return SUCCESS_EXITVAL on success, FAILURE_EXITVAL on error
     """
 
-    logger = logging.getLogger(__name__)
-
     cmds_base = []
     for directory in dirs_to_process:
         cmd_base = CommandSequenceBase(directory, commands, loglevel=loglevel,

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -52,7 +52,7 @@ if (major_version < 3):
     print("Need Python 3, you are running {}".format(major_version))
     sys.exit(1)
 
-__version__ = "1.4"
+__version__ = "1.5"
 
 
 def worker(base):

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -92,8 +92,8 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
     """
 
     cmds_base = []
-    for dir in dirs_to_process:
-        cmd_base = CommandSequenceBase(dir, commands, loglevel=loglevel,
+    for directory in dirs_to_process:
+        cmd_base = CommandSequenceBase(directory, commands, loglevel=loglevel,
                                        cleanup=cleanup,
                                        driveon=driveon, url=uri,
                                        http_headers=http_headers,

--- a/tools/src/test/python/test_sync.py
+++ b/tools/src/test/python/test_sync.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+#
+
+import logging
+
+import pytest
+from multiprocessing import pool
+
+from mockito import verify, ANY, patch
+
+from opengrok_tools.sync import do_sync
+from opengrok_tools.utils.exitvals import SUCCESS_EXITVAL, FAILURE_EXITVAL
+
+
+@pytest.mark.parametrize(['check_config', 'expected_times'], [(True, 0), (False, 1)])
+def test_dosync_check_config_empty(check_config, expected_times):
+    commands = []
+    with patch(pool.Pool.map, lambda x, y, z: []):
+        assert do_sync(logging.INFO, commands, None, ["foo", "bar"], [],
+                       "http://localhost:8080/source", 42, check_config=check_config) == SUCCESS_EXITVAL
+        verify(pool.Pool, times=expected_times).map(ANY, ANY, ANY)

--- a/tools/src/test/python/test_sync.py
+++ b/tools/src/test/python/test_sync.py
@@ -31,7 +31,8 @@ from multiprocessing import pool
 from mockito import verify, ANY, patch
 
 from opengrok_tools.sync import do_sync
-from opengrok_tools.utils.exitvals import SUCCESS_EXITVAL, FAILURE_EXITVAL
+from opengrok_tools.utils.commandsequence import CommandConfigurationException
+from opengrok_tools.utils.exitvals import SUCCESS_EXITVAL
 
 
 @pytest.mark.parametrize(['check_config', 'expected_times'], [(True, 0), (False, 1)])
@@ -41,3 +42,10 @@ def test_dosync_check_config_empty(check_config, expected_times):
         assert do_sync(logging.INFO, commands, None, ["foo", "bar"], [],
                        "http://localhost:8080/source", 42, check_config=check_config) == SUCCESS_EXITVAL
         verify(pool.Pool, times=expected_times).map(ANY, ANY, ANY)
+
+
+def test_dosync_check_config_invalid():
+    commands = ["foo"]
+    with pytest.raises(CommandConfigurationException):
+        do_sync(logging.INFO, commands, None, ["foo", "bar"], [],
+                "http://localhost:8080/source", 42, check_config=True)


### PR DESCRIPTION
After releasing 1.7.31 with the incompatible change to the API call configuration (#3924) used by both `opengrok-mirror` and `opengrok-sync`, I realized that only `opengrok-mirror` has an option to check the configuration. This change adds `--check_config` to `opengrok-sync` so they are on par.