### PR TITLE
use FINE to log directory creation task

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -586,7 +586,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
                 LOGGER.log(Level.WARNING, "Unable to create cache directory ''{0}''.", dir);
             }
         }
-        elapsed.report(LOGGER, String.format("Done creating directories for %s (%s)", repository, label));
+        elapsed.report(LOGGER, Level.FINE, String.format("Done creating directories for %s (%s)", repository, label));
     }
 
     @Override


### PR DESCRIPTION
Observing indexer run of Linux kernel with regular logging configuration, the directory creation log entries stand out a little bit:
```
INFO: Generating history cache for all repositories ...
Nov 04, 2022 2:10:40 PM org.opengrok.indexer.history.HistoryGuru createHistoryCacheReal
INFO: Creating history cache for 1 repositories
Nov 04, 2022 2:10:40 PM org.opengrok.indexer.history.HistoryGuru createHistoryCache
INFO: Creating history cache for /var/opengrok/src.linux/linux (GitRepository) without renamed file handling
Nov 04, 2022 2:11:25 PM org.opengrok.indexer.util.Statistics logIt
INFO: Done creating directories for {dir=/var/opengrok/src.linux/linux,type=git,historyCache=on,renamed=false,merge=false,annotationCache=off} (regular files for history till revision cd7175edf963a92b2c3cd491d3e34afd357e7284) (took 130 ms)
Nov 04, 2022 2:12:12 PM org.opengrok.indexer.util.Statistics logIt
INFO: Done creating directories for {dir=/var/opengrok/src.linux/linux,type=git,historyCache=on,renamed=false,merge=false,annotationCache=off} (regular files for history till revision a64ae7a2256b56bbd2830749c580fa533b69758c) (took 125 ms)
Nov 04, 2022 2:13:06 PM org.opengrok.indexer.util.Statistics logIt
INFO: Done creating directories for {dir=/var/opengrok/src.linux/linux,type=git,historyCache=on,renamed=false,merge=false,annotationCache=off} (regular files for history till revision 9cf7826743e5c78dcfcfdc99d17f79ce6d3a2942) (took 137 ms)
...
```
They should use finer (sic!) log level.