### PR TITLE
shutdown search executor at the end of indexing

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -203,6 +203,15 @@ public final class RuntimeEnvironment {
                 });
     }
 
+    public void shutdownSearchExecutor() {
+        getSearchExecutor().shutdownNow();
+        try {
+            getSearchExecutor().awaitTermination(getIndexerCommandTimeout(), TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            LOGGER.log(Level.WARNING, "failed to await shutdown of search executor", e);
+        }
+    }
+
     public ExecutorService getRevisionExecutor() {
         return lzRevisionExecutor.get();
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -413,7 +413,7 @@ public final class Indexer {
             System.err.println("Exception: " + e.getLocalizedMessage());
             System.exit(1);
         } finally {
-            env.getSearchExecutor().shutdownNow();
+            env.shutdownSearchExecutor();
             stats.report(LOGGER, "Indexer finished", "indexer.total");
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -413,6 +413,7 @@ public final class Indexer {
             System.err.println("Exception: " + e.getLocalizedMessage());
             System.exit(1);
         } finally {
+            env.getSearchExecutor().shutdownNow();
             stats.report(LOGGER, "Indexer finished", "indexer.total");
         }
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -24,6 +24,7 @@
  */
 package org.opengrok.indexer.index;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -40,6 +41,7 @@ import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -177,17 +179,14 @@ public class IndexerTest {
         assertEquals(p1.getTabSize(), newP1.getTabSize(), "project tabsize");
     }
 
-    /**
-     * Test of doIndexerExecution method, of class Indexer.
-     */
     @Test
-    void testMain() {
-        System.out.println("Generate index by using command line options");
+    void testParseOptions() throws ParseException {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        String[] argv = {"-S", "-P", "-H", "-Q", "off", "-s",
-                repository.getSourceRoot(), "-d", repository.getDataRoot(),
+        String[] argv = {"-S", "-P", "-H", "-Q", "off",
+                "-s", repository.getSourceRoot(),
+                "-d", repository.getDataRoot(),
                 "-v", "-c", env.getCtags()};
-        Indexer.main(argv);
+        assertDoesNotThrow(() -> Indexer.parseOptions(argv));
     }
 
     private static class MyIndexChangeListener implements IndexChangedListener {
@@ -226,7 +225,6 @@ public class IndexerTest {
     /**
      * Test indexing w.r.t. setIndexVersionedFilesOnly() setting,
      * i.e. if this option is set to true, index only files tracked by SCM.
-     * @throws Exception
      */
     @Test
     void testIndexWithSetIndexVersionedFilesOnly() throws Exception {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -231,6 +231,7 @@ public class IndexerTest {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setSourceRoot(repository.getSourceRoot());
         env.setDataRoot(repository.getDataRoot());
+        env.setHistoryEnabled(true);
         env.setRepositories(repository.getSourceRoot());
 
         List<RepositoryInfo> repos = env.getRepositories();
@@ -412,6 +413,7 @@ public class IndexerTest {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setSourceRoot(repository.getSourceRoot());
         env.setDataRoot(repository.getDataRoot());
+        RuntimeEnvironment.getInstance().setIndexVersionedFilesOnly(false);
 
         Project project = new Project("bug3430");
         project.setPath("/bug3430");
@@ -431,6 +433,7 @@ public class IndexerTest {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setSourceRoot(repository.getSourceRoot());
         env.setDataRoot(repository.getDataRoot());
+        RuntimeEnvironment.getInstance().setIndexVersionedFilesOnly(false);
 
         // Make the test consistent. If run in sequence with other tests, env.hasProjects() returns true.
         // The same should work for standalone test run.

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -332,6 +332,7 @@ public class IndexerTest {
         env.setSourceRoot(testrepo.getSourceRoot());
         env.setDataRoot(testrepo.getDataRoot());
         env.setRepositories(testrepo.getSourceRoot());
+        env.setHistoryEnabled(true);
 
         // Create history cache.
         Indexer.getInstance().prepareIndexer(env, true, true,

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web;
@@ -167,6 +167,7 @@ public final class WebappListener
         env.stopExpirationTimer();
         try {
             env.shutdownRevisionExecutor();
+            env.shutdownSearchExecutor();
         } catch (InterruptedException e) {
             LOGGER.log(Level.WARNING, "Could not shutdown revision executor", e);
         }

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -58,8 +58,7 @@ import java.util.logging.Logger;
  *
  * @author Trond Norbye
  */
-public final class WebappListener
-        implements ServletContextListener, ServletRequestListener {
+public final class WebappListener implements ServletContextListener, ServletRequestListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WebappListener.class);
     private final Timer startupTimer = Timer.builder("webapp.startup.latency").


### PR DESCRIPTION
The search Executor used for index searches performed during indexing since PR #4008 has to be shutdown at the end of the indexing, otherwise the indexer will hang in JVM after printing the 'Indexer finished' message.

The thread list in such case is visible in [jstack.log](https://github.com/oracle/opengrok/files/9192939/jstack.log). This change fixes that.
