### PR TITLE
improve logging for repository invalidation

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
@@ -189,6 +189,7 @@ public final class RepositoryFactory {
 
             if ((!isNested || referenceRepo.isNestable()) && isEnabled(clazz) &&
                     referenceRepo.isRepositoryFor(file, cmdType)) {
+
                 repo = clazz.getDeclaredConstructor().newInstance();
 
                 if (env.isProjectsEnabled() && relFile.equals(File.separator)) {
@@ -201,8 +202,7 @@ public final class RepositoryFactory {
                 repo.setDirectoryName(file);
 
                 if (!repo.isWorking()) {
-                    LOGGER.log(Level.WARNING,
-                            "{0} not working (missing binaries?): {1}",
+                    LOGGER.log(Level.WARNING, "{0} not working (missing binaries?): {1}",
                             new Object[]{
                                 repo.getClass().getSimpleName(),
                                 file.getPath()


### PR DESCRIPTION
This change improves logging of repository invalidation. Example:

```
20-Jul-2022 18:15:06.645 FINE [RMI TCP Connection(6)-127.0.0.1] org.opengrok.indexer.history.HistoryGuru.invalidateRepositories invalidating 3 repositories
20-Jul-2022 18:15:06.825 INFO [RMI TCP Connection(6)-127.0.0.1] org.opengrok.indexer.util.Statistics.logIt Done invalidating repositories (3 valid, 3 working) (took 178 ms)
```