### PR TITLE
reinstate the use of the fetchHistoryWhenNotInCache indexer tunable

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -207,8 +207,7 @@ public final class Configuration {
     /*
      * Set to false if we want to disable fetching history of individual files
      * (by running appropriate SCM command) when the history is not found
-     * in history cache for repositories capable of fetching history for
-     * directories.
+     * in history cache for repositories capable of fetching history for directories.
      */
     private boolean fetchHistoryWhenNotInCache;
     /*

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -522,7 +522,8 @@ public final class HistoryGuru {
          * fetched in the first phase of indexing.
          */
         if (env.isIndexer() && isHistoryIndexDone() &&
-                repository.isHistoryEnabled() && repository.hasHistoryForDirectories()) {
+                repository.isHistoryEnabled() && repository.hasHistoryForDirectories() &&
+                !env.isFetchHistoryWhenNotInCache()) {
             LOGGER.log(Level.FINE, "not getting the history for ''{0}'' in repository {1} as the it supports "
                     + "history for directories",
                     new Object[]{file, repository});


### PR DESCRIPTION
This change restores the use of the `fetchHistoryWhenNotInCache` indexer tunable as documented on https://github.com/oracle/opengrok/wiki/Indexer-configuration