### PR TITLE
unify thread naming

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/OpenGrokThreadFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/OpenGrokThreadFactory.java
@@ -1,0 +1,50 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.configuration;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * ThreadFactory to be used throughout OpenGrok to make sure all threads have common prefix.
+ */
+public class OpenGrokThreadFactory implements ThreadFactory {
+    private final String threadPrefix;
+
+    public OpenGrokThreadFactory(String name) {
+        if (!name.endsWith("-")) {
+            threadPrefix = name + "-";
+        } else {
+            threadPrefix = name;
+        }
+    }
+
+    @Override
+    public Thread newThread(@NotNull Runnable runnable) {
+        Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+        thread.setName("OpenGrok-" + threadPrefix + thread.getId());
+        return thread;
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -62,7 +62,6 @@ import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
-import org.apache.lucene.util.NamedThreadFactory;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.authorization.AuthorizationFramework;
@@ -196,11 +195,7 @@ public final class RuntimeEnvironment {
     private ExecutorService newSearchExecutor() {
         return Executors.newFixedThreadPool(
                 this.getMaxSearchThreadCount(),
-                runnable -> {
-                    Thread thread = Executors.defaultThreadFactory().newThread(runnable);
-                    thread.setName("search-" + thread.getId());
-                    return thread;
-                });
+                new OpenGrokThreadFactory("search"));
     }
 
     public void shutdownSearchExecutor() {
@@ -218,7 +213,7 @@ public final class RuntimeEnvironment {
 
     private ExecutorService newRevisionExecutor() {
         return Executors.newFixedThreadPool(this.getMaxRevisionThreadCount(),
-                new NamedThreadFactory("get-revision"));
+                new OpenGrokThreadFactory("get-revision"));
     }
 
     public void shutdownRevisionExecutor() throws InterruptedException {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -81,6 +81,7 @@ import org.eclipse.jgit.util.io.NullOutputStream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
+import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
@@ -784,7 +785,7 @@ public class GitRepository extends RepositoryWithHistoryTraversal {
      */
     @Override
     protected void buildTagList(File directory, CommandTimeoutType cmdType) {
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final ExecutorService executor = Executors.newSingleThreadExecutor(new OpenGrokThreadFactory("git-tags"));
         final Future<?> future = executor.submit(() -> rebuildTagList(directory));
         executor.shutdown();
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -50,6 +50,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.Configuration.RemoteSCM;
+import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
 import org.opengrok.indexer.configuration.PathAccepter;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -984,11 +985,7 @@ public final class HistoryGuru {
             parallelismLevel = env.getRepositoryInvalidationParallelism();
         }
         final ExecutorService executor = Executors.newFixedThreadPool(parallelismLevel,
-                runnable -> {
-                    Thread thread = Executors.defaultThreadFactory().newThread(runnable);
-                    thread.setName("invalidate-repos-" + thread.getId());
-                    return thread;
-                });
+                new OpenGrokThreadFactory("invalidate-repos-"));
 
         for (RepositoryInfo repositoryInfo : repos) {
             executor.submit(() -> {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/BoundedBlockingObjectPool.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/BoundedBlockingObjectPool.java
@@ -5,6 +5,7 @@
  * https://dzone.com/articles/generic-and-concurrent-object : "Feel free to use
  * it, change it, add more implementations. Happy coding!"
  * Portions Copyright (c) 2017-2018, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  */
 
 package org.opengrok.indexer.util;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/BoundedBlockingObjectPool.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/BoundedBlockingObjectPool.java
@@ -16,6 +16,8 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
 import org.opengrok.indexer.logger.LoggerFactory;
 
 /**
@@ -37,7 +39,7 @@ public final class BoundedBlockingObjectPool<T> extends AbstractObjectPool<T>
     private final LinkedBlockingDeque<T> objects;
     private final ObjectValidator<T> validator;
     private final ObjectFactory<T> objectFactory;
-    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final ExecutorService executor = Executors.newCachedThreadPool(new OpenGrokThreadFactory("bounded"));
     private volatile boolean puttingLast;
     private volatile boolean shutdownCalled;
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTaskManager.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTaskManager.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api;
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTaskManager.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTaskManager.java
@@ -23,7 +23,7 @@
 package org.opengrok.web.api;
 
 import jakarta.ws.rs.core.Response;
-import org.apache.lucene.util.NamedThreadFactory;
+import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.web.api.v1.controller.StatusController;
 
@@ -76,7 +76,11 @@ public final class ApiTaskManager {
     }
 
     static String getQueueName(String name) {
-        return name.replaceAll("^/", "").replace("/", "-");
+        String suffix = name.replaceAll("^/", "").replace("/", "-");
+        if (!suffix.startsWith("-")) {
+             suffix = "-" + suffix;
+        }
+        return "api_task" + suffix;
     }
 
     /**
@@ -121,7 +125,7 @@ public final class ApiTaskManager {
         }
 
         queues.put(queueName, Executors.newFixedThreadPool(threadCount,
-                new NamedThreadFactory(getQueueName(queueName))));
+                new OpenGrokThreadFactory(queueName)));
     }
 
     /**

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/impl/SuggesterServiceImpl.java
@@ -31,6 +31,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.opengrok.indexer.Metrics;
+import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
 import org.opengrok.suggest.Suggester;
 import org.opengrok.suggest.Suggester.NamedIndexDir;
 import org.opengrok.suggest.Suggester.NamedIndexReader;
@@ -78,7 +79,8 @@ public class SuggesterServiceImpl implements SuggesterService {
 
     private Suggester suggester;
 
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1,
+            new OpenGrokThreadFactory("suggester-scheduler"));
 
     private ScheduledFuture<?> future;
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskManagerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/ApiTaskManagerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api;
 
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -47,9 +48,9 @@ class ApiTaskManagerTest {
     @Test
     void testQueueName() {
         String name = "foo";
-        assertEquals(name, ApiTaskManager.getQueueName(name));
+        assertTrue(ApiTaskManager.getQueueName(name).endsWith(name));
         name = "/foo";
-        assertEquals(name.substring(1), ApiTaskManager.getQueueName(name));
+        assertFalse(ApiTaskManager.getQueueName(name).contains("/"));
     }
 
     private Object doNothing() {

--- a/plugins/src/main/java/opengrok/auth/plugin/util/WebHook.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/util/WebHook.java
@@ -22,6 +22,8 @@
  */
 package opengrok.auth.plugin.util;
 
+import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
+
 import java.io.Serializable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -56,10 +58,9 @@ public class WebHook implements Serializable {
     }
 
     public Future<String> post() {
-        CompletableFuture<String> completableFuture
-                = new CompletableFuture<>();
+        CompletableFuture<String> completableFuture = new CompletableFuture<>();
 
-        Executors.newCachedThreadPool().submit(() -> {
+        Executors.newCachedThreadPool(new OpenGrokThreadFactory("webhook-")).submit(() -> {
             int status = RestfulClient.postIt(getURI(), getContent());
             completableFuture.complete(String.valueOf(status));
             return null;

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -109,7 +109,8 @@ public final class Suggester implements Closeable {
             Runtime.getRuntime().availableProcessors(),
             runnable -> {
                 Thread thread = Executors.defaultThreadFactory().newThread(runnable);
-                thread.setName("suggester-lookup-" + thread.getId());
+                // This should match the naming in OpenGrokThreadFactory class.
+                thread.setName("OpenGrok-suggester-lookup-" + thread.getId());
                 return thread;
             });
 


### PR DESCRIPTION
This change introduces thread factory (succinctly called `OpenGrokThreadFactory`) that uses a common prefix to name threads and replaces various (hopefully all) thread pool creations to use this factory. This will make it easier to identify threads spawned by OpenGrok (indexer or webapp).