### PR TITLE
fix(sec): upgrade com.thoughtworks.xstream:xstream to 1.4.20

### DIFF
--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -114,7 +114,7 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.19</version>
+            <version>1.4.20</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.thoughtworks.xstream:xstream 1.4.19
- [CVE-2022-41966](https://www.oscs1024.com/hd/CVE-2022-41966)


### What did I do？
Upgrade com.thoughtworks.xstream:xstream from 1.4.19 to 1.4.20 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS