### PR TITLE
use Smile to serialize AnnotationData

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -196,7 +196,7 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-cbor</artifactId>
+            <artifactId>jackson-dataformat-smile</artifactId>
             <version>${jackson.version}</version>
         </dependency>
         <dependency>

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -195,6 +195,11 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AbstractCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AbstractCache.java
@@ -75,7 +75,12 @@ public abstract class AbstractCache implements Cache {
             throw new CacheException("Failed to get path relative to source root for " + file, e);
         }
 
-        return new File(TandemPath.join(sb.toString(), ".gz"));
+        String suffix = getCacheFileSuffix();
+        if (suffix != null && !suffix.isEmpty()) {
+            return new File(TandemPath.join(sb.toString(), suffix));
+        }
+
+        return new File(sb.toString());
     }
 
     public List<String> clearCache(Collection<RepositoryInfo> repositories) {
@@ -124,5 +129,9 @@ public abstract class AbstractCache implements Cache {
         }
 
         clearWithParent(historyFile);
+    }
+
+    public String getCacheFileSuffix() {
+        return ".gz";
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AnnotationData.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AnnotationData.java
@@ -22,6 +22,7 @@
  */
 package org.opengrok.indexer.history;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.jetbrains.annotations.TestOnly;
 
 import java.io.File;
@@ -36,6 +37,7 @@ import java.util.stream.Collectors;
 /**
  * Holds serializable content for {@link Annotation}.
  */
+@JsonPropertyOrder({"revision", "filename"})
 public class AnnotationData implements Serializable {
 
     private static final long serialVersionUID = -1;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AnnotationData.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AnnotationData.java
@@ -60,7 +60,7 @@ public class AnnotationData implements Serializable {
      * shortening with very long filenames), on the other hand it is necessary to deserialize the object
      * to tell whether it is stale.
      */
-    private String revision;
+    String revision;
 
     public List<AnnotationLine> getLines() {
         return annotationLines;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Cache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Cache.java
@@ -103,4 +103,9 @@ public interface Cache {
      * @throws CacheException on error
      */
     boolean isUpToDate(File file) throws CacheException;
+
+    /**
+     * @return suffix used for the cache files
+     */
+    String getCacheFileSuffix();
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileAnnotationCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileAnnotationCache.java
@@ -100,11 +100,13 @@ public class FileAnnotationCache extends AbstractCache implements AnnotationCach
             if (parser.getCurrentName().equals("revision")) {
                 parser.nextToken();
                 if (!parser.getCurrentToken().equals(JsonToken.VALUE_STRING)) {
-                    LOGGER.log(Level.WARNING, "failed to get revision from ''{0}''", cacheFile);
+                    LOGGER.log(Level.WARNING, "the value of the ''revision'' field in ''{0}'' is not string",
+                            cacheFile);
                     return null;
                 }
                 return parser.getValueAsString();
             } else {
+                LOGGER.log(Level.WARNING, "the first serialized field is not ''revision'' in ''{0}''", cacheFile);
                 return null;
             }
         } catch (IOException e) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileAnnotationCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileAnnotationCache.java
@@ -23,7 +23,7 @@
 package org.opengrok.indexer.history;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
+import com.fasterxml.jackson.dataformat.smile.databind.SmileMapper;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.jetbrains.annotations.Nullable;
@@ -64,7 +64,7 @@ public class FileAnnotationCache extends AbstractCache implements AnnotationCach
      * Read annotation from a file.
      */
     static Annotation readCache(File file) throws IOException {
-        ObjectMapper mapper = new CBORMapper();
+        ObjectMapper mapper = new SmileMapper();
         return new Annotation(mapper.readValue(file, AnnotationData.class));
     }
 
@@ -154,7 +154,7 @@ public class FileAnnotationCache extends AbstractCache implements AnnotationCach
     }
 
     private void writeCache(AnnotationData annotationData, File outfile) throws IOException {
-        ObjectMapper mapper = new CBORMapper();
+        ObjectMapper mapper = new SmileMapper();
         mapper.writeValue(outfile, annotationData);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -311,7 +311,9 @@ public final class HistoryGuru {
             return null;
         }
 
+        Statistics statistics = new Statistics();
         completeAnnotationWithHistory(file, annotation, repo);
+        statistics.report(LOGGER, Level.FINEST, String.format("completed annotation with history for '%s'", file));
 
         return annotation;
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -213,7 +213,13 @@ class IndexDatabaseTest {
 
         for (String dirName : new String[] {"historycache", "annotationcache", IndexDatabase.XREF_DIR}) {
             File dataDir = new File(env.getDataRootFile(), dirName);
-            File dataFile = new File(dataDir, TandemPath.join(fileName, ".gz"));
+            String cacheFile;
+            if (dirName.equals("annotationcache")) {
+                cacheFile = fileName;
+            } else {
+                cacheFile = TandemPath.join(fileName, ".gz");
+            }
+            File dataFile = new File(dataDir, cacheFile);
 
             if (shouldExist) {
                 assertTrue(dataFile.exists(), "file " + fileName + " not found in " + dirName);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -210,21 +210,27 @@ class IndexDatabaseTest {
      */
     private void checkDataExistence(String fileName, boolean shouldExist) {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        HistoryGuru historyGuru = HistoryGuru.getInstance();
 
         for (String dirName : new String[] {"historycache", "annotationcache", IndexDatabase.XREF_DIR}) {
             File dataDir = new File(env.getDataRootFile(), dirName);
+            File file = new File(env.getServerName(), fileName);
             String cacheFile;
             if (dirName.equals("annotationcache")) {
-                cacheFile = fileName;
+                if (shouldExist) {
+                    assertTrue(historyGuru.hasAnnotationCacheForFile(file));
+                } else {
+                    assertFalse(historyGuru.hasAnnotationCacheForFile(file));
+                }
             } else {
                 cacheFile = TandemPath.join(fileName, ".gz");
-            }
-            File dataFile = new File(dataDir, cacheFile);
+                File dataFile = new File(dataDir, cacheFile);
 
-            if (shouldExist) {
-                assertTrue(dataFile.exists(), "file " + fileName + " not found in " + dirName);
-            } else {
-                assertFalse(dataFile.exists(), "file " + fileName + " found in " + dirName);
+                if (shouldExist) {
+                    assertTrue(dataFile.exists(), "file " + fileName + " not found in " + dirName);
+                } else {
+                    assertFalse(dataFile.exists(), "file " + fileName + " found in " + dirName);
+                }
             }
         }
     }


### PR DESCRIPTION
This is another tradeoff I am going to do (trading space for speed). To change the serialization scheme for annotation cache, I had multiple requirements for the implementation:
  - speedy enough not to be noticeable in the UI (tens of ms)
  - robust and well maintained library
  - easy to use from Java (i.e. without running external tools or defining serialization scheme by hand)
  - ideally extendable with Java annotations and such
  - space efficient without compression => potentially being usable in streaming mode

I did not have many requirements for the format itself, assumed it will be some binary format.

Looked at bunch of alternatives to discover Jackson (that is already used in the webapp) offers some binary serialization formats so I went with exploring these.

To measure the impact, I used the OpenSolaris ON Mercurial repository (yeah). The de-serialization latency test used `usr/src/cmd/svc/configd/rc_node.c` from the UI.

Type | indexing time | cache size | deserialization
--- | --- | --- | ---
compressed XML (current) | 30:58 | 209M | >600ms
CBOR | 24:47 | 893M | <30ms
Smile | 25:36 | 562M | <20ms

So, Smile looks like a viable format. I do realize that currently older version of Jackson is used that most probably does not have all the performance improvements for CBOR.

Another advantage is that this avoids maintaining class white/black-lists.

This will require reindexing projects that have annotation cache enabled from scratch. There is currently no way how annotation cache can be recreated from scratch. That said, one can leave xrefs and history cache and just wipe out the index and annotation cache (there are REST APIs).

Also, at least conceptually, this is paving the way for other serialization format changes, notably for history cache.