### PR TITLE
add API endpoint for project groups

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -12,6 +12,11 @@ Some of the APIs are asynchronous. They return status code 202 (Accepted) and a 
 for the status endpoint to check for the result of the API call. Once the status API returns result other than 202,
 the client should issue DELETE request to this URL to clean up server resources.
 
+For all entry points that modify web application configuration it is worth noting that
+the configuration has to be retrieved and stored on disk (using the configuration specific
+entry points) in order to be persistent (e.g. in case of application server restart or
+web application redeploy).
+
 ## Annotation [/annotation{?path}]
 
 ### Get annotation for a file [GET]
@@ -291,12 +296,16 @@ The paths are relative to source root, starting with /.
 
 + Response 204
 
-## Projects [/projects]
+## Groups [/groups]
 
-For all entry points that modify web application configuration it is worth noting that
-the configuration has to be retrieved and stored on disk (using the configuration specific
-entry points) in order to be persistent (e.g. in case of application server restart or
-web application redeploy).
+### returns a list of all groups [GET]
+
++ Response 200 (application/json)
+  + Body
+
+            ["foo","bar"]
+
+## Projects [/projects]
 
 ### returns a list of all projects [GET]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -309,6 +309,8 @@ The paths are relative to source root, starting with /.
 
 ### returns list of all projects for given group [GET]
 
+This includes also projects of any sub-groups.
+
 + Response 200 (application/json)
   + Body
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -305,6 +305,15 @@ The paths are relative to source root, starting with /.
 
             ["foo","bar"]
 
+## Projects of a group [/groups/{group}/allprojects]
+
+### returns list of all projects for given group [GET]
+
++ Response 200 (application/json)
+  + Body
+
+            ["foo","bar"]
+
 ## Projects [/projects]
 
 ### returns a list of all projects [GET]

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Group.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Group.java
@@ -28,6 +28,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+
+import org.jetbrains.annotations.Nullable;
 import org.opengrok.indexer.util.ClassUtil;
 
 /**
@@ -283,6 +285,7 @@ public class Group implements Comparable<Group>, Nameable {
      * @param name name of a group
      * @return group that fits the name
      */
+    @Nullable
     public static Group getByName(String name) {
         Group ret = null;
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -63,6 +63,7 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.NamedThreadFactory;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.authorization.AuthorizationFramework;
 import org.opengrok.indexer.authorization.AuthorizationStack;
@@ -513,10 +514,11 @@ public final class RuntimeEnvironment {
     }
 
     /**
-     * Get all of the groups.
+     * Get all the groups.
      *
-     * @return a set containing all of the groups (may be null)
+     * @return a set containing all the groups (maybe {@code null})
      */
+    @Nullable
     public Set<Group> getGroups() {
         return syncReadConfiguration(Configuration::getGroups);
     }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/GroupsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/GroupsController.java
@@ -25,9 +25,7 @@ package org.opengrok.web.api.v1.controller;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.MediaType;
-import org.glassfish.jersey.server.ResourceConfig;
 import org.opengrok.indexer.configuration.Group;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
@@ -51,4 +49,6 @@ public final class GroupsController {
             return Collections.emptyList();
         }
     }
+
+    // TODO: add enpoint for matching project to group list
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/GroupsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/GroupsController.java
@@ -31,13 +31,11 @@ import jakarta.ws.rs.core.Response;
 import org.opengrok.indexer.configuration.Group;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
-import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.web.Laundromat;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 @Path(GroupsController.GROUPS_PATH)

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/GroupsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/GroupsController.java
@@ -1,0 +1,54 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.api.v1.controller;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MediaType;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.opengrok.indexer.configuration.Group;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Path(GroupsController.GROUPS_PATH)
+public final class GroupsController {
+    public static final String GROUPS_PATH = "/groups";
+
+    private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<String> listGroups() {
+        if (env.hasGroups()) {
+            return Objects.requireNonNull(env.getGroups()).stream().map(Group::getName).collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/GroupsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/GroupsController.java
@@ -44,8 +44,6 @@ import java.util.stream.Collectors;
 public final class GroupsController {
     public static final String GROUPS_PATH = "/groups";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GroupsController.class);
-
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
     @GET

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/GroupsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/GroupsControllerTest.java
@@ -1,0 +1,84 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.api.v1.controller;
+
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.GenericType;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.configuration.Group;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GroupsControllerTest extends OGKJerseyTest {
+
+    private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig(GroupsController.class);
+    }
+
+    private List<String> listGroups() {
+        GenericType<List<String>> type = new GenericType<>() {
+        };
+
+        return target("groups")
+                .request()
+                .get(type);
+    }
+
+    @Test
+    void emptyGroups() {
+        env.setGroups(new HashSet<>());
+        assertFalse(env.hasGroups());
+        List<String> groups = listGroups();
+        assertNotNull(groups);
+        assertEquals(0, groups.size());
+    }
+
+    @Test
+    void testGroupList() {
+        Set<Group> groups = new TreeSet<>();
+        Group group;
+        group = new Group("group-foo", "project-(1|2|3)");
+        groups.add(group);
+        group = new Group("group-bar", "project-(7|8|9)");
+        groups.add(group);
+        env.setGroups(groups);
+        assertTrue(env.hasGroups());
+
+        List<String> groupsResult = listGroups();
+        assertEquals(groups.stream().map(Group::getName).collect(Collectors.toSet()), new HashSet<>(groupsResult));
+    }
+}

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/GroupsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/GroupsControllerTest.java
@@ -22,13 +22,17 @@
  */
 package org.opengrok.web.api.v1.controller;
 
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.GenericType;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.Test;
 import org.opengrok.indexer.configuration.Group;
+import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -38,6 +42,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GroupsControllerTest extends OGKJerseyTest {
@@ -80,5 +85,72 @@ class GroupsControllerTest extends OGKJerseyTest {
 
         List<String> groupsResult = listGroups();
         assertEquals(groups.stream().map(Group::getName).collect(Collectors.toSet()), new HashSet<>(groupsResult));
+    }
+
+    private List<String> listAllProjects(String groupName) {
+        GenericType<List<String>> type = new GenericType<>() {
+        };
+
+        return target("groups")
+                .path(groupName)
+                .path("allprojects")
+                .request()
+                .get(type);
+    }
+
+    @Test
+    void testGetAllProjectsEmpty() {
+        Set<Group> groups = new TreeSet<>();
+        Group group;
+        String groupName = "group-foo";
+        group = new Group(groupName, "project-(1|2|3)");
+        groups.add(group);
+        env.setGroups(groups);
+        assertTrue(env.hasGroups());
+
+        List<String> groupsResult = listAllProjects(groupName);
+        assertNotNull(groupsResult);
+        assertTrue(groupsResult.isEmpty());
+    }
+
+    @Test
+    void testGetAllProjectsNonexistent() {
+        env.setGroups(Collections.emptySet());
+        Set<Group> groupsEnv = env.getGroups();
+        assertNotNull(groupsEnv);
+        assertTrue(groupsEnv.isEmpty());
+
+        assertThrows(NotFoundException.class, () -> listAllProjects("nonexistent-group"));
+    }
+
+    @Test
+    void testGetAllProjects() {
+        // Set projects.
+        Project foo = new Project("project-1", "/foo");
+        Project bar = new Project("project-2", "/foo-bar");
+        HashMap<String, Project> projects = new HashMap<>();
+        projects.put("foo", foo);
+        projects.put("bar", bar);
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setProjectsEnabled(true);
+        env.setProjects(projects);
+
+        // Set group.
+        Set<Group> groups = new TreeSet<>();
+        Group group;
+        String groupName = "group-foo";
+        group = new Group(groupName, "project-(1|2|3)");
+        groups.add(group);
+        env.setGroups(groups);
+        assertTrue(env.hasGroups());
+
+        // Verify that the group has the projects.
+        Set<Project> expectedProjects = group.getAllProjects();
+        assertFalse(expectedProjects.isEmpty());
+        assertEquals(2, expectedProjects.size());
+
+        List<String> groupsResult = listAllProjects(groupName);
+        assertEquals(expectedProjects.stream().map(Project::getName).collect(Collectors.toList()),
+                groupsResult);
     }
 }


### PR DESCRIPTION
This change introduces API endpoints for project groups. This chunk of changes contains endpoints for querying various group related data.

The authorization is done via `IncomingFilter`.

Approaches #2516.