### PR TITLE
docker: add openssh-client to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ LABEL maintainer="https://github.com/oracle/opengrok"
 # hadolint ignore=DL3008,DL3009
 RUN apt-get update && \
     apt-get install --no-install-recommends -y git subversion mercurial unzip inotify-tools python3 python3-pip \
-    python3-venv python3-setuptools
+    python3-venv python3-setuptools openssh-client
 
 # compile and install universal-ctags
 # hadolint ignore=DL3003,DL3008


### PR DESCRIPTION
add ssh cli to be abble to fetch/pull git repository over ssh protocol.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
