### PR TITLE
make sure all IndexSearcher instances use an executor

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/IndexSearcherFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/IndexSearcherFactory.java
@@ -1,0 +1,42 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.configuration;
+
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.SearcherFactory;
+
+/**
+ * Factory for IndexSearcher objects with search executor.
+ */
+public class IndexSearcherFactory extends SearcherFactory {
+    public IndexSearcher newSearcher(IndexReader reader) {
+        return newSearcher(reader, null);
+    }
+
+    @Override
+    public IndexSearcher newSearcher(IndexReader reader, IndexReader prev) {
+        // The previous IndexReader is not used here.
+        return new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1808,7 +1808,7 @@ public final class RuntimeEnvironment {
         if (mgr == null) {
             File indexDir = new File(getDataRootPath(), IndexDatabase.INDEX_DIR);
             Directory dir = FSDirectory.open(new File(indexDir, projectName).toPath());
-            mgr = new SearcherManager(dir, new ThreadpoolSearcherFactory());
+            mgr = new SearcherManager(dir, new SuperIndexSearcherFactory());
             searcherManagerMap.put(projectName, mgr);
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -58,7 +58,6 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiReader;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuperIndexSearcherFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuperIndexSearcherFactory.java
@@ -18,7 +18,7 @@
  */
 
  /*
-  * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+  * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
   */
 package org.opengrok.indexer.configuration;
 
@@ -31,12 +31,11 @@ import org.apache.lucene.search.SearcherFactory;
  * to make sure the searcher threads are constrained to single thread pool.
  * @author vkotal
  */
-class ThreadpoolSearcherFactory extends SearcherFactory {
+class SuperIndexSearcherFactory extends SearcherFactory {
 
     @Override
     public SuperIndexSearcher newSearcher(IndexReader r, IndexReader prev) {
         // The previous IndexReader is not used here.
         return new SuperIndexSearcher(r, RuntimeEnvironment.getInstance().getSearchExecutor());
     }
-
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/DirectoryHistoryReader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/DirectoryHistoryReader.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -102,7 +102,7 @@ public class DirectoryHistoryReader {
                 throw new IOException("Could not locate index database");
             }
             // The search results will be sorted by date.
-            IndexSearcher searcher = new IndexSearcher(ireader);
+            IndexSearcher searcher = new IndexSearcher(ireader, RuntimeEnvironment.getInstance().getSearchExecutor());
             SortField sfield = new SortField(QueryBuilder.DATE, SortField.Type.STRING, true);
             Sort sort = new Sort(sfield);
             QueryParser qparser = new QueryParser(QueryBuilder.PATH, new CompatibleAnalyser());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/DirectoryHistoryReader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/DirectoryHistoryReader.java
@@ -93,16 +93,17 @@ public class DirectoryHistoryReader {
      * @throws IOException when index cannot be accessed
      */
     public DirectoryHistoryReader(String path) throws IOException {
-        IndexReader ireader = null;
+        IndexReader indexReader = null;
         try {
             // Prepare for index search.
             String srcRoot = RuntimeEnvironment.getInstance().getSourceRootPath();
-            ireader = IndexDatabase.getIndexReader(path);
-            if (ireader == null) {
-                throw new IOException("Could not locate index database");
+            indexReader = IndexDatabase.getIndexReader(path);
+            if (indexReader == null) {
+                throw new IOException(String.format("Could not locate index database for '%s'", path));
             }
             // The search results will be sorted by date.
-            IndexSearcher searcher = new IndexSearcher(ireader, RuntimeEnvironment.getInstance().getSearchExecutor());
+            IndexSearcher searcher = RuntimeEnvironment.getInstance().
+                    getIndexSearcherFactory().newSearcher(indexReader);
             SortField sfield = new SortField(QueryBuilder.DATE, SortField.Type.STRING, true);
             Sort sort = new Sort(sfield);
             QueryParser qparser = new QueryParser(QueryBuilder.PATH, new CompatibleAnalyser());
@@ -130,7 +131,7 @@ public class DirectoryHistoryReader {
                     try {
                         cdate = DateTools.stringToDate(doc.get(QueryBuilder.DATE));
                     } catch (java.text.ParseException ex) {
-                        LOGGER.log(Level.WARNING, String.format("Could not get date for %s", path), ex);
+                        LOGGER.log(Level.WARNING, String.format("Could not get date for '%s'", path), ex);
                         cdate = new Date();
                     }
                     int ls = rpath.lastIndexOf('/');
@@ -138,11 +139,12 @@ public class DirectoryHistoryReader {
                         String rparent = rpath.substring(0, ls);
                         String rbase = rpath.substring(ls + 1);
                         History hist = null;
+                        File f = new File(srcRoot + rparent, rbase);
                         try {
-                            File f = new File(srcRoot + rparent, rbase);
                             hist = HistoryGuru.getInstance().getHistory(f);
                         } catch (HistoryException e) {
-                            LOGGER.log(Level.WARNING, "An error occurred while getting history reader", e);
+                            LOGGER.log(Level.WARNING,
+                                    String.format("An error occurred while getting history reader for '%s'", f), e);
                         }
                         if (hist == null) {
                             put(cdate, "", "-", "", rpath);
@@ -164,11 +166,12 @@ public class DirectoryHistoryReader {
             // into history object.
             history = new History(entries);
         } finally {
-            if (ireader != null) {
+            if (indexReader != null) {
                 try {
-                    ireader.close();
+                    indexReader.close();
                 } catch (Exception ex) {
-                    LOGGER.log(Level.WARNING, "An error occurred while closing reader", ex);
+                    LOGGER.log(Level.WARNING,
+                            String.format("An error occurred while closing index reader for '%s'", path), ex);
                 }
             }
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexAnalysisSettingsAccessor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexAnalysisSettingsAccessor.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -37,6 +38,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
 import org.opengrok.indexer.analysis.CompatibleAnalyser;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.search.QueryBuilder;
 
 /**
@@ -73,9 +75,10 @@ public class IndexAnalysisSettingsAccessor {
      * @return a defined instance, which is empty if none could be found
      * @throws IOException if I/O error occurs while searching Lucene
      */
-    public IndexAnalysisSettings3[] read(IndexReader reader, int n)
-            throws IOException {
-        IndexSearcher searcher = new IndexSearcher(reader);
+    public IndexAnalysisSettings3[] read(IndexReader reader, int n) throws IOException {
+
+        IndexSearcher searcher = new IndexSearcher(reader,
+                RuntimeEnvironment.getInstance().getIndexerParallelizer().getFixedExecutor());
         Query q;
         try {
             q = new QueryParser(QueryBuilder.OBJUID, new CompatibleAnalyser()).

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexAnalysisSettingsAccessor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexAnalysisSettingsAccessor.java
@@ -77,8 +77,7 @@ public class IndexAnalysisSettingsAccessor {
      */
     public IndexAnalysisSettings3[] read(IndexReader reader, int n) throws IOException {
 
-        IndexSearcher searcher = new IndexSearcher(reader,
-                RuntimeEnvironment.getInstance().getIndexerParallelizer().getFixedExecutor());
+        IndexSearcher searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
         Query q;
         try {
             q = new QueryParser(QueryBuilder.OBJUID, new CompatibleAnalyser()).

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexAnalysisSettingsAccessor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexAnalysisSettingsAccessor.java
@@ -77,7 +77,7 @@ public class IndexAnalysisSettingsAccessor {
      */
     public IndexAnalysisSettings3[] read(IndexReader reader, int n) throws IOException {
 
-        IndexSearcher searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
+        IndexSearcher searcher = RuntimeEnvironment.getInstance().getIndexSearcherFactory().newSearcher(reader);
         Query q;
         try {
             q = new QueryParser(QueryBuilder.OBJUID, new CompatibleAnalyser()).

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1852,10 +1852,10 @@ public class IndexDatabase {
      * Get an indexReader for the Index database where a given file.
      *
      * @param path the file to get the database for
-     * @return The index database where the file should be located or null if it
-     * cannot be located.
+     * @return The index database where the file should be located or {@code null} if it cannot be located.
      */
     @SuppressWarnings("java:S2095")
+    @Nullable
     public static IndexReader getIndexReader(String path) {
         IndexReader ret = null;
 
@@ -1939,7 +1939,7 @@ public class IndexDatabase {
 
         Document doc;
         Query q = new QueryBuilder().setPath(path).build();
-        IndexSearcher searcher = new IndexSearcher(indexReader, RuntimeEnvironment.getInstance().getSearchExecutor());
+        IndexSearcher searcher = RuntimeEnvironment.getInstance().getIndexSearcherFactory().newSearcher(indexReader);
         Statistics stat = new Statistics();
         TopDocs top = searcher.search(q, 1);
         stat.report(LOGGER, Level.FINEST, "search via getDocument() done",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1939,7 +1939,7 @@ public class IndexDatabase {
 
         Document doc;
         Query q = new QueryBuilder().setPath(path).build();
-        IndexSearcher searcher = new IndexSearcher(indexReader);
+        IndexSearcher searcher = new IndexSearcher(indexReader, RuntimeEnvironment.getInstance().getSearchExecutor());
         Statistics stat = new Statistics();
         TopDocs top = searcher.search(q, 1);
         stat.report(LOGGER, Level.FINEST, "search via getDocument() done",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/NumLinesLOCAccessor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/NumLinesLOCAccessor.java
@@ -97,7 +97,7 @@ class NumLinesLOCAccessor {
          * directories or other object data (e.g. IndexAnalysisSettings3), which
          * have no stored PATH.
          */
-        IndexSearcher searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
+        IndexSearcher searcher = RuntimeEnvironment.getInstance().getIndexSearcherFactory().newSearcher(reader);
 
         Query query;
         try {
@@ -139,7 +139,7 @@ class NumLinesLOCAccessor {
             List<AccumulatedNumLinesLOC> counts, boolean isAggregatingDeltas) throws IOException {
 
         // Search for existing documents with QueryBuilder.D.
-        IndexSearcher searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
+        IndexSearcher searcher = RuntimeEnvironment.getInstance().getIndexSearcherFactory().newSearcher(reader);
 
         for (AccumulatedNumLinesLOC entry : counts) {
             Query query = new TermQuery(new Term(QueryBuilder.D, entry.getPath()));
@@ -206,7 +206,7 @@ class NumLinesLOCAccessor {
 
     private DSearchResult newDSearch(IndexReader reader, int n) throws IOException {
         // Search for existing documents with QueryBuilder.D.
-        IndexSearcher searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
+        IndexSearcher searcher = RuntimeEnvironment.getInstance().getIndexSearcherFactory().newSearcher(reader);
         Query query;
         try {
             QueryParser parser = new QueryParser(QueryBuilder.D, new CompatibleAnalyser());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/NumLinesLOCAccessor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/NumLinesLOCAccessor.java
@@ -97,8 +97,7 @@ class NumLinesLOCAccessor {
          * directories or other object data (e.g. IndexAnalysisSettings3), which
          * have no stored PATH.
          */
-        IndexSearcher searcher = new IndexSearcher(reader,
-                RuntimeEnvironment.getInstance().getIndexerParallelizer().getFixedExecutor());
+        IndexSearcher searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
 
         Query query;
         try {
@@ -140,8 +139,7 @@ class NumLinesLOCAccessor {
             List<AccumulatedNumLinesLOC> counts, boolean isAggregatingDeltas) throws IOException {
 
         // Search for existing documents with QueryBuilder.D.
-        IndexSearcher searcher = new IndexSearcher(reader,
-                RuntimeEnvironment.getInstance().getIndexerParallelizer().getFixedExecutor());
+        IndexSearcher searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
 
         for (AccumulatedNumLinesLOC entry : counts) {
             Query query = new TermQuery(new Term(QueryBuilder.D, entry.getPath()));
@@ -208,8 +206,7 @@ class NumLinesLOCAccessor {
 
     private DSearchResult newDSearch(IndexReader reader, int n) throws IOException {
         // Search for existing documents with QueryBuilder.D.
-        IndexSearcher searcher = new IndexSearcher(reader,
-                RuntimeEnvironment.getInstance().getIndexerParallelizer().getFixedExecutor());
+        IndexSearcher searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
         Query query;
         try {
             QueryParser parser = new QueryParser(QueryBuilder.D, new CompatibleAnalyser());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/NumLinesLOCAccessor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/NumLinesLOCAccessor.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -41,6 +42,7 @@ import org.opengrok.indexer.analysis.CompatibleAnalyser;
 import org.opengrok.indexer.analysis.AccumulatedNumLinesLOC;
 import org.opengrok.indexer.analysis.NullableNumLinesLOC;
 import org.opengrok.indexer.analysis.NumLinesLOC;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.search.QueryBuilder;
 
 import java.io.File;
@@ -87,8 +89,7 @@ class NumLinesLOCAccessor {
      * @return a value indicating whether any defined number-of-lines and
      * lines-of-code were found
      */
-    public boolean register(NumLinesLOCAggregator countsAggregator, IndexReader reader)
-            throws IOException {
+    public boolean register(NumLinesLOCAggregator countsAggregator, IndexReader reader) throws IOException {
 
         /*
          * Search for existing documents with any value of PATH. Those are
@@ -96,7 +97,8 @@ class NumLinesLOCAccessor {
          * directories or other object data (e.g. IndexAnalysisSettings3), which
          * have no stored PATH.
          */
-        IndexSearcher searcher = new IndexSearcher(reader);
+        IndexSearcher searcher = new IndexSearcher(reader,
+                RuntimeEnvironment.getInstance().getIndexerParallelizer().getFixedExecutor());
 
         Query query;
         try {
@@ -138,7 +140,8 @@ class NumLinesLOCAccessor {
             List<AccumulatedNumLinesLOC> counts, boolean isAggregatingDeltas) throws IOException {
 
         // Search for existing documents with QueryBuilder.D.
-        IndexSearcher searcher = new IndexSearcher(reader);
+        IndexSearcher searcher = new IndexSearcher(reader,
+                RuntimeEnvironment.getInstance().getIndexerParallelizer().getFixedExecutor());
 
         for (AccumulatedNumLinesLOC entry : counts) {
             Query query = new TermQuery(new Term(QueryBuilder.D, entry.getPath()));
@@ -205,7 +208,8 @@ class NumLinesLOCAccessor {
 
     private DSearchResult newDSearch(IndexReader reader, int n) throws IOException {
         // Search for existing documents with QueryBuilder.D.
-        IndexSearcher searcher = new IndexSearcher(reader);
+        IndexSearcher searcher = new IndexSearcher(reader,
+                RuntimeEnvironment.getInstance().getIndexerParallelizer().getFixedExecutor());
         Query query;
         try {
             QueryParser parser = new QueryParser(QueryBuilder.D, new CompatibleAnalyser());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -18,7 +18,7 @@
  */
 
  /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search;
@@ -176,14 +176,13 @@ public class SearchEngine {
 
     /**
      * Search one index. This is used if no projects are set up.
-     * @param paging whether to use paging (if yes, first X pages will load
-     * faster)
+     * @param paging whether to use paging (if yes, first X pages will load  faster)
      * @param root which db to search
      * @throws IOException
      */
     private void searchSingleDatabase(File root, boolean paging) throws IOException {
         IndexReader ireader = DirectoryReader.open(FSDirectory.open(root.toPath()));
-        searcher = new IndexSearcher(ireader);
+        searcher = new IndexSearcher(ireader, RuntimeEnvironment.getInstance().getSearchExecutor());
         searchIndex(searcher, paging);
     }
 
@@ -203,9 +202,8 @@ public class SearchEngine {
         // We use MultiReader even for single project. This should
         // not matter given that MultiReader is just a cheap wrapper
         // around set of IndexReader objects.
-        MultiReader searchables = RuntimeEnvironment.getInstance().
-            getMultiReader(projects, searcherList);
-        searcher = new IndexSearcher(searchables);
+        MultiReader searchables = RuntimeEnvironment.getInstance().getMultiReader(projects, searcherList);
+        searcher = new IndexSearcher(searchables, RuntimeEnvironment.getInstance().getSearchExecutor());
         searchIndex(searcher, paging);
     }
 
@@ -324,7 +322,6 @@ public class SearchEngine {
         try {
             query = newBuilder.build();
             if (query != null) {
-
                 if (projects.isEmpty()) {
                     // search the index database
                     //NOTE this assumes that src does not contain any project, just

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -181,15 +181,14 @@ public class SearchEngine {
      * @throws IOException
      */
     private void searchSingleDatabase(File root, boolean paging) throws IOException {
-        IndexReader ireader = DirectoryReader.open(FSDirectory.open(root.toPath()));
-        searcher = new IndexSearcher(ireader, RuntimeEnvironment.getInstance().getSearchExecutor());
+        IndexReader indexReader = DirectoryReader.open(FSDirectory.open(root.toPath()));
+        searcher = RuntimeEnvironment.getInstance().getIndexSearcherFactory().newSearcher(indexReader);
         searchIndex(searcher, paging);
     }
 
     /**
      * Perform search on multiple indexes in parallel.
-     * @param paging whether to use paging (if yes, first X pages will load
-     * faster)
+     * @param paging whether to use paging (if yes, first X pages will load faster)
      * @param root list of projects to search
      * @throws IOException
      */
@@ -203,7 +202,7 @@ public class SearchEngine {
         // not matter given that MultiReader is just a cheap wrapper
         // around set of IndexReader objects.
         MultiReader searchables = RuntimeEnvironment.getInstance().getMultiReader(projects, searcherList);
-        searcher = new IndexSearcher(searchables, RuntimeEnvironment.getInstance().getSearchExecutor());
+        searcher = RuntimeEnvironment.getInstance().getIndexSearcherFactory().newSearcher(searchables);
         searchIndex(searcher, paging);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -384,7 +384,7 @@ public class SearchHelper {
                 // no project setup
                 FSDirectory dir = FSDirectory.open(indexDir.toPath());
                 reader = DirectoryReader.open(dir);
-                searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
+                searcher = RuntimeEnvironment.getInstance().getIndexSearcherFactory().newSearcher(reader);
                 closeOnDestroy = true;
             } else {
                 // Check list of project names first to make sure all of them
@@ -415,7 +415,7 @@ public class SearchHelper {
                 // given that MultiReader is just a cheap wrapper around set of IndexReader objects.
                 reader = RuntimeEnvironment.getInstance().getMultiReader(projects, searcherList);
                 if (reader != null) {
-                    searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
+                    searcher = RuntimeEnvironment.getInstance().getIndexSearcherFactory().newSearcher(reader);
                 } else {
                     errorMsg = "Failed to initialize search. Check the index";
                     if (!projects.isEmpty()) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2011, Jens Elkner.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
@@ -176,7 +176,7 @@ public class SearchHelper {
     private IndexReader reader;
     /**
      * the searcher used to open/search the index. Automatically set via
-     * {@link #prepareExec(SortedSet)}.
+     * {@link #prepareExec(SortedSet)}. Used only for setup with no projects.
      */
     private IndexSearcher searcher;
     /**
@@ -384,7 +384,7 @@ public class SearchHelper {
                 // no project setup
                 FSDirectory dir = FSDirectory.open(indexDir.toPath());
                 reader = DirectoryReader.open(dir);
-                searcher = new IndexSearcher(reader);
+                searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
                 closeOnDestroy = true;
             } else {
                 // Check list of project names first to make sure all of them
@@ -411,12 +411,11 @@ public class SearchHelper {
                     return this;
                 }
 
-                // We use MultiReader even for single project. This should
-                // not matter given that MultiReader is just a cheap wrapper
-                // around set of IndexReader objects.
+                // We use MultiReader even for single project. This should not matter
+                // given that MultiReader is just a cheap wrapper around set of IndexReader objects.
                 reader = RuntimeEnvironment.getInstance().getMultiReader(projects, searcherList);
                 if (reader != null) {
-                    searcher = new IndexSearcher(reader);
+                    searcher = new IndexSearcher(reader, RuntimeEnvironment.getInstance().getSearchExecutor());
                 } else {
                     errorMsg = "Failed to initialize search. Check the index";
                     if (!projects.isEmpty()) {


### PR DESCRIPTION
For multi-segment indexes, it is desirable to use [`IndexSearcher` with an executor](https://lucene.apache.org/core/8_8_1/core/org/apache/lucene/search/IndexSearcher.html#IndexSearcher-org.apache.lucene.index.IndexReader-java.util.concurrent.Executor-) so that the segments can be search in parallel.

This change addresses both indexer and webapp. For the former, the threads created should respect indexing parallelism level, for the latter the already existing search executor fixed thread pool should be used.

In a way this fixes the situation with `ThreadpoolSearcherFactory` - even though it is used to create `IndexSearcher` objects with a executor, these objects are not really used for searching (see #4009).

I verified with debugger/decompiler in IDEA that UI based searches that go through `SearchHelper` end up in the Lucene's `search()` method that actually submits tasks to the executor (based on _leaves_ of the `IndexReaderContext` object associated with given `IndexSearcher`).

Complements PR #3983.