### PR TITLE
fix(sec): upgrade jackson-databind to 2.12.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <jersey.version>3.0.2</jersey.version>
         <!-- Jackson version needs to match the version of Jackson which Jersey
         depends on or otherwise weird things will happen. -->
-        <jackson.version>2.12.2</jackson.version>
+        <jackson.version>2.12.6.1</jackson.version>
         <junit.version>5.7.2</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>


### PR DESCRIPTION
Upgrade jackson-databind from 2.12.2 to 2.12.6.1 for vulnerability fix:
- [MPS-2022-12500](https://www.oscs1024.com/hd/MPS-2022-12500)
- [CVE-2020-36518](https://www.oscs1024.com/hd/MPS-2022-6242)

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
