### PR TITLE
Subversion fixes

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
+import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.configuration.Configuration.RemoteSCM;
 import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
 import org.opengrok.indexer.configuration.PathAccepter;
@@ -465,10 +466,18 @@ public final class HistoryGuru {
         }
 
         // This should return true for Annotate view.
-        return ((env.getRemoteScmSupported() == RemoteSCM.ON)
-                || (env.getRemoteScmSupported() == RemoteSCM.UIONLY)
-                || (env.getRemoteScmSupported() == RemoteSCM.DIRBASED)
+        Configuration.RemoteSCM globalRemoteSupport = env.getRemoteScmSupported();
+        boolean remoteSupported = ((globalRemoteSupport == RemoteSCM.ON)
+                || (globalRemoteSupport == RemoteSCM.UIONLY)
+                || (globalRemoteSupport == RemoteSCM.DIRBASED)
                 || !repo.isRemote());
+
+        if (!remoteSupported) {
+            LOGGER.log(Level.FINEST, "not eligible to display history for ''{0}'' as repository {1} is remote " +
+                    "and the global setting is {2}", new Object[]{file, repo, globalRemoteSupport});
+        }
+
+        return remoteSupported;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -109,8 +109,7 @@ public class MercurialRepository extends RepositoryWithHistoryTraversal {
             = TEMPLATE_STUB + FILE_LIST
             + END_OF_ENTRY + "\\n";
 
-    private static final Pattern LOG_COPIES_PATTERN
-            = Pattern.compile("^(\\d+):(.*)");
+    private static final Pattern LOG_COPIES_PATTERN = Pattern.compile("^(\\d+):(.*)");
 
     /**
      * This is a static replacement for 'working' field. Effectively, check if hg is working once in a JVM

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -539,7 +539,10 @@ public class MercurialRepository extends RepositoryWithHistoryTraversal {
 
     private static boolean isHgWorking() {
         String repoCommand = getCommand(MercurialRepository.class, CMD_PROPERTY_KEY, CMD_FALLBACK);
-        return checkCmd(repoCommand);
+        boolean works = checkCmd(repoCommand);
+        LOGGER.log(Level.WARNING, "Command ''{0}'' does not work. " +
+                "Some operations with Mercurial repositories will fail as a result.", repoCommand);
+        return works;
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
@@ -364,7 +364,12 @@ public class SubversionRepository extends Repository {
 
     private static boolean isSvnWorking() {
         String repoCommand = getCommand(SubversionRepository.class, CMD_PROPERTY_KEY, CMD_FALLBACK);
-        return checkCmd(repoCommand, "--help");
+        boolean works = checkCmd(repoCommand, "--help");
+        if (!works) {
+            LOGGER.log(Level.WARNING, "Command ''{0}'' does not work. " +
+                    "Some operations with Subversion repositories will fail as a result.", repoCommand);
+        }
+        return works;
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/LazilyInstantiate.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/LazilyInstantiate.java
@@ -95,7 +95,9 @@ public class LazilyInstantiate<T> implements Supplier<T> {
         this.current = this::swapper;
     }
 
-    //swaps the itself out for a supplier of an instantiated object
+    /**
+     * Swaps itself out for a supplier of an instantiated object.
+     */
     private synchronized T swapper() {
         if (!(current instanceof Factory)) {
             T obj = supplier.get();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/SubversionHistoryParserTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/SubversionHistoryParserTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Ric Harris <harrisric@users.noreply.github.com>.
  */
 package org.opengrok.indexer.history;
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author austvik
  */
-public class SubversionHistoryParserTest {
+class SubversionHistoryParserTest {
 
     private SubversionHistoryParser instance;
 
@@ -59,7 +59,7 @@ public class SubversionHistoryParserTest {
      * Test of parse method, of class SubversionHistoryParser.
      */
     @Test
-    public void parseEmpty() throws Exception {
+    void parseEmpty() throws Exception {
         // Empty repository shoud produce at least valid XML.
         History result = instance.parse("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<log>\n" + "</log>");
@@ -72,7 +72,7 @@ public class SubversionHistoryParserTest {
      * Test of parsing output similar to that in subversions own svn repository.
      */
     @Test
-    public void parseALaSvn() throws Exception {
+    void parseALaSvn() throws Exception {
         String revId1 = "12345";
         String author1 = "username1";
         String date1 = "2007-09-11T11:48:56.123456Z";
@@ -177,14 +177,17 @@ public class SubversionHistoryParserTest {
 
     }
 
-
     @Test
-    public void testDateFormats() {
+    void testDateFormats() {
         DateTimeTestData[] dates = new DateTimeTestData[] {
-                new DateTimeTestData("2020-03-24T17:11:35.545818Z", LocalDateTime.of(2020, 3, 24, 17, 11, 35, 545000000)),
-                new DateTimeTestData("2007-09-11T11:48:56.123456Z", LocalDateTime.of(2007, 9, 11, 11, 48, 56, 123000000)),
-                new DateTimeTestData("2007-09-11T11:48:56.000000Z", LocalDateTime.of(2007, 9, 11, 11, 48, 56)),
-                new DateTimeTestData("2007-09-11T11:48:56.Z", LocalDateTime.of(2007, 9, 11, 11, 48, 56)),
+                new DateTimeTestData("2020-03-24T17:11:35.545818Z",
+                        LocalDateTime.of(2020, 3, 24, 17, 11, 35, 545000000)),
+                new DateTimeTestData("2007-09-11T11:48:56.123456Z",
+                        LocalDateTime.of(2007, 9, 11, 11, 48, 56, 123000000)),
+                new DateTimeTestData("2007-09-11T11:48:56.000000Z",
+                        LocalDateTime.of(2007, 9, 11, 11, 48, 56)),
+                new DateTimeTestData("2007-09-11T11:48:56.Z",
+                        LocalDateTime.of(2007, 9, 11, 11, 48, 56)),
                 new DateTimeTestData("2007-09-11 11:48:56Z"),
                 new DateTimeTestData("2007-09-11T11:48:56"),
                 new DateTimeTestData("2007-09-11T11:48:56.123456"),


### PR DESCRIPTION
This change mainly converts `SubversionRepository` to use lazy instantiation of the `working` flag so that is checked once per JVM run. This should speed up repository invalidation and other operations a bit.

Also contains improved logging for `HistoryGuru#hasHistory()`.