### PR TITLE
create all directories in deploy_war()

### DIFF
--- a/tools/src/main/python/opengrok_tools/deploy.py
+++ b/tools/src/main/python/opengrok_tools/deploy.py
@@ -18,7 +18,7 @@
 # CDDL HEADER END
 
 #
-# Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
 #
 
@@ -116,7 +116,10 @@ def deploy_war(logger, source_war, target_war, config_file=None,
                        config_file, insert_path)
             source_war = tmp_war.name
 
-    logger.debug("Installing {} to {}".format(source_war, target_war))
+    logger.debug(f"Installing '{source_war}' to '{target_war}'")
+    target_dir = os.path.dirname(target_war)
+    if not os.path.isdir(target_dir):
+        os.makedirs(target_dir)
     copyfile(source_war, target_war)
 
     if tmp_war:
@@ -150,7 +153,7 @@ def main():
     try:
         deploy_war(logger, args.source_war[0], args.target_war[0], args.config,
                    args.insert)
-    except XMLProcessingException as e:
+    except (XMLProcessingException, OSError) as e:
         return fatal(e, exit=False)
 
 

--- a/tools/src/test/python/test_deploy.py
+++ b/tools/src/test/python/test_deploy.py
@@ -34,7 +34,7 @@ def test_deploy_dirs():
     logger = logging.getLogger(__name__)
 
     with tempfile.NamedTemporaryFile(suffix=".war", delete=False) as source_war_fp:
-        source_war_fp.write("foo")
+        source_war_fp.write(b"foo")
         source_war = source_war_fp.name
 
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tools/src/test/python/test_deploy.py
+++ b/tools/src/test/python/test_deploy.py
@@ -23,6 +23,7 @@
 # Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
 #
 
+import filecmp
 import logging
 import os
 import tempfile
@@ -44,5 +45,6 @@ def test_deploy_dirs():
         deploy_war(logger, source_war, target_war)
         assert os.path.isdir(target_dir)
         assert os.path.isfile(target_war)
+        assert filecmp.cmp(source_war, target_war)
 
     os.unlink(source_war)

--- a/tools/src/test/python/test_deploy.py
+++ b/tools/src/test/python/test_deploy.py
@@ -33,7 +33,7 @@ from opengrok_tools.deploy import deploy_war
 def test_deploy_dirs():
     logger = logging.getLogger(__name__)
 
-    with tempfile.NamedTemporaryFile() as source_war_fp, tempfile.TemporaryDirectory() as tmp_dir:
+    with tempfile.NamedTemporaryFile(suffix=".war") as source_war_fp, tempfile.TemporaryDirectory() as tmp_dir:
         source_war = source_war_fp.name
         assert os.path.isfile(source_war)
         target_war = os.path.join(tmp_dir, "foo", "bar", "my.war")

--- a/tools/src/test/python/test_deploy.py
+++ b/tools/src/test/python/test_deploy.py
@@ -44,3 +44,5 @@ def test_deploy_dirs():
         deploy_war(logger, source_war, target_war)
         assert os.path.isdir(target_dir)
         assert os.path.isfile(target_war)
+
+    os.unlink(source_war)

--- a/tools/src/test/python/test_deploy.py
+++ b/tools/src/test/python/test_deploy.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# See LICENSE.txt included in this distribution for the specific
+# language governing permissions and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at LICENSE.txt.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+#
+
+import logging
+import os
+import tempfile
+
+from opengrok_tools.deploy import deploy_war
+
+
+def test_deploy_dirs():
+    logger = logging.getLogger(__name__)
+
+    with tempfile.NamedTemporaryFile() as source_war_fp, tempfile.TemporaryDirectory() as tmp_dir:
+        source_war = source_war_fp.name
+        assert os.path.isfile(source_war)
+        target_war = os.path.join(tmp_dir, "foo", "bar", "my.war")
+        target_dir = os.path.dirname(target_war)
+        deploy_war(logger, source_war, target_war)
+        assert os.path.isdir(target_dir)
+        assert os.path.isfile(target_war)

--- a/tools/src/test/python/test_deploy.py
+++ b/tools/src/test/python/test_deploy.py
@@ -33,8 +33,11 @@ from opengrok_tools.deploy import deploy_war
 def test_deploy_dirs():
     logger = logging.getLogger(__name__)
 
-    with tempfile.NamedTemporaryFile(suffix=".war") as source_war_fp, tempfile.TemporaryDirectory() as tmp_dir:
+    with tempfile.NamedTemporaryFile(suffix=".war", delete=False) as source_war_fp:
+        source_war_fp.write("foo")
         source_war = source_war_fp.name
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
         assert os.path.isfile(source_war)
         target_war = os.path.join(tmp_dir, "foo", "bar", "my.war")
         target_dir = os.path.dirname(target_war)


### PR DESCRIPTION
This change allows to use `opengrok-deploy` in a way so that the target file path does not have all path components created.