### PR TITLE
handle null returned from doCtags()

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -492,7 +492,7 @@ public class Ctags implements Resettable {
     /**
      * Run ctags on a file.
      * @param file file path to process
-     * @return Definitions
+     * @return valid instance of {@link Definitions} or {@code null} on error
      * @throws IOException I/O exception
      * @throws InterruptedException interrupted command
      */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -47,6 +47,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.jetbrains.annotations.Nullable;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.index.IndexerParallelizer;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -495,6 +496,7 @@ public class Ctags implements Resettable {
      * @throws IOException I/O exception
      * @throws InterruptedException interrupted command
      */
+    @Nullable
     public Definitions doCtags(String file) throws IOException, InterruptedException {
 
         if (file.length() < 1 || "\n".equals(file)) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
@@ -93,7 +93,7 @@ public class CtagsUtil {
         Ctags ctags = new Ctags();
         try {
             Definitions definitions = ctags.doCtags(inputPath.toString());
-            if (definitions.numberOfSymbols() > 1) {
+            if (definitions != null && definitions.numberOfSymbols() > 1) {
                 return true;
             }
         } catch (IOException | InterruptedException e) {


### PR DESCRIPTION
Windows build has failed with:
```
java.lang.NullPointerException
	at org.opengrok.indexer.util.CtagsUtil.canProcessFiles(CtagsUtil.java:96)
	at org.opengrok.indexer.util.CtagsUtil.validate(CtagsUtil.java:65)
	at org.opengrok.indexer.util.CtagsUtilTest.testValidateWithInvalidExtraOptions(CtagsUtilTest.java:79)
```
This is because the process failure was actually detected like this:
```
WARNING: Error from ctags: ctags.exe: Unknown option: --fooBar
Jan 05, 2023 4:43:48 PM org.opengrok.indexer.analysis.Ctags readTags
WARNING: ctags: Unexpected end of file!
Jan 05, 2023 4:43:48 PM org.opengrok.indexer.analysis.Ctags readTags
WARNING: ctags exited with code: 1
Jan 05, 2023 4:43:48 PM org.opengrok.indexer.analysis.Ctags doCtags
WARNING: execution exception
java.util.concurrent.ExecutionException: java.lang.InterruptedException: tagLine == null
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)
	at org.opengrok.indexer.analysis.Ctags.doCtags(Ctags.java:548)
	at org.opengrok.indexer.util.CtagsUtil.canProcessFiles(CtagsUtil.java:95)
	at org.opengrok.indexer.util.CtagsUtil.validate(CtagsUtil.java:65)
	at org.opengrok.indexer.util.CtagsUtilTest.validate(CtagsUtilTest.java:62)
```
This change fixes that.