### PR TITLE
add ignore property to project configuration check

### DIFF
--- a/tools/src/main/python/opengrok_tools/utils/mirror.py
+++ b/tools/src/main/python/opengrok_tools/utils/mirror.py
@@ -604,7 +604,8 @@ def check_project_configuration(multiple_project_config, hookdir=False,
                               HOOK_TIMEOUT_PROPERTY, PROXY_PROPERTY,
                               IGNORED_REPOS_PROPERTY, HOOKS_PROPERTY,
                               DISABLED_REASON_PROPERTY, INCOMING_PROPERTY,
-                              IGNORE_ERR_PROPERTY, STRIP_OUTGOING_PROPERTY]
+                              IGNORE_ERR_PROPERTY, STRIP_OUTGOING_PROPERTY,
+                              IGNORE_PROPERTY]
 
     if not multiple_project_config:
         return True


### PR DESCRIPTION
Forgot to add the new property in #4061 to the list of allowed project properties in `opengrok-mirror` configuration.