### PR TITLE
add status_code to the Response mock

### DIFF
--- a/tools/src/test/python/test_restful.py
+++ b/tools/src/test/python/test_restful.py
@@ -167,7 +167,9 @@ def test_headers_timeout_requests():
     timeout = 44
 
     def mock_requests_get(uri, **kwargs):
-        return mock(spec=requests.Response)
+        m =  mock(spec=requests.Response)
+        m.status_code = 200
+        return m
 
     with patch(requests.get, mock_requests_get):
         do_api_call("GET", uri, headers=headers, timeout=timeout)


### PR DESCRIPTION
Recently the Python tests started failing in `test_headers_timeout_requests()` because of:

```
>       if r.status_code == 202:
E       AttributeError: 'Dummy' has no attribute 'status_code' configured
```

This change should fix that.