### PR TITLE
fix event handling in Docker (redux)

### DIFF
--- a/docker/periodic_timer.py
+++ b/docker/periodic_timer.py
@@ -8,13 +8,13 @@ import time
 
 class PeriodicTimer:
     """
-    Helper class to facilitate waiting for periodic events.
-    Requires the start() function to be called first.
+    Helper class to facilitate waiting for (periodic) events.
+    For periodic events, start() function has to be called first.
     """
 
     def __init__(self, interval):
         """
-        :param interval: interval in seconds
+        :param interval: interval in seconds, can be 0
         """
         self._interval = interval
         self._flag = 0
@@ -22,9 +22,10 @@ class PeriodicTimer:
 
     def start(self):
         """
-        Start the notification thread.
+        Start the periodic notification thread if the configured interval is positive.
         """
-        threading.Thread(target=self.run, daemon=True).start()
+        if self._interval > 0:
+            threading.Thread(target=self.run, daemon=True).start()
 
     def run(self):
         """
@@ -34,9 +35,10 @@ class PeriodicTimer:
             time.sleep(self._interval)
             self.notify_all()
 
-    def wait_for_tick(self):
+    def wait_for_event(self):
         """
-        Wait for the next tick of the timer
+        Wait for the wakeup event. This can be either tick of the timer from run(),
+        or notification via notify_all().
         """
         with self._cv:
             last_flag = self._flag


### PR DESCRIPTION
This change fixes how the Docker startup program works with the recently introduced `PeriodicTimer` class. Firstly, the instance need to be referenced with `global`. Also, it should be created before the sync threads and the Flask app are started. Also, it should be possible to trigger reindex even though the periodic timer is set to 0.