### PR TITLE
use indexing parallelism when creating xref watcher thread pool

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
@@ -242,7 +242,7 @@ public class IndexerParallelizer implements AutoCloseable {
 
     private void createLazyCtagsWatcherExecutor() {
         lzCtagsWatcherExecutor = LazilyInstantiate.using(() ->
-                new ScheduledThreadPoolExecutor(1,
+                new ScheduledThreadPoolExecutor(indexingParallelism,
                         new OpenGrokThreadFactory("ctags-watcher")));
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
@@ -248,7 +248,7 @@ public class IndexerParallelizer implements AutoCloseable {
 
     private void createLazyXrefWatcherExecutor() {
         lzXrefWatcherExecutor = LazilyInstantiate.using(() ->
-                new ScheduledThreadPoolExecutor(1,
+                new ScheduledThreadPoolExecutor(indexingParallelism,
                         new OpenGrokThreadFactory("xref-watcher")));
     }
 


### PR DESCRIPTION
This change bumps the pool size for xref watcher from 1 to the indexer parallelism level (by default set to the number of CPUs in the system). This speeds up the indexing by about 20% when indexing the Linux kernel repository from scratch on my laptop with 8 CPUs and using `--threads 32` and not using `-H` (i.e. only 2nd phase of indexing was run).

before and after the change: ![indexer-before](https://user-images.githubusercontent.com/2934284/200050514-62e06576-6295-4cd4-8669-fc0fa96ddfd3.png)
![indexer-after](https://user-images.githubusercontent.com/2934284/200050541-bd1d481c-a3b7-4a2f-8524-35c7699b4c41.png)
