### PR TITLE
handle cache directory failures

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CacheUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CacheUtil.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CacheUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CacheUtil.java
@@ -22,6 +22,7 @@
  */
 package org.opengrok.indexer.history;
 
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -64,7 +65,15 @@ public class CacheUtil {
         }
     }
 
+    /**
+     *
+     * @param repository {@link RepositoryInfo} instance
+     * @param cache {@link Cache} instance
+     * @return absolute directory path for top level cache directory of given repository.
+     * Will return {@code null} on error.
+     */
     @VisibleForTesting
+    @Nullable
     public static String getRepositoryCacheDataDirname(RepositoryInfo repository, Cache cache) {
         String repoDirBasename;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -446,10 +446,14 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
         // File based history cache does not store files for individual changesets so strip them.
         history.strip();
 
-        File histDataDir = new File(CacheUtil.getRepositoryCacheDataDirname(repository, this));
+        String repoCachePath = CacheUtil.getRepositoryCacheDataDirname(repository, this);
+        if (repoCachePath == null) {
+            throw new CacheException(String.format("failed to get cache directory path for %s", repository));
+        }
+        File histDataDir = new File(repoCachePath);
         // Check the directory again in case of races (might happen in the presence of sub-repositories).
         if (!histDataDir.isDirectory() && !histDataDir.mkdirs() && !histDataDir.isDirectory()) {
-            LOGGER.log(Level.WARNING, "cannot create history cache directory for ''{0}''", histDataDir);
+            throw new CacheException(String.format("cannot create history cache directory for '%s'", histDataDir));
         }
 
         Set<String> regularFiles = map.keySet().stream().


### PR DESCRIPTION
When browsing the code, I noticed that the `null` value from `CacheUtil.getRepositoryCacheDataDirname()` is not handled in `FileHistoryCache#store()`. This change provides remedy by throwing `CacheException`. It might be better to throw the exception from `getRepositoryCacheDataDirname()`, however not in this change.