### PR TITLE
add support for Tomcat 10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN cp `ls -t distribution/target/*.tar.gz | head -1` /opengrok.tar.gz
 # Store the version in a file so that the tools can report it.
 RUN mvn help:evaluate -Dexpression=project.version -q -DforceStdout > /mvn/VERSION
 
-FROM tomcat:10.0-jdk11
+FROM tomcat:10.1-jdk11
 LABEL maintainer="https://github.com/oracle/opengrok"
 
 # Add Perforce apt source.

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -191,6 +191,11 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/DummyHttpServletRequest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/DummyHttpServletRequest.java
@@ -26,6 +26,7 @@ package org.opengrok.indexer.web;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.ServletRequest;
@@ -99,30 +100,12 @@ public class DummyHttpServletRequest implements HttpServletRequest {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
-        public jakarta.servlet.http.HttpSessionContext getSessionContext() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
         public Object getAttribute(String string) {
             return attrs.get(string);
         }
 
         @Override
-        @SuppressWarnings("deprecation")
-        public Object getValue(String string) {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
         public Enumeration<String> getAttributeNames() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public String[] getValueNames() {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
@@ -132,18 +115,8 @@ public class DummyHttpServletRequest implements HttpServletRequest {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
-        public void putValue(String string, Object o) {
-        }
-
-        @Override
         public void removeAttribute(String string) {
             attrs.remove(string);
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public void removeValue(String string) {
         }
 
         @Override
@@ -288,11 +261,6 @@ public class DummyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public boolean isRequestedSessionIdFromURL() {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    @Override @Deprecated
-    public boolean isRequestedSessionIdFromUrl() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
@@ -456,11 +424,6 @@ public class DummyHttpServletRequest implements HttpServletRequest {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
-    @Override @Deprecated
-    public String getRealPath(String string) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
     @Override
     public int getRemotePort() {
         throw new UnsupportedOperationException("Not supported yet.");
@@ -513,6 +476,21 @@ public class DummyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public DispatcherType getDispatcherType() {
+        return null;
+    }
+
+    @Override
+    public String getRequestId() {
+        return "123";
+    }
+
+    @Override
+    public String getProtocolRequestId() {
+        return null;
+    }
+
+    @Override
+    public ServletConnection getServletConnection() {
         return null;
     }
 }

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -68,7 +68,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -95,7 +95,7 @@ public final class WebappListener implements ServletContextListener, ServletRequ
             int idx;
             if ((idx = serverInfo.indexOf('/')) > 0) {
                 String version = serverInfo.substring(idx + 1);
-                if (!version.startsWith("10.0")) {
+                if (!version.startsWith("10.")) {
                     LOGGER.log(Level.SEVERE, "Unsupported Tomcat version: {0}", version);
                     throw new Error("Unsupported Tomcat version");
                 }

--- a/opengrok-web/src/main/webapp/WEB-INF/web.xml
+++ b/opengrok-web/src/main/webapp/WEB-INF/web.xml
@@ -2,8 +2,8 @@
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
-         version="5.0">
+         https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
     <display-name>OpenGrok</display-name>
     <description>A wicked fast source browser</description>

--- a/opengrok-web/src/test/java/org/opengrok/web/CookieFilterTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/CookieFilterTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
-public class CookieFilterTest {
+class CookieFilterTest {
     static class DummyHttpServletResponse implements HttpServletResponse {
 
         @Override
@@ -71,18 +71,6 @@ public class CookieFilterTest {
 
         @Override
         public String encodeRedirectURL(String s) {
-            return null;
-        }
-
-        @Override
-        @Deprecated
-        public String encodeUrl(String s) {
-            return null;
-        }
-
-        @Override
-        @Deprecated
-        public String encodeRedirectUrl(String s) {
             return null;
         }
 
@@ -139,12 +127,6 @@ public class CookieFilterTest {
 
         @Override
         public void setStatus(int i) {
-
-        }
-
-        @Override
-        @Deprecated
-        public void setStatus(int i, String s) {
 
         }
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
@@ -23,7 +23,12 @@
  */
 package org.opengrok.web.api.v1.controller;
 
-import jakarta.ws.rs.core.Application;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,8 +60,13 @@ public class SuggesterControllerProjectsDisabledTest extends OGKJerseyTest {
     private static TestRepository repository;
 
     @Override
-    protected Application configure() {
-        return new RestApp();
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
+        return new GrizzlyWebTestContainerFactory();
     }
 
     @BeforeAll

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -28,6 +28,12 @@ import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.Response;
 import org.apache.lucene.index.Term;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -93,8 +99,13 @@ public class SuggesterControllerTest extends OGKJerseyTest {
     private static TestRepository repository;
 
     @Override
-    protected Application configure() {
-        return new RestApp();
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
+        return new GrizzlyWebTestContainerFactory();
     }
 
     @BeforeAll

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -24,7 +24,6 @@
 package org.opengrok.web.api.v1.controller;
 
 import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.Response;
 import org.apache.lucene.index.Term;

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -26,6 +26,12 @@ package org.opengrok.web.api.v1.controller;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.jupiter.api.Test;
 import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -49,13 +55,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SystemControllerTest extends OGKJerseyTest {
+class SystemControllerTest extends OGKJerseyTest {
 
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
     @Override
-    protected Application configure() {
-        return new RestApp();
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
+        return new GrizzlyWebTestContainerFactory();
     }
 
     /**

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -24,7 +24,6 @@
 package org.opengrok.web.api.v1.controller;
 
 import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.test.DeploymentContext;

--- a/plugins/src/test/java/opengrok/auth/plugin/util/DummyHttpServletRequestLdap.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/util/DummyHttpServletRequestLdap.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.ServletRequest;
@@ -91,30 +92,12 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
-        public jakarta.servlet.http.HttpSessionContext getSessionContext() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
         public Object getAttribute(String string) {
             return attrs.get(string);
         }
 
         @Override
-        @SuppressWarnings("deprecation")
-        public Object getValue(String string) {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
         public Enumeration<String> getAttributeNames() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public String[] getValueNames() {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
@@ -124,18 +107,8 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
-        public void putValue(String string, Object o) {
-        }
-
-        @Override
         public void removeAttribute(String string) {
             attrs.remove(string);
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public void removeValue(String string) {
         }
 
         @Override
@@ -270,12 +243,6 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
 
     @Override
     public boolean isRequestedSessionIdFromURL() {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    @Override
-    @Deprecated
-    public boolean isRequestedSessionIdFromUrl() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
@@ -435,12 +402,6 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
     }
 
     @Override
-    @Deprecated
-    public String getRealPath(String string) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    @Override
     public int getRemotePort() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
@@ -492,6 +453,21 @@ public class DummyHttpServletRequestLdap implements HttpServletRequest {
 
     @Override
     public DispatcherType getDispatcherType() {
+        return null;
+    }
+
+    @Override
+    public String getRequestId() {
+        return "123";
+    }
+
+    @Override
+    public String getProtocolRequestId() {
+        return null;
+    }
+
+    @Override
+    public ServletConnection getServletConnection() {
         return null;
     }
 }

--- a/plugins/src/test/java/opengrok/auth/plugin/util/DummyHttpServletRequestUser.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/util/DummyHttpServletRequestUser.java
@@ -25,6 +25,7 @@ package opengrok.auth.plugin.util;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.ServletRequest;
@@ -86,30 +87,12 @@ public class DummyHttpServletRequestUser implements HttpServletRequest {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
-        public jakarta.servlet.http.HttpSessionContext getSessionContext() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
         public Object getAttribute(String string) {
             return attrs.get(string);
         }
 
         @Override
-        @SuppressWarnings("deprecation")
-        public Object getValue(String string) {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
         public Enumeration<String> getAttributeNames() {
-            throw new UnsupportedOperationException("Not supported yet.");
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public String[] getValueNames() {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
@@ -119,18 +102,8 @@ public class DummyHttpServletRequestUser implements HttpServletRequest {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
-        public void putValue(String string, Object o) {
-        }
-
-        @Override
         public void removeAttribute(String string) {
             attrs.remove(string);
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public void removeValue(String string) {
         }
 
         @Override
@@ -281,12 +254,6 @@ public class DummyHttpServletRequestUser implements HttpServletRequest {
 
     @Override
     public boolean isRequestedSessionIdFromURL() {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    @Override
-    @Deprecated
-    public boolean isRequestedSessionIdFromUrl() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
@@ -446,12 +413,6 @@ public class DummyHttpServletRequestUser implements HttpServletRequest {
     }
 
     @Override
-    @Deprecated
-    public String getRealPath(String string) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    @Override
     public int getRemotePort() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
@@ -503,6 +464,21 @@ public class DummyHttpServletRequestUser implements HttpServletRequest {
 
     @Override
     public DispatcherType getDispatcherType() {
+        return null;
+    }
+
+    @Override
+    public String getRequestId() {
+        return "123";
+    }
+
+    @Override
+    public String getProtocolRequestId() {
+        return null;
+    }
+
+    @Override
+    public ServletConnection getServletConnection() {
         return null;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jersey.version>3.1.0</jersey.version>
         <!-- Jackson version needs to match the version of Jackson which Jersey
+        (notably the jersey-media-json-jackson artifact used in opengrok-web)
         depends on or otherwise weird things will happen. -->
         <jackson.version>2.14.1</jackson.version>
         <junit.version>5.7.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <compileSource>11</compileSource>
         <compileTarget>11</compileTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jersey.version>3.0.2</jersey.version>
+        <jersey.version>3.1.0-M8</jersey.version>
         <!-- Jackson version needs to match the version of Jackson which Jersey
         depends on or otherwise weird things will happen. -->
         <jackson.version>2.12.2</jackson.version>
@@ -149,7 +149,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <dependency>
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <compileSource>11</compileSource>
         <compileTarget>11</compileTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jersey.version>3.1.0-M8</jersey.version>
+        <jersey.version>3.1.0</jersey.version>
         <!-- Jackson version needs to match the version of Jackson which Jersey
         depends on or otherwise weird things will happen. -->
         <jackson.version>2.12.2</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <jersey.version>3.1.0</jersey.version>
         <!-- Jackson version needs to match the version of Jackson which Jersey
         depends on or otherwise weird things will happen. -->
-        <jackson.version>2.12.2</jackson.version>
+        <jackson.version>2.14.1</jackson.version>
         <junit.version>5.7.2</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>


### PR DESCRIPTION
This change addresses the lack of support for Tomcat 10.1. The biggest challenge were the Jackson-Jersey dependencies. I casually tested the UI when deployed on Tomcat 10.1.0 and also checked the search API, plus built a Docker image and let it run for a bit to see if the API calls done during resync do not blow up.