### PR TITLE
normalize scan depth based on the number of path components

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, Aleksandr Kirillov <alexkirillovsamara@gmail.com>.
  */
@@ -226,9 +226,9 @@ public final class Configuration {
      * The directory hierarchy depth to limit the scanning for repositories.
      * E.g. if the /mercurial/ directory (relative to source root) is a repository
      * and /mercurial/usr/closed/ is sub-repository, the latter will be discovered
-     * only if the depth is set to 2 or greater.
+     * only if the depth is set to 3 or greater.
      */
-    public static final int defaultScanningDepth = 2;
+    public static final int DEFAULT_SCANNING_DEPTH = 3;
 
     /**
      * The name of the eftar file relative to the <var>DATA_ROOT</var>, which
@@ -576,7 +576,7 @@ public final class Configuration {
         //setReviewPage("http://arc.myserver.org/caselog/PSARC/");
         setReviewPattern("\\b(\\d{4}/\\d{3})\\b"); // in form e.g. PSARC 2008/305
         setRevisionMessageCollapseThreshold(200);
-        setScanningDepth(defaultScanningDepth); // default depth of scanning for repositories
+        setScanningDepth(DEFAULT_SCANNING_DEPTH); // default depth of scanning for repositories
         setScopesEnabled(true);
         setSourceRoot(null);
         //setTabSize(4);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -804,11 +804,18 @@ public final class RuntimeEnvironment {
      * Search through the directory for repositories and use the result to replace
      * the lists of repositories in both RuntimeEnvironment/Configuration and HistoryGuru.
      *
-     * @param dir the directories to start the search in
+     * @param dir paths of directories to start the search in
      */
     public void setRepositories(String... dir) {
+        int scanDepth = RuntimeEnvironment.getInstance().getScanningDepth();
+        if (scanDepth == 0) {
+            LOGGER.log(Level.INFO, "maximum scan depth is set to 0, will not scan for repositories");
+            return;
+        }
+
         List<RepositoryInfo> repos = new ArrayList<>(HistoryGuru.getInstance().
                 addRepositories(Arrays.stream(dir).map(File::new).toArray(File[]::new)));
+
         setRepositories(repos);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -760,11 +760,12 @@ public final class HistoryGuru {
                 try {
                     repository = RepositoryFactory.getRepository(file, CommandTimeoutType.INDEXER, isNested);
                 } catch (InstantiationException | NoSuchMethodException | InvocationTargetException e) {
-                    LOGGER.log(Level.WARNING, "Could not create repository for '"
-                            + file + "', could not instantiate the repository.", e);
+                    LOGGER.log(Level.WARNING,
+                            String.format("Could not create repository for '%s': could not instantiate the repository.",
+                                    file), e);
                 } catch (IllegalAccessException iae) {
-                    LOGGER.log(Level.WARNING, "Could not create repository for '"
-                            + file + "', missing access rights.", iae);
+                    LOGGER.log(Level.WARNING,
+                            String.format("Could not create repository for '%s': missing access rights.", file), iae);
                     continue;
                 } catch (ForbiddenSymlinkException e) {
                     LOGGER.log(Level.WARNING, "Could not create repository for ''{0}'': {1}",

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -352,20 +352,24 @@ public class HistoryGuruTest {
         certainlyMkdirs(sub3);
 
         int originalScanDepth = env.getScanningDepth();
-        env.setScanningDepth(0);
 
+        // Test default scan depth value.
         HistoryGuru instance = HistoryGuru.getInstance();
         Collection<RepositoryInfo> addedRepos = instance.addRepositories(
                 Collections.singleton(Paths.get(repository.getSourceRoot(), topLevelDirName).toString()));
-        assertEquals(1, addedRepos.size(), "should add to max depth");
+        assertEquals(2, addedRepos.size(),
+                "2 repositories should be discovered with default scan depth setting");
 
-        env.setScanningDepth(1);
+        // Reduction of scan depth should cause reduction of repositories.
         List<String> repoDirs = addedRepos.stream().map(RepositoryInfo::getDirectoryName).collect(Collectors.toList());
         instance.removeRepositories(repoDirs);
+        env.setScanningDepth(originalScanDepth - 1);
         addedRepos = instance.addRepositories(
                 Collections.singleton(Paths.get(repository.getSourceRoot(), topLevelDirName).toString()));
-        assertEquals(2, addedRepos.size(), "should add to increased max depth");
+        assertEquals(1, addedRepos.size(),
+                "1 repository should be discovered with reduced scan depth");
 
+        // cleanup
         env.setScanningDepth(originalScanDepth);
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -156,8 +156,7 @@ public class ProjectsController {
         HistoryGuru histGuru = HistoryGuru.getInstance();
 
         // There is no need to perform the work of invalidateRepositories(),
-        // since addRepositories() calls getRepository() for each of
-        // the repos.
+        // since addRepositories() calls getRepository() for each of the repositories.
         return new ArrayList<>(histGuru.addRepositories(new File[]{projDir}));
     }
 


### PR DESCRIPTION
This change unifies scan depth handling across various use cases (the`-S` indexer option can be specified multiple times and takes a path as argument), fixing the regression introduced with parallel repository scanning.

Tested with projects enabled and source root directory (`/var/opengrok/src.depth`) that had single project (Git repository) and there was Mercurial repository 2 levels below the project:
```
/var/opengrok/src.depth/
└── securitylab
    ├── .git
    │   ├── branches
    │   ├── hooks
     ...
    ├── foo
    │   └── bar
    │       └── .hg
    │           ├── cache
     ...
```

When running with `--depth 3` (the new default) 2 repositories were discovered, with `--depth 2` just the top level repository was discovered.