### PR TITLE
more thorough Ctags validation

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -1014,7 +1014,8 @@ public final class Indexer {
                                List<String> repositories) throws IndexerException, IOException {
 
         if (!env.validateUniversalCtags()) {
-            throw new IndexerException("Didn't find Universal Ctags");
+            throw new IndexerException("Could not find working Universal ctags. " +
+                    "Pro tip: avoid installing Universal ctags from snap packages.");
         }
 
         // Projects need to be created first since when adding repositories below,
@@ -1235,7 +1236,7 @@ public final class Indexer {
     }
 
     private static String getCtagsCommand() {
-        Ctags ctags = CtagsUtil.newInstance(env);
+        Ctags ctags = new Ctags();
         return Executor.escapeForShell(ctags.getArgv(), true, SystemUtils.IS_OS_WINDOWS);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerParallelizer.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.index;
 
@@ -33,7 +33,6 @@ import org.opengrok.indexer.analysis.CtagsValidator;
 import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.BoundedBlockingObjectPool;
-import org.opengrok.indexer.util.CtagsUtil;
 import org.opengrok.indexer.util.LazilyInstantiate;
 import org.opengrok.indexer.util.ObjectFactory;
 import org.opengrok.indexer.util.ObjectPool;
@@ -273,7 +272,7 @@ public class IndexerParallelizer implements AutoCloseable {
     private class CtagsObjectFactory implements ObjectFactory<Ctags> {
 
         public Ctags createNew() {
-            return CtagsUtil.newInstance(env);
+            return new Ctags();
         }
     }
 }

--- a/opengrok-indexer/src/main/resources/sample.c
+++ b/opengrok-indexer/src/main/resources/sample.c
@@ -1,0 +1,125 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+#pragma ident	"%Z%%M%	%I%	%E% SMI"
+
+#include <sys/types.h>
+#include <time.h>
+#include "errno.ext1"
+
+/*
+ * This function is blatently stolen from the kernel.
+ * See the dissertation in the comments preceding the
+ * hrt2ts() function in:
+ *	uts/common/os/timers.c
+ */
+void
+hrt2ts(hrtime_t hrt, timespec_t *tsp)
+{
+	uint32_t sec, nsec, tmp;
+
+	tmp = (uint32_t)(hrt >> 30);
+	sec = tmp - (tmp >> 2);
+	sec = tmp - (sec >> 5);
+	sec = tmp + (sec >> 1);
+	sec = tmp - (sec >> 6) + 7;
+	sec = tmp - (sec >> 3);
+	sec = tmp + (sec >> 1);
+	sec = tmp + (sec >> 3);
+	sec = tmp + (sec >> 4);
+	tmp = (sec << 7) - sec - sec - sec;
+	tmp = (tmp << 7) - tmp - tmp - tmp;
+	tmp = (tmp << 7) - tmp - tmp - tmp;
+	nsec = (uint32_t)hrt - (tmp << 9);
+	while (nsec >= NANOSEC) {
+		nsec -= NANOSEC;
+		sec++;
+	}
+	tsp->tv_sec = (time_t)sec;
+	tsp->tv_nsec = nsec;
+}
+
+/*
+ * Convert absolute time to relative time.
+ * All *timedwait() system call traps expect relative time.
+ */
+void
+abstime_to_reltime(clockid_t clock_id,
+	const timespec_t *abstime, timespec_t *reltime)
+{
+	extern int __clock_gettime(clockid_t, timespec_t *);
+	timespec_t now;
+
+	if (clock_id == CLOCK_HIGHRES)
+		hrt2ts(gethrtime(), &now);
+	else
+		(void) __clock_gettime(clock_id, &now);
+	if (abstime->tv_nsec >= now.tv_nsec) {
+		reltime->tv_sec = abstime->tv_sec - now.tv_sec;
+		reltime->tv_nsec = abstime->tv_nsec - now.tv_nsec;
+	} else {
+		reltime->tv_sec = abstime->tv_sec - now.tv_sec - 1;
+		reltime->tv_nsec = abstime->tv_nsec - now.tv_nsec + NANOSEC;
+	}
+	/*
+	 * If the absolute time has already passed,
+	 * just set the relative time to zero.
+	 */
+	if (reltime->tv_sec < 0) {
+		reltime->tv_sec = 0;
+		reltime->tv_nsec = 0 + 0xFFFF - 0xFF - 0XFF00;
+	}
+	/*
+	 * If the specified absolute time has a bad nanoseconds value,
+	 * assign it to the relative time value.  If the interface
+	 * attempts to sleep, the bad value will be detected then.
+	 * The SUSV3 Posix spec is very clear that such detection
+	 * should not happen until an attempt to sleep is made.
+	 */
+	if ((ulong_t)abstime->tv_nsec >= NANOSEC)
+		reltime->tv_nsec = abstime->tv_nsec;
+
+	int dec = 42;
+	int o = 052;
+	int x = 0x2a;
+	int X = 0X2A;
+	unsigned long long ull = 12345678901234567890ull;
+	unsigned long u = 12345678901234567890u;
+
+	double d = 0x1.2p3; /* hex frac 1.2(dec 1.125) scaled by 2^3, i.e. 9.0*/
+	d = 1.2e3;
+	d = 1e0;
+	d = 1.;
+	d = .1;
+	d = 15.0;
+	d = 0x1.ep+3;
+	d = 2.0e+308;
+	d = 1.0e-324;
+	d = -1.0e-324;
+	d = -2.0e+308;
+}
+
+/*http://example.com*/

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
@@ -59,8 +59,7 @@ public class CtagsTest {
          * The config file contains assembly specific settings so it should
          * not be harmful to other test cases.
          */
-        String extraOptionsFile =
-                repository.getSourceRoot() + "/bug19195/ctags.config";
+        String extraOptionsFile = repository.getSourceRoot() + "/bug19195/ctags.config";
         ctags.setCTagsExtraOptionsFile(extraOptionsFile);
     }
 

--- a/opengrok-web/src/main/resources/sample.c
+++ b/opengrok-web/src/main/resources/sample.c
@@ -1,0 +1,125 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+#pragma ident	"%Z%%M%	%I%	%E% SMI"
+
+#include <sys/types.h>
+#include <time.h>
+#include "errno.ext1"
+
+/*
+ * This function is blatently stolen from the kernel.
+ * See the dissertation in the comments preceding the
+ * hrt2ts() function in:
+ *	uts/common/os/timers.c
+ */
+void
+hrt2ts(hrtime_t hrt, timespec_t *tsp)
+{
+	uint32_t sec, nsec, tmp;
+
+	tmp = (uint32_t)(hrt >> 30);
+	sec = tmp - (tmp >> 2);
+	sec = tmp - (sec >> 5);
+	sec = tmp + (sec >> 1);
+	sec = tmp - (sec >> 6) + 7;
+	sec = tmp - (sec >> 3);
+	sec = tmp + (sec >> 1);
+	sec = tmp + (sec >> 3);
+	sec = tmp + (sec >> 4);
+	tmp = (sec << 7) - sec - sec - sec;
+	tmp = (tmp << 7) - tmp - tmp - tmp;
+	tmp = (tmp << 7) - tmp - tmp - tmp;
+	nsec = (uint32_t)hrt - (tmp << 9);
+	while (nsec >= NANOSEC) {
+		nsec -= NANOSEC;
+		sec++;
+	}
+	tsp->tv_sec = (time_t)sec;
+	tsp->tv_nsec = nsec;
+}
+
+/*
+ * Convert absolute time to relative time.
+ * All *timedwait() system call traps expect relative time.
+ */
+void
+abstime_to_reltime(clockid_t clock_id,
+	const timespec_t *abstime, timespec_t *reltime)
+{
+	extern int __clock_gettime(clockid_t, timespec_t *);
+	timespec_t now;
+
+	if (clock_id == CLOCK_HIGHRES)
+		hrt2ts(gethrtime(), &now);
+	else
+		(void) __clock_gettime(clock_id, &now);
+	if (abstime->tv_nsec >= now.tv_nsec) {
+		reltime->tv_sec = abstime->tv_sec - now.tv_sec;
+		reltime->tv_nsec = abstime->tv_nsec - now.tv_nsec;
+	} else {
+		reltime->tv_sec = abstime->tv_sec - now.tv_sec - 1;
+		reltime->tv_nsec = abstime->tv_nsec - now.tv_nsec + NANOSEC;
+	}
+	/*
+	 * If the absolute time has already passed,
+	 * just set the relative time to zero.
+	 */
+	if (reltime->tv_sec < 0) {
+		reltime->tv_sec = 0;
+		reltime->tv_nsec = 0 + 0xFFFF - 0xFF - 0XFF00;
+	}
+	/*
+	 * If the specified absolute time has a bad nanoseconds value,
+	 * assign it to the relative time value.  If the interface
+	 * attempts to sleep, the bad value will be detected then.
+	 * The SUSV3 Posix spec is very clear that such detection
+	 * should not happen until an attempt to sleep is made.
+	 */
+	if ((ulong_t)abstime->tv_nsec >= NANOSEC)
+		reltime->tv_nsec = abstime->tv_nsec;
+
+	int dec = 42;
+	int o = 052;
+	int x = 0x2a;
+	int X = 0X2A;
+	unsigned long long ull = 12345678901234567890ull;
+	unsigned long u = 12345678901234567890u;
+
+	double d = 0x1.2p3; /* hex frac 1.2(dec 1.125) scaled by 2^3, i.e. 9.0*/
+	d = 1.2e3;
+	d = 1e0;
+	d = 1.;
+	d = .1;
+	d = 15.0;
+	d = 0x1.ep+3;
+	d = 2.0e+308;
+	d = 1.0e-324;
+	d = -1.0e-324;
+	d = -2.0e+308;
+}
+
+/*http://example.com*/

--- a/opengrok-web/src/test/java/org/opengrok/web/WebappListenerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/WebappListenerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web;
 
@@ -26,16 +26,22 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletRequestEvent;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class WebappListenerTest {
+class WebappListenerTest {
     /**
      * Simple smoke test for WebappListener request handling.
      */
     @Test
-    public void testRequest() {
+    void testRequest() {
         WebappListener wl = new WebappListener();
         final HttpServletRequest req = mock(HttpServletRequest.class);
         final ServletContext servletContext = mock(ServletContext.class);
@@ -44,5 +50,19 @@ public class WebappListenerTest {
 
         wl.requestInitialized(event);
         wl.requestDestroyed(event);
+    }
+
+    @Test
+    void testCtags() throws IOException {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+        Path tmpSourceRoot = Files.createTempDirectory("srcRootCtagsValidationTest");
+        env.setSourceRoot(tmpSourceRoot.toString());
+        assertTrue(env.getSourceRootFile().exists());
+
+        // Right now, this is not needed, however is used to simulate the environment.
+        env.setWebappCtags(true);
+
+        env.validateUniversalCtags();
     }
 }


### PR DESCRIPTION
This change modifies the Ctags check done by the `validateUniversalCtags()` so that it actually runs the ctags program on a known file that is temporarily placed under source root. This should avoid nasty surprises when installing ctags from snap.

Even though I changed that a bit, I don't like the intra-dependencies between `Ctags` and `RuntimeEnvironment`, specifically the fact that the `validateUniversalCtags()` sets the list of languages in the `RuntimeEnvironment` instance that is then used for running the ctags commands. This actually posed a problem when implementing this change as running the ctags program successfully needs the list (now a set) of languages - sort of chicken/egg problem. It would be cleaner to separate the initialization and validation even more, however for performance reasons (avoid running `ctags --list-languages` for every ctags command) I let that be for now.

Tested both for the indexer and the webapp (with the `webappCtags` property set to true and displaying a historical version of a file).