### PR TITLE
make index database "optimization" explicit operation

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -167,7 +167,6 @@ public final class Configuration {
     private String reviewPattern;
     private String webappLAF;
     private RemoteSCM remoteScmSupported;
-    private boolean optimizeDatabase;
     private boolean quickContextScan;
 
     private LuceneLockName luceneLocking = LuceneLockName.OFF;
@@ -557,7 +556,6 @@ public final class Configuration {
         setMessageLimit(500);
         setNavigateWindowEnabled(false);
         setNestingMaximum(1);
-        setOptimizeDatabase(true);
         setPluginDirectory(null);
         setPluginStack(new AuthorizationStack(AuthControlFlag.REQUIRED, "default stack"));
         setPrintProgress(false);
@@ -1086,14 +1084,6 @@ public final class Configuration {
 
     public void setRemoteScmSupported(RemoteSCM remoteScmSupported) {
         this.remoteScmSupported = remoteScmSupported;
-    }
-
-    public boolean isOptimizeDatabase() {
-        return optimizeDatabase;
-    }
-
-    public void setOptimizeDatabase(boolean optimizeDatabase) {
-        this.optimizeDatabase = optimizeDatabase;
     }
 
     public LuceneLockName getLuceneLocking() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1085,14 +1085,6 @@ public final class RuntimeEnvironment {
         syncWriteConfiguration(remoteScmSupported, Configuration::setRemoteScmSupported);
     }
 
-    public boolean isOptimizeDatabase() {
-        return syncReadConfiguration(Configuration::isOptimizeDatabase);
-    }
-
-    public void setOptimizeDatabase(boolean optimizeDatabase) {
-        syncWriteConfiguration(optimizeDatabase, Configuration::setOptimizeDatabase);
-    }
-
     public LuceneLockName getLuceneLocking() {
         return syncReadConfiguration(Configuration::getLuceneLocking);
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1812,17 +1812,11 @@ public class IndexDatabase {
                 terms = MultiTerms.getTerms(ireader, QueryBuilder.U);
                 iter = terms.iterator(); // init uid iterator
             }
-            while (iter != null && iter.term() != null) {
-                String value = iter.term().utf8ToString();
-                if (value.isEmpty()) {
-                    iter.next();
-                    continue;
-                }
-
-                files.add(Util.uid2url(value));
-                BytesRef next = iter.next();
-                if (next == null) {
-                    iter = null;
+            BytesRef term;
+            while (iter != null && (term = iter.next()) != null) {
+                String value = term.utf8ToString();
+                if (!value.isEmpty()) {
+                    files.add(Util.uid2url(value));
                 }
             }
         } finally {
@@ -1897,17 +1891,13 @@ public class IndexDatabase {
                 terms = MultiTerms.getTerms(ireader, QueryBuilder.DEFS);
                 iter = terms.iterator(); // init uid iterator
             }
-            while (iter != null && iter.term() != null) {
-                if (iter.docFreq() > 16 && iter.term().utf8ToString().length() > freq) {
-                    LOGGER.warning(iter.term().utf8ToString());
-                }
-                BytesRef next = iter.next();
-                if (next == null) {
-                    iter = null;
+            BytesRef term;
+            while (iter != null && (term = iter.next()) != null) {
+                if (iter.docFreq() > 16 && term.utf8ToString().length() > freq) {
+                    LOGGER.log(Level.WARNING, "{0}", term.utf8ToString());
                 }
             }
         } finally {
-
             if (ireader != null) {
                 try {
                     ireader.close();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -165,7 +165,7 @@ public class IndexDatabase {
     private boolean isCountingDeltas;
     private boolean isWithDirectoryCounts;
     private List<String> directories;
-    private LockFactory lockfact;
+    private LockFactory lockFactory;
     private final BytesRef emptyBR = new BytesRef("");
 
     // Directory where we store indexes
@@ -195,7 +195,7 @@ public class IndexDatabase {
     public IndexDatabase(Project project, IndexDownArgsFactory factory) throws IOException {
         indexDownArgsFactory = factory;
         this.project = project;
-        lockfact = NoLockFactory.INSTANCE;
+        lockFactory = NoLockFactory.INSTANCE;
         initialize();
     }
 
@@ -329,8 +329,8 @@ public class IndexDatabase {
                 }
             }
 
-            lockfact = pickLockFactory(env);
-            indexDirectory = FSDirectory.open(indexDir.toPath(), lockfact);
+            lockFactory = pickLockFactory(env);
+            indexDirectory = FSDirectory.open(indexDir.toPath(), lockFactory);
             pathAccepter = env.getPathAccepter();
             analyzerGuru = new AnalyzerGuru();
             xrefDir = new File(env.getDataRootFile(), XREF_DIR);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -832,18 +832,16 @@ public class IndexDatabase {
         CountDownLatch latch = new CountDownLatch(dbs.size());
         for (IndexDatabase d : dbs) {
             final IndexDatabase db = d;
-            if (db.isDirty()) {
-                parallelizer.getFixedExecutor().submit(() -> {
-                    try {
-                        db.reduceSegmentCount();
-                    } catch (Throwable e) {
-                        LOGGER.log(Level.SEVERE,
-                            "Problem reducing segment count of Lucene index database: ", e);
-                    } finally {
-                        latch.countDown();
-                    }
-                });
-            }
+            parallelizer.getFixedExecutor().submit(() -> {
+                try {
+                    db.reduceSegmentCount();
+                } catch (Throwable e) {
+                    LOGGER.log(Level.SEVERE,
+                        "Problem reducing segment count of Lucene index database: ", e);
+                } finally {
+                    latch.countDown();
+                }
+            });
         }
 
         try {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1853,61 +1853,6 @@ public class IndexDatabase {
         }
     }
 
-    static void listFrequentTokens(List<String> subFiles) throws IOException {
-        final int limit = 4;
-
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (env.hasProjects()) {
-            if (subFiles == null || subFiles.isEmpty()) {
-                for (Project project : env.getProjectList()) {
-                    IndexDatabase db = new IndexDatabase(project);
-                    db.listTokens(limit);
-                }
-            } else {
-                for (String path : subFiles) {
-                    Project project = Project.getProject(path);
-                    if (project == null) {
-                        LOGGER.log(Level.WARNING, "Could not find a project for \"{0}\"", path);
-                    } else {
-                        IndexDatabase db = new IndexDatabase(project);
-                        db.listTokens(limit);
-                    }
-                }
-            }
-        } else {
-            IndexDatabase db = new IndexDatabase();
-            db.listTokens(limit);
-        }
-    }
-
-    public void listTokens(int freq) throws IOException {
-        IndexReader ireader = null;
-        TermsEnum iter = null;
-        Terms terms;
-
-        try {
-            ireader = DirectoryReader.open(indexDirectory);
-            if (ireader.numDocs() > 0) {
-                terms = MultiTerms.getTerms(ireader, QueryBuilder.DEFS);
-                iter = terms.iterator(); // init uid iterator
-            }
-            BytesRef term;
-            while (iter != null && (term = iter.next()) != null) {
-                if (iter.docFreq() > 16 && term.utf8ToString().length() > freq) {
-                    LOGGER.log(Level.WARNING, "{0}", term.utf8ToString());
-                }
-            }
-        } finally {
-            if (ireader != null) {
-                try {
-                    ireader.close();
-                } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "An error occurred while closing index reader", e);
-                }
-            }
-        }
-    }
-
     /**
      * Get an indexReader for the Index database where a given file.
      *

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -637,7 +637,10 @@ public class IndexDatabase {
                 try {
                     if (terms != null) {
                         uidIter = terms.iterator();
-                        TermsEnum.SeekStatus stat = uidIter.seekCeil(new BytesRef(startUid)); //init uid
+                        // The seekCeil() is pretty important because it makes uidIter.term() to become non-null.
+                        // Various indexer methods rely on this when working with the uidIter iterator - rather
+                        // than calling uidIter.next() first thing, they check uidIter.term().
+                        TermsEnum.SeekStatus stat = uidIter.seekCeil(new BytesRef(startUid));
                         if (stat == TermsEnum.SeekStatus.END) {
                             uidIter = null;
                             LOGGER.log(Level.WARNING,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -160,7 +160,7 @@ public class IndexDatabase {
     private CopyOnWriteArrayList<IndexChangedListener> listeners;
     private File dirtyFile;
     private final Object lock = new Object();
-    private boolean dirty;
+    private boolean dirty;  // Whether the index was modified either by adding or removing a document.
     private boolean running;
     private boolean isCountingDeltas;
     private boolean isWithDirectoryCounts;
@@ -1698,6 +1698,7 @@ public class IndexDatabase {
                     }
                 }))).get();
         } catch (InterruptedException | ExecutionException e) {
+            interrupted = true;
             int successCount = successCounter.intValue();
             double successPct = 100.0 * successCount / worksCount;
             String exmsg = String.format("%d successes (%.1f%%) after aborting parallel-indexing",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -874,13 +874,7 @@ public class IndexDatabase {
             wrt.forceMerge(1);
             elapsed.report(LOGGER, String.format("Done reducing number of segments in index%s", projectDetail),
                     "indexer.db.reduceSegments");
-            synchronized (lock) {
-                if (dirtyFile.exists() && !dirtyFile.delete()) {
-                    LOGGER.log(Level.FINE, "Failed to remove \"dirty-file\": {0}",
-                        dirtyFile.getAbsolutePath());
-                }
-                dirty = false;
-            }
+            unsetDirty();
         } catch (IOException e) {
             writerException = e;
             LOGGER.log(Level.SEVERE, "ERROR: reducing number of segments index", e);
@@ -926,6 +920,15 @@ public class IndexDatabase {
             } catch (IOException e) {
                 LOGGER.log(Level.FINE, "When creating dirty file: ", e);
             }
+        }
+    }
+
+    private void unsetDirty() {
+        synchronized (lock) {
+            if (dirtyFile.exists() && !dirtyFile.delete()) {
+                LOGGER.log(Level.FINE, "Failed to remove \"dirty-file\": {0}", dirtyFile.getAbsolutePath());
+            }
+            dirty = false;
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -219,10 +219,11 @@ public class IndexDatabase {
     /**
      * Update the index database for all the projects.
      *
+     * @param clearDirty clear dirty flag of index database(s) in the end
      * @param listener where to signal the changes to the database
      * @throws IOException if an error occurs
      */
-    static CountDownLatch updateAll(IndexChangedListener listener) throws IOException {
+    static CountDownLatch updateAll(boolean clearDirty, IndexChangedListener listener) throws IOException {
 
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         List<IndexDatabase> dbs = new ArrayList<>();
@@ -238,6 +239,9 @@ public class IndexDatabase {
         IndexerParallelizer parallelizer = RuntimeEnvironment.getInstance().getIndexerParallelizer();
         CountDownLatch latch = new CountDownLatch(dbs.size());
         for (IndexDatabase d : dbs) {
+            if (clearDirty) {
+                d.setClearDirtyOnUpdate();
+            }
             final IndexDatabase db = d;
             if (listener != null) {
                 db.addIndexChangedListener(listener);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -1087,7 +1087,7 @@ public final class Indexer {
         IndexerParallelizer parallelizer = env.getIndexerParallelizer();
         final CountDownLatch latch;
         if (subFiles == null || subFiles.isEmpty()) {
-            latch = IndexDatabase.updateAll(progress);
+            latch = IndexDatabase.updateAll(clearDirty, progress);
         } else {
             List<IndexDatabase> dbs = new ArrayList<>();
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -116,7 +116,7 @@ public final class Indexer {
     private static Configuration cfg = null;
     private static boolean checkIndex = false;
     private static boolean runIndex = true;
-    private static boolean optimize = false;
+    private static boolean reduceSegmentCount = false;
     private static boolean addProjects = false;
     private static boolean searchRepositories = false;
     private static boolean bareConfig = false;
@@ -390,8 +390,8 @@ public final class Indexer {
                 getInstance().doIndexerExecution(subFiles, progress);
             }
 
-            if (optimize) {
-                IndexDatabase.optimizeAll();
+            if (reduceSegmentCount) {
+                IndexDatabase.reduceSegmentCountAll();
             }
 
             writeConfigToFile(env, configFilename);
@@ -676,10 +676,10 @@ public final class Indexer {
                     "Maximum depth of nested repositories. Default is 1.").execute(v ->
                     cfg.setNestingMaximum((Integer) v));
 
-            parser.on("-O", "--optimize",
+            parser.on("--reduceSegmentCount",
                     "Reduce the number of segments in each index database. This might ",
                     "(or might not) bring some improved performance.").
-                    execute(v -> { optimize = true; }
+                    execute(v -> { reduceSegmentCount = true; }
             );
 
             parser.on("-o", "--ctagOpts", "=path",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -387,7 +387,7 @@ public final class Indexer {
             // And now index it all.
             if (runIndex) {
                 IndexChangedListener progress = new DefaultIndexChangedListener();
-                getInstance().doIndexerExecution(subFiles, progress);
+                getInstance().doIndexerExecution(!reduceSegmentCount, subFiles, progress);
             }
 
             if (reduceSegmentCount) {
@@ -1074,11 +1074,12 @@ public final class Indexer {
      * by passing source code files through ctags, generating xrefs
      * and storing data from the source files in the index (along with history, if any).
      *
+     * @param clearDirty clear dirty flag of index database(s) in the end
      * @param subFiles index just some subdirectories
      * @param progress object to receive notifications as indexer progress is made
      * @throws IOException if I/O exception occurred
      */
-    public void doIndexerExecution(List<String> subFiles, IndexChangedListener progress) throws IOException {
+    public void doIndexerExecution(boolean clearDirty, List<String> subFiles, IndexChangedListener progress) throws IOException {
         Statistics elapsed = new Statistics();
         LOGGER.info("Starting indexing");
 
@@ -1100,6 +1101,9 @@ public final class Indexer {
                         db = new IndexDatabase();
                     } else {
                         db = new IndexDatabase(project);
+                    }
+                    if (clearDirty) {
+                        db.setClearDirtyOnUpdate();
                     }
                     int idx = dbs.indexOf(db);
                     if (idx != -1) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -679,8 +679,7 @@ public final class Indexer {
             parser.on("--reduceSegmentCount",
                     "Reduce the number of segments in each index database. This might ",
                     "(or might not) bring some improved performance.").
-                    execute(v -> { reduceSegmentCount = true; }
-            );
+                    execute(v -> reduceSegmentCount = true);
 
             parser.on("-o", "--ctagOpts", "=path",
                 "File with extra command line options for ctags.").

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -166,8 +166,6 @@ public final class Indexer {
         List<String> subFiles = RuntimeEnvironment.getInstance().getSubFiles();
         Set<String> subFilesArgs = new HashSet<>();
 
-        boolean createDict = false;
-
         try {
             argv = parseOptions(argv);
 
@@ -375,7 +373,7 @@ public final class Indexer {
                         collect(Collectors.toSet());
             }
             getInstance().prepareIndexer(env, searchPaths, addProjects,
-                    createDict, runIndex, subFiles, new ArrayList<>(repositories));
+                    runIndex, subFiles, new ArrayList<>(repositories));
 
             // Set updated configuration in RuntimeEnvironment. This is called so that repositories discovered
             // in prepareIndexer() are stored in the Configuration used by RuntimeEnvironment.
@@ -964,13 +962,12 @@ public final class Indexer {
     public void prepareIndexer(RuntimeEnvironment env,
                                boolean searchRepositories,
                                boolean addProjects,
-                               boolean createDict,
                                List<String> subFiles,
                                List<String> repositories) throws IndexerException, IOException {
 
         prepareIndexer(env,
                 searchRepositories ? Collections.singleton(env.getSourceRootPath()) : Collections.emptySet(),
-                addProjects, createDict, true, subFiles, repositories);
+                addProjects, true, subFiles, repositories);
     }
 
     /**
@@ -983,7 +980,6 @@ public final class Indexer {
      * @param env runtime environment
      * @param searchPaths list of paths in which to search for repositories
      * @param addProjects if true, add projects
-     * @param createDict if true, create dictionary
      * @param createHistoryCache create history cache flag
      * @param subFiles list of directories
      * @param repositories list of repositories
@@ -991,12 +987,11 @@ public final class Indexer {
      * @throws IOException I/O exception
      */
     public void prepareIndexer(RuntimeEnvironment env,
-            Set<String> searchPaths,
-            boolean addProjects,
-            boolean createDict,
-            boolean createHistoryCache,
-            List<String> subFiles,
-            List<String> repositories) throws IndexerException, IOException {
+                               Set<String> searchPaths,
+                               boolean addProjects,
+                               boolean createHistoryCache,
+                               List<String> subFiles,
+                               List<String> repositories) throws IndexerException, IOException {
 
         if (!env.validateUniversalCtags()) {
             throw new IndexerException("Didn't find Universal Ctags");
@@ -1032,10 +1027,6 @@ public final class Indexer {
                 HistoryGuru.getInstance().createCache();
             }
             LOGGER.info("Done generating history cache");
-        }
-
-        if (createDict) {
-            IndexDatabase.listFrequentTokens(subFiles);
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -385,7 +385,7 @@ public final class Indexer {
             // And now index it all.
             if (runIndex) {
                 IndexChangedListener progress = new DefaultIndexChangedListener();
-                getInstance().doIndexerExecution(!reduceSegmentCount, subFiles, progress);
+                getInstance().doIndexerExecution(subFiles, progress);
             }
 
             if (reduceSegmentCount) {
@@ -1066,12 +1066,11 @@ public final class Indexer {
      * by passing source code files through ctags, generating xrefs
      * and storing data from the source files in the index (along with history, if any).
      *
-     * @param clearDirty clear dirty flag of index database(s) in the end
      * @param subFiles index just some subdirectories
      * @param progress object to receive notifications as indexer progress is made
      * @throws IOException if I/O exception occurred
      */
-    public void doIndexerExecution(boolean clearDirty, List<String> subFiles, IndexChangedListener progress) throws IOException {
+    public void doIndexerExecution(List<String> subFiles, IndexChangedListener progress) throws IOException {
         Statistics elapsed = new Statistics();
         LOGGER.info("Starting indexing");
 
@@ -1079,7 +1078,7 @@ public final class Indexer {
         IndexerParallelizer parallelizer = env.getIndexerParallelizer();
         final CountDownLatch latch;
         if (subFiles == null || subFiles.isEmpty()) {
-            latch = IndexDatabase.updateAll(clearDirty, progress);
+            latch = IndexDatabase.updateAll(progress);
         } else {
             List<IndexDatabase> dbs = new ArrayList<>();
 
@@ -1093,9 +1092,6 @@ public final class Indexer {
                         db = new IndexDatabase();
                     } else {
                         db = new IndexDatabase(project);
-                    }
-                    if (clearDirty) {
-                        db.setClearDirtyOnUpdate();
                     }
                     int idx = dbs.indexOf(db);
                     if (idx != -1) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -677,8 +677,9 @@ public final class Indexer {
                     cfg.setNestingMaximum((Integer) v));
 
             parser.on("--reduceSegmentCount",
-                    "Reduce the number of segments in each index database. This might ",
-                    "(or might not) bring some improved performance.").
+                    "Reduce the number of segments in each index database to 1. This might ",
+                    "(or might not) bring some improved performance. Anyhow, this operation",
+                    "takes non-trivial time to complete.").
                     execute(v -> reduceSegmentCount = true);
 
             parser.on("-o", "--ctagOpts", "=path",

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.executables;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.executables;
@@ -76,7 +76,7 @@ public class JarAnalyzerTest {
         env.setHistoryEnabled(false);
         IndexChangedListener progress = new DefaultIndexChangedListener();
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, null);
+                null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
 
         Indexer.getInstance().doIndexerExecution(true, null, progress);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.executables;
@@ -79,7 +79,7 @@ public class JarAnalyzerTest {
                 false, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
 
-        Indexer.getInstance().doIndexerExecution(true, null, progress);
+        Indexer.getInstance().doIndexerExecution(null, progress);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
@@ -79,7 +79,7 @@ public class JarAnalyzerTest {
                 null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
 
-        Indexer.getInstance().doIndexerExecution(true, null, progress);
+        Indexer.getInstance().doIndexerExecution(null, progress);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
@@ -79,7 +79,7 @@ public class JarAnalyzerTest {
                 false, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
 
-        Indexer.getInstance().doIndexerExecution(null, progress);
+        Indexer.getInstance().doIndexerExecution(true, null, progress);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
@@ -402,14 +402,6 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    void testOptimizeDatabase() {
-        RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
-        assertTrue(instance.isOptimizeDatabase());
-        instance.setOptimizeDatabase(false);
-        assertFalse(instance.isOptimizeDatabase());
-    }
-
-    @Test
     void testUsingLuceneLocking() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertEquals(LuceneLockName.OFF, instance.getLuceneLocking());

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -97,7 +97,7 @@ class IndexCheckTest {
         configuration.setProjectsEnabled(projectsEnabled);
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         IndexCheck.check(configuration, subFiles);
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -97,7 +97,7 @@ class IndexCheckTest {
         configuration.setProjectsEnabled(projectsEnabled);
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
-        Indexer.getInstance().doIndexerExecution(null, null);
+        Indexer.getInstance().doIndexerExecution(true, null, null);
 
         IndexCheck.check(configuration, subFiles);
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -97,7 +97,7 @@ class IndexCheckTest {
         configuration.setProjectsEnabled(projectsEnabled);
         Indexer.getInstance().prepareIndexer(env, true, true,
                 null, null);
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         IndexCheck.check(configuration, subFiles);
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -96,7 +96,7 @@ class IndexCheckTest {
         env.setProjectsEnabled(projectsEnabled);
         configuration.setProjectsEnabled(projectsEnabled);
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, null);
+                null, null);
         Indexer.getInstance().doIndexerExecution(true, null, null);
 
         IndexCheck.check(configuration, subFiles);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
@@ -208,7 +208,7 @@ public class IndexDatabaseSymlinksTest {
         Indexer indexer = Indexer.getInstance();
         indexer.prepareIndexer(env, true, true, false, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        indexer.doIndexerExecution(null, null);
+        indexer.doIndexerExecution(true, null, null);
     }
 
     private void assertSymlinkAsExpected(String message, File expectedCanonical, Path symlink)

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -206,7 +206,7 @@ public class IndexDatabaseSymlinksTest {
 
     private static void runIndexer() throws IndexerException, IOException {
         Indexer indexer = Indexer.getInstance();
-        indexer.prepareIndexer(env, true, true, false, null, null);
+        indexer.prepareIndexer(env, true, true, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
         indexer.doIndexerExecution(true, null, null);
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
@@ -208,7 +208,7 @@ public class IndexDatabaseSymlinksTest {
         Indexer indexer = Indexer.getInstance();
         indexer.prepareIndexer(env, true, true, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        indexer.doIndexerExecution(true, null, null);
+        indexer.doIndexerExecution(null, null);
     }
 
     private void assertSymlinkAsExpected(String message, File expectedCanonical, Path symlink)

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseSymlinksTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -208,7 +208,7 @@ public class IndexDatabaseSymlinksTest {
         Indexer indexer = Indexer.getInstance();
         indexer.prepareIndexer(env, true, true, false, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        indexer.doIndexerExecution(true, null, null);
+        indexer.doIndexerExecution(null, null);
     }
 
     private void assertSymlinkAsExpected(String message, File expectedCanonical, Path symlink)

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -152,7 +152,7 @@ class IndexDatabaseTest {
 
         env.setDefaultProjectsFromNames(new TreeSet<>(Arrays.asList("/c")));
 
-        indexer.doIndexerExecution(null, null);
+        indexer.doIndexerExecution(true, null, null);
 
         env.clearFileCollector();
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -152,7 +152,7 @@ class IndexDatabaseTest {
 
         env.setDefaultProjectsFromNames(new TreeSet<>(Arrays.asList("/c")));
 
-        indexer.doIndexerExecution(true, null, null);
+        indexer.doIndexerExecution(null, null);
 
         env.clearFileCollector();
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -142,7 +142,7 @@ class IndexDatabaseTest {
         indexer = Indexer.getInstance();
         indexer.prepareIndexer(
                 env, true, true,
-                false, null, null);
+                null, null);
 
         // Reset the state of the git project w.r.t. history based reindex.
         // It is the responsibility of each test that relies on the per project tunable
@@ -470,7 +470,7 @@ class IndexDatabaseTest {
         HistoryGuru.getInstance().clear();
         indexer.prepareIndexer(
                 env, true, true,
-                false, List.of("/git"), null);
+                List.of("/git"), null);
         env.generateProjectRepositoriesMap();
 
         // Check history cache w.r.t. the merge changeset.
@@ -590,7 +590,7 @@ class IndexDatabaseTest {
         HistoryGuru.getInstance().clear();
         indexer.prepareIndexer(
                 env, true, true,
-                false, List.of("/git"), null);
+                List.of("/git"), null);
         env.setRepositories(new ArrayList<>(HistoryGuru.getInstance().getRepositories()));
         env.generateProjectRepositoriesMap();
 
@@ -644,7 +644,7 @@ class IndexDatabaseTest {
         // for the 2nd stage of indexing.
         indexer.prepareIndexer(
                 env, true, true,
-                false, List.of("/git"), null);
+                List.of("/git"), null);
 
         // Verify the collected files.
         FileCollector fileCollector = env.getFileCollector("git");
@@ -678,7 +678,7 @@ class IndexDatabaseTest {
         HistoryGuru.getInstance().clear();
         indexer.prepareIndexer(
                 env, true, true,
-                false, List.of("/git"), null);
+                List.of("/git"), null);
         env.generateProjectRepositoriesMap();
 
         verifyIndexDown(gitProject, historyBased);
@@ -699,7 +699,7 @@ class IndexDatabaseTest {
         HistoryGuru.getInstance().clear();
         indexer.prepareIndexer(
                 env, true, true,
-                false, List.of("/git"), null);
+                List.of("/git"), null);
         env.generateProjectRepositoriesMap();
 
         verifyIndexDown(gitProject, true);
@@ -734,7 +734,7 @@ class IndexDatabaseTest {
         // Re-generate the history cache so that the git repository is ready for history based re-index.
         indexer.prepareIndexer(
                 env, true, true,
-                false, List.of("/git"), null);
+                List.of("/git"), null);
         env.generateProjectRepositoriesMap();
 
         // Emulate forcing reindex from scratch.

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerRepoTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerRepoTest.java
@@ -100,7 +100,7 @@ class IndexerRepoTest {
                 env,
                 true, // search for repositories
                 true, // scan and add projects
-                false, // don't create dictionary
+                // don't create dictionary
                 null, // subFiles - not needed since we don't list files
                 null); // repositories - not needed when not refreshing history
         env.generateProjectRepositoriesMap();
@@ -165,7 +165,7 @@ class IndexerRepoTest {
                 env,
                 true, // search for repositories
                 true, // scan and add projects
-                false, // don't create dictionary
+                // don't create dictionary
                 null, // subFiles - not needed since we don't list files
                 null); // repositories - not needed when not refreshing history
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -105,7 +105,7 @@ public class IndexerTest {
         env.setHistoryEnabled(false);
         Indexer.getInstance().prepareIndexer(env, true, true,
                 null, null);
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         // There should be certain number of xref files produced.
         List<String> result = null;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -105,7 +105,7 @@ public class IndexerTest {
         env.setHistoryEnabled(false);
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
-        Indexer.getInstance().doIndexerExecution(null, null);
+        Indexer.getInstance().doIndexerExecution(true, null, null);
 
         // There should be certain number of xref files produced.
         List<String> result = null;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, Ric Harris <harrisric@users.noreply.github.com>.
  */
@@ -105,7 +105,7 @@ public class IndexerTest {
         env.setHistoryEnabled(false);
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         // There should be certain number of xref files produced.
         List<String> result = null;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, Ric Harris <harrisric@users.noreply.github.com>.
  */
@@ -104,7 +104,7 @@ public class IndexerTest {
         env.setDataRoot(repository.getDataRoot());
         env.setHistoryEnabled(false);
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, null);
+                null, null);
         Indexer.getInstance().doIndexerExecution(true, null, null);
 
         // There should be certain number of xref files produced.
@@ -150,7 +150,7 @@ public class IndexerTest {
                 env,
                 false, // don't search for repositories
                 true, // scan and add projects
-                false, // don't create dictionary
+                // don't create dictionary
                 null, // subFiles - not needed since we don't list files
                 null); // repositories - not needed when not refreshing history
 
@@ -337,7 +337,7 @@ public class IndexerTest {
 
         // Create history cache.
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, List.of("mercurial"));
+                null, List.of("mercurial"));
         File historyFile = new File(env.getDataRootPath(),
                 TandemPath.join("historycache" + path, ".gz"));
         assertTrue(historyFile.exists(), String.format("history cache for %s has to exist", path));
@@ -503,7 +503,7 @@ public class IndexerTest {
         env.setDataRoot(repository.getDataRoot());
         env.setHistoryEnabled(false);
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, null);
+                null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
         assertEquals(1, env.getDefaultProjects().size());
         assertEquals(new TreeSet<>(Collections.singletonList("c")),
@@ -528,7 +528,7 @@ public class IndexerTest {
         projectSet.add("/no-project-x32ds1");
 
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, null);
+                null, null);
         env.setDefaultProjectsFromNames(projectSet);
         assertEquals(4, env.getDefaultProjects().size());
         assertEquals(new TreeSet<>(Arrays.asList("lisp", "pascal", "perl", "data")),
@@ -552,7 +552,7 @@ public class IndexerTest {
         defaultProjects.add("/no-project-x32ds1");
 
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, null);
+                null, null);
         env.setDefaultProjectsFromNames(defaultProjects);
         Set<String> projects = new TreeSet<>(Arrays.asList(new File(repository.getSourceRoot()).list()));
         assertEquals(projects.size(), env.getDefaultProjects().size());

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, Ric Harris <harrisric@users.noreply.github.com>.
  */

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search;
@@ -69,7 +69,7 @@ public class SearchEngineTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search;
@@ -67,7 +67,7 @@ public class SearchEngineTest {
         env.setHistoryEnabled(false);
 
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, null);
+                null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
         Indexer.getInstance().doIndexerExecution(true, null, null);
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -69,7 +69,7 @@ public class SearchEngineTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -69,7 +69,7 @@ public class SearchEngineTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        Indexer.getInstance().doIndexerExecution(null, null);
+        Indexer.getInstance().doIndexerExecution(true, null, null);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;
@@ -79,7 +79,7 @@ class SearchAndContextFormatterTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
@@ -79,7 +79,7 @@ class SearchAndContextFormatterTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        Indexer.getInstance().doIndexerExecution(null, null);
+        Indexer.getInstance().doIndexerExecution(true, null, null);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;
@@ -77,7 +77,7 @@ class SearchAndContextFormatterTest {
         env.setDataRoot(repository.getDataRoot());
         env.setHistoryEnabled(false);
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, null);
+                null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
         Indexer.getInstance().doIndexerExecution(true, null, null);
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
@@ -79,7 +79,7 @@ class SearchAndContextFormatterTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
@@ -128,7 +128,7 @@ public class SearchAndContextFormatterTest2 {
         assertNotNull(proj1, "symlink1 project");
         proj1.setTabSize(TABSIZE);
 
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
@@ -128,7 +128,7 @@ public class SearchAndContextFormatterTest2 {
         assertNotNull(proj1, "symlink1 project");
         proj1.setTabSize(TABSIZE);
 
-        Indexer.getInstance().doIndexerExecution(null, null);
+        Indexer.getInstance().doIndexerExecution(true, null, null);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;
@@ -128,7 +128,7 @@ public class SearchAndContextFormatterTest2 {
         assertNotNull(proj1, "symlink1 project");
         proj1.setTabSize(TABSIZE);
 
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         configFile = File.createTempFile("configuration", ".xml");
         env.writeConfiguration(configFile);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest2.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;
@@ -121,7 +121,7 @@ public class SearchAndContextFormatterTest2 {
 
         env.setHistoryEnabled(false);
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, null);
+                null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
 
         Project proj1 = env.getProjects().get(SYMLINK1);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
@@ -74,7 +74,7 @@ class SearchHelperTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
     }
 
     private SearchHelper getSearchHelper(String searchTerm) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
@@ -72,7 +72,7 @@ class SearchHelperTest {
         System.out.println("Generating index by using the class methods");
 
         Indexer.getInstance().prepareIndexer(env, true, true,
-            false, null, null);
+                null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
         Indexer.getInstance().doIndexerExecution(true, null, null);
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
@@ -74,7 +74,7 @@ class SearchHelperTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
             false, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        Indexer.getInstance().doIndexerExecution(null, null);
+        Indexer.getInstance().doIndexerExecution(true, null, null);
     }
 
     private SearchHelper getSearchHelper(String searchTerm) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
@@ -74,7 +74,7 @@ class SearchHelperTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
             false, null, null);
         env.setDefaultProjectsFromNames(new TreeSet<>(Collections.singletonList("/c")));
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
     }
 
     private SearchHelper getSearchHelper(String searchTerm) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -671,7 +671,6 @@ public class UtilTest {
                 env,
                 true, // search for repositories
                 true, // scan and add projects
-                false, // don't create dictionary
                 null, // subFiles - not needed since we don't list files
                 null); // repositories - not needed when not refreshing history
         env.generateProjectRepositoriesMap();

--- a/opengrok-web/src/test/java/org/opengrok/web/DiffTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/DiffTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web;
 
@@ -62,7 +62,7 @@ class DiffTest {
                 env,
                 true, // search for repositories
                 true, // scan and add projects
-                false, // don't create dictionary
+                // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
     }

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -333,7 +333,7 @@ public class PageConfigTest {
                 env,
                 true, // search for repositories
                 true, // scan and add projects
-                false, // don't create dictionary
+                // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
         indexer.doIndexerExecution(true, null, null);

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -336,7 +336,7 @@ public class PageConfigTest {
                 false, // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
-        indexer.doIndexerExecution(null, null);
+        indexer.doIndexerExecution(true, null, null);
 
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
             @Override

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -336,7 +336,7 @@ public class PageConfigTest {
                 // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
-        indexer.doIndexerExecution(true, null, null);
+        indexer.doIndexerExecution(null, null);
 
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
             @Override

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -336,7 +336,7 @@ public class PageConfigTest {
                 false, // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
-        indexer.doIndexerExecution(true, null, null);
+        indexer.doIndexerExecution(null, null);
 
         DummyHttpServletRequest req1 = new DummyHttpServletRequest() {
             @Override

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/AnnotationControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/AnnotationControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -78,7 +78,7 @@ public class AnnotationControllerTest extends OGKJerseyTest {
                 env,
                 true, // search for repositories
                 true, // scan and add projects
-                false, // don't create dictionary
+                // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
     }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
@@ -73,7 +73,7 @@ public class FileControllerTest extends OGKJerseyTest {
                 false, // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
-        Indexer.getInstance().doIndexerExecution(true, Collections.singletonList("/git"), null);
+        Indexer.getInstance().doIndexerExecution(Collections.singletonList("/git"), null);
     }
 
     @AfterEach

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
@@ -74,7 +74,7 @@ public class FileControllerTest extends OGKJerseyTest {
                 // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
-        Indexer.getInstance().doIndexerExecution(true, Collections.singletonList("/git"), null);
+        Indexer.getInstance().doIndexerExecution(Collections.singletonList("/git"), null);
     }
 
     @AfterEach

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
@@ -73,7 +73,7 @@ public class FileControllerTest extends OGKJerseyTest {
                 false, // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
-        Indexer.getInstance().doIndexerExecution(Collections.singletonList("/git"), null);
+        Indexer.getInstance().doIndexerExecution(true, Collections.singletonList("/git"), null);
     }
 
     @AfterEach

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -70,7 +71,7 @@ public class FileControllerTest extends OGKJerseyTest {
                 env,
                 true, // search for repositories
                 true, // scan and add projects
-                false, // don't create dictionary
+                // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
         Indexer.getInstance().doIndexerExecution(true, Collections.singletonList("/git"), null);

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -79,7 +79,7 @@ class HistoryControllerTest extends OGKJerseyTest {
                 env,
                 true, // search for repositories
                 true, // scan and add projects
-                false, // don't create dictionary
+                // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
     }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
@@ -317,7 +317,7 @@ class ProjectsControllerTest extends OGKJerseyTest {
                 false, // don't create dictionary
                 subFiles, // subFiles - needed when refreshing history partially
                 repos); // repositories - needed when refreshing history partially
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         for (String proj : projectsToDelete) {
             deleteProject(proj);
@@ -588,7 +588,7 @@ class ProjectsControllerTest extends OGKJerseyTest {
                 false, // don't create dictionary
                 new ArrayList<>(), // subFiles - needed when refreshing history partially
                 new ArrayList<>()); // repositories - needed when refreshing history partially
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         List<String> filesFromRequest = target("projects")
                 .path(projectName)

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
@@ -317,7 +317,7 @@ class ProjectsControllerTest extends OGKJerseyTest {
                 false, // don't create dictionary
                 subFiles, // subFiles - needed when refreshing history partially
                 repos); // repositories - needed when refreshing history partially
-        Indexer.getInstance().doIndexerExecution(null, null);
+        Indexer.getInstance().doIndexerExecution(true, null, null);
 
         for (String proj : projectsToDelete) {
             deleteProject(proj);
@@ -588,7 +588,7 @@ class ProjectsControllerTest extends OGKJerseyTest {
                 false, // don't create dictionary
                 new ArrayList<>(), // subFiles - needed when refreshing history partially
                 new ArrayList<>()); // repositories - needed when refreshing history partially
-        Indexer.getInstance().doIndexerExecution(null, null);
+        Indexer.getInstance().doIndexerExecution(true, null, null);
 
         List<String> filesFromRequest = target("projects")
                 .path(projectName)

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
@@ -314,7 +314,7 @@ class ProjectsControllerTest extends OGKJerseyTest {
                 env,
                 false, // don't search for repositories
                 false, // don't scan and add projects
-                false, // don't create dictionary
+                // don't create dictionary
                 subFiles, // subFiles - needed when refreshing history partially
                 repos); // repositories - needed when refreshing history partially
         Indexer.getInstance().doIndexerExecution(true, null, null);
@@ -585,7 +585,7 @@ class ProjectsControllerTest extends OGKJerseyTest {
                 env,
                 false, // don't search for repositories
                 true, // add projects
-                false, // don't create dictionary
+                // don't create dictionary
                 new ArrayList<>(), // subFiles - needed when refreshing history partially
                 new ArrayList<>()); // repositories - needed when refreshing history partially
         Indexer.getInstance().doIndexerExecution(true, null, null);

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
@@ -317,7 +317,7 @@ class ProjectsControllerTest extends OGKJerseyTest {
                 // don't create dictionary
                 subFiles, // subFiles - needed when refreshing history partially
                 repos); // repositories - needed when refreshing history partially
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         for (String proj : projectsToDelete) {
             deleteProject(proj);
@@ -588,7 +588,7 @@ class ProjectsControllerTest extends OGKJerseyTest {
                 // don't create dictionary
                 new ArrayList<>(), // subFiles - needed when refreshing history partially
                 new ArrayList<>()); // repositories - needed when refreshing history partially
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         List<String> filesFromRequest = target("projects")
                 .path(projectName)

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/RepositoriesControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/RepositoriesControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -102,7 +102,7 @@ public class RepositoriesControllerTest extends OGKJerseyTest {
                 env,
                 true, // search for repositories
                 true, // scan and add projects
-                false, // don't create dictionary
+                // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -70,7 +70,7 @@ public class SuggesterControllerProjectsDisabledTest extends OGKJerseyTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
         env.setDefaultProjectsFromNames(Collections.singleton("__all__"));
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         env.getSuggesterConfig().setRebuildCronConfig(null);
     }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -68,7 +68,7 @@ public class SuggesterControllerProjectsDisabledTest extends OGKJerseyTest {
         env.setProjectsEnabled(false);
         env.setSourceRoot(repository.getSourceRoot() + File.separator + "java");
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, null);
+                null, null);
         env.setDefaultProjectsFromNames(Collections.singleton("__all__"));
         Indexer.getInstance().doIndexerExecution(true, null, null);
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
@@ -70,7 +70,7 @@ public class SuggesterControllerProjectsDisabledTest extends OGKJerseyTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
         env.setDefaultProjectsFromNames(Collections.singleton("__all__"));
-        Indexer.getInstance().doIndexerExecution(null, null);
+        Indexer.getInstance().doIndexerExecution(true, null, null);
 
         env.getSuggesterConfig().setRebuildCronConfig(null);
     }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
@@ -70,7 +70,7 @@ public class SuggesterControllerProjectsDisabledTest extends OGKJerseyTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 null, null);
         env.setDefaultProjectsFromNames(Collections.singleton("__all__"));
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         env.getSuggesterConfig().setRebuildCronConfig(null);
     }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -107,7 +107,7 @@ public class SuggesterControllerTest extends OGKJerseyTest {
         env.setHistoryEnabled(false);
         env.setProjectsEnabled(true);
         Indexer.getInstance().prepareIndexer(env, true, true,
-                false, null, null);
+                null, null);
         env.setDefaultProjectsFromNames(Collections.singleton("__all__"));
         Indexer.getInstance().doIndexerExecution(true, null, null);
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -109,7 +109,7 @@ public class SuggesterControllerTest extends OGKJerseyTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 null, null);
         env.setDefaultProjectsFromNames(Collections.singleton("__all__"));
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         env.getSuggesterConfig().setRebuildCronConfig(null);
     }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -109,7 +109,7 @@ public class SuggesterControllerTest extends OGKJerseyTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
         env.setDefaultProjectsFromNames(Collections.singleton("__all__"));
-        Indexer.getInstance().doIndexerExecution(true, null, null);
+        Indexer.getInstance().doIndexerExecution(null, null);
 
         env.getSuggesterConfig().setRebuildCronConfig(null);
     }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -109,7 +109,7 @@ public class SuggesterControllerTest extends OGKJerseyTest {
         Indexer.getInstance().prepareIndexer(env, true, true,
                 false, null, null);
         env.setDefaultProjectsFromNames(Collections.singleton("__all__"));
-        Indexer.getInstance().doIndexerExecution(null, null);
+        Indexer.getInstance().doIndexerExecution(true, null, null);
 
         env.getSuggesterConfig().setRebuildCronConfig(null);
     }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;


### PR DESCRIPTION
This change removes the automatic index "optimization" (a.k.a. reduction of segment count for given index to 1) at the end of the indexing. The outcome is reduced indexing time - indexing [linux kernel repo](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git) with history off takes 06:49 minutes, out of which 50 seconds is the "optimization" step; with the step off, the indexing time is 6:03 minutes, which means 12 % improvement. On the other hand, it might theoretically slow down the search a bit and also the index size might increase - in multi segment index, each segment typically contains deleted documents. These are expunged on segment merge which happens during indexing. Comparing the size of the index of the linux kernel repository without and with the changes, there is no significant difference - in both cases the index directory had 1.5 GB (the real difference was some 45 MB) and there were 16 segments at the end of the indexing in the changed case. The number of the segments is not the same for each reindex of the same data due to the parallel nature of the indexing.

While this might seem as a overturn to the less optimal handling, it just normalizes the situation - Lucene documents consider the reduction to single segment to be extreme and useful only for long term index archival. The other alternative would be to reduce the segments to some other number however that would be highly dependent on given index. To address the search latency, I plan to submit a PR that will create [`IndexSearcher`](https://lucene.apache.org/core/8_8_1/core/org/apache/lucene/search/IndexSearcher.html#IndexSearcher-org.apache.lucene.index.IndexReader-java.util.concurrent.Executor-) objects with a dedicated executors so that index segments can be searched in parallel.

I chose a bit of a more aggressive approach - instead of setting the default to false, this is now explicit operation invoked via the `--reduceSegmentCount` indexer option. Still softer approach than ripping this functionality out altogether. The limitation of the programming of this option's handling is that when used together with index database update, it reduces the segment count for all index databases, not just those that changed. It can be run as a standalone operation when combined with the `-n` / `--noIndex` option.

That said, I think the `reduceSegmentCount` functionality should be eventually replaced by tunables to control the Lucene segment merge policy type and its parameters.