### PR TITLE
add xref performance meters

### DIFF
--- a/dev/checkstyle/suppressions.xml
+++ b/dev/checkstyle/suppressions.xml
@@ -40,7 +40,7 @@ Portions Copyright (c) 2018-2020, Chris Fraire <cfraire@me.com>.
 
     <suppress checks="ParameterNumber" files="CtagsReader\.java|Definitions\.java|
         |JFlexXrefUtils\.java|FileAnalyzerFactory\.java|SearchController\.java|
-        |Context\.java|HistoryContext\.java|Suggester\.java|
+        |Context\.java|HistoryContext\.java|Suggester\.java|AnalyzerGuru\.java|
 	|ProjectHelperTestBase\.java|SearchHelper\.java" />
 
     <suppress checks="FileLength" files="RuntimeEnvironment\.java|IndexDatabase\.java" />

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -699,6 +699,7 @@ public class AnalyzerGuru {
      * @param defs definitions for the source file, if available
      * @param annotation annotation information for the file
      * @param project project the file belongs to
+     * @param file file object, used for logging only
      * @throws java.io.IOException if an error occurs while creating the output
      */
     public static void writeDumpedXref(String contextPath,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2011, Jens Elkner.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
@@ -64,7 +64,6 @@ import org.apache.commons.lang3.SystemUtils;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.Annotation;
-import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.logger.LoggerFactory;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1086,10 +1086,9 @@ public final class Util {
      *
      * @param out destination for the HTML output
      * @throws IOException if an error happens while writing to {@code out}
-     * @throws HistoryException if the history guru cannot be accesses
      */
     @SuppressWarnings("boxing")
-    public static void dumpConfiguration(Appendable out) throws IOException, HistoryException {
+    public static void dumpConfiguration(Appendable out) throws IOException {
         out.append("<table border=\"1\" width=\"100%\">");
         out.append("<tr><th>Variable</th><th>Value</th></tr>");
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
@@ -1122,8 +1121,8 @@ public final class Util {
     }
 
     /**
-     * Just read the given source and dump as is to the given destination. Does
-     * nothing, if one or more of the parameters is {@code null}.
+     * Just read the given source and dump as is to the given destination.
+     * Does nothing, if one or more of the parameters is {@code null}.
      *
      * @param out write destination
      * @param in source to read
@@ -1134,6 +1133,7 @@ public final class Util {
         if (in == null || out == null) {
             return;
         }
+
         char[] buf = new char[8192];
         int len = 0;
         while ((len = in.read(buf)) >= 0) {
@@ -1148,13 +1148,11 @@ public final class Util {
      * @param out dump destination
      * @param dir directory, which should contains the file.
      * @param filename the basename of the file to dump.
-     * @param compressed if {@code true} the denoted file is assumed to be
-     * gzipped.
+     * @param compressed if {@code true} the denoted file is assumed to be gzipped.
      * @return {@code true} on success (everything read and written).
      * @throws NullPointerException if a parameter is {@code null}.
      */
-    public static boolean dump(Writer out, File dir, String filename,
-            boolean compressed) {
+    public static boolean dump(Writer out, File dir, String filename, boolean compressed) {
         return dump(out, new File(dir, filename), compressed);
     }
 
@@ -1163,17 +1161,17 @@ public final class Util {
      * gets caught and logged, but not re-thrown.
      *
      * @param out dump destination
-     * @param file file to dump.
-     * @param compressed if {@code true} the denoted file is assumed to be
-     * gzipped.
-     * @return {@code true} on success (everything read and written).
-     * @throws NullPointerException if a parameter is {@code null}.
+     * @param file file to dump
+     * @param compressed if {@code true} the denoted file is assumed to be gzipped
+     * @return {@code true} on success (everything read and written)
+     * @throws NullPointerException if a parameter is {@code null}
      */
     public static boolean dump(Writer out, File file, boolean compressed) {
         if (!file.exists()) {
             return false;
         }
-        /**
+
+        /*
          * For backward compatibility, read the OpenGrok-produced document
          * using the system default charset.
          */
@@ -1183,21 +1181,21 @@ public final class Util {
             }
             return true;
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING,
-                    "An error occurred while piping file " + file + ": ", e);
+            LOGGER.log(Level.WARNING, String.format("An error occurred while piping file '%s': ", file), e);
         }
+
         return false;
     }
 
     /**
-     * Silently dump an xref file to the given destination. All
-     * {@link IOException}s get caught and logged, but not re-thrown.
+     * Silently dump a xref file to the given destination.
+     * All {@link IOException}s get caught and logged, but not re-thrown.
      * @param out dump destination
      * @param file file to dump
      * @param compressed if {@code true} the denoted file is assumed to be gzipped
      * @param contextPath an optional override of "/source/" as the context path
      * @return {@code true} on success (everything read and written)
-     * @throws NullPointerException if a parameter is {@code null}.
+     * @throws NullPointerException if a parameter is {@code null}
      */
     public static boolean dumpXref(Writer out, File file, boolean compressed, String contextPath) {
 
@@ -1214,26 +1212,26 @@ public final class Util {
                 dumpXref(out, in, contextPath);
                 return true;
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "An error occurred while piping file " + file, e);
+            LOGGER.log(Level.WARNING, String.format("An error occurred while piping file '%s'", file), e);
         }
 
         return false;
     }
 
     /**
-     * Silently dump an xref file to the given destination. All
-     * {@link IOException}s get caught and logged, but not re-thrown.
+     * Dump a xref file to the given destination.
      * @param out dump destination
      * @param in source to read
      * @param contextPath an optional override of "/source/" as the context path
      * @throws IOException as defined by the given reader/writer
-     * @throws NullPointerException if a parameter is {@code null}.
+     * @throws NullPointerException if a parameter is {@code null}
      */
-    public static void dumpXref(Writer out, Reader in, String contextPath)
-            throws IOException {
+    public static void dumpXref(Writer out, Reader in, String contextPath) throws IOException {
+
         if (in == null || out == null) {
             return;
         }
+
         XrefSourceTransformer xform = new XrefSourceTransformer(in);
         xform.setWriter(out);
         xform.setContextPath(contextPath);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, Ric Harris <harrisric@users.noreply.github.com>.
  */
@@ -400,7 +400,7 @@ public class IndexerTest {
             }
             try (FileReader in = new FileReader(f); StringWriter out = new StringWriter()) {
                 try {
-                    AnalyzerGuru.writeXref(factory, in, out, null, null, null);
+                    AnalyzerGuru.writeXref(factory, in, out, null, null, null, f);
                 } catch (UnsupportedOperationException exp) {
                     // ignore
                 }

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1197,6 +1197,7 @@ public final class PageConfig {
                 : "";
     }
 
+    @Nullable
     private File checkFileInner(File file, File dir, String name) {
         File f = new File(dir, name);
         if (f.exists() && f.isFile()) {
@@ -1210,6 +1211,7 @@ public final class PageConfig {
         return null;
     }
 
+    @Nullable
     private File checkFile(File file, File dir, String name, boolean compressed) {
         File f;
         if (compressed) {
@@ -1222,6 +1224,7 @@ public final class PageConfig {
         return checkFileInner(file, dir, name);
     }
 
+    @Nullable
     private File checkFileResolve(File dir, String name, boolean compressed) {
         File lresourceFile = new File(getSourceRootPath() + getPath(), name);
         if (!lresourceFile.canRead()) {

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1236,11 +1236,10 @@ public final class PageConfig {
 
     /**
      * Find the files with the given names in the {@link #getPath()} directory
-     * relative to the cross-file directory of the opengrok data directory. It is
-     * tried to find the compressed file first by appending the file extension
-     * ".gz" to the filename. If that fails or an uncompressed version of the
-     * file is younger than its compressed version, the uncompressed file gets
-     * used.
+     * relative to the cross-file directory of the opengrok data directory. It will
+     * try to find the compressed file first by appending the file extension
+     * {@code ".gz"} to the filename. If that fails or an uncompressed version of the
+     * file is younger than its compressed version, the uncompressed file gets used.
      *
      * @param filenames filenames to lookup.
      * @return an empty array if the related directory does not exist or the

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -16,7 +16,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
 
@@ -251,7 +251,7 @@ document.pageReady.push(function() { pageReadyList();});
                          */
                         r = new InputStreamReader(bin);
                         // dumpXref() is also useful here for translating links.
-                        Util.dumpXref(out, r, request.getContextPath());
+                        Util.dumpXref(out, r, request.getContextPath(), resourceFile);
                     } else if (g == AbstractAnalyzer.Genre.PLAIN) {
 %>
 <div id="src" data-navigate-window-enabled="<%= navigateWindowEnabled %>">
@@ -303,7 +303,7 @@ include file="/xref.jspf"
 <%
         }
     } else {
-        // Requesting cross referenced file with no known revision.
+        // Requesting cross-referenced file with no known revision.
         File xrefFile = cfg.findDataFile();
         if (xrefFile != null) {
 %>

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -264,7 +264,7 @@ document.pageReady.push(function() { pageReadyList();});
                         r = IOUtils.createBOMStrippedReader(bin,
                             StandardCharsets.UTF_8.name());
                         AnalyzerGuru.writeDumpedXref(request.getContextPath(), a,
-                                r, out, defs, annotation, project);
+                                r, out, defs, annotation, project, resourceFile);
     %></pre>
 </div><%
                     } else {

--- a/opengrok-web/src/main/webapp/xref.jspf
+++ b/opengrok-web/src/main/webapp/xref.jspf
@@ -16,7 +16,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
 --%>
@@ -133,16 +133,14 @@ org.opengrok.indexer.web.QueryParameters"
     <pre><%
                     } else if (g == AbstractAnalyzer.Genre.HTML) {
                         /*
-                         * For backward compatibility, read the
-                         * OpenGrok-produced document using the system
-                         * default charset.
+                         * For backward compatibility, read the OpenGrok-produced document
+                         * using the system default charset.
                          */
                         r = new InputStreamReader(in);
                         /*
-                         * dumpXref() is also useful here for
-                         * translating links.
+                         * dumpXref() is also useful here for translating links.
                          */
-                        Util.dumpXref(out, r, request.getContextPath());
+                        Util.dumpXref(out, r, request.getContextPath(), resourceFile);
                     } else {
     %>Download binary file, <a href="<%= rawPath %>?<%= QueryParameters.REVISION_PARAM_EQ %>
 <%= Util.uriEncode(rev) %>"><%= basename %></a><%

--- a/opengrok-web/src/main/webapp/xref.jspf
+++ b/opengrok-web/src/main/webapp/xref.jspf
@@ -126,7 +126,7 @@ org.opengrok.indexer.web.QueryParameters"
                         r = IOUtils.createBOMStrippedReader(in, StandardCharsets.UTF_8.name());
                         AnalyzerGuru.writeDumpedXref(request.getContextPath(),
                             a, r, out,
-                            defs, annotation, project);
+                            defs, annotation, project, resourceFile);
                     } else if (g == AbstractAnalyzer.Genre.IMAGE) {
         %></pre>
     <img src="<%= rawPath %>?<%= QueryParameters.REVISION_PARAM_EQ %><%= Util.uriEncode(rev) %>" alt="Image from Source Repository"/>


### PR DESCRIPTION
This change adds bunch of meters for the xref handling. Inspired by https://github.com/oracle/opengrok/discussions/4137. Decided to pass on the decompression meter.

Looks like this:
```
xref_file_get_total{what="miss",} 2.0
xref_file_get_total{what="hits",} 3.0
xref_write_latency_seconds_count 2.0
xref_write_latency_seconds_sum 0.058302
xref_write_latency_seconds_max 0.002391
xref_dump_latency_seconds_max 0.001895
xref_dump_latency_seconds_count 5.0
xref_dump_latency_seconds_sum 0.074593
```

Fixes #4142.