### PR TITLE
use lazy instantiation of the working state of Perforce

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -540,8 +540,10 @@ public class MercurialRepository extends RepositoryWithHistoryTraversal {
     private static boolean isHgWorking() {
         String repoCommand = getCommand(MercurialRepository.class, CMD_PROPERTY_KEY, CMD_FALLBACK);
         boolean works = checkCmd(repoCommand);
-        LOGGER.log(Level.WARNING, "Command ''{0}'' does not work. " +
-                "Some operations with Mercurial repositories will fail as a result.", repoCommand);
+        if (!works) {
+            LOGGER.log(Level.WARNING, "Command ''{0}'' does not work. " +
+                    "Some operations with Mercurial repositories will fail as a result.", repoCommand);
+        }
         return works;
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
@@ -211,8 +211,10 @@ public class PerforceRepository extends Repository {
     private static boolean isP4Working() {
         String repoCommand = getCommand(PerforceRepository.class, CMD_PROPERTY_KEY, CMD_FALLBACK);
         boolean works = checkCmd(repoCommand, "-V");
-        LOGGER.log(Level.WARNING, "Command ''{0}'' does not work. " +
-                "Some operations with Perforce repositories will fail as a result.", repoCommand);
+        if (!works) {
+            LOGGER.log(Level.WARNING, "Command ''{0}'' does not work. " +
+                    "Some operations with Perforce repositories will fail as a result.", repoCommand);
+        }
         return works;
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
@@ -210,7 +210,7 @@ public class PerforceRepository extends Repository {
 
     private static boolean isP4Working() {
         String repoCommand = getCommand(PerforceRepository.class, CMD_PROPERTY_KEY, CMD_FALLBACK);
-        boolean works = checkCmd(repoCommand, "help");
+        boolean works = checkCmd(repoCommand, "-V");
         LOGGER.log(Level.WARNING, "Command ''{0}'' does not work. " +
                 "Some operations with Perforce repositories will fail as a result.", repoCommand);
         return works;


### PR DESCRIPTION
This should make it more efficient to invalidate Perforce repositories and also provide warning in case the Perforce command is not working.