### PR TITLE
return power to the HistoryGuru

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -581,4 +581,9 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
                 return true;
         }
     }
+
+    @Override
+    public String toString() {
+        return getName() + ":indexed=" + isIndexed() + ",history=" + isHistoryEnabled();
+    }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -655,15 +655,12 @@ class FileHistoryCache implements HistoryCache {
     }
 
     /**
-     * Check if the cache is up to date for the specified file.
      * @param file the file to check
-     * @param cachedFile the file which contains the cached history for
-     * the file
-     * @return {@code true} if the cache is up to date, {@code false} otherwise
+     * @param cachedFile the file which contains the cached history for the file
+     * @return {@code true} if the cache is up-to-date for the file, {@code false} otherwise
      */
     private boolean isUpToDate(File file, File cachedFile) {
-        return cachedFile != null && cachedFile.exists() &&
-                file.lastModified() <= cachedFile.lastModified();
+        return cachedFile != null && cachedFile.exists() && file.lastModified() <= cachedFile.lastModified();
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
@@ -57,17 +57,9 @@ interface HistoryCache {
      * @param withFiles A flag saying whether the returned history should include a list of files
      *                  touched by each changeset. If false, the implementation is allowed to skip the file list,
      *                  but it doesn't have to.
-     * @param fallback whether to fall back to {@link Repository#getHistory(File)}
-     *                 if the history cannot be retrieved from the cache
      * @throws HistoryException if the history cannot be fetched
      * @throws ForbiddenSymlinkException if symbolic-link checking encounters
      * an ineligible link
-     */
-    History get(File file, @Nullable Repository repository, boolean withFiles, boolean fallback)
-            throws HistoryException, ForbiddenSymlinkException;
-
-    /**
-     * Usually a wrapper of {@link HistoryCache#get(File, Repository, boolean, boolean)}.
      */
     History get(File file, @Nullable Repository repository, boolean withFiles)
             throws HistoryException, ForbiddenSymlinkException;
@@ -153,8 +145,4 @@ interface HistoryCache {
      * @throws HistoryException if an error occurred while getting the info
      */
     String getInfo() throws HistoryException;
-
-    // Set and query if history index phase is done.
-    void setHistoryIndexDone();
-    boolean isHistoryIndexDone();
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -679,6 +679,12 @@ public final class HistoryGuru {
     }
 
     private void createCacheReal(Collection<Repository> repositories) {
+        if (repositories.isEmpty()) {
+            LOGGER.log(Level.WARNING, "History cache is enabled however the list of repositories is empty. " +
+                    "Either specify the repositories in configuration or let the indexer scan them.");
+            return;
+        }
+
         Statistics elapsed = new Statistics();
         ExecutorService executor = env.getIndexerParallelizer().getHistoryExecutor();
         // Since we know each repository object from the repositories

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -254,15 +254,19 @@ public final class HistoryGuru {
     /**
      * @param file file to get the history entry for
      * @param ui is the request coming from the UI
-     * @return last (newest) history entry for given file or null
+     * @return last (newest) history entry for given file or {@code null}
      * @throws HistoryException if history retrieval failed
      */
     @Nullable
     public HistoryEntry getLastHistoryEntry(File file, boolean ui) throws HistoryException {
+        Statistics statistics = new Statistics();
+        LOGGER.log(Level.FINEST, "started retrieval of last history entry for ''{0}''", file);
         final File dir = file.isDirectory() ? file : file.getParentFile();
         final Repository repository = getRepository(dir);
 
         if (!isRepoHistoryEligible(repository, file, ui)) {
+            LOGGER.log(Level.FINER, "cannot retrieve the last history entry for ''{0}'' in {1} because of settings",
+                    new Object[]{file, repository});
             return null;
         }
 
@@ -282,7 +286,15 @@ public final class HistoryGuru {
             return null;
         }
 
-        return repository.getLastHistoryEntry(file, ui);
+        HistoryEntry lastHistoryEntry = repository.getLastHistoryEntry(file, ui);
+        if (lastHistoryEntry != null) {
+            LOGGER.log(Level.FINEST, "got latest history entry {0} for ''{1}'' using repository {2}",
+                    new Object[]{lastHistoryEntry, file, repository});
+        }
+        statistics.report(LOGGER, Level.FINEST,
+                String.format("finished retrieval of last history entry for '%s' (%s)",
+                        file, lastHistoryEntry != null ? "success" : "fail"), "history.lasthistoryentry");
+        return lastHistoryEntry;
     }
 
     public History getHistory(File file, boolean withFiles, boolean ui) throws HistoryException {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -673,7 +673,7 @@ public final class HistoryGuru {
             elapsed.report(LOGGER, "Done history cache for " + path);
         } else {
             LOGGER.log(Level.WARNING,
-                    "Skipping creation of historycache of {0} repository in {1}: Missing SCM dependencies?",
+                    "Skipping creation of history cache of {0} repository in {1}: Missing SCM dependencies?",
                     new Object[]{type, path});
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -648,7 +648,7 @@ public final class HistoryGuru {
 
         if (!repository.isHistoryEnabled()) {
             LOGGER.log(Level.INFO,
-                    "Skipping history cache creation of {0} repository in {1} and its subdirectories",
+                    "Skipping history cache creation of {0} repository in ''{1}'' and its subdirectories",
                     new Object[]{type, path});
             return;
         }
@@ -700,7 +700,7 @@ public final class HistoryGuru {
             }
         }
 
-        LOGGER.log(Level.INFO, "Creating historycache for {0} repositories",
+        LOGGER.log(Level.INFO, "Creating history cache for {0} repositories",
                 repos2process.size());
         final CountDownLatch latch = new CountDownLatch(repos2process.size());
         for (final Map.Entry<Repository, String> entry : repos2process.entrySet()) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -370,7 +370,11 @@ public final class HistoryGuru {
          * since the history of all files in this repository should have been
          * fetched in the first phase of indexing.
          */
-        if (isHistoryIndexDone() && repository.isHistoryEnabled() && repository.hasHistoryForDirectories()) {
+        if (env.isIndexer() && isHistoryIndexDone() &&
+                repository.isHistoryEnabled() && repository.hasHistoryForDirectories()) {
+            LOGGER.log(Level.FINE, "not getting the history for ''{0}'' in repository {1} as the it supports "
+                    + "history for directories",
+                    new Object[]{file, repository});
             return null;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -97,33 +97,6 @@ public abstract class Repository extends RepositoryInfo {
      */
     abstract boolean hasHistoryForDirectories();
 
-    @Override
-    public String toString() {
-        StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append("{");
-        stringBuilder.append("dir=");
-        stringBuilder.append(this.getDirectoryName());
-        stringBuilder.append(",");
-        stringBuilder.append("type=");
-        stringBuilder.append(getType());
-        stringBuilder.append(",");
-
-        if (!isHistoryEnabled()) {
-            stringBuilder.append("history=off");
-        } else {
-            stringBuilder.append("renamed=");
-            stringBuilder.append(this.isHandleRenamedFiles());
-            stringBuilder.append(",");
-            stringBuilder.append("merge=");
-            stringBuilder.append(this.isMergeCommitsEnabled());
-            stringBuilder.append(",");
-            stringBuilder.append("historyBased=");
-            stringBuilder.append(this.isHistoryBasedReindex());
-        }
-        stringBuilder.append("}");
-        return stringBuilder.toString();
-    }
-
     /**
      * Get the history for the specified file or directory.
      * It is expected that {@link History#getRenamedFiles()} and {@link HistoryEntry#getFiles()} are empty for files.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -366,6 +366,26 @@ public class RepositoryInfo implements Serializable {
 
     @Override
     public String toString() {
-        return type + ":" + directoryNameRelative;
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("{");
+        stringBuilder.append("dir=");
+        stringBuilder.append(this.getDirectoryName());
+        stringBuilder.append(",");
+        stringBuilder.append("type=");
+        stringBuilder.append(getType());
+        stringBuilder.append(",");
+
+        if (!isHistoryEnabled()) {
+            stringBuilder.append("history=off");
+        } else {
+            stringBuilder.append("history=on,");
+            stringBuilder.append("renamed=");
+            stringBuilder.append(this.isHandleRenamedFiles());
+            stringBuilder.append(",");
+            stringBuilder.append("merge=");
+            stringBuilder.append(this.isMergeCommitsEnabled());
+        }
+        stringBuilder.append("}");
+        return stringBuilder.toString();
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -840,7 +840,6 @@ class FileHistoryCacheTest {
     private void checkNoHistoryFetchRepo(String repoName, String filename, boolean hasHistory) throws Exception {
 
         File reposRoot = new File(repositories.getSourceRoot(), repoName);
-        Repository repo = RepositoryFactory.getRepository(reposRoot);
 
         // Make sure the file exists in the repository.
         File repoFile = new File(reposRoot, filename);
@@ -858,7 +857,6 @@ class FileHistoryCacheTest {
     @EnabledForRepository({MERCURIAL, SCCS})
     @Test
     void testNoHistoryFetch() throws Exception {
-        // Do not create history cache for files which do not have it cached.
         env.setFetchHistoryWhenNotInCache(false);
 
         // Pretend we are done with first phase of indexing.

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -860,6 +860,7 @@ class FileHistoryCacheTest {
         env.setFetchHistoryWhenNotInCache(false);
 
         // Pretend we are done with first phase of indexing.
+        env.setIndexer(true);
         HistoryGuru.getInstance().setHistoryIndexDone();
 
         // First try repo with ability to fetch history for directories.

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1291,12 +1291,15 @@ public final class PageConfig {
     @Nullable
     public String getLatestRevision() {
         if (!getEnv().isHistoryEnabled()) {
+            LOGGER.log(Level.FINE, "will not get latest revision for ''{0}'' as history is disabled",
+                    getResourceFile());
             return null;
         }
 
         // Try getting the history revision from the index first.
         String lastRev = getLastRevFromIndex();
         if (lastRev != null) {
+            LOGGER.log(Level.FINEST, "got last revision of ''{0}'' from the index", getResourceFile());
             return lastRev;
         }
 
@@ -1305,7 +1308,7 @@ public final class PageConfig {
         try {
             return getLastRevFromHistory();
         } catch (HistoryException e) {
-            LOGGER.log(Level.WARNING, "cannot get latest revision for {0}", getPath());
+            LOGGER.log(Level.WARNING, "cannot get latest revision for ''{0}'' using history", getPath());
             return null;
         }
     }

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1330,7 +1330,8 @@ public final class PageConfig {
      * w.r.t. last modified time of the file or the last commit ID is not stored in the document.
      */
     @Nullable
-    private String getLastRevFromIndex() {
+    @VisibleForTesting
+    String getLastRevFromIndex() {
         Document doc = null;
         try {
             doc = IndexDatabase.getDocument(getResourceFile());

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opengrok.web.api.v1.controller.HistoryController.getHistoryDTO;
 
 class HistoryControllerTest extends OGKJerseyTest {
@@ -130,6 +131,7 @@ class HistoryControllerTest extends OGKJerseyTest {
                 .get();
         HistoryDTO history = response.readEntity(new GenericType<>() {
         });
+        assertNotNull(history);
         assertEquals(size, history.getEntries().size());
         assertEquals("Kryštof Tulinger <krystof.tulinger@oracle.com>", history.getEntries().get(0).getAuthor());
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -132,7 +132,8 @@ class HistoryControllerTest extends OGKJerseyTest {
                 .queryParam("start", start)
                 .request()
                 .get();
-        HistoryDTO history = response.readEntity(new GenericType<>() {});
+        HistoryDTO history = response.readEntity(new GenericType<>() {
+        });
         assertNotNull(history);
         assertEquals(size, history.getEntries().size());
         assertEquals("Kryštof Tulinger <krystof.tulinger@oracle.com>", history.getEntries().get(0).getAuthor());

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -49,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.opengrok.web.api.v1.controller.HistoryController.getHistoryDTO;
 
-public class HistoryControllerTest extends OGKJerseyTest {
+class HistoryControllerTest extends OGKJerseyTest {
 
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
@@ -96,7 +97,7 @@ public class HistoryControllerTest extends OGKJerseyTest {
     }
 
     @Test
-    public void testHistoryDTOEquals() {
+    void testHistoryDTOEquals() {
         HistoryEntry historyEntry = new HistoryEntry(
                 "1",
                 new Date(1245446973L / 60 * 60 * 1000),
@@ -117,7 +118,7 @@ public class HistoryControllerTest extends OGKJerseyTest {
     }
 
     @Test
-    public void testHistoryGet() throws Exception {
+    void testHistoryGet() throws Exception {
         final String path = "git";
         int size = 5;
         int start = 2;

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -129,8 +129,7 @@ class HistoryControllerTest extends OGKJerseyTest {
                 .queryParam("start", start)
                 .request()
                 .get();
-        HistoryDTO history = response.readEntity(new GenericType<>() {
-        });
+        HistoryDTO history = response.readEntity(new GenericType<>() {});
         assertNotNull(history);
         assertEquals(size, history.getEntries().size());
         assertEquals("Kryštof Tulinger <krystof.tulinger@oracle.com>", history.getEntries().get(0).getAuthor());

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -118,6 +118,9 @@ class HistoryControllerTest extends OGKJerseyTest {
         assertNotEquals(history1, history2);
     }
 
+    /**
+     * This test retrieves history for a directory, which means it will not go through history cache.
+     */
     @Test
     void testHistoryGet() throws Exception {
         final String path = "git";


### PR DESCRIPTION
This change returns power to the `HistoryGuru` w.r.t. fallback to the repository method when getting history. Previously this was done in `FileHistoryCache`, meaning any implementation would have to perform the fallback (and associated checks) which does not make sense. History cache should be just that.

Discovered when looking at #3953 so this also includes metering and logging for fetching last history entry.

