### PR TITLE
make sure getHistoryGet() implementations for CVSRepository are aligned

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSRepository.java
@@ -24,8 +24,6 @@
 package org.opengrok.indexer.history;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -319,7 +319,7 @@ public final class HistoryGuru {
     }
 
     /**
-     * Gets a named revision of the specified file into the specified target.
+     * Gets a named revision of the specified file into the specified target file.
      *
      * @param target a require target file
      * @param parent The directory containing the file
@@ -328,12 +328,9 @@ public final class HistoryGuru {
      * @return {@code true} if content was found
      * @throws java.io.IOException if an I/O error occurs
      */
-    public boolean getRevision(File target, String parent, String basename,
-            String rev) throws IOException {
-
+    public boolean getRevision(File target, String parent, String basename, String rev) throws IOException {
         Repository repo = getRepository(new File(parent));
-        return repo != null && repo.getHistoryGet(target, parent,
-                basename, rev);
+        return repo != null && repo.getHistoryGet(target, parent, basename, rev);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -44,6 +44,7 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.jetbrains.annotations.Nullable;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -153,7 +154,7 @@ public abstract class Repository extends RepositoryInfo {
         }
     }
 
-    public Repository() {
+    Repository() {
         super();
         ignoredFiles = new ArrayList<>();
         ignoredDirs = new ArrayList<>();
@@ -225,9 +226,8 @@ public abstract class Repository extends RepositoryInfo {
      * @param revision the revision we expect the oldest entry to have
      * @throws HistoryException if the oldest entry was not the one we expected
      */
-    void removeAndVerifyOldestChangeset(List<HistoryEntry> entries,
-            String revision)
-            throws HistoryException {
+    void removeAndVerifyOldestChangeset(List<HistoryEntry> entries, String revision) throws HistoryException {
+
         HistoryEntry entry = entries.isEmpty() ? null : entries.remove(entries.size() - 1);
 
         // TODO We should check more thoroughly that the changeset is the one
@@ -244,7 +244,7 @@ public abstract class Repository extends RepositoryInfo {
 
     /**
      * Gets the contents of a specific version of a named file, and copies
-     * into the specified target.
+     * into the specified target file.
      *
      * @param target a required target file which will be overwritten
      * @param parent the name of the directory containing the file
@@ -267,6 +267,7 @@ public abstract class Repository extends RepositoryInfo {
      * @param rev the revision to get
      * @return a defined instance if contents were found; or else {@code null}
      */
+    @Nullable
     public InputStream getHistoryGet(String parent, String basename, String rev) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         if (getHistoryGet(out, parent, basename, rev)) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSRepositoryTest.java
@@ -154,9 +154,9 @@ public class CVSRepositoryTest {
         try (FileChannel outChan = new FileOutputStream(mainC, true).getChannel()) {
             outChan.truncate(0);
         }
-        FileWriter fw = new FileWriter(mainC);
-        fw.write("#include <foo.h>\n");
-        fw.close();
+        try (FileWriter fw = new FileWriter(mainC)) {
+            fw.write("#include <foo.h>\n");
+        }
         runCvsCommand(root, "commit", "-m", "change on a branch", "main.c");
 
         // Check that annotation for the changed line has branch revision.

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSRepositoryTest.java
@@ -30,6 +30,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,7 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.CVS;
 
 /**
- *
+ * Tests for {@link CVSRepository} functionality.
  * @author austvik
  */
 @EnabledForRepository(CVS)
@@ -120,7 +122,7 @@ public class CVSRepositoryTest {
     @Test
     void testGetBranchNoBranch() throws Exception {
         setUpTestRepository();
-        File root = new File(repository.getSourceRoot(), "cvs_test/cvsrepo");
+        File root = Path.of(repository.getSourceRoot(), "cvs_test", "cvsrepo").toFile();
         CVSRepository cvsrepo = (CVSRepository) RepositoryFactory.getRepository(root);
         assertNull(cvsrepo.getBranch());
     }
@@ -135,24 +137,23 @@ public class CVSRepositoryTest {
     @Test
     void testNewBranch() throws Exception {
         setUpTestRepository();
-        File root = new File(repository.getSourceRoot(), "cvs_test/cvsrepo");
+        File root = Path.of(repository.getSourceRoot(), "cvs_test", "cvsrepo").toFile();
 
         // Create new branch and switch to it.
         runCvsCommand(root, "tag", "-b", "mybranch");
         // Note that the 'update' command will change the entries in 'cvsroot' directory.
         runCvsCommand(root, "update", "-r", "mybranch");
 
-        // Now the repository object can be instantiated so that determineBranch()
-        // will be called.
+        // Now the repository object can be instantiated and determineBranch() will be called.
         CVSRepository cvsrepo = (CVSRepository) RepositoryFactory.getRepository(root);
 
         assertEquals("mybranch", cvsrepo.getBranch());
 
         // Change the content and commit.
         File mainC = new File(root, "main.c");
-        FileChannel outChan = new FileOutputStream(mainC, true).getChannel();
-        outChan.truncate(0);
-        outChan.close();
+        try (FileChannel outChan = new FileOutputStream(mainC, true).getChannel()) {
+            outChan.truncate(0);
+        }
         FileWriter fw = new FileWriter(mainC);
         fw.write("#include <foo.h>\n");
         fw.close();
@@ -167,6 +168,32 @@ public class CVSRepositoryTest {
         assertEquals("1.2.2.1", mainCHistory.getHistoryEntries().get(0).getRevision());
         assertEquals("1.2", mainCHistory.getHistoryEntries().get(1).getRevision());
         assertEquals("1.1", mainCHistory.getHistoryEntries().get(2).getRevision());
+    }
+
+    @Test
+    void testGetHistoryGet() throws Exception {
+        setUpTestRepository();
+        File root = Path.of(repository.getSourceRoot(), "cvs_test", "cvsrepo").toFile();
+        CVSRepository cvsRepo = (CVSRepository) RepositoryFactory.getRepository(root);
+
+        Path repoRoot = Path.of(repository.getSourceRoot(), "cvs_test", "cvsrepo");
+        assertTrue(repoRoot.toFile().exists());
+        String repoFile = "main.c";
+        String revision = "1.2";
+
+        File tmpFile = File.createTempFile("cvsGetHistoryGetTest", "");
+        assertTrue(tmpFile.exists());
+        try (FileOutputStream out = new FileOutputStream(tmpFile)) {
+            assertTrue(cvsRepo.getHistoryGet(out, repoRoot.toString(), repoFile, revision));
+        }
+
+        String revisionContents1 = new String(Files.readAllBytes(tmpFile.toPath()));
+        tmpFile.delete();
+        assertTrue(revisionContents1.length() > 0);
+
+        String revisionContents2 = new String(cvsRepo.getHistoryGet(repoRoot.toString(), repoFile, revision).
+                readAllBytes());
+        assertEquals(revisionContents1, revisionContents2);
     }
 
     /**


### PR DESCRIPTION
This change transforms the implementation of `CVSRepository#getHistoryGet(String parent, String basename, String rev)` into `CVSRepository#getHistoryGet(OutputStream out, String parent, String basename, String rev)` so that getting contents of older revisions actually works.

This is done because `HistoryGuru#getRevision()` (used by `xref.jsp`) calls the 4-arg version and `CVSRepository` extends `RCSRepository` which implements it.

I did a bit of cleanup in other files as well.