### PR TITLE
Fix check if url root is 'source'

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -488,7 +488,7 @@ def main():
     # Note that deploy is done before Tomcat is started.
     deploy(logger, url_root)
 
-    if url_root != '/source':
+    if url_root != 'source':
         setup_redirect_source(logger, url_root)
 
     env = {}


### PR DESCRIPTION
When deploying the Docker image with `URL_ROOT: '/source'` the container will run into an exception and not continue to start.

This commit edits the check, to allow setting `URL_ROOT: '/source'``.

The reason for this is the check in `start.py` if the url root is `/source`. But the string is stripped of slashes in the method `set_url_root`.

Relevant logging message:
```
2022-09-21 06:28:21,947    DEBUG opengrok_tools | URL_ROOT = source
2022-09-21 06:28:24,888    DEBUG opengrok_tools | Setting up redirect from /source to 'source'
Exception in thread Sync thread:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 946, in run
    self._target(*self._args, **self._kwargs)
  File "/scripts/start.py", line 320, in project_syncer
    wait_for_tomcat(logger, uri)
  File "/scripts/start.py", line 202, in wait_for_tomcat
    ret = get(uri)
  File "/usr/local/lib/python3.10/dist-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/requests/sessions.py", line 587, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.10/dist-packages/requests/sessions.py", line 723, in send
    history = [resp for resp in gen]
  File "/usr/local/lib/python3.10/dist-packages/requests/sessions.py", line 723, in <listcomp>
    history = [resp for resp in gen]
  File "/usr/local/lib/python3.10/dist-packages/requests/sessions.py", line 191, in resolve_redirects
    raise TooManyRedirects(
requests.exceptions.TooManyRedirects: Exceeded 30 redirects.
```
