### PR TITLE
handle resource as a stream for ctags check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.0.2</version>
+                <version>7.4.4</version>
                 <configuration>
                     <skipSystemScope>true</skipSystemScope>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>


### PR DESCRIPTION
When running the indexer from a jar file, the recently added ctags check results in:
```
Jan 06, 2023 5:38:08 PM org.opengrok.indexer.index.Indexer main
SEVERE: Unexpected Exception
java.nio.file.FileSystemNotFoundException
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.getFileSystem(ZipFileSystemProvider.java:169)
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.getPath(ZipFileSystemProvider.java:155)
	at java.base/java.nio.file.Path.of(Path.java:208)
	at org.opengrok.indexer.util.CtagsUtil.getResourceFile(CtagsUtil.java:131)
	at org.opengrok.indexer.util.CtagsUtil.canProcessFiles(CtagsUtil.java:77)
	at org.opengrok.indexer.util.CtagsUtil.validate(CtagsUtil.java:65)
	at org.opengrok.indexer.configuration.RuntimeEnvironment.validateUniversalCtags(RuntimeEnvironment.java:685)
	at org.opengrok.indexer.index.Indexer.prepareIndexer(Indexer.java:1026)
	at org.opengrok.indexer.index.Indexer.main(Indexer.java:384)
```
This change fixes this by converting the resource file handling to stream based.