### PR TITLE
use docker pushrm to update README on Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Build docker image
+name: Build Docker image
 
 on: [push, pull_request]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,8 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
+    - name: Install Python pre-requisites
+      run: python3 -m pip install requests
     - name: Optionally update README on Docker hub
       env:
         OPENGROK_PULL_REQUEST: ${{ github.head_ref }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout master branch
-      uses: actions/checkout@v2
-    - name: Build Docker image
+      uses: actions/checkout@v3
+    - name: Build and optionally push Docker image
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -16,14 +16,12 @@ jobs:
         OPENGROK_PULL_REQUEST: ${{ github.head_ref }}
         OPENGROK_REF: ${{ github.ref }}
       run: ./dev/docker.sh
-    - name: push README to Dockerhub on release
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: christian-korneck/update-container-description-action@v1
-      env:
-        DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASS: ${{ secrets.DOCKER_PASSWORD }}
+    - uses: actions/setup-python@v4
       with:
-        destination_container_repo: opengrok/docker
-        provider: dockerhub
-        short_description: 'Official OpenGrok Docker image'
-        readme_file: 'docker/README.md'
+        python-version: '3.10'
+    - name: Optionally update README on Docker hub
+      env:
+        OPENGROK_PULL_REQUEST: ${{ github.head_ref }}
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: ./dev/dockerhub_readme.py

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,3 +16,14 @@ jobs:
         OPENGROK_PULL_REQUEST: ${{ github.head_ref }}
         OPENGROK_REF: ${{ github.ref }}
       run: ./dev/docker.sh
+    - name: push README to Dockerhub on release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: christian-korneck/update-container-description-action@v1
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASS: ${{ secrets.DOCKER_PASSWORD }}
+      with:
+        destination_container_repo: opengrok/docker
+        provider: dockerhub
+        short_description: 'Official OpenGrok Docker image'
+        readme_file: 'docker/README.md'

--- a/dev/dockerhub_readme.py
+++ b/dev/dockerhub_readme.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+"""
+ Update the README on Docker hub.
+
+ This script uses the following secure variables:
+  - DOCKER_USERNAME
+  - DOCKER_PASSWORD
+
+ These are set via https://github.com/oracle/opengrok/settings/secrets
+"""
+
+import logging
+import os
+import sys
+
+import requests
+
+API_URL = "https://hub.docker.com/v2"
+IMAGE = "opengrok/docker"
+MAIN_REPO_SLUG = "oracle/opengrok"
+
+
+def get_token(username, password):
+    """
+    :param username: Docker hub username
+    :param password: Docker hub password
+    :return JWT token string from Docker hub API response
+    """
+
+    logger = logging.getLogger(__name__)
+
+    logger.debug("Getting Docker hub token using username/password")
+    headers = {"Content-Type": "application/json"}
+    data = {"username": f"{username}", "password": f"{password}"}
+    response = requests.post(f"{API_URL}/users/login/", headers=headers, json=data)
+    response.raise_for_status()
+
+    return response.json()["token"]
+
+
+def update_readme(image, readme_file_path, username, password):
+    """
+    Update README file for given image on Docker hub.
+    :param image: image path (in the form of "namespace_name/repository_name")
+    :param readme_file_path path to the README file
+    :param username: Docker hub username
+    :param password: Docker hub password
+    """
+
+    logger = logging.getLogger(__name__)
+
+    token = get_token(username, password)
+    headers = {"Content-Type": "application/json", "Authorization": f"JWT {token}"}
+    with open(readme_file_path, "r") as readme_fp:
+        readme_data = readme_fp.read()
+    logger.info("Updating README file on Docker hub")
+    body_data = {"full_description": readme_data}
+    response = requests.patch(
+        f"{API_URL}/repositories/{image}/",
+        headers=headers,
+        json=body_data,
+    )
+    response.raise_for_status()
+
+
+def check_push_env():
+    """
+    Check environment variables.
+    Will exit the program if the environment is not setup for pushing images to Docker hub.
+    Specifically, number of environment variables is required:
+      - DOCKER_USERNAME
+      - DOCKER_PASSWORD
+    :return Docker hub username and password
+    """
+
+    logger = logging.getLogger(__name__)
+
+    if os.environ.get("OPENGROK_PULL_REQUEST"):
+        logger.info("Not updating Docker hub README for pull requests")
+        sys.exit(0)
+
+    docker_username = os.environ.get("DOCKER_USERNAME")
+    if docker_username is None:
+        logger.info("DOCKER_USERNAME is empty, exiting")
+        sys.exit(1)
+
+    docker_password = os.environ.get("DOCKER_PASSWORD")
+    if docker_password is None:
+        logger.info("DOCKER_PASSWORD is empty, exiting")
+        sys.exit(1)
+
+    return docker_username, docker_password
+
+
+def main():
+    """
+    main program - update Docker hub README and exit.
+    """
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    docker_username, docker_password = check_push_env()
+    try:
+        update_readme(IMAGE, "docker/README.md", docker_username, docker_password)
+    except requests.exceptions.HTTPError as exc:
+        logger.error(exc)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change fixes Docker hub README update. Before this change it failed because the payload was not actually formed JSON even though the Content-type header claimed so. Originally https://github.com/christian-korneck/docker-pushrm based Github action was used, however this was not possible.

As mentioned on https://stackoverflow.com/a/58478262/11582827 , it would be better if the conditional in the Github workflow was based on the `release` build type however the workflow needs to work for other types as well.