### PR TITLE
improve Index searcher efficiency

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -34,6 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.PatternSyntaxException;
 
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.ClassUtil;
@@ -548,6 +549,7 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
      * @param file the file to lookup
      * @return the project that this file belongs to (or {@code null} if the file doesn't belong to a project)
      */
+    @Nullable
     public static Project getProject(File file) {
         Project ret = null;
         try {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuperIndexSearcher.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuperIndexSearcher.java
@@ -22,6 +22,7 @@
  */
 package org.opengrok.indexer.configuration;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
@@ -50,5 +51,9 @@ public class SuperIndexSearcher extends IndexSearcher {
 
     public SearcherManager getSearcherManager() {
         return (searcherManager);
+    }
+
+    public void release() throws IOException {
+        getSearcherManager().release(this);
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuperIndexSearcherFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuperIndexSearcherFactory.java
@@ -27,7 +27,7 @@ import org.apache.lucene.search.SearcherFactory;
 
 /**
  * Factory for producing IndexSearcher objects.
- * This is used inside getIndexSearcher() to produce new SearcherManager objects
+ * This is used inside getSuperIndexSearcher() to produce new SearcherManager objects
  * to make sure the searcher threads are constrained to single thread pool.
  * @author vkotal
  */

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -83,7 +83,7 @@ public class SearchEngineTest {
     }
 
     @Test
-    public void testIsValidQuery() {
+    void testIsValidQuery() {
         SearchEngine instance = new SearchEngine();
         assertFalse(instance.isValidQuery());
         instance.setFile("foo");
@@ -91,7 +91,7 @@ public class SearchEngineTest {
     }
 
     @Test
-    public void testDefinition() {
+    void testDefinition() {
         SearchEngine instance = new SearchEngine();
         assertNull(instance.getDefinition());
         String defs = "This is a definition";
@@ -100,7 +100,7 @@ public class SearchEngineTest {
     }
 
     @Test
-    public void testFile() {
+    void testFile() {
         SearchEngine instance = new SearchEngine();
         assertNull(instance.getFile());
         String file = "This is a File";
@@ -109,7 +109,7 @@ public class SearchEngineTest {
     }
 
     @Test
-    public void testFreetext() {
+    void testFreetext() {
         SearchEngine instance = new SearchEngine();
         assertNull(instance.getFreetext());
         String freetext = "This is just a piece of text";
@@ -118,7 +118,7 @@ public class SearchEngineTest {
     }
 
     @Test
-    public void testHistory() {
+    void testHistory() {
         SearchEngine instance = new SearchEngine();
         assertNull(instance.getHistory());
         String hist = "This is a piece of history";
@@ -127,7 +127,7 @@ public class SearchEngineTest {
     }
 
     @Test
-    public void testSymbol() {
+    void testSymbol() {
         SearchEngine instance = new SearchEngine();
         assertNull(instance.getSymbol());
         String sym = "This is a symbol";
@@ -136,7 +136,7 @@ public class SearchEngineTest {
     }
 
     @Test
-    public void testGetQuery() throws Exception {
+    void testGetQuery() throws Exception {
         SearchEngine instance = new SearchEngine();
         instance.setHistory("Once upon a time");
         instance.setFile("Makefile");

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -118,7 +118,7 @@ public class SuggesterServiceImpl implements SuggesterService {
 
             for (SuperIndexSearcher s : superIndexSearchers) {
                 try {
-                    s.getSearcherManager().release(s);
+                    s.release();
                 } catch (IOException e) {
                     logger.log(Level.WARNING, "Could not release " + s, e);
                 }
@@ -131,20 +131,20 @@ public class SuggesterServiceImpl implements SuggesterService {
             final List<SuperIndexSearcher> superIndexSearchers
     ) {
         if (env.isProjectsEnabled()) {
-            return projects.stream().map(project -> {
+            return projects.stream().map(projectName -> {
                 try {
-                    SuperIndexSearcher searcher = env.getIndexSearcher(project);
+                    SuperIndexSearcher searcher = env.getSuperIndexSearcher(projectName);
                     superIndexSearchers.add(searcher);
-                    return new NamedIndexReader(project, searcher.getIndexReader());
+                    return new NamedIndexReader(projectName, searcher.getIndexReader());
                 } catch (IOException e) {
-                    logger.log(Level.WARNING, "Could not get index reader for " + project, e);
+                    logger.log(Level.WARNING, "Could not get index reader for " + projectName, e);
                 }
                 return null;
             }).filter(Objects::nonNull).collect(Collectors.toList());
         } else {
             SuperIndexSearcher searcher;
             try {
-                searcher = env.getIndexSearcher("");
+                searcher = env.getSuperIndexSearcher("");
                 superIndexSearchers.add(searcher);
                 return Collections.singletonList(new NamedIndexReader("", searcher.getIndexReader()));
             } catch (IOException e) {

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class FileControllerTest extends OGKJerseyTest {
+class FileControllerTest extends OGKJerseyTest {
 
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
@@ -91,7 +91,7 @@ public class FileControllerTest extends OGKJerseyTest {
     }
 
     @Test
-    public void testFileContent() throws IOException {
+    void testFileContent() throws IOException {
         final String path = "git/header.h";
         byte[] encoded = Files.readAllBytes(Paths.get(repository.getSourceRoot(), path));
         String contents = new String(encoded);
@@ -104,7 +104,7 @@ public class FileControllerTest extends OGKJerseyTest {
     }
 
     @Test
-    public void testFileGenre() {
+    void testFileGenre() {
         final String path = "git/main.c";
         String genre = target("file")
                 .path("genre")


### PR DESCRIPTION
This change, or rather set of changes, purges all unnecessary `FSDirectory.open()` calls from all webapp related classes, replacing the related code blocks with calls to retrieve `(Super)IndexSearcher` instances (that can be used to get `IndexReader` instances). This should speed up the webapp a bit by avoiding the syscalls and I/O related to opening the index files.

As for the first part of https://github.com/oracle/opengrok/issues/4009#issue-1317000722 (about the `MultiReader` relationship to `IndexSearcher`s), I think it is not in dire need of addressing.