### PR TITLE
add more SCMs to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,16 @@ RUN mvn help:evaluate -Dexpression=project.version -q -DforceStdout > /mvn/VERSI
 FROM tomcat:10.0-jdk11
 LABEL maintainer="https://github.com/oracle/opengrok"
 
+# Add Perforce apt source.
+RUN apt-get update && \
+    apt-get install -y gnupg2
+RUN curl -sS https://package.perforce.com/perforce.pubkey | gpg --dearmor > /etc/apt/trusted.gpg.d/perforce.gpg
+RUN echo 'deb http://package.perforce.com/apt/ubuntu bionic release' > /etc/apt/sources.list.d/perforce.list
+
 # install dependencies and Python tools
 # hadolint ignore=DL3008,DL3009
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y git subversion mercurial cvs cssc bzr rcs rcs-blame \
+    apt-get install --no-install-recommends -y git subversion mercurial cvs cssc bzr rcs rcs-blame helix-p4d \
     unzip inotify-tools python3 python3-pip \
     python3-venv python3-setuptools openssh-client
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ LABEL maintainer="https://github.com/oracle/opengrok"
 # install dependencies and Python tools
 # hadolint ignore=DL3008,DL3009
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y git subversion mercurial unzip inotify-tools python3 python3-pip \
+    apt-get install --no-install-recommends -y git subversion mercurial cvs cssc bzr rcs rcs-blame \
+    unzip inotify-tools python3 python3-pip \
     python3-venv python3-setuptools openssh-client
 
 # compile and install universal-ctags

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,9 +44,13 @@ is doing, use the `docker logs` command.
 
 ### Source Code Management systems supported
 
+- Bazaar
+- CVS
 - Mercurial
 - Git
 - Subversion
+- SCCS
+- RCS
 
 ### Tags and versioning
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -46,11 +46,12 @@ is doing, use the `docker logs` command.
 
 - Bazaar
 - CVS
-- Mercurial
 - Git
-- Subversion
-- SCCS
+- Mercurial
+- Perforce
 - RCS
+- SCCS
+- Subversion
 
 ### Tags and versioning
 


### PR DESCRIPTION
Adds bunch of SCMs so that the Docker image is more usable.

The Perforce addition was based on https://github.com/oracle/opengrok/discussions/4090#discussioncomment-4060064 which I refined (notably to avoid using the deprecated `apt-key` command)