### PR TITLE
display 'H A D' links in the webapp sensibly

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -451,6 +451,12 @@ public final class HistoryGuru {
             return false;
         }
 
+        if (!repo.isHistoryEnabled()) {
+            LOGGER.log(Level.FINEST, "repository {0} for ''{1}'' does not have history enabled " +
+                            "to check history presence", new Object[]{repo, file});
+            return false;
+        }
+
         if (!repo.fileHasHistory(file)) {
             LOGGER.log(Level.FINEST, "''{0}'' in repository {1} does not have history to check history presence",
                     new Object[]{file, repo});

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -514,6 +514,7 @@ public final class HistoryGuru {
         if (!repo.isWorking()) {
             LOGGER.log(Level.FINEST, "repository {0} for ''{1}'' is not working to check annotation presence",
                     new Object[]{repo, file});
+            return false;
         }
 
         return repo.fileHasAnnotation(file);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -566,11 +566,9 @@ public abstract class Repository extends RepositoryInfo {
     /**
      * Set the name of the external client command that should be used to access
      * the repository wrt. the given parameters. Does nothing, if this
-     * repository's <var>RepoCommand</var> has already been set (i.e. has a
-     * non-{@code null} value).
+     * repository's <var>RepoCommand</var> has already been set (i.e. has a non-{@code null} value).
      *
-     * @param propertyKey property key to lookup the corresponding system
-     * property.
+     * @param propertyKey property key to look up the corresponding system property.
      * @param fallbackCommand the command to use, if lookup fails.
      * @return the command to use.
      * @see #RepoCommand

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
@@ -212,7 +212,7 @@ public final class Results {
                     out.write("<tr>");
                 }
                 evenRow = !evenRow;
-                Util.writeHAD(out, sh.getContextPath(), rpathE, false);
+                Util.writeHAD(out, sh.getContextPath(), rpathE);
                 out.write("<td class=\"f\"><a href=\"");
                 out.write(xrefPrefixE);
                 out.write(rpathE);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/FileExtraZipper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/FileExtraZipper.java
@@ -50,9 +50,7 @@ public class FileExtraZipper {
     public List<DirectoryEntry> zip(File dir, List<String> files, List<NullableNumLinesLOC> extras) {
 
         if (extras == null) {
-            return files.stream().map(f ->
-                new DirectoryEntry(new File(dir, f))).collect(
-                Collectors.toList());
+            return files.stream().map(f -> new DirectoryEntry(new File(dir, f))).collect(Collectors.toList());
         }
 
         Map<String, NullableNumLinesLOC> byName = indexExtraByName(extras);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -858,22 +858,23 @@ public final class Util {
     }
 
     /**
-     * Write the 'H A D' links. This is used for search results and directory
-     * listings.
+     * Write the 'H A D' links. This is used for search results and directory listings.
      *
-     * @param out writer for producing output
-     * @param ctxE URI encoded prefix
+     * @param out   writer for producing output
+     * @param ctxE  URI encoded prefix
      * @param entry file/directory name to write
-     * @param isDir is directory
      * @throws IOException depends on the destination (<var>out</var>).
      */
-    public static void writeHAD(Writer out, String ctxE, String entry, boolean isDir) throws IOException {
+    public static void writeHAD(Writer out, String ctxE, String entry) throws IOException {
 
         String downloadPrefixE = ctxE + Prefix.DOWNLOAD_P;
         String xrefPrefixE = ctxE + Prefix.XREF_P;
 
         out.write("<td class=\"q\">");
-        if (RuntimeEnvironment.getInstance().isHistoryEnabled()) {
+        File file = new File(RuntimeEnvironment.getInstance().getSourceRootPath(), entry);
+
+        // Write the 'H' (History) link.
+        if (HistoryGuru.getInstance().hasHistory(file)) {
             String histPrefixE = ctxE + Prefix.HIST_L;
 
             out.write("<a href=\"");
@@ -885,13 +886,18 @@ public final class Util {
             out.write("\" title=\"History\">H</a>");
         }
 
-        if (!isDir) {
+        // Write the 'A' (Annotation) link.
+        if (HistoryGuru.getInstance().hasAnnotation(file)) {
             out.write(" <a href=\"");
             out.write(xrefPrefixE);
             out.write(entry);
             out.write("?");
             out.write(QueryParameters.ANNOTATION_PARAM_EQ_TRUE);
             out.write("\" title=\"Annotate\">A</a> ");
+        }
+
+        // Write the 'D' (Download) link.
+        if (!file.isDirectory()) {
             out.write("<a href=\"");
             out.write(downloadPrefixE);
             out.write(entry);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -877,7 +877,7 @@ public final class Util {
         if (HistoryGuru.getInstance().hasHistory(file)) {
             String histPrefixE = ctxE + Prefix.HIST_L;
 
-            out.write("<a href=\"");
+            out.write(anchorLinkStart);
             out.write(histPrefixE);
             if (!entry.startsWith("/")) {
                 entry = "/" + entry;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -77,10 +77,10 @@ public final class Util {
 
     private static final int BOLD_COUNT_THRESHOLD = 1000;
 
-    private static final String anchorLinkStart = "<a href=\"";
-    private static final String anchorClassStart = "<a class=\"";
-    private static final String anchorEnd = "</a>";
-    private static final String closeQuotedTag = "\">";
+    private static final String ANCHOR_LINK_START = "<a href=\"";
+    private static final String ANCHOR_CLASS_START = "<a class=\"";
+    private static final String ANCHOR_END = "</a>";
+    private static final String CLOSE_QUOTED_TAG = "\">";
 
     private static final String RE_Q_ESC_AMP_AMP = "\\?|&amp;|&";
     private static final String RE_Q_E_A_A_COUNT_EQ_VAL = "(" + RE_Q_ESC_AMP_AMP + "|\\b)" +
@@ -441,9 +441,9 @@ public final class Util {
             if (isDir || i < pnames.length - 1) {
                 pwd.append(PATH_SEPARATOR);
             }
-            markup.append(anchorLinkStart).append(prefix).append(pwd)
-                    .append(postfix).append(closeQuotedTag).append(pnames[i])
-                    .append(anchorEnd);
+            markup.append(ANCHOR_LINK_START).append(prefix).append(pwd)
+                    .append(postfix).append(CLOSE_QUOTED_TAG).append(pnames[i])
+                    .append(ANCHOR_END);
             if (isDir || i < pnames.length - 1) {
                 markup.append(sep);
             }
@@ -712,15 +712,15 @@ public final class Util {
         if (num > 1 && !skipNewline) {
             out.write("\n");
         }
-        out.write(anchorClassStart);
+        out.write(ANCHOR_CLASS_START);
         out.write(num % 10 == 0 ? "hl" : "l");
         out.write("\" name=\"");
         out.write(snum);
         out.write("\" href=\"#");
         out.write(snum);
-        out.write(closeQuotedTag);
+        out.write(CLOSE_QUOTED_TAG);
         out.write(snum);
-        out.write(anchorEnd);
+        out.write(ANCHOR_END);
 
         if (annotation != null) {
             writeAnnotation(num, out, annotation, userPageLink, userPageSuffix, project);
@@ -733,7 +733,7 @@ public final class Util {
         boolean enabled = annotation.isEnabled(num);
         out.write("<span class=\"blame\">");
         if (enabled) {
-            out.write(anchorClassStart);
+            out.write(ANCHOR_CLASS_START);
             out.write("r");
             out.write("\" style=\"background-color: ");
             out.write(annotation.getColors().getOrDefault(r, "inherit"));
@@ -753,7 +753,7 @@ public final class Util {
                 out.write("&lt;br/&gt;version: " + annotation.getFileVersion(r) + "/"
                         + annotation.getRevisions().size());
             }
-            out.write(closeQuotedTag);
+            out.write(CLOSE_QUOTED_TAG);
         }
         StringBuilder buf = new StringBuilder();
         final boolean most_recent_revision = annotation.getFileVersion(r) == annotation.getRevisions().size();
@@ -771,10 +771,10 @@ public final class Util {
         if (enabled) {
             RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
-            out.write(anchorEnd);
+            out.write(ANCHOR_END);
 
             // Write link to search the revision in current project.
-            out.write(anchorClassStart);
+            out.write(ANCHOR_CLASS_START);
             out.write("search\" href=\"" + env.getUrlPrefix());
             out.write(QueryParameters.DEFS_SEARCH_PARAM_EQ);
             out.write("&amp;");
@@ -789,9 +789,9 @@ public final class Util {
             out.write("&quot;&amp;");
             out.write(QueryParameters.TYPE_SEARCH_PARAM_EQ);
             out.write("\" title=\"Search history for this revision");
-            out.write(closeQuotedTag);
+            out.write(CLOSE_QUOTED_TAG);
             out.write("S");
-            out.write(anchorEnd);
+            out.write(ANCHOR_END);
         }
         String a = annotation.getAuthor(num);
         if (userPageLink == null) {
@@ -801,18 +801,18 @@ public final class Util {
             out.write(HtmlConsts.ZSPAN);
             buf.setLength(0);
         } else {
-            out.write(anchorClassStart);
+            out.write(ANCHOR_CLASS_START);
             out.write("a\" href=\"");
             out.write(userPageLink);
             out.write(uriEncode(a));
             if (userPageSuffix != null) {
                 out.write(userPageSuffix);
             }
-            out.write(closeQuotedTag);
+            out.write(CLOSE_QUOTED_TAG);
             htmlize(a, buf);
             out.write(buf.toString());
             buf.setLength(0);
-            out.write(anchorEnd);
+            out.write(ANCHOR_END);
         }
         out.write("</span>");
     }
@@ -877,7 +877,7 @@ public final class Util {
         if (HistoryGuru.getInstance().hasHistory(file)) {
             String histPrefixE = ctxE + Prefix.HIST_L;
 
-            out.write(anchorLinkStart);
+            out.write(ANCHOR_LINK_START);
             out.write(histPrefixE);
             if (!entry.startsWith("/")) {
                 entry = "/" + entry;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2011, Jens Elkner.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -150,8 +150,7 @@ public class HistoryGuruTest {
     @Test
     void getCacheInfo() throws HistoryException {
         // FileHistoryCache is used by default
-        assertEquals("FileHistoryCache",
-                HistoryGuru.getInstance().getCacheInfo());
+        assertEquals("FileHistoryCache", HistoryGuru.getInstance().getCacheInfo());
     }
 
     @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -142,7 +142,7 @@ public class HistoryGuruTest {
         HistoryGuru instance = HistoryGuru.getInstance();
         for (File f : FILES) {
             if (instance.hasAnnotation(f)) {
-                instance.annotate(f, null);
+                assertNotNull(instance.annotate(f, null));
             }
         }
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.web;
@@ -616,5 +616,15 @@ public class UtilTest {
         assertThat(params.get("param2"), contains(""));
         assertTrue(params.containsKey("param3"));
         assertThat(params.get("param4"), contains("value4"));
+    }
+
+    @Test
+    void testWriteHADNegative() throws Exception {
+        StringWriter writer = new StringWriter();
+        String filePath = "/git/nonexistent.c";
+        Util.writeHAD(writer, "/source", filePath);
+        String output = writer.toString();
+        assertEquals("<td class=\"q\"><a href=\"/source/download/git/nonexistent.c\" title=\"Download\">D</a></td>",
+                output);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -624,7 +624,7 @@ public class UtilTest {
      * @throws Exception on error
      */
     @Test
-    void testWriteHADNegative() throws Exception {
+    void testWriteHADNonexistentFile() throws Exception {
         StringWriter writer = new StringWriter();
         String filePath = "/nonexistent/file.c";
         Util.writeHAD(writer, "/source", filePath);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -31,8 +31,6 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -26,6 +26,7 @@ package org.opengrok.indexer.web;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -618,6 +619,10 @@ public class UtilTest {
         assertThat(params.get("param4"), contains("value4"));
     }
 
+    /**
+     * Test {@link Util#writeHAD(Writer, String, String)} for a file path that does not map to any repository.
+     * @throws Exception on error
+     */
     @Test
     void testWriteHADNegative() throws Exception {
         StringWriter writer = new StringWriter();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -621,10 +621,10 @@ public class UtilTest {
     @Test
     void testWriteHADNegative() throws Exception {
         StringWriter writer = new StringWriter();
-        String filePath = "/git/nonexistent.c";
+        String filePath = "/nonexistent/file.c";
         Util.writeHAD(writer, "/source", filePath);
         String output = writer.toString();
-        assertEquals("<td class=\"q\"><a href=\"/source/download/git/nonexistent.c\" title=\"Download\">D</a></td>",
+        assertEquals("<td class=\"q\"><a href=\"/source/download/nonexistent/file.c\" title=\"Download\">D</a></td>",
                 output);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -61,7 +61,7 @@ public class UtilTest {
 
     @BeforeAll
     public static void setUpClass() {
-        // Some of the methods have different results in different locales.
+        // Some methods have different results in different locales.
         // Set locale to en_US for these tests.
         savedLocale = Locale.getDefault();
         Locale.setDefault(Locale.US);
@@ -74,7 +74,7 @@ public class UtilTest {
     }
 
     @Test
-    public void htmlize() throws IOException {
+    void htmlize() throws IOException {
         String[][] input_output = {
                 {"This is a test", "This is a test"},
                 {"Newline\nshould become <br/>", "Newline<br/>should become &lt;br/&gt;"},
@@ -91,7 +91,7 @@ public class UtilTest {
     }
 
     @Test
-    public void breadcrumbPath() {
+    void breadcrumbPath() {
         assertNull(Util.breadcrumbPath("/root/", null));
 
         assertEquals("", Util.breadcrumbPath("/root/", ""));
@@ -129,7 +129,7 @@ public class UtilTest {
     }
 
     @Test
-    public void redableSize() {
+    void readableSize() {
         assertEquals("0 ", Util.readableSize(0));
         assertEquals("1 ", Util.readableSize(1));
         assertEquals("-1 ", Util.readableSize(-1));
@@ -143,7 +143,7 @@ public class UtilTest {
     }
 
     @Test
-    public void readableLine() throws Exception {
+    void readableLine() throws Exception {
         StringWriter out = new StringWriter();
         // hmmm - where do meaningful tests start?
         Util.readableLine(42, out, null, null, null, null);
@@ -157,7 +157,7 @@ public class UtilTest {
     }
 
     @Test
-    public void path2uid() {
+    void path2uid() {
         assertEquals("\u0000etc\u0000passwd\u0000date",
                 Util.path2uid("/etc/passwd", "date"));
     }
@@ -169,13 +169,13 @@ public class UtilTest {
     }
 
     @Test
-    public void uid2url() {
+    void uid2url() {
         assertEquals("/etc/passwd", Util.uid2url(
                 Util.path2uid("/etc/passwd", "date")));
     }
 
     @Test
-    public void testUriEncode() {
+    void testUriEncode() {
         assertEquals("", Util.uriEncode(""));
         assertEquals("a+b", Util.uriEncode("a b"));
         assertEquals("a%23b", Util.uriEncode("a#b"));
@@ -184,7 +184,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testUriEncodePath() {
+    void testUriEncodePath() {
         assertEquals("", Util.uriEncodePath(""));
         assertEquals("/", Util.uriEncodePath("/"));
         assertEquals("a", Util.uriEncodePath("a"));
@@ -200,7 +200,7 @@ public class UtilTest {
     }
 
     @Test
-    public void formQuoteEscape() {
+    void formQuoteEscape() {
         assertEquals("", Util.formQuoteEscape(null));
         assertEquals("abc", Util.formQuoteEscape("abc"));
         assertEquals("&quot;abc&quot;", Util.formQuoteEscape("\"abc\""));
@@ -208,7 +208,7 @@ public class UtilTest {
     }
 
     @Test
-    public void diffline() {
+    void diffline() {
         String[][] tests = {
                 {
                         "if (a < b && foo < bar && c > d)",
@@ -273,7 +273,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testEncode() {
+    void testEncode() {
         String[][] tests = new String[][] {
                 {"Test <code>title</code>", "Test&nbsp;&#60;code&#62;title&#60;/code&#62;"},
                 {"ahoj", "ahoj"},
@@ -288,7 +288,7 @@ public class UtilTest {
     }
 
     @Test
-    public void dumpConfiguration() throws Exception {
+    void dumpConfiguration() throws Exception {
         StringBuilder out = new StringBuilder();
         Util.dumpConfiguration(out);
         String s = out.toString();
@@ -303,13 +303,13 @@ public class UtilTest {
     }
 
     @Test
-    public void jsStringLiteral() {
+    void jsStringLiteral() {
         assertEquals("\"abc\\n\\r\\\"\\\\\"",
                 Util.jsStringLiteral("abc\n\r\"\\"));
     }
 
     @Test
-    public void stripPathPrefix() {
+    void stripPathPrefix() {
         assertEquals("/", Util.stripPathPrefix("/", "/"));
         assertEquals("/abc", Util.stripPathPrefix("/abc", "/abc"));
         assertEquals("/abc/", Util.stripPathPrefix("/abc", "/abc/"));
@@ -326,7 +326,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testSlider() {
+    void testSlider() {
         /*
          * Test if contains all five pages for 55 results paginated by 10
          */
@@ -342,7 +342,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testIsUrl() {
+    void testIsUrl() {
         assertTrue(Util.isHttpUri("http://www.example.com"));
         assertTrue(Util.isHttpUri("http://example.com"));
         assertTrue(Util.isHttpUri("https://example.com"));
@@ -364,7 +364,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testRedactUrl() {
+    void testRedactUrl() {
         assertEquals("/foo/bar", Util.redactUrl("/foo/bar"));
         assertEquals("http://foo/bar?r=xxx", Util.redactUrl("http://foo/bar?r=xxx"));
         assertEquals("http://" + Util.REDACTED_USER_INFO + "@foo/bar?r=xxx",
@@ -374,7 +374,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testLinkify() throws URISyntaxException, MalformedURLException {
+    void testLinkify() throws URISyntaxException, MalformedURLException {
         assertTrue(Util.linkify("http://www.example.com")
                 .matches("<a.*?href=\"http://www\\.example\\.com\".*?>.*?</a>"));
         assertTrue(Util.linkify("https://example.com")
@@ -419,7 +419,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testBuildLink() throws URISyntaxException, MalformedURLException {
+    void testBuildLink() throws URISyntaxException, MalformedURLException {
         assertEquals("<a href=\"http://www.example.com\">link</a>", Util.buildLink("link", "http://www.example.com"));
         assertEquals("<a href=\"http://www.example.com?url=xasw&beta=gama\">link</a>",
                 Util.buildLink("link", "http://www.example.com?url=xasw&beta=gama"));
@@ -444,17 +444,17 @@ public class UtilTest {
     }
 
     @Test
-    public void testBuildLinkInvalidUrl1() {
+    void testBuildLinkInvalidUrl1() {
         assertThrows(MalformedURLException.class, () -> Util.buildLink("link", "www.example.com")); // invalid protocol
     }
 
     @Test
-    public void testBuildLinkInvalidUrl2() {
+    void testBuildLinkInvalidUrl2() {
         assertThrows(URISyntaxException.class, () -> Util.buildLink("link", "http://www.exa\"mp\"le.com")); // invalid authority
     }
 
     @Test
-    public void testLinkifyPattern() {
+    void testLinkifyPattern() {
         String text
                 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
                 + "sed do eiusmod tempor incididunt as per 12345698 ut labore et dolore magna "
@@ -499,7 +499,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testCompleteUrl() {
+    void testCompleteUrl() {
         HttpServletRequest req = new DummyHttpServletRequest() {
             @Override
             public int getServerPort() {
@@ -540,24 +540,24 @@ public class UtilTest {
     }
 
     @Test
-    public void getQueryParamsNullTest() {
+    void getQueryParamsNullTest() {
         assertThrows(IllegalArgumentException.class, () -> Util.getQueryParams(null));
     }
 
     @Test
-    public void getQueryParamsEmptyTest() throws MalformedURLException {
+    void getQueryParamsEmptyTest() throws MalformedURLException {
         URL url = new URL("http://test.com/test");
         assertTrue(Util.getQueryParams(url).isEmpty());
     }
 
     @Test
-    public void getQueryParamsEmptyTest2() throws MalformedURLException {
+    void getQueryParamsEmptyTest2() throws MalformedURLException {
         URL url = new URL("http://test.com/test?");
         assertTrue(Util.getQueryParams(url).isEmpty());
     }
 
     @Test
-    public void getQueryParamsSingleTest() throws MalformedURLException {
+    void getQueryParamsSingleTest() throws MalformedURLException {
         URL url = new URL("http://test.com?param1=value1");
         Map<String, List<String>> params = Util.getQueryParams(url);
 
@@ -567,7 +567,7 @@ public class UtilTest {
     }
 
     @Test
-    public void getQueryParamsMultipleTest() throws MalformedURLException {
+    void getQueryParamsMultipleTest() throws MalformedURLException {
         URL url = new URL("http://test.com?param1=value1&param2=value2");
         Map<String, List<String>> params = Util.getQueryParams(url);
 
@@ -578,7 +578,7 @@ public class UtilTest {
     }
 
     @Test
-    public void getQueryParamsMultipleSameTest() throws MalformedURLException {
+    void getQueryParamsMultipleSameTest() throws MalformedURLException {
         URL url = new URL("http://test.com?param1=value1&param1=value2");
         Map<String, List<String>> params = Util.getQueryParams(url);
 
@@ -588,7 +588,7 @@ public class UtilTest {
     }
 
     @Test
-    public void getQueryParamsEncodedTest() throws MalformedURLException {
+    void getQueryParamsEncodedTest() throws MalformedURLException {
         URL url = new URL("http://test.com?param1=%3Fvalue%3F");
         Map<String, List<String>> params = Util.getQueryParams(url);
 
@@ -598,7 +598,7 @@ public class UtilTest {
     }
 
     @Test
-    public void getQueryParamsEmptyValueTest() throws MalformedURLException {
+    void getQueryParamsEmptyValueTest() throws MalformedURLException {
         URL url = new URL("http://test.com?param1=");
 
         Map<String, List<String>> params = Util.getQueryParams(url);
@@ -607,7 +607,7 @@ public class UtilTest {
     }
 
     @Test
-    public void getQueryParamsEmptyAndNormalValuesCombinedTest() throws MalformedURLException {
+    void getQueryParamsEmptyAndNormalValuesCombinedTest() throws MalformedURLException {
         URL url = new URL("http://test.com?param1=value1&param2=&param3&param4=value4");
 
         Map<String, List<String>> params = Util.getQueryParams(url);
@@ -617,5 +617,4 @@ public class UtilTest {
         assertTrue(params.containsKey("param3"));
         assertThat(params.get("param4"), contains("value4"));
     }
-
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/DirectoryListing.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/DirectoryListing.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2011, Jens Elkner.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */

--- a/opengrok-web/src/main/java/org/opengrok/web/DirectoryListing.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/DirectoryListing.java
@@ -152,7 +152,7 @@ public class DirectoryListing {
     }
 
     /**
-     * Write a HTML-ized listing of the given directory to the given destination.
+     * Write HTML-ized listing of the given directory to the given destination.
      *
      * @param contextPath path used for link prefixes
      * @param dir the directory to list
@@ -161,8 +161,7 @@ public class DirectoryListing {
      *  <var>dir</var> with the source root directory stripped off).
      * @param entries basenames of potential children of the directory to list,
      *  but filtered by {@link PathAccepter}.
-     * @return a possible empty list of README files included in the written
-     *  listing.
+     * @return a possible empty list of README files included in the written listing.
      * @throws IOException when cannot write to the {@code out} parameter
      * @throws HistoryException when failed to get last modified time for files in directory
      */
@@ -209,8 +208,7 @@ public class DirectoryListing {
             out.write("</tr>\n");
         }
 
-        Map<String, Date> modTimes =
-                HistoryGuru.getInstance().getLastModifiedTimes(dir);
+        Map<String, Date> modTimes = HistoryGuru.getInstance().getLastModifiedTimes(dir);
 
         if (entries != null) {
             for (DirectoryEntry entry : entries) {
@@ -251,7 +249,7 @@ public class DirectoryListing {
                     out.write("</a>");
                 }
                 out.write("</td>");
-                Util.writeHAD(out, contextPath, path + filename, isDir);
+                Util.writeHAD(out, contextPath, path + filename);
                 printDateSize(out, child, modTimes.get(filename), dateFormatter);
                 printNumlines(out, entry, isDir);
                 printLoc(out, entry, isDir);

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1064,9 +1064,9 @@ public final class PageConfig {
      */
     public String getSourceRootPath() {
         if (sourceRootPath == null) {
-            String srcpath = getEnv().getSourceRootPath();
-            if (srcpath != null) {
-                sourceRootPath = srcpath.replace(File.separatorChar, PATH_SEPARATOR);
+            String srcPathEnv = getEnv().getSourceRootPath();
+            if (srcPathEnv != null) {
+                sourceRootPath = srcPathEnv.replace(File.separatorChar, PATH_SEPARATOR);
             }
         }
         return sourceRootPath;
@@ -1107,8 +1107,8 @@ public final class PageConfig {
      * @return true if file/directory corresponding to the request path exists however is unreadable, false otherwise
      */
     public boolean isUnreadable() {
-        File f = new File(getSourceRootPath(), getPath());
-        return f.exists() && !f.canRead();
+        File file = new File(getSourceRootPath(), getPath());
+        return file.exists() && !file.canRead();
     }
 
     /**
@@ -1123,12 +1123,12 @@ public final class PageConfig {
      * @see #getSourceRootPath()
      */
     public File getResourceFile(String path) {
-        File f;
-        f = new File(getSourceRootPath(), path);
-        if (!f.canRead()) {
+        File file;
+        file = new File(getSourceRootPath(), path);
+        if (!file.canRead()) {
             return null;
         }
-        return f;
+        return file;
     }
 
     /**

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -440,7 +440,7 @@ public final class PageConfig {
      * that directory, sorted alphabetically
      *
      * <p>
-     * For the root directory (/xref/) an authorization is performed for each
+     * For the root directory (/xref/), authorization check is performed for each
      * project in case that projects are used.
      *
      * @see #getResourceFile()
@@ -1091,8 +1091,7 @@ public final class PageConfig {
      * No check is made, whether the obtained path is really an accessible resource on disk.
      *
      * @see HttpServletRequest#getPathInfo()
-     * @return a possible empty String (denotes the source root directory) but
-     * not {@code null}.
+     * @return a possible empty String (denotes the source root directory) but not {@code null}.
      */
     public String getPath() {
         if (path == null) {
@@ -1113,15 +1112,14 @@ public final class PageConfig {
     }
 
     /**
-     * Get the on disk file for the given path.
+     * Get the file object for the given path.
      *
      * NOTE: If a repository contains hard or symbolic links, the returned file
      * may finally point to a file outside the source root directory.
      *
      * @param path the path to the file relatively to the source root
      * @return null if the related file or directory is not
-     * available (can not be find below the source root directory), the readable
-     * file or directory otherwise.
+     * available (can not be found below the source root directory), the readable file or directory otherwise.
      * @see #getSourceRootPath()
      */
     public File getResourceFile(String path) {


### PR DESCRIPTION
When working on #3990, I noticed that the 'H A D' links are printed irrespective to whether history for given repository is enabled. This change fixes that.

Also, I did some cleanup in related classes.