### PR TITLE
Docker signal handling redux

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -571,29 +571,20 @@ def main():
 
         start_rest_thread(logger)
 
-    # Ideally the signal handlers should be installed as early as possible,
-    # however that does not play well with the worker pool communication used by do_sync().
-    signal.signal(signal.SIGTERM, signal_handler)
-    signal.signal(signal.SIGINT, signal_handler)
-
-    # Start Tomcat last. It will be the foreground process.
+    # Start Tomcat last.
     logger.info("Starting Tomcat")
-    global tomcat_popen
     tomcat_popen = subprocess.Popen([os.path.join(tomcat_root, 'bin',
                                                   'catalina.sh'),
                                     'run'])
-    tomcat_popen.wait()
 
-
-def signal_handler(signum, frame):
-    print("Received signal {}".format(signum))
-
-    global tomcat_popen
+    sigset = set()
+    sigset.add(signal.SIGTERM)
+    sigset.add(signal.SIGINT)
+    signum = signal.sigwait(sigset)
+    logger.info("Received signal {}".format(signum))
     if tomcat_popen:
-        print("Terminating Tomcat {}".format(tomcat_popen))
+        logger.info("Terminating Tomcat {}".format(tomcat_popen))
         tomcat_popen.terminate()
-
-    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/docker/start.py
+++ b/docker/start.py
@@ -571,6 +571,11 @@ def main():
 
         start_rest_thread(logger)
 
+    # Ideally the signal handlers should be installed as early as possible,
+    # however that does not play well with the worker pool communication used by do_sync().
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+
     # Start Tomcat last. It will be the foreground process.
     logger.info("Starting Tomcat")
     global tomcat_popen
@@ -592,7 +597,4 @@ def signal_handler(signum, frame):
 
 
 if __name__ == "__main__":
-    signal.signal(signal.SIGTERM, signal_handler)
-    signal.signal(signal.SIGINT, signal_handler)
-
     main()


### PR DESCRIPTION
This change should resolve the problems with unwanted occasional Docker container termination. Even though on Ctrl-C the container logs (as displayed via `docker-compose`) do not display the indication of the cleanup, `strace`-ing the main `start.py` process confirms:
```
rt_sigtimedwait([INT TERM], {si_signo=SIGTERM, si_code=SI_USER, si_pid=0, si_uid=0}, NULL, 8) = 15 (SIGTERM)
getpid()                                = 1
write(1, "2022-12-07 21:00:34,470     INFO"..., 69) = 69
 | 00000  32 30 32 32 2d 31 32 2d  30 37 20 32 31 3a 30 30  2022-12-07 21:00 |
 | 00010  3a 33 34 2c 34 37 30 20  20 20 20 20 49 4e 46 4f  :34,470     INFO |
 | 00020  20 6f 70 65 6e 67 72 6f  6b 5f 74 6f 6f 6c 73 20   opengrok_tools  |
 | 00030  7c 20 52 65 63 65 69 76  65 64 20 73 69 67 6e 61  | Received signa |
 | 00040  6c 20 31 35 0a                                    l 15.            |
getpid()                                = 1
write(1, "2022-12-07 21:00:34,479     INFO"..., 146) = 146
 | 00000  32 30 32 32 2d 31 32 2d  30 37 20 32 31 3a 30 30  2022-12-07 21:00 |
 | 00010  3a 33 34 2c 34 37 39 20  20 20 20 20 49 4e 46 4f  :34,479     INFO |
 | 00020  20 6f 70 65 6e 67 72 6f  6b 5f 74 6f 6f 6c 73 20   opengrok_tools  |
 | 00030  7c 20 54 65 72 6d 69 6e  61 74 69 6e 67 20 54 6f  | Terminating To |
 | 00040  6d 63 61 74 20 3c 50 6f  70 65 6e 3a 20 72 65 74  mcat <Popen: ret |
 | 00050  75 72 6e 63 6f 64 65 3a  20 4e 6f 6e 65 20 61 72  urncode: None ar |
 | 00060  67 73 3a 20 5b 27 2f 75  73 72 2f 6c 6f 63 61 6c  gs: ['/usr/local |
 | 00070  2f 74 6f 6d 63 61 74 2f  62 69 6e 2f 63 61 74 61  /tomcat/bin/cata |
 | 00080  6c 69 6e 61 2e 73 68 27  2c 20 27 72 75 6e 27 5d  lina.sh', 'run'] |
 | 00090  3e 0a                                             >.               |
wait4(11, 0x7fffd5b9312c, WNOHANG, NULL) = 0
kill(11, SIGTERM)                       = 0
wait4(11, 0x7fffd5b934ec, WNOHANG, NULL) = 0
getpid()                                = 1
...
```