### PR TITLE
match the exact number of dashes when parsing CVS history

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
@@ -82,7 +82,7 @@ class CVSHistoryParser implements Executor.StreamHandler {
                     s = in.readLine();
                 }
             }
-            if (state == ParseState.REVISION && s.startsWith("revision")) {
+            if (state == ParseState.REVISION && s.startsWith("revision ")) {
                 if (entry != null) {
                     entries.add(entry);
                 }
@@ -96,7 +96,7 @@ class CVSHistoryParser implements Executor.StreamHandler {
                 state = ParseState.METADATA;
                 s = in.readLine();
             }
-            if (state == ParseState.METADATA && s.startsWith("date:")) {
+            if (state == ParseState.METADATA && s.startsWith("date: ")) {
                 parseDateAuthor(entry, s);
 
                 state = ParseState.COMMENT;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
@@ -51,8 +51,8 @@ class CVSHistoryParser implements Executor.StreamHandler {
     private CVSRepository cvsRepository = new CVSRepository();
 
    /**
-     * Process the output from the log command and insert the HistoryEntries
-     * into the history field.
+     * Process the output from the log command and insert the {@link HistoryEntry} objects created therein
+     * into the {@link #history} field.
      *
      * @param input The output from the process
      * @throws java.io.IOException If an error occurs while reading the stream

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
@@ -105,7 +105,7 @@ class CVSHistoryParser implements Executor.StreamHandler {
             if (state == ParseState.COMMENT) {
                 if (s.equals("----------------------------")) {
                     state = ParseState.REVISION;
-                } else if (s.startsWith("========")) {
+                } else if (s.equals("=============================================================================")) {
                     state = ParseState.NAMES;
                 } else {
                     if (entry != null) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
@@ -76,23 +76,7 @@ class CVSHistoryParser implements Executor.StreamHandler {
             }
             if (state == ParseState.TAG) {
                 if (s.startsWith("\t")) {
-                    String[] pair = s.trim().split(": ");
-                    if (pair.length != 2) {
-                        //
-                        // Overriding processStream() thus need to comply with the
-                        // set of exceptions it can throw.
-                        //
-                        throw new IOException("Failed to parse tag: '" + s + "'");
-                    } else {
-                        if (tags.containsKey(pair[1])) {
-                            // Join multiple tags for one revision
-                            String oldtag = tags.get(pair[1]);
-                            tags.remove(pair[1]);
-                            tags.put(pair[1], oldtag + " " + pair[0]);
-                        } else {
-                            tags.put(pair[1], pair[0]);
-                        }
-                    }
+                    parseTag(tags, s);
                 } else {
                     state = ParseState.REVISION;
                     s = in.readLine();
@@ -156,6 +140,26 @@ class CVSHistoryParser implements Executor.StreamHandler {
         }
 
         history.setHistoryEntries(entries);
+    }
+
+    private void parseTag(HashMap<String, String> tags, String s) throws IOException {
+        String[] pair = s.trim().split(": ");
+        if (pair.length != 2) {
+            //
+            // Overriding processStream() thus need to comply with the
+            // set of exceptions it can throw.
+            //
+            throw new IOException("Failed to parse tag: '" + s + "'");
+        } else {
+            if (tags.containsKey(pair[1])) {
+                // Join multiple tags for one revision
+                String oldTag = tags.get(pair[1]);
+                tags.remove(pair[1]);
+                tags.put(pair[1], oldTag + " " + pair[0]);
+            } else {
+                tags.put(pair[1], pair[0]);
+            }
+        }
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
@@ -97,26 +97,7 @@ class CVSHistoryParser implements Executor.StreamHandler {
                 s = in.readLine();
             }
             if (state == ParseState.METADATA && s.startsWith("date:")) {
-                for (String pair : s.split(";")) {
-                    String[] keyVal = pair.split(":", 2);
-                    String key = keyVal[0].trim();
-                    String val = keyVal[1].trim();
-
-                    if ("date".equals(key)) {
-                        try {
-                            val = val.replace('/', '-');
-                            entry.setDate(cvsrepo.parse(val));
-                        } catch (ParseException pe) {
-                            //
-                            // Overriding processStream() thus need to comply with the
-                            // set of exceptions it can throw.
-                            //
-                            throw new IOException("Failed to parse date: '" + val + "'", pe);
-                        }
-                    } else if ("author".equals(key)) {
-                        entry.setAuthor(val);
-                    }
-                }
+                parseDateAuthor(entry, s);
 
                 state = ParseState.COMMENT;
                 s = in.readLine();
@@ -140,6 +121,29 @@ class CVSHistoryParser implements Executor.StreamHandler {
         }
 
         history.setHistoryEntries(entries);
+    }
+
+    private void parseDateAuthor(HistoryEntry entry, String s) throws IOException {
+        for (String pair : s.split(";")) {
+            String[] keyVal = pair.split(":", 2);
+            String key = keyVal[0].trim();
+            String val = keyVal[1].trim();
+
+            if ("date".equals(key)) {
+                try {
+                    val = val.replace('/', '-');
+                    entry.setDate(cvsrepo.parse(val));
+                } catch (ParseException pe) {
+                    //
+                    // Overriding processStream() thus need to comply with the
+                    // set of exceptions it can throw.
+                    //
+                    throw new IOException("Failed to parse date: '" + val + "'", pe);
+                }
+            } else if ("author".equals(key)) {
+                entry.setAuthor(val);
+            }
+        }
     }
 
     private void parseTag(HashMap<String, String> tags, String s) throws IOException {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
@@ -138,7 +138,7 @@ class CVSHistoryParser implements Executor.StreamHandler {
                 s = in.readLine();
             }
             if (state == ParseState.COMMENT) {
-                if (s.startsWith("--------")) {
+                if (s.equals("----------------------------")) {
                     state = ParseState.REVISION;
                 } else if (s.startsWith("========")) {
                     state = ParseState.NAMES;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
@@ -210,12 +210,13 @@ class CVSHistoryParser implements Executor.StreamHandler {
     }
 
     /**
-     * Parse the given string.
+     * Parse the given string. Used for testing.
      *
      * @param buffer The string to be parsed
      * @return The parsed history
      * @throws IOException if we fail to parse the buffer
      */
+    @VisibleForTesting
     History parse(String buffer) throws IOException {
         processStream(new ByteArrayInputStream(buffer.getBytes(StandardCharsets.UTF_8)));
         return history;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSHistoryParser.java
@@ -48,7 +48,7 @@ class CVSHistoryParser implements Executor.StreamHandler {
     }
 
     private History history;
-    private CVSRepository cvsrepo = new CVSRepository();
+    private CVSRepository cvsRepository = new CVSRepository();
 
    /**
      * Process the output from the log command and insert the HistoryEntries
@@ -132,7 +132,7 @@ class CVSHistoryParser implements Executor.StreamHandler {
             if ("date".equals(key)) {
                 try {
                     val = val.replace('/', '-');
-                    entry.setDate(cvsrepo.parse(val));
+                    entry.setDate(cvsRepository.parse(val));
                 } catch (ParseException pe) {
                     //
                     // Overriding processStream() thus need to comply with the
@@ -181,13 +181,13 @@ class CVSHistoryParser implements Executor.StreamHandler {
      * Parse the history for the specified file.
      *
      * @param file the file to parse history for
-     * @param repos Pointer to the SubversionRepository
+     * @param repository Pointer to the SubversionRepository
      * @return object representing the file's history
      */
-    History parse(File file, Repository repos) throws HistoryException {
-        cvsrepo = (CVSRepository) repos;
+    History parse(File file, Repository repository) throws HistoryException {
+        cvsRepository = (CVSRepository) repository;
         try {
-            Executor executor = cvsrepo.getHistoryLogExecutor(file);
+            Executor executor = cvsRepository.getHistoryLogExecutor(file);
             int status = executor.exec(true, this);
 
             if (status != 0) {
@@ -202,7 +202,7 @@ class CVSHistoryParser implements Executor.StreamHandler {
         // In case there is a branch, the log entries can be returned in
         // unsorted order (as a result of using '-r1.1:branch' for 'cvs log')
         // so they need to be sorted according to revision.
-        if (cvsrepo.getBranch() != null && !cvsrepo.getBranch().isEmpty()) {
+        if (cvsRepository.getBranch() != null && !cvsRepository.getBranch().isEmpty()) {
             sortHistoryEntries(history);
         }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSHistoryParserTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSHistoryParserTest.java
@@ -34,6 +34,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -171,11 +173,30 @@ class CVSHistoryParserTest {
     void testHistoryForDirectory() throws Exception {
         File repoRoot = setUpTestRepository();
         assertTrue(repoRoot.exists());
+        assertTrue(repoRoot.isDirectory());
         CVSRepository repository = (CVSRepository) RepositoryFactory.getRepository(repoRoot);
         assertNotNull(repository);
         History history = repository.getHistory(repoRoot);
         assertNotNull(history);
         assertNotNull(history.getHistoryEntries());
         assertEquals(3, history.getHistoryEntries().size());
+
+        List<HistoryEntry> entries = List.of(
+                new HistoryEntry("1.1.1.1", new Date(1220544581000L),
+                        "austvik",
+                        "Add files\n", true),
+                new HistoryEntry("1.2", new Date(1220544684000L),
+                        "austvik",
+                        "Added a comment\n", true),
+                new HistoryEntry("1.1", new Date(1220544581000L),
+                        "austvik",
+                        "branches:  1.1.1;\n" +
+                                "Initial revision\n", true)
+                );
+
+        assertEquals(entries.size(), history.getHistoryEntries().size());
+        History expectedHistory = new History(entries);
+        expectedHistory.setTags(Map.of("1.1.1.1", "start"));
+        assertEquals(expectedHistory, history);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSHistoryParserTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/CVSHistoryParserTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @author austvik
  */
-public class CVSHistoryParserTest {
+class CVSHistoryParserTest {
 
     CVSHistoryParser instance;
 
@@ -55,7 +55,7 @@ public class CVSHistoryParserTest {
      * @throws Exception exception
      */
     @Test
-    public void parseEmpty() throws Exception {
+    void parseEmpty() throws Exception {
         History result = instance.parse("");
         assertNotNull(result);
         assertEquals(0, result.getHistoryEntries().size(), "Should not contain any history entries");
@@ -63,11 +63,9 @@ public class CVSHistoryParserTest {
 
     /**
      * Parse something that could come out from the W3C public CVS repository.
-     *
-     * @throws java.lang.Exception
      */
     @Test
-    public void parseALaW3C() throws Exception {
+    void parseALaW3C() throws Exception {
         String revId1 = "1.2";
         String revId2 = "1.2.4.5";
         String revId3 = "1.134";
@@ -104,7 +102,8 @@ public class CVSHistoryParserTest {
                 "date: " + date1 + ";  author: " + author1 +
                 ";  state: Exp;  lines: +6 -2;\n" +
                 "some comment that is\n" +
-                "spanning two lines\n" +
+                "--------\n" +
+                "spanning multiple lines\n" +
                 "==========================================================" +
                 "===================\n";
         History result = instance.parse(output);
@@ -123,7 +122,7 @@ public class CVSHistoryParserTest {
         assertEquals(author1, e2.getAuthor());
         assertEquals(0, e2.getFiles().size());
         assertTrue(e2.getMessage().contains("some"), "Should contain comment of both lines: line 1");
-        assertTrue(e2.getMessage().contains("two"), "Should contain comment of both lines: line 2");
+        assertTrue(e2.getMessage().contains("multiple"), "Should contain comment of both lines: line 2");
 
         assertEquals(Map.of(revId2, tag1), result.getTags());
     }


### PR DESCRIPTION
This change makes the code in `CVSHistoryParser` a bit more resilient. While there I refactored the code and added a test for per directory history.

fixes #957.