### PR TITLE
add logging to debug webapp problems

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
@@ -121,8 +121,7 @@ interface HistoryCache {
      * @param repository the repository in which the directory lives
      * @return a map from file names to modification times
      */
-    Map<String, Date> getLastModifiedTimes(File directory, Repository repository)
-        throws HistoryException;
+    Map<String, Date> getLastModifiedTimes(File directory, Repository repository) throws HistoryException;
 
     /**
      * Clear the history cache for a repository.

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -699,8 +699,7 @@ public final class PageConfig {
      */
     public String getRequestedRevision() {
         if (rev == null) {
-            String tmp = Laundromat.launderInput(
-                    req.getParameter(QueryParameters.REVISION_PARAM));
+            String tmp = Laundromat.launderInput(req.getParameter(QueryParameters.REVISION_PARAM));
             rev = (tmp != null && tmp.length() > 0) ? tmp : "";
         }
         return rev;
@@ -726,8 +725,7 @@ public final class PageConfig {
      */
     public boolean hasAnnotations() {
         if (hasAnnotation == null) {
-            hasAnnotation = !isDir()
-                    && HistoryGuru.getInstance().hasHistory(getResourceFile());
+            hasAnnotation = !isDir() && HistoryGuru.getInstance().hasAnnotation(getResourceFile());
         }
         return hasAnnotation;
     }
@@ -739,8 +737,7 @@ public final class PageConfig {
      */
     public boolean annotate() {
         if (annotate == null) {
-            annotate = hasAnnotations()
-                    && Boolean.parseBoolean(req.getParameter(QueryParameters.ANNOTATION_PARAM));
+            annotate = hasAnnotations() && Boolean.parseBoolean(req.getParameter(QueryParameters.ANNOTATION_PARAM));
         }
         return annotate;
     }


### PR DESCRIPTION
This change adds various log statements that should help when debugging web app problems. A user that had the 'History' and 'Annotate' links greyed out inspired me.

The `PageConfig#hasAnnotations()` was converted to use `HistoryGuru#hasAnnotation()`.

Also, I unsplit some lines and tidied the code.

The log level for the added messages is mostly FINE or FINEST, to be used with https://github.com/oracle/opengrok/wiki/Debugging#web-application