### PR TITLE
make username/password configurable on project/repository level

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -92,7 +92,13 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
      */
     private Boolean mergeCommitsEnabled = null;
 
+    /**
+     * Username to used for repository authentication. This is propagated to all repositories of this project.
+     */
     private String username = null;
+    /**
+     * Password to used for repository authentication. This is propagated to all repositories of this project.
+     */
     private String password = null;
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -73,8 +73,7 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     private int tabSize;
 
     /**
-     * A flag if the navigate window should be opened by default when browsing
-     * the source code of this project.
+     * If navigate window should be opened by default when browsing the source code of this project.
      */
     private Boolean navigateWindowEnabled = null;
 
@@ -92,6 +91,9 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
      * This flag enables/disables per project merge commits.
      */
     private Boolean mergeCommitsEnabled = null;
+
+    private String username = null;
+    private String password = null;
 
     /**
      * This marks the project as (not)ready before initial index is done. this
@@ -307,6 +309,22 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
      */
     public void setHistoryBasedReindex(boolean flag) {
         this.historyBasedReindex = flag;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getPassword() {
+        return password;
     }
 
     @VisibleForTesting

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -317,18 +317,32 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
         this.historyBasedReindex = flag;
     }
 
+    /**
+     * Set username to be used for repository authentication.
+     * @param username username
+     */
     public void setUsername(String username) {
         this.username = username;
     }
 
+    /**
+     * @return username used for repository authentication
+     */
     public String getUsername() {
         return username;
     }
 
+    /**
+     * Set password to be used for repository authentication.
+     * @param password password
+     */
     public void setPassword(String password) {
         this.password = password;
     }
 
+    /**
+     * @return password used for repository authentication
+     */
     public String getPassword() {
         return password;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
@@ -156,8 +156,7 @@ public final class RepositoryFactory {
     }
 
     /**
-     * Returns a repository for the given file, or null if no repository was
-     * found.
+     * Returns a repository for the given file, or null if no repository was found.
      *
      * Note that the operations performed by this method take quite a long time
      * thanks to external commands being executed. For that reason, when run

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -163,19 +163,19 @@ public class RepositoryInfo implements Serializable {
         this.historyEnabled = flag;
     }
 
-    public String getUsername() {
+    String getUsername() {
         return username;
     }
 
-    public void setUsername(String username) {
+    void setUsername(String username) {
         this.username = username;
     }
 
-    public String getPassword() {
+    String getPassword() {
         return password;
     }
 
-    public void setPassword(String password) {
+    void setPassword(String password) {
         this.password = password;
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -163,13 +163,21 @@ public class RepositoryInfo implements Serializable {
         this.historyEnabled = flag;
     }
 
-    public String getUsername() { return username; }
+    public String getUsername() {
+        return username;
+    }
 
-    public void setUsername(String username) { this.username = username; }
+    public void setUsername(String username) {
+        this.username = username;
+    }
 
-    public String getPassword() { return password; }
+    public String getPassword() {
+        return password;
+    }
 
-    public void setPassword(String password) { this.password = password; }
+    public void setPassword(String password) {
+        this.password = password;
+    }
 
     /**
      * @return relative path to source root

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -81,6 +81,10 @@ public class RepositoryInfo implements Serializable {
     private boolean mergeCommitsEnabled;
     @DTOElement
     private boolean historyBasedReindex;
+    @DTOElement
+    private String username;
+    @DTOElement
+    private String password;
 
     /**
      * Empty constructor to support serialization.
@@ -102,6 +106,8 @@ public class RepositoryInfo implements Serializable {
         this.handleRenamedFiles = orig.handleRenamedFiles;
         this.mergeCommitsEnabled = orig.mergeCommitsEnabled;
         this.historyBasedReindex = orig.historyBasedReindex;
+        this.username = orig.username;
+        this.password = orig.password;
     }
 
     /**
@@ -156,6 +162,14 @@ public class RepositoryInfo implements Serializable {
     public void setHistoryEnabled(boolean flag) {
         this.historyEnabled = flag;
     }
+
+    public String getUsername() { return username; }
+
+    public void setUsername(String username) { this.username = username; }
+
+    public String getPassword() { return password; }
+
+    public void setPassword(String password) { this.password = password; }
 
     /**
      * @return relative path to source root
@@ -331,6 +345,8 @@ public class RepositoryInfo implements Serializable {
             setHandleRenamedFiles(proj.isHandleRenamedFiles());
             setMergeCommitsEnabled(proj.isMergeCommitsEnabled());
             setHistoryBasedReindex(proj.isHistoryBasedReindex());
+            setUsername(proj.getUsername());
+            setPassword(proj.getPassword());
         } else {
             RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
@@ -385,6 +401,17 @@ public class RepositoryInfo implements Serializable {
             stringBuilder.append("merge=");
             stringBuilder.append(this.isMergeCommitsEnabled());
         }
+
+        stringBuilder.append(",");
+        if (getUsername() != null) {
+            stringBuilder.append("username:set");
+            stringBuilder.append(",");
+        }
+        if (getPassword() != null) {
+            stringBuilder.append("password:set");
+            stringBuilder.append(",");
+        }
+
         stringBuilder.append("}");
         return stringBuilder.toString();
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -163,18 +163,32 @@ public class RepositoryInfo implements Serializable {
         this.historyEnabled = flag;
     }
 
+    /**
+     * @return username to be used for authentication
+     */
     String getUsername() {
         return username;
     }
 
+    /**
+     * Set username to be used for authentication.
+     * @param username username
+     */
     void setUsername(String username) {
         this.username = username;
     }
 
+    /**
+     * @return password to be used for authentication
+     */
     String getPassword() {
         return password;
     }
 
+    /**
+     * Set password to be used for authentication.
+     * @param password password
+     */
     void setPassword(String password) {
         this.password = password;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
@@ -35,6 +35,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -56,9 +57,6 @@ public class SubversionRepository extends Repository {
     private static final Logger LOGGER = LoggerFactory.getLogger(SubversionRepository.class);
 
     private static final long serialVersionUID = 1L;
-
-    private static final String ENV_SVN_USERNAME = "OPENGROK_SUBVERSION_USERNAME";
-    private static final String ENV_SVN_PASSWORD = "OPENGROK_SUBVERSION_PASSWORD";
 
     /**
      * The property name used to obtain the client command for this repository.
@@ -365,12 +363,12 @@ public class SubversionRepository extends Repository {
         return working;
     }
 
-    private List<String> getAuthCommandLineParams() {
+    @VisibleForTesting
+    List<String> getAuthCommandLineParams() {
         List<String> result = new ArrayList<>();
-        String userName = System.getenv(ENV_SVN_USERNAME);
-        String password = System.getenv(ENV_SVN_PASSWORD);
-        if (userName != null && !userName.isEmpty() && password != null
-                && !password.isEmpty()) {
+        String userName = getUsername();
+        String password = getPassword();
+        if (userName != null && !userName.isEmpty() && password != null && !password.isEmpty()) {
             result.add("--username");
             result.add(userName);
             result.add("--password");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ProjectTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ProjectTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.configuration;
 
@@ -40,14 +40,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ProjectTest {
+class ProjectTest {
 
     /**
      * Test that a {@code Project} instance can be encoded and decoded without
      * errors. Bug #3077.
      */
     @Test
-    public void testEncodeDecode() {
+    void testEncodeDecode() {
         // Create an exception listener to detect errors while encoding and
         // decoding
         final LinkedList<Exception> exceptions = new LinkedList<>();
@@ -83,7 +83,7 @@ public class ProjectTest {
      * Test project matching.
      */
     @Test
-    public void testGetProject() {
+    void testGetProject() {
         // Create 2 projects, one being prefix of the other.
         Project foo = new Project("Project foo", "/foo");
         Project bar = new Project("Project foo-bar", "/foo-bar");
@@ -111,7 +111,7 @@ public class ProjectTest {
      * Test getProjectDescriptions().
      */
     @Test
-    public void testGetProjectDescriptions() {
+    void testGetProjectDescriptions() {
         // Create 2 projects.
         Project foo = new Project("foo", "/foo");
         Project bar = new Project("bar", "/bar");
@@ -136,7 +136,7 @@ public class ProjectTest {
      * Insert the value from configuration.
      */
     @Test
-    public void testMergeProjects1() {
+    void testMergeProjects1() {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setTabSize(new Configuration().getTabSize() + 3731);
         env.setNavigateWindowEnabled(!new Configuration().isNavigateWindowEnabled());
@@ -164,7 +164,7 @@ public class ProjectTest {
      * Do not overwrite customized project property.
      */
     @Test
-    public void testMergeProjects2() {
+    void testMergeProjects2() {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setTabSize(new Configuration().getTabSize() + 3731);
 
@@ -199,7 +199,7 @@ public class ProjectTest {
      * Create a project fill with defaults from the configuration.
      */
     @Test
-    public void testCreateProjectWithConfiguration() {
+    void testCreateProjectWithConfiguration() {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setTabSize(4);
 
@@ -209,7 +209,7 @@ public class ProjectTest {
     }
 
     @Test
-    public void testEquality() {
+    void testEquality() {
         Project g1 = new Project();
         Project g2 = new Project();
         assertEquals(g1, g2, "null == null");
@@ -223,5 +223,21 @@ public class ProjectTest {
         assertEquals(g1, g2, "\"name\" == \"NAME\"");
         assertEquals(g1, g1, "\"name\" == \"name\"");
         assertEquals(g2, g2, "\"NAME\" == \"NAME\"");
+    }
+
+    @Test
+    void testUsername() {
+        Project project = new Project();
+        final String username = "foo";
+        project.setUsername(username);
+        assertEquals(username, project.getUsername());
+    }
+
+    @Test
+    void testPassword() {
+        Project project = new Project();
+        final String password = "foo";
+        project.setPassword(password);
+        assertEquals(password, project.getPassword());
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
@@ -86,7 +86,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testDataRoot() throws IOException {
+    void testDataRoot() throws IOException {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertNull(instance.getDataRootFile());
         assertNull(instance.getDataRootPath());
@@ -104,7 +104,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testIncludeRoot() throws IOException {
+    void testIncludeRoot() throws IOException {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertNull(instance.getIncludeRootPath());
 
@@ -124,7 +124,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testSourceRoot() throws IOException {
+    void testSourceRoot() throws IOException {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertNull(instance.getSourceRootFile());
         assertNull(instance.getSourceRootPath());
@@ -137,7 +137,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testProjects() throws IOException {
+    void testProjects() throws IOException {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         instance.setProjectsEnabled(true);
         assertFalse(instance.hasProjects());
@@ -158,7 +158,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testGroups() {
+    void testGroups() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertFalse(instance.hasGroups());
         assertNotNull(instance.getGroups());
@@ -176,7 +176,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testPerThreadConsistency() throws InterruptedException {
+    void testPerThreadConsistency() throws InterruptedException {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         String path = "/tmp/dataroot1";
         instance.setDataRoot(path);
@@ -191,13 +191,13 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testUrlPrefix() {
+    void testUrlPrefix() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertEquals("/source/s?", instance.getUrlPrefix());
     }
 
     @Test
-    public void testCtags() {
+    void testCtags() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         String instanceCtags = instance.getCtags();
         assertNotNull(instanceCtags);
@@ -216,7 +216,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testFetchHistoryWhenNotInCache() {
+    void testFetchHistoryWhenNotInCache() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertTrue(instance.isFetchHistoryWhenNotInCache());
         instance.setFetchHistoryWhenNotInCache(false);
@@ -224,7 +224,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testUseHistoryCache() {
+    void testUseHistoryCache() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertTrue(instance.useHistoryCache());
         instance.setUseHistoryCache(false);
@@ -232,7 +232,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testGenerateHtml() {
+    void testGenerateHtml() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertTrue(instance.isGenerateHtml());
         instance.setGenerateHtml(false);
@@ -240,7 +240,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testCompressXref() {
+    void testCompressXref() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertTrue(instance.isCompressXref());
         instance.setCompressXref(false);
@@ -248,7 +248,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testQuickContextScan() {
+    void testQuickContextScan() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertTrue(instance.isQuickContextScan());
         instance.setQuickContextScan(false);
@@ -256,7 +256,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testRepositories() {
+    void testRepositories() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertNotNull(instance.getRepositories());
         instance.removeRepositories();
@@ -267,7 +267,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testRamBufferSize() {
+    void testRamBufferSize() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertEquals(16, instance.getRamBufferSize(), 0);  //default is 16
         instance.setRamBufferSize(256);
@@ -275,7 +275,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testAllowLeadingWildcard() {
+    void testAllowLeadingWildcard() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertTrue(instance.isAllowLeadingWildcard());
         instance.setAllowLeadingWildcard(false);
@@ -283,7 +283,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testIgnoredNames() {
+    void testIgnoredNames() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertNotNull(instance.getIgnoredNames());
         instance.setIgnoredNames(null);
@@ -291,7 +291,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testUserPage() {
+    void testUserPage() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         String page = "http://www.myserver.org/viewProfile.jspa?username=";
         assertNull(instance.getUserPage());   // default value is null
@@ -300,7 +300,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testBugPage() {
+    void testBugPage() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         String page = "http://bugs.myserver.org/bugdatabase/view_bug.do?bug_id=";
         assertNull(instance.getBugPage());   // default value is null
@@ -309,7 +309,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testBugPattern() {
+    void testBugPattern() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         String[] tests = new String[]{
             "\\b([12456789][0-9]{6})\\b",
@@ -324,7 +324,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testInvalidBugPattern() {
+    void testInvalidBugPattern() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         String[] tests = new String[]{
             "\\b([",
@@ -341,7 +341,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testReviewPage() {
+    void testReviewPage() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         String page = "http://arc.myserver.org/caselog/PSARC/";
         assertNull(instance.getReviewPage());   // default value is null
@@ -350,7 +350,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testReviewPattern() {
+    void testReviewPattern() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         String[] tests = new String[]{
             "\\b(\\d{4}/\\d{3})\\b",
@@ -365,7 +365,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testInvalidReviewPattern() {
+    void testInvalidReviewPattern() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         String[] tests = new String[]{
             "\\b([",
@@ -382,7 +382,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testWebappLAF() {
+    void testWebappLAF() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertEquals("default", instance.getWebappLAF());
         instance.setWebappLAF("foo");
@@ -390,7 +390,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testRemoteScmSupported() {
+    void testRemoteScmSupported() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertEquals(Configuration.RemoteSCM.OFF, instance.getRemoteScmSupported());
         instance.setRemoteScmSupported(Configuration.RemoteSCM.ON);
@@ -402,7 +402,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testOptimizeDatabase() {
+    void testOptimizeDatabase() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertTrue(instance.isOptimizeDatabase());
         instance.setOptimizeDatabase(false);
@@ -410,13 +410,13 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testUsingLuceneLocking() {
+    void testUsingLuceneLocking() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertEquals(LuceneLockName.OFF, instance.getLuceneLocking());
     }
 
     @Test
-    public void testIndexVersionedFilesOnly() {
+    void testIndexVersionedFilesOnly() {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         assertFalse(instance.isIndexVersionedFilesOnly());
         instance.setIndexVersionedFilesOnly(true);
@@ -424,7 +424,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testXMLencdec() throws IOException {
+    void testXMLencdec() throws IOException {
         Configuration c = new Configuration();
         String m = c.getXMLRepresentationAsString();
         Configuration o = Configuration.makeXMLStringAsConfiguration(m);
@@ -435,7 +435,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testAuthorizationFlagDecode() throws IOException {
+    void testAuthorizationFlagDecode() throws IOException {
         String confString = "<?xml version='1.0' encoding='UTF-8'?>\n"
                 + "<java class=\"java.beans.XMLDecoder\" version=\"1.8.0_121\">\n"
                 + " <object class=\"org.opengrok.indexer.configuration.Configuration\">\n"
@@ -498,7 +498,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testAuthorizationStackDecode() throws IOException {
+    void testAuthorizationStackDecode() throws IOException {
         String confString = "<?xml version='1.0' encoding='UTF-8'?>\n"
                 + "<java class=\"java.beans.XMLDecoder\" version=\"1.8.0_121\">\n"
                 + " <object class=\"org.opengrok.indexer.configuration.Configuration\">\n"
@@ -625,7 +625,7 @@ public class RuntimeEnvironmentTest {
         assertTrue(pluginConfiguration.getStack().get(2).getFlag().isRequisite());
         assertEquals("Requisite", pluginConfiguration.getStack().get(2).getName());
 
-        /**
+        /*
          * Third element is a stack which defines two nested plugins.
          */
         assertTrue(pluginConfiguration.getStack().get(1) instanceof AuthorizationStack);
@@ -647,7 +647,7 @@ public class RuntimeEnvironmentTest {
         assertTrue(plugin.getSetup().get("plugin") instanceof AuthorizationPlugin);
         assertEquals(pluginConfiguration.getStack().get(0), plugin.getSetup().get("plugin"));
 
-        /**
+        /*
          * Fourth element is a stack slightly changed from the previous stack.
          * Only the setup for the particular plugin is changed.
          */
@@ -670,7 +670,7 @@ public class RuntimeEnvironmentTest {
         assertTrue(plugin.getSetup().get("plugin") instanceof AuthorizationPlugin);
         assertEquals(pluginConfiguration.getStack().get(0), plugin.getSetup().get("plugin"));
 
-        /**
+        /*
          * Fifth element is a direct copy of the first stack.
          */
         assertTrue(pluginConfiguration.getStack().get(4) instanceof AuthorizationStack);
@@ -699,7 +699,7 @@ public class RuntimeEnvironmentTest {
      * @throws IOException I/O exception
      */
     @Test
-    public void testAuthorizationFlagDecodeInvalid() throws IOException {
+    void testAuthorizationFlagDecodeInvalid() throws IOException {
         String confString = "<?xml version='1.0' encoding='UTF-8'?>\n"
                 + "<java class=\"java.beans.XMLDecoder\" version=\"1.8.0_121\">\n"
                 + " <object class=\"org.opengrok.indexer.configuration.Configuration\">\n"
@@ -722,8 +722,6 @@ public class RuntimeEnvironmentTest {
 
     /**
      * Testing invalid class names for authorization checks.
-     *
-     * @throws IOException I/O exception
      */
     @Test
     void testAuthorizationDecodeInvalid() {
@@ -748,7 +746,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testBug3095() throws IOException {
+    void testBug3095() throws IOException {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         File file = new File("foobar");
         assertTrue(file.createNewFile());
@@ -762,7 +760,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testBug3154() throws IOException {
+    void testBug3154() throws IOException {
         RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
         File file = File.createTempFile("dataroot", null);
         assertTrue(file.delete());
@@ -775,7 +773,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testObfuscateEMail() throws IOException {
+    void testObfuscateEMail() throws IOException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
         // By default, don't obfuscate.
@@ -809,7 +807,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void isChattyStatusPage() {
+    void isChattyStatusPage() {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
         // By default, status page should not be chatty.
@@ -829,8 +827,8 @@ public class RuntimeEnvironmentTest {
      * @throws ForbiddenSymlinkException forbidden symlink exception
      */
     @Test
-    public void testGetPathRelativeToSourceRoot() throws IOException,
-            ForbiddenSymlinkException {
+    void testGetPathRelativeToSourceRoot() throws IOException, ForbiddenSymlinkException {
+
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
         // Create and set source root.
@@ -861,7 +859,7 @@ public class RuntimeEnvironmentTest {
             expex = e;
         }
         assertNotNull(expex, "getPathRelativeToSourceRoot() should have thrown " +
-                "IOexception for symlink that is not allowed");
+                "IOException for symlink that is not allowed");
 
         // Allow the symlink and retest.
         env.setAllowedSymlinks(new HashSet<>(Arrays.asList(symlink.getPath())));
@@ -874,7 +872,7 @@ public class RuntimeEnvironmentTest {
     }
 
     @Test
-    public void testPopulateGroupsMultipleTimes() {
+    void testPopulateGroupsMultipleTimes() {
         // create a structure with two repositories
         final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         Project project1 = new Project("bar", "/bar");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryInfoTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryInfoTest.java
@@ -24,7 +24,6 @@
 package org.opengrok.indexer.history;
 
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryInfoTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryInfoTest.java
@@ -18,14 +18,18 @@
  */
 
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
 import java.io.File;
+import java.nio.file.Paths;
+import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,14 +39,14 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  *
  * @author Vladimir Kotal
  */
-public class RepositoryInfoTest {
+class RepositoryInfoTest {
     @BeforeEach
     public void setUp() {
         RuntimeEnvironment.getInstance().setSourceRoot("/src");
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         String repoDirectory = "/src/foo";
 
         RepositoryInfo ri1 = new RepositoryInfo();
@@ -54,5 +58,44 @@ public class RepositoryInfoTest {
 
         ri2.setDirectoryName(new File(repoDirectory));
         assertEquals(ri1, ri2);
+    }
+
+    @Test
+    void testUsername() {
+        RepositoryInfo repositoryInfo = new RepositoryInfo();
+        final String username = "foo";
+        repositoryInfo.setUsername(username);
+        assertEquals(username, repositoryInfo.getUsername());
+    }
+
+    @Test
+    void testPassword() {
+        RepositoryInfo repositoryInfo = new RepositoryInfo();
+        final String password = "foo";
+        repositoryInfo.setPassword(password);
+        assertEquals(password, repositoryInfo.getPassword());
+    }
+
+    @Test
+    void testFillFromProjectUsernamePassword() {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+        env.setProjectsEnabled(true);
+
+        final String projectName = "proj";
+        Project project = new Project(projectName);
+        final String dirName = "/proj";
+        project.setPath(dirName);
+        final String username = "foo";
+        final String password = "bar";
+        project.setUsername(username);
+        project.setPassword(password);
+        env.setProjects(Map.of(projectName, project));
+
+        RepositoryInfo repositoryInfo = new RepositoryInfo();
+        repositoryInfo.setDirectoryNameRelative(dirName);
+        repositoryInfo.fillFromProject();
+        assertEquals(username, repositoryInfo.getUsername());
+        assertEquals(password, repositoryInfo.getPassword());
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/SubversionRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/SubversionRepositoryTest.java
@@ -74,7 +74,7 @@ class SubversionRepositoryTest {
     void testUsernamePassword() {
         final SubversionRepository repository = new SubversionRepository();
         final String username = "foo";
-        final String password= "bar";
+        final String password = "bar";
         repository.setUsername(username);
         repository.setPassword(password);
         assertEquals(List.of("--username", username, "--password", password), repository.getAuthCommandLineParams());
@@ -91,7 +91,7 @@ class SubversionRepositoryTest {
     @Test
     void testNullUsernameNonNullPassword() {
         final SubversionRepository repository = new SubversionRepository();
-        final String password= "bar";
+        final String password = "bar";
         assertNull(repository.getUsername());
         repository.setPassword(password);
         assertTrue(repository.getAuthCommandLineParams().isEmpty());

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/SubversionRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/SubversionRepositoryTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Ric Harris <harrisric@users.noreply.github.com>.
  */
 package org.opengrok.indexer.history;
@@ -26,14 +26,17 @@ package org.opengrok.indexer.history;
 import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SubversionRepositoryTest {
+class SubversionRepositoryTest {
 
     @Test
-    public void testDateFormats() {
+    void testDateFormats() {
         String[][] tests = new String[][]{
             {"abcd", "expected exception"},
             {"2016-01-01 10:00:00", "expected exception"},
@@ -65,5 +68,41 @@ public class SubversionRepositoryTest {
                 assertNotNull(test[1], "Shouldn't throw a parsing exception for date: " + test[0]);
             }
         }
+    }
+
+    @Test
+    void testUsernamePassword() {
+        final SubversionRepository repository = new SubversionRepository();
+        final String username = "foo";
+        final String password= "bar";
+        repository.setUsername(username);
+        repository.setPassword(password);
+        assertEquals(List.of("--username", username, "--password", password), repository.getAuthCommandLineParams());
+    }
+
+    @Test
+    void testNullUsernameNullPassword() {
+        final SubversionRepository repository = new SubversionRepository();
+        assertNull(repository.getUsername());
+        assertNull(repository.getPassword());
+        assertTrue(repository.getAuthCommandLineParams().isEmpty());
+    }
+
+    @Test
+    void testNullUsernameNonNullPassword() {
+        final SubversionRepository repository = new SubversionRepository();
+        final String password= "bar";
+        assertNull(repository.getUsername());
+        repository.setPassword(password);
+        assertTrue(repository.getAuthCommandLineParams().isEmpty());
+    }
+
+    @Test
+    void testNonNullUsernameNullPassword() {
+        final SubversionRepository repository = new SubversionRepository();
+        final String username = "foo";
+        assertNull(repository.getPassword());
+        repository.setUsername(username);
+        assertTrue(repository.getAuthCommandLineParams().isEmpty());
     }
 }


### PR DESCRIPTION
This change introduces project/repository properties for setting username/password. Currently this is used only for Subversion, where it replaces the environment variables used so far (`OPENGROK_SUBVERSION_USERNAME`, `OPENGROK_SUBVERSION_PASSWORD`). This impacts both indexer and the webapp.

This is a departure from global username/password towards per project username/password. While technically the username/password can be defined on repository level, the code is not ready for this just yet (`RepositoryInfo#fillFromProject()`) and also it is not clear whether this level of granularity is actually needed.

Example of per project [read-only configuration](https://github.com/oracle/opengrok/wiki/Read-only-configuration) with username/password:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<java version="11.0.4" class="java.beans.XMLDecoder">
 <object class="org.opengrok.indexer.configuration.Configuration" id="Configuration0">

  <void property="projects">
   <void method="put">
    <string>some-project-with-subversion-repositories</string>
    <object class="org.opengrok.indexer.configuration.Project">
     <void property="username">
      <string>foo</string>
     </void>
     <void property="password">
      <string>bar</string>
     </void>
    </object>
   </void>
  </void>

 </object>
</java>
```