### PR TITLE
fix mockito usage in Python tools' tests

### DIFF
--- a/tools/setup.py
+++ b/tools/setup.py
@@ -46,7 +46,7 @@ setup(
         'pytest',
         'GitPython',
         'pytest-xdist',
-        'mockito==1.3.0',
+        'mockito>=1.3.3',
         'pytest-mockito',
     ],
     entry_points={

--- a/tools/src/test/python/test_mirror.py
+++ b/tools/src/test/python/test_mirror.py
@@ -211,7 +211,7 @@ def test_disabled_command_api():
     call is specified in the configuration for disabled project.
     """
     def mock_call_rest_api(command, b, http_headers=None, timeout=None, api_timeout=None):
-        return mock(spec=requests.Response)
+        return mock({"status_code": 200}, spec=requests.Response, strict=False)
 
     with patch(opengrok_tools.utils.mirror.call_rest_api,
                mock_call_rest_api):
@@ -249,7 +249,7 @@ def test_disabled_command_api_text_append(monkeypatch):
         assert text
         assert text.find(text_to_append)
 
-        return mock(spec=requests.Response)
+        return mock({"status_code": 200}, spec=requests.Response, strict=False)
 
     with monkeypatch.context() as m:
         m.setattr("opengrok_tools.utils.mirror.call_rest_api",
@@ -302,7 +302,7 @@ def test_ignore_errors_sync(monkeypatch, per_project):
     Test that ignore errors overrides failed repository sync().
     """
 
-    mock_repo = mock(spec=GitRepository)
+    mock_repo = mock({"path": "foo"}, spec=GitRepository, strict=False)
     when(mock_repo).sync().thenReturn(FAILURE_EXITVAL)
 
     def mock_get_repos(*args, **kwargs):
@@ -338,7 +338,7 @@ def test_ignore_errors_hooks(monkeypatch, hook_type, per_project):
     """
 
     def mock_get_repos(*args, **kwargs):
-        return [mock(spec=GitRepository)]
+        return [mock({"path": "foo"}, spec=GitRepository, strict=False)]
 
     spy2(opengrok_tools.utils.mirror.process_hook)
     project_name = "foo"
@@ -381,7 +381,7 @@ def test_disabled_command_run_args():
     """
     Make sure that run_command() calls Command.execute().
     """
-    cmd = mock(spec=Command)
+    cmd = mock(spec=Command, strict=False)
     project_name = "foo"
     run_command(cmd, project_name)
     verify(cmd).execute()

--- a/tools/src/test/python/test_readconfig.py
+++ b/tools/src/test/python/test_readconfig.py
@@ -34,7 +34,7 @@ def test_read_config_empty_yaml():
     tmpf = tempfile.NamedTemporaryFile(mode='w+t', delete=False)
     tmpf.file.write('#foo\n')
     tmpf.close()
-    res = read_config(mock(spec=logging.Logger), tmpf.name)
+    res = read_config(mock(spec=logging.Logger, strict=False), tmpf.name)
     os.remove(tmpf.name)
     assert res is not None
     assert type(res) == dict

--- a/tools/src/test/python/test_restful.py
+++ b/tools/src/test/python/test_restful.py
@@ -167,7 +167,7 @@ def test_headers_timeout_requests():
     timeout = 44
 
     def mock_requests_get(uri, **kwargs):
-        return mock(spec=requests.Response)
+        return mock({"status_code": 200}, spec=requests.Response, strict=False)
 
     with patch(requests.get, mock_requests_get):
         do_api_call("GET", uri, headers=headers, timeout=timeout)


### PR DESCRIPTION
This change fixes `mock()` usage in Python tools' tests.