### PR TITLE
disable pytest-xdist for now

### DIFF
--- a/tools/setup.cfg
+++ b/tools/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [tool:pytest]
-addopts = -vv --color=yes --numprocesses=auto
+addopts = -vv --color=yes
 testpaths = src/test/python

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -45,7 +45,6 @@ setup(
     tests_require=[
         'pytest',
         'GitPython',
-        'pytest-xdist',
         'mockito>=1.3.3',
         'pytest-mockito',
     ],


### PR DESCRIPTION
The tools build has started failing recently due to exception within [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) used to run the tests for the Python tools:
```
maximum crashed workers reached: 32
[gw39] node down: Traceback (most recent call last):
  File "/home/vkotal/opengrok-vladak-scratch/tools/target/.eggs/execnet-1.9.0-py3.8.egg/execnet/gateway_base.py", line 1084, in executetask
    do_exec(co, loc)  # noqa
/home/vkotal/opengrok-vladak-scratch/tools/target/env/lib/python3.8/site-packages/setuptools/installer.py:27: SetuptoolsDeprecat  File "/home/vkotal/opengrok-vladak-scratch/tools/target/.eggs/pytest_xdist-2.5.0-py3.8.egg/xdist/remote.py", line 290, in <module>
ionWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
    interactor = WorkerInteractor(config, channel)  # type: ignore[name-defined]
  warnings.warn(
  File "/home/vkotal/opengrok-vladak-scratch/tools/target/.eggs/pytest_xdist-2.5.0-py3.8.egg/xdist/remote.py", line 40, in __ini/home/vkotal/opengrok-vladak-scratch/tools/target/env/lib/python3.8/site-packages/setuptools/command/easy_install.py:144: EasyInt__
    self.log = py.log.Producer("worker-%s" % self.workerid)
stallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
AttributeError: module 'py' has no attribute 'log'
  warnings.warn(
```
This change removes the use of python-xdist, therefore losing the ability to run Python tools tests in parallel. That's no big deal currently as this saves just a bunch of seconds.

While I can reproduce this locally when running `mvn verify` in `tools`, the exact mechanism of the failure is not clear to me yet - installing pytest-xdist in pristine Python venv followed by import of `py` and `py.log.Producer("foo")` does not lead to the problem. There has been a change to pytest-xdist recently that [removes the line of code causing the exception](https://github.com/pytest-dev/pytest-xdist/pull/822). Once pytest-xdist ships a new release (3.0.x) containing the change, the build can be switched back to pytest-xdist.