### PR TITLE
remove double quotes in log message in FileAnnotationCache

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileAnnotationCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileAnnotationCache.java
@@ -178,7 +178,7 @@ public class FileAnnotationCache extends AbstractCache implements AnnotationCach
         Statistics statistics = new Statistics();
         try {
             CacheUtil.writeCache(annotation.annotationData, cacheFile);
-            statistics.report(LOGGER, Level.FINEST, String.format("wrote annotation for ''%s''", file),
+            statistics.report(LOGGER, Level.FINEST, String.format("wrote annotation for '%s'", file),
                     "cache.annotation.file.store.latency");
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "failed to write annotation to cache", e);


### PR DESCRIPTION
This change removes extra pair of single quotes in log message emitted in store().