### PR TITLE
decrease log level for annotation problems

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AccuRevAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AccuRevAnnotationParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -49,11 +49,14 @@ public class AccuRevAnnotationParser implements Executor.StreamHandler {
      */
     private final Annotation annotation;
 
+    private final String fileName;
+
     /**
      * @param fileName the name of the file being annotated
      */
     public AccuRevAnnotationParser(String fileName) {
         annotation = new Annotation(fileName);
+        this.fileName = fileName;
     }
 
     /**
@@ -85,14 +88,14 @@ public class AccuRevAnnotationParser implements Executor.StreamHandler {
                         String author  = matcher.group(2);
                         annotation.addLine(version, author, true);
                     } else {
-                        LOGGER.log(Level.SEVERE,
-                                "Did not find annotation in line {0}: [{1}]",
-                                new Object[]{lineno, line});
+                        LOGGER.log(Level.WARNING,
+                                "Did not find annotation in line {0} for ''{1}'': [{2}]",
+                                new Object[]{lineno, this.fileName, line});
                     }
                 }
             } catch (IOException e) {
-                LOGGER.log(Level.SEVERE,
-                        "Could not read annotations for " + annotation.getFilename(), e);
+                LOGGER.log(Level.WARNING,
+                        String.format("Could not read annotations for '%s'", this.fileName), e);
             }
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarAnnotationParser.java
@@ -23,7 +23,6 @@
 package org.opengrok.indexer.history;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarAnnotationParser.java
@@ -18,11 +18,12 @@
  */
 
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -49,14 +50,16 @@ public class BazaarAnnotationParser implements Executor.StreamHandler {
     /**
      * Pattern used to extract author/revision.
      */
-    private static final Pattern BLAME_PATTERN
-            = Pattern.compile("^\\W*(\\S+)\\W+(\\S+).*$");
+    private static final Pattern BLAME_PATTERN = Pattern.compile("^\\W*(\\S+)\\W+(\\S+).*$");
+
+    private final String fileName;
 
     /**
      * @param fileName the name of the file being annotated
      */
     public BazaarAnnotationParser(String fileName) {
         annotation = new Annotation(fileName);
+        this.fileName = fileName;
     }
 
     /**
@@ -82,9 +85,9 @@ public class BazaarAnnotationParser implements Executor.StreamHandler {
                     String author = matcher.group(2).trim();
                     annotation.addLine(rev, author, true);
                 } else {
-                    LOGGER.log(Level.SEVERE,
-                            "Error: did not find annotation in line {0}: [{1}]",
-                            new Object[]{String.valueOf(lineno), line});
+                    LOGGER.log(Level.WARNING,
+                            "Error: did not find annotation in line {0} for ''{1}'': [{2}]",
+                            new Object[]{String.valueOf(lineno), this.fileName, line});
                 }
             }
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSAnnotationParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -43,19 +43,21 @@ public class CVSAnnotationParser implements Executor.StreamHandler {
     /**
      * Pattern used to extract author/revision from {@code cvs annotate}.
      */
-    private static final Pattern ANNOTATE_PATTERN
-            = Pattern.compile("([\\.\\d]+)\\W+\\((\\w+)");
+    private static final Pattern ANNOTATE_PATTERN = Pattern.compile("([\\.\\d]+)\\W+\\((\\w+)");
 
     /**
      * Store annotation created by processStream.
      */
     private final Annotation annotation;
 
+    private final String fileName;
+
     /**
      * @param fileName the name of the file being annotated
      */
     public CVSAnnotationParser(String fileName) {
         annotation = new Annotation(fileName);
+        this.fileName = fileName;
     }
 
     /**
@@ -76,8 +78,7 @@ public class CVSAnnotationParser implements Executor.StreamHandler {
         Matcher matcher = ANNOTATE_PATTERN.matcher(line);
         while ((line = in.readLine()) != null) {
             // Skip header
-            if (!hasStarted && (line.length() == 0
-                    || !Character.isDigit(line.charAt(0)))) {
+            if (!hasStarted && (line.length() == 0 || !Character.isDigit(line.charAt(0)))) {
                 continue;
             }
             hasStarted = true;
@@ -90,9 +91,9 @@ public class CVSAnnotationParser implements Executor.StreamHandler {
                 String author = matcher.group(2).trim();
                 annotation.addLine(rev, author, true);
             } else {
-                LOGGER.log(Level.SEVERE,
-                        "Error: did not find annotation in line {0}: [{1}]",
-                        new Object[]{String.valueOf(lineno), line});
+                LOGGER.log(Level.WARNING,
+                        "Error: did not find annotation in line {0} for ''{1}'': [{2}]",
+                        new Object[]{String.valueOf(lineno), this.fileName, line});
             }
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialAnnotationParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -50,8 +50,7 @@ class MercurialAnnotationParser implements Executor.StreamHandler {
     /**
      * Pattern used to extract author/revision from {@code hg annotate}.
      */
-    private static final Pattern ANNOTATION_PATTERN
-            = Pattern.compile("^\\s*(\\d+):");
+    private static final Pattern ANNOTATION_PATTERN = Pattern.compile("^\\s*(\\d+):");
 
     MercurialAnnotationParser(File file, HashMap<String, HistoryEntry> revs) {
         this.file = file;
@@ -78,9 +77,9 @@ class MercurialAnnotationParser implements Executor.StreamHandler {
                     }
                     annotation.addLine(rev, Util.getEmail(author.trim()), true);
                 } else {
-                    LOGGER.log(Level.SEVERE,
-                            "Error: did not find annotation in line {0}: [{1}]",
-                            new Object[]{lineno, line});
+                    LOGGER.log(Level.WARNING,
+                            "Error: did not find annotation in line {0} for ''{1}'': [{2}]",
+                            new Object[]{lineno, this.file, line});
                 }
             }
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceAnnotationParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -101,14 +101,14 @@ public class PerforceAnnotationParser implements Executor.StreamHandler {
                     String author = revAuthor.get(revision);
                     annotation.addLine(revision, author, true);
                 } else {
-                    LOGGER.log(Level.SEVERE,
-                            "Error: did not find annotation in line {0}: [{1}]",
-                            new Object[]{lineno, line});
+                    LOGGER.log(Level.WARNING,
+                            "Error: did not find annotation in line {0} for ''{1}'': [{2}]",
+                            new Object[]{lineno, this.file, line});
                 }
             }
         } catch (IOException e) {
-            LOGGER.log(Level.SEVERE,
-                    "Error: Could not read annotations for " + annotation.getFilename(), e);
+            LOGGER.log(Level.WARNING,
+                    String.format("Error: Could not read annotations for '%s'", this.file), e);
         }
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RCSAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RCSAnnotationParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -67,9 +67,9 @@ public class RCSAnnotationParser implements Executor.StreamHandler {
                     String author = matcher.group(2);
                     annotation.addLine(rev, author, true);
                 } else {
-                    LOGGER.log(Level.SEVERE,
-                            "Error: did not find annotation in line {0}: [{1}]",
-                            new Object[]{lineno, line});
+                    LOGGER.log(Level.WARNING,
+                            "Error: did not find annotation in line {0} for ''{1}'': [{2}]",
+                            new Object[]{lineno, this.file, line});
                 }
             }
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SSCMRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SSCMRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -333,9 +333,9 @@ public class SSCMRepository extends Repository {
                 String author = matcher.group(1);
                 ret.addLine(rev, author, true);
             } else if (hasStarted) {
-                LOGGER.log(Level.SEVERE,
-                        "Error: did not find annotation in line {0}: [{1}]",
-                        new Object[]{String.valueOf(lineno), line});
+                LOGGER.log(Level.WARNING,
+                        "Error: did not find annotation in line {0} for ''{1}'': [{2}]",
+                        new Object[]{String.valueOf(lineno), fileName, line});
             }
         }
         return ret;


### PR DESCRIPTION
When running indexer to create annotation cache for some repositories, I noticed these log entries:
```
2022-10-31 14:46:38.034+0100 SEVERE t1253 MercurialAnnotationParser.processStream: Error: did not find annotation in line 1: [thunderbird-icon.png: binary file]
```
The log severity is too high. The SEVERE should be reserved for general indexer failures, not used for problems to create particular index  data.

Also, luckily, the output in this case contained the filename so one might be able to see what is going on, however sometimes this is not the case. A filename should be added to the log statement.