### PR TITLE
reimplement incoming check via git log

### DIFF
--- a/tools/src/main/python/opengrok_tools/scm/git.py
+++ b/tools/src/main/python/opengrok_tools/scm/git.py
@@ -52,8 +52,23 @@ class GitRepository(Repository):
         return self._run_custom_sync_command([self.command, 'pull', '--ff-only'])
 
     def incoming_check(self):
+        """
+        :return: True if there are any incoming changes present, False otherwise
+        """
         self._configure_git_pull()
-        return self._run_custom_incoming_command([self.command, 'pull', '--dry-run'])
+        self.fetch()
+        branch = self.get_branch()
+        status, out = self._run_command([self.command, 'log',
+                                         '--pretty=tformat:%H', '--reverse', '..origin/' + branch])
+        if status == 0:
+            lines = out.split('\n')
+            if len(lines) == 0:
+                return False
+        else:
+            raise RepositoryException("failed to check for incoming changes in {}: {}".
+                                      format(self, status))
+
+        return True
 
     def get_branch(self):
         status, out = self._run_command([self.command, 'branch', '--show-current'])

--- a/tools/src/main/python/opengrok_tools/scm/git.py
+++ b/tools/src/main/python/opengrok_tools/scm/git.py
@@ -59,7 +59,7 @@ class GitRepository(Repository):
         self.fetch()
         branch = self.get_branch()
         status, out = self._run_command([self.command, 'log',
-                                         '--pretty=tformat:%H', '--reverse', '..origin/' + branch])
+                                         '--pretty=tformat:%H', '..origin/' + branch])
         if status == 0:
             lines = out.split('\n')
             if len(lines) == 0:

--- a/tools/src/main/python/opengrok_tools/scm/git.py
+++ b/tools/src/main/python/opengrok_tools/scm/git.py
@@ -61,8 +61,7 @@ class GitRepository(Repository):
         status, out = self._run_command([self.command, 'log',
                                          '--pretty=tformat:%H', '..origin/' + branch])
         if status == 0:
-            lines = out.split('\n')
-            if len(lines) == 0:
+            if len(out) == 0:
                 return False
         else:
             raise RepositoryException("failed to check for incoming changes in {}: {}".

--- a/tools/src/test/python/test_mirror_incoming_retval.py
+++ b/tools/src/test/python/test_mirror_incoming_retval.py
@@ -37,7 +37,8 @@ from opengrok_tools.scm import get_repository
 from opengrok_tools.utils.exitvals import CONTINUE_EXITVAL, SUCCESS_EXITVAL
 
 
-def setup_module(module):
+@pytest.fixture(scope="module", autouse=True)
+def setup():
     # The default has changed for python 3.8 (see https://github.com/oracle/opengrok/issues/3296).
     # Because of the mocking we need to use the "fork" type to propagate all mocks to the
     # processes spawned by mirror command

--- a/tools/src/test/python/test_mirror_incoming_retval.py
+++ b/tools/src/test/python/test_mirror_incoming_retval.py
@@ -37,6 +37,14 @@ from opengrok_tools.scm import get_repository
 from opengrok_tools.utils.exitvals import CONTINUE_EXITVAL, SUCCESS_EXITVAL
 
 
+@pytest.fixture(scope="module", autouse=True)
+def setup():
+    # The default has changed for python 3.8 (see https://github.com/oracle/opengrok/issues/3296).
+    # Because of the mocking we need to use the "fork" type to propagate all mocks to the
+    # processes spawned by mirror command
+    multiprocessing.set_start_method('fork')
+
+
 @pytest.mark.parametrize('do_changes', [True, False])
 @pytest.mark.skipif(not os.name.startswith("posix"), reason="requires posix")
 def test_incoming_retval(monkeypatch, do_changes):
@@ -44,11 +52,6 @@ def test_incoming_retval(monkeypatch, do_changes):
     Test that the special CONTINUE_EXITVAL value bubbles all the way up to
     the mirror.py return value.
     """
-
-    # The default has changed for python 3.8 (see https://github.com/oracle/opengrok/issues/3296).
-    # Because of the mocking we need to use the "fork" type to propagate all mocks to the
-    # processes spawned by mirror command
-    multiprocessing.set_start_method('fork')
 
     class MockResponse:
 

--- a/tools/src/test/python/test_mirror_incoming_retval.py
+++ b/tools/src/test/python/test_mirror_incoming_retval.py
@@ -37,8 +37,7 @@ from opengrok_tools.scm import get_repository
 from opengrok_tools.utils.exitvals import CONTINUE_EXITVAL, SUCCESS_EXITVAL
 
 
-@pytest.fixture(scope="module", autouse=True)
-def setup():
+def setup_module(module):
     # The default has changed for python 3.8 (see https://github.com/oracle/opengrok/issues/3296).
     # Because of the mocking we need to use the "fork" type to propagate all mocks to the
     # processes spawned by mirror command


### PR DESCRIPTION
This changes the way how incoming check for Git is done in the tools, particularly `opengrok-mirror`. This should provide some better robustness.