### PR TITLE
make Project/Group comparison case sensitive

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Group.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Group.java
@@ -18,12 +18,13 @@
  */
 
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;
 
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
@@ -252,16 +253,12 @@ public class Group implements Comparable<Group>, Nameable {
 
     @Override
     public int compareTo(Group o) {
-        return getName().toUpperCase(Locale.ROOT).compareTo(
-                o.getName().toUpperCase(Locale.ROOT));
+        return getName().compareTo(o.getName());
     }
 
     @Override
     public int hashCode() {
-        int hash = 3;
-        hash = 41 * hash + (this.name == null ? 0 :
-                this.name.toUpperCase(Locale.ROOT).hashCode());
-        return hash;
+        return Objects.hashCode(name);
     }
 
     @Override
@@ -280,8 +277,7 @@ public class Group implements Comparable<Group>, Nameable {
         int numNull = (name == null ? 1 : 0) + (other.name == null ? 1 : 0);
         switch (numNull) {
             case 0:
-                return name.toUpperCase(Locale.ROOT).equals(
-                        other.name.toUpperCase(Locale.ROOT));
+                return name.equals(other.name);
             case 1:
                 return false;
             default:

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Group.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Group.java
@@ -23,7 +23,6 @@
  */
 package org.opengrok.indexer.configuration;
 
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -27,7 +27,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Level;
@@ -585,16 +585,12 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
 
     @Override
     public int compareTo(Project p2) {
-        return getName().toUpperCase(Locale.ROOT).compareTo(
-                p2.getName().toUpperCase(Locale.ROOT));
+        return getName().compareTo(p2.getName());
     }
 
     @Override
     public int hashCode() {
-        int hash = 3;
-        hash = 41 * hash + (this.name == null ? 0 :
-                this.name.toUpperCase(Locale.ROOT).hashCode());
-        return hash;
+        return Objects.hashCode(name);
     }
 
     @Override
@@ -613,8 +609,7 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
         int numNull = (name == null ? 1 : 0) + (other.name == null ? 1 : 0);
         switch (numNull) {
             case 0:
-                return name.toUpperCase(Locale.ROOT).equals(
-                        other.name.toUpperCase(Locale.ROOT));
+                return name.equals(other.name);
             case 1:
                 return false;
             default:

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/GroupTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/GroupTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.configuration;
 
@@ -39,14 +39,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GroupTest {
+class GroupTest {
 
     /**
      * Test that a {@code Group} instance can be encoded and decoded without
      * errors.
      */
     @Test
-    public void testEncodeDecode() {
+    void testEncodeDecode() {
         // Create an exception listener to detect errors while encoding and
         // decoding
         final LinkedList<Exception> exceptions = new LinkedList<>();
@@ -79,7 +79,7 @@ public class GroupTest {
     }
 
     @Test
-    public void invalidPatternTest() {
+    void invalidPatternTest() {
         testPattern("*dangling asterisk", false);
         testPattern(".*(", false);
         testPattern("+", false);
@@ -102,7 +102,7 @@ public class GroupTest {
     }
 
     @Test
-    public void basicTest() {
+    void basicTest() {
         Group g = new Group("Random name", "abcd");
 
         assertEquals("Random name", g.getName());
@@ -140,7 +140,7 @@ public class GroupTest {
     }
 
     @Test
-    public void subgroupsTest() {
+    void subgroupsTest() {
         Group g1 = new Group("Random name", "abcd");
         Group g2 = new Group("Random name2", "efgh");
         Group g3 = new Group("Random name3", "xyz");
@@ -177,7 +177,7 @@ public class GroupTest {
     }
 
     @Test
-    public void projectTest() {
+    void projectTest() {
         Group random1 = new Group("Random name", "abcd");
         Group random2 = new Group("Random name2", "efgh");
 
@@ -205,7 +205,7 @@ public class GroupTest {
     }
 
     @Test
-    public void testEquality() {
+    void testEquality() {
         Group g1 = new Group();
         Group g2 = new Group();
         assertEquals(g1, g2, "null == null");
@@ -213,11 +213,5 @@ public class GroupTest {
         g1 = new Group("name");
         g2 = new Group("other");
         assertNotEquals(g1, g2, "\"name\" != \"other\"");
-
-        g1 = new Group("name");
-        g2 = new Group("NAME");
-        assertEquals(g1, g2, "\"name\" == \"NAME\"");
-        assertEquals(g1, g1, "\"name\" == \"name\"");
-        assertEquals(g2, g2, "\"NAME\" == \"NAME\"");
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ProjectTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ProjectTest.java
@@ -217,12 +217,6 @@ class ProjectTest {
         g1 = new Project("name");
         g2 = new Project("other");
         assertNotEquals(g1, g2, "\"name\" != \"other\"");
-
-        g1 = new Project("name");
-        g2 = new Project("NAME");
-        assertEquals(g1, g2, "\"name\" == \"NAME\"");
-        assertEquals(g1, g1, "\"name\" == \"name\"");
-        assertEquals(g2, g2, "\"NAME\" == \"NAME\"");
     }
 
     @Test


### PR DESCRIPTION
This change removes the upper case conversion of Project/Group names. It is not clear to me why it was there in the first place.