### PR TITLE
skip deleted documents during index traversal

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -58,6 +58,11 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <version>1.21</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
         </dependency>

--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
 Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
 
@@ -60,7 +60,7 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
+            <version>${commons-io.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileCollector.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileCollector.java
@@ -22,6 +22,8 @@
  */
 package org.opengrok.indexer.history;
 
+import org.jetbrains.annotations.VisibleForTesting;
+
 import java.util.Collection;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -62,5 +64,10 @@ public class FileCollector extends ChangesetVisitor {
 
     void addFiles(Collection<String> files) {
         this.files.addAll(files);
+    }
+
+    @VisibleForTesting
+    public void reset() {
+        files.clear();
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -799,13 +799,17 @@ public class IndexDatabase {
                 deletedUids.size(), indexDirectory));
     }
 
+    private void logIgnoredUid(String uid) {
+        LOGGER.log(Level.FINEST, "ignoring deleted document for {0} at {1}",
+                new Object[]{Util.uid2url(uid), Util.uid2date(uid)});
+    }
+
     private void processTrailingTerms(String startUid, boolean usedHistory, IndexDownArgs args) throws IOException {
         while (uidIter != null && uidIter.term() != null
                 && uidIter.term().utf8ToString().startsWith(startUid)) {
 
             if (deletedUids.contains(uidIter.term().utf8ToString())) {
-                // TODO: check that path and date are logged in readable form
-                LOGGER.log(Level.FINEST, "ignoring deleted document for {0}", uidIter.term().utf8ToString());
+                logIgnoredUid(uidIter.term().utf8ToString());
                 BytesRef next = uidIter.next();
                 if (next == null) {
                     uidIter = null;
@@ -1610,7 +1614,7 @@ public class IndexDatabase {
                 && Util.uid2url(uidIter.term().utf8ToString()).compareTo(path) <= 0) {
 
             if (deletedUids.contains(uidIter.term().utf8ToString())) {
-                LOGGER.log(Level.FINEST, "ignoring deleted document for {0}", uidIter.term().utf8ToString());
+                logIgnoredUid(uidIter.term().utf8ToString());
                 BytesRef next = uidIter.next();
                 if (next == null) {
                     uidIter = null;
@@ -1673,7 +1677,7 @@ public class IndexDatabase {
                     && uidIter.term().compareTo(buid) < 0) {
 
                 if (deletedUids.contains(uidIter.term().utf8ToString())) {
-                    LOGGER.log(Level.FINEST, "ignoring deleted document for {0}", uidIter.term().utf8ToString());
+                    logIgnoredUid(uidIter.term().utf8ToString());
                     BytesRef next = uidIter.next();
                     if (next == null) {
                         uidIter = null;
@@ -1699,7 +1703,7 @@ public class IndexDatabase {
             // If the file was not modified, probably skip to the next one.
             if (uidIter != null && uidIter.term() != null && uidIter.term().bytesEquals(buid)) {
                 if (deletedUids.contains(uidIter.term().utf8ToString())) {
-                    LOGGER.log(Level.FINEST, "ignoring deleted document for {0}", uidIter.term().utf8ToString());
+                    logIgnoredUid(uidIter.term().utf8ToString());
                     BytesRef next = uidIter.next();
                     if (next == null) {
                         uidIter = null;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -2117,9 +2117,9 @@ public class IndexDatabase {
             writer.prepareCommit();
             hasPendingCommit = true;
 
+            Statistics completerStat = new Statistics();
             int n = completer.complete();
-            // TODO: add elapsed
-            LOGGER.log(Level.FINE, "completed {0} object(s)", n);
+            completerStat.report(LOGGER, Level.FINE, String.format("completed %d object(s)", n));
 
             // Just before commit(), reset the `hasPendingCommit' flag,
             // since after commit() is called, there is no need for

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -172,7 +172,7 @@ public class IndexDatabase {
     private List<String> directories;
     private LockFactory lockFactory;
     private final BytesRef emptyBR = new BytesRef("");
-    private Set<String> deletedUids = new HashSet<>();
+    private final Set<String> deletedUids = new HashSet<>();
 
     // Directory where we store indexes
     public static final String INDEX_DIR = "index";

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -2117,7 +2117,7 @@ public class IndexDatabase {
         try {
             writeAnalysisSettings();
 
-            LOGGER.log(Level.FINE, "preparing to commit changes to Lucene index"); // TODO add info about which database
+            LOGGER.log(Level.FINE, "preparing to commit changes to {0}", this);
             writer.prepareCommit();
             hasPendingCommit = true;
 
@@ -2282,5 +2282,14 @@ public class IndexDatabase {
 
     private static class AcceptSymlinkRet {
         String localRelPath;
+    }
+
+    @Override
+    public String toString() {
+        if (this.project != null) {
+            return "index database for project '" + this.project.getName() + "'";
+        }
+
+        return "global index database";
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -69,6 +69,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexWriterConfig.OpenMode;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Term;
@@ -84,6 +85,7 @@ import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.NativeFSLockFactory;
 import org.apache.lucene.store.NoLockFactory;
 import org.apache.lucene.store.SimpleFSLockFactory;
+import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -135,6 +137,8 @@ public class IndexDatabase {
 
     private static final Set<String> REVERT_COUNTS_FIELDS;
 
+    private static final Set<String> LIVE_CHECK_FIELDS;
+
     private static final Object INSTANCE_LOCK = new Object();
 
     /**
@@ -168,6 +172,7 @@ public class IndexDatabase {
     private List<String> directories;
     private LockFactory lockFactory;
     private final BytesRef emptyBR = new BytesRef("");
+    private Set<String> deletedUids = new HashSet<>();
 
     // Directory where we store indexes
     public static final String INDEX_DIR = "index";
@@ -175,6 +180,8 @@ public class IndexDatabase {
     public static final String SUGGESTER_DIR = "suggester";
 
     private final IndexDownArgsFactory indexDownArgsFactory;
+
+    private final IndexWriterConfigFactory indexWriterConfigFactory;
 
     /**
      * Create a new instance of the Index Database. Use this constructor if you
@@ -197,6 +204,24 @@ public class IndexDatabase {
         indexDownArgsFactory = factory;
         this.project = project;
         lockFactory = NoLockFactory.INSTANCE;
+        indexWriterConfigFactory = new IndexWriterConfigFactory();
+        initialize();
+    }
+
+    /**
+     * Create a new instance of an Index Database for a given project.
+     *
+     * @param project the project to create the database for
+     * @param indexDownArgsFactory {@link IndexDownArgsFactory} instance
+     * @param indexWriterConfigFactory {@link IndexWriterConfigFactory} instance
+     * @throws java.io.IOException if an error occurs while creating directories
+     */
+    public IndexDatabase(Project project, IndexDownArgsFactory indexDownArgsFactory,
+                         IndexWriterConfigFactory indexWriterConfigFactory) throws IOException {
+        this.indexDownArgsFactory = indexDownArgsFactory;
+        this.project = project;
+        lockFactory = NoLockFactory.INSTANCE;
+        this.indexWriterConfigFactory = indexWriterConfigFactory;
         initialize();
     }
 
@@ -214,6 +239,10 @@ public class IndexDatabase {
         REVERT_COUNTS_FIELDS.add(QueryBuilder.PATH);
         REVERT_COUNTS_FIELDS.add(QueryBuilder.NUML);
         REVERT_COUNTS_FIELDS.add(QueryBuilder.LOC);
+
+        LIVE_CHECK_FIELDS = new HashSet<>();
+        LIVE_CHECK_FIELDS.add(QueryBuilder.U);
+        LIVE_CHECK_FIELDS.add(QueryBuilder.PATH);
     }
 
     /**
@@ -581,11 +610,7 @@ public class IndexDatabase {
 
         IOException finishingException = null;
         try {
-            Analyzer analyzer = AnalyzerGuru.getAnalyzer();
-            IndexWriterConfig iwc = new IndexWriterConfig(analyzer);
-            iwc.setOpenMode(OpenMode.CREATE_OR_APPEND);
-            iwc.setRAMBufferSizeMB(env.getRamBufferSize());
-            writer = new IndexWriter(indexDirectory, iwc);
+            writer = new IndexWriter(indexDirectory, indexWriterConfigFactory.get());
             writer.commit(); // to make sure index exists on the disk
             completer = new PendingFileCompleter();
 
@@ -609,6 +634,7 @@ public class IndexDatabase {
 
                 String startUid = Util.path2uid(dir, "");
                 reader = DirectoryReader.open(indexDirectory); // open existing index
+                setupDeletedUids();
                 countsAggregator = new NumLinesLOCAggregator();
                 settings = readAnalysisSettings();
                 if (settings == null) {
@@ -734,9 +760,58 @@ public class IndexDatabase {
         }
     }
 
+    /**
+     * The traversal of the uid terms done in {@link #processFile(IndexDownArgs, File, String)}
+     * and {@link #processFileIncremental(IndexDownArgs, File, String)} needs to skip over deleted documents
+     * that are often found in multi-segment indexes. This method stores the uids of these documents
+     * and is expected to be called before the traversal for the top level directory is started.
+     * @throws IOException if the index cannot be read for some reason
+     */
+    private void setupDeletedUids() throws IOException {
+        // This method might be called repeatedly from within the same IndexDatabase instance
+        // for various directories so the map needs to be reset so that it does not contain unrelated uids.
+        deletedUids.clear();
+
+        Bits liveDocs = MultiBits.getLiveDocs(reader);  // Will return null if there are no deletions.
+        if (liveDocs == null) {
+            LOGGER.log(Level.FINEST, "no deletions found in {0}", reader);
+            return;
+        }
+
+        Statistics stat = new Statistics();
+        LOGGER.log(Level.FINEST, "traversing the documents in {0} to collect uids of deleted documents",
+                indexDirectory);
+        for (int i = 0; i < reader.maxDoc(); i++) {
+            if (!liveDocs.get(i)) {
+                Document doc = reader.document(i, LIVE_CHECK_FIELDS);  // use limited-field version
+                IndexableField field = doc.getField(QueryBuilder.U);
+                if (field != null) {
+                    if (LOGGER.isLoggable(Level.FINEST)) {
+                        String uidString = field.stringValue();
+                        LOGGER.log(Level.FINEST, "adding ''{0}'' at {1} to deleted uid set",
+                                new Object[]{Util.uid2url(uidString), Util.uid2date(uidString)});
+                    }
+                    deletedUids.add(field.stringValue());
+                }
+            }
+        }
+        stat.report(LOGGER, Level.FINEST, String.format("found %s deleted documents in %s",
+                deletedUids.size(), indexDirectory));
+    }
+
     private void processTrailingTerms(String startUid, boolean usedHistory, IndexDownArgs args) throws IOException {
         while (uidIter != null && uidIter.term() != null
                 && uidIter.term().utf8ToString().startsWith(startUid)) {
+
+            if (deletedUids.contains(uidIter.term().utf8ToString())) {
+                // TODO: check that path and date are logged in readable form
+                LOGGER.log(Level.FINEST, "ignoring deleted document for {0}", uidIter.term().utf8ToString());
+                BytesRef next = uidIter.next();
+                if (next == null) {
+                    uidIter = null;
+                }
+                continue;
+            }
 
             if (usedHistory) {
                 // Allow for forced reindex. For history based reindex the trailing terms
@@ -1524,19 +1599,31 @@ public class IndexDatabase {
      * @param path path of the file argument relative to source root (with leading slash)
      * @throws IOException on error
      */
-    private void processFileIncremental(IndexDownArgs args, File file, String path) throws IOException {
-        if (uidIter != null) {
-            path = Util.fixPathIfWindows(path);
-            // Traverse terms until reaching one that matches the path of given file.
-            while (uidIter != null && uidIter.term() != null
-                    && uidIter.term().compareTo(emptyBR) != 0
-                    && Util.uid2url(uidIter.term().utf8ToString()).compareTo(path) < 0) {
+    @VisibleForTesting
+    void processFileIncremental(IndexDownArgs args, File file, String path) throws IOException {
+        final boolean fileExists = file.exists();
 
+        path = Util.fixPathIfWindows(path);
+        // Traverse terms until reaching document beyond path of given file.
+        while (uidIter != null && uidIter.term() != null
+                && uidIter.term().compareTo(emptyBR) != 0
+                && Util.uid2url(uidIter.term().utf8ToString()).compareTo(path) <= 0) {
+
+            if (deletedUids.contains(uidIter.term().utf8ToString())) {
+                LOGGER.log(Level.FINEST, "ignoring deleted document for {0}", uidIter.term().utf8ToString());
+                BytesRef next = uidIter.next();
+                if (next == null) {
+                    uidIter = null;
+                }
+                continue;
+            }
+
+            /*
+             * Possibly short-circuit to force reindexing of prior-version indexes.
+             */
+            String termPath = Util.uid2url(uidIter.term().utf8ToString());
+            if (!termPath.equals(path)) {
                 // A file that was not changed.
-                /*
-                 * Possibly short-circuit to force reindexing of prior-version indexes.
-                 */
-                String termPath = Util.uid2url(uidIter.term().utf8ToString());
                 File termFile = new File(RuntimeEnvironment.getInstance().getSourceRootFile(), termPath);
                 boolean matchOK = (isWithDirectoryCounts || isCountingDeltas) &&
                         checkSettings(termFile, termPath);
@@ -1546,45 +1633,20 @@ public class IndexDatabase {
                     args.curCount++;
                     args.works.add(new IndexFileWork(termFile, termPath));
                 }
-
-                BytesRef next = uidIter.next();
-                if (next == null) {
-                    uidIter = null;
-                }
-            }
-
-            if (uidIter != null && uidIter.term() != null
-                    && Util.uid2url(uidIter.term().utf8ToString()).equals(path)) {
-                /*
-                 * At this point we know that the file has corresponding term in the index
-                 * and has changed in some way. Either it was deleted or it was changed.
-                 */
-                if (!file.exists()) {
-                    removeFile(true);
-                } else {
-                    removeFile(false);
-
-                    args.curCount++;
-                    args.works.add(new IndexFileWork(file, path));
-                }
-
-                BytesRef next = uidIter.next();
-                if (next == null) {
-                    uidIter = null;
-                }
             } else {
-                // Potentially new file. A file might be added and then deleted,
-                // so it is necessary to check its existence.
-                if (file.exists()) {
-                    args.curCount++;
-                    args.works.add(new IndexFileWork(file, path));
-                }
+                removeFile(!fileExists);
             }
-        } else {
-            if (file.exists()) {
-                args.curCount++;
-                args.works.add(new IndexFileWork(file, path));
+
+            BytesRef next = uidIter.next();
+            if (next == null) {
+                uidIter = null;
             }
+        }
+
+        // The function would not be called if the file was not changed in some way.
+        if (fileExists) {
+            args.curCount++;
+            args.works.add(new IndexFileWork(file, path));
         }
     }
 
@@ -1595,7 +1657,8 @@ public class IndexDatabase {
      * @param path path corresponding to the file parameter, relative to source root (with leading slash)
      * @throws IOException on error
      */
-    private void processFile(IndexDownArgs args, File file, String path) throws IOException {
+    @VisibleForTesting
+    void processFile(IndexDownArgs args, File file, String path) throws IOException {
         if (uidIter != null) {
             path = Util.fixPathIfWindows(path);
             String uid = Util.path2uid(path,
@@ -1608,6 +1671,15 @@ public class IndexDatabase {
             while (uidIter != null && uidIter.term() != null
                     && uidIter.term().compareTo(emptyBR) != 0
                     && uidIter.term().compareTo(buid) < 0) {
+
+                if (deletedUids.contains(uidIter.term().utf8ToString())) {
+                    LOGGER.log(Level.FINEST, "ignoring deleted document for {0}", uidIter.term().utf8ToString());
+                    BytesRef next = uidIter.next();
+                    if (next == null) {
+                        uidIter = null;
+                    }
+                    continue;
+                }
 
                 // If the term's path matches path of currently processed file,
                 // it is clear that the file has been modified and thus
@@ -1626,6 +1698,14 @@ public class IndexDatabase {
 
             // If the file was not modified, probably skip to the next one.
             if (uidIter != null && uidIter.term() != null && uidIter.term().bytesEquals(buid)) {
+                if (deletedUids.contains(uidIter.term().utf8ToString())) {
+                    LOGGER.log(Level.FINEST, "ignoring deleted document for {0}", uidIter.term().utf8ToString());
+                    BytesRef next = uidIter.next();
+                    if (next == null) {
+                        uidIter = null;
+                    }
+                    return;
+                }
 
                 /*
                  * Possibly short-circuit to force reindexing of prior-version indexes.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexWriterConfigFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexWriterConfigFactory.java
@@ -1,0 +1,44 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.index;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.opengrok.indexer.analysis.AnalyzerGuru;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+
+public class IndexWriterConfigFactory {
+
+    IndexWriterConfigFactory() {
+    }
+
+    public IndexWriterConfig get() {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+        Analyzer analyzer = AnalyzerGuru.getAnalyzer();
+        IndexWriterConfig iwc = new IndexWriterConfig(analyzer);
+        iwc.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
+        iwc.setRAMBufferSizeMB(env.getRamBufferSize());
+        return iwc;
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/IOUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/IOUtils.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.apache.commons.io.FileUtils;
 import org.opengrok.indexer.logger.LoggerFactory;
 
 /**
@@ -81,32 +83,7 @@ public final class IOUtils {
      * @throws IOException if any read error
      */
     public static void removeRecursive(Path path) throws IOException {
-        Files.walkFileTree(path, new SimpleFileVisitor<>() {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                    throws IOException {
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-                // Try to delete the file anyway.
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                if (exc == null) {
-                    Files.delete(dir);
-                    return FileVisitResult.CONTINUE;
-                } else {
-                    // Directory traversal failed.
-                    throw exc;
-                }
-            }
-        });
+        FileUtils.deleteDirectory(path.toFile());
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/IOUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/IOUtils.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, Trond Norbye.
  * Portions Copyright (c) 2017, 2021, Chris Fraire <cfraire@me.com>.
  */
@@ -33,11 +33,8 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -820,7 +820,7 @@ public final class Util {
     /**
      * Generate a string from the given path and date in a way that allows
      * stable lexicographic sorting (i.e. gives always the same results) as a
-     * walk of the file hierarchy. Thus null character (\u0000) is used both to
+     * walk of the file hierarchy. Thus, null character (\u0000) is used both to
      * separate directory components and to separate the path from the date.
      *
      * @param path path to mangle.
@@ -841,6 +841,16 @@ public final class Util {
     public static String uid2url(String uid) {
         String url = uid.replace('\u0000', PATH_SEPARATOR);
         return url.substring(0, url.lastIndexOf(PATH_SEPARATOR)); // remove date from end
+    }
+
+    /**
+     * Extracts the date embedded in the uid.
+     *
+     * @param uid uid
+     * @return date embedded in the uid
+     */
+    public static String uid2date(String uid) {
+        return uid.substring(uid.lastIndexOf('\u0000') + 1);
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
@@ -22,6 +22,7 @@
  */
 package org.opengrok.indexer.index;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
@@ -245,7 +246,7 @@ class IndexerVsDeletedDocumentsTest {
 
     @AfterEach
     void cleanup() throws IOException {
-        IOUtils.removeRecursive(Path.of(env.getDataRootPath()));
+        FileUtils.deleteDirectory(env.getDataRootFile());
         IOUtils.removeRecursive(Path.of(env.getSourceRootPath()));
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
@@ -40,6 +40,7 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.treewalk.TreeWalk;
@@ -403,14 +404,13 @@ class IndexerVsDeletedDocumentsTest {
 
                 // Check the commit contain fooPath.
                 RevTree tree = commit.getTree();
-                try (TreeWalk treeWalk = new TreeWalk(gitRepo.getRepository())) {
+                try (Repository repo = gitRepo.getRepository(); TreeWalk treeWalk = new TreeWalk(repo)) {
                     treeWalk.addTree(tree);
                     treeWalk.setRecursive(true);
                     // Should be sufficient to check just one of the paths expected to be changed.
                     treeWalk.setFilter(PathFilter.create(fooFileName));
                     assertTrue(treeWalk.next());
                 }
-
             }
             assertTrue(commits > 0);
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
@@ -1,0 +1,470 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.index;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.MultiBits;
+import org.apache.lucene.index.MultiTerms;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.NoMergeScheduler;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.NoLockFactory;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevTree;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.filter.PathFilter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opengrok.indexer.analysis.AnalyzerGuru;
+import org.opengrok.indexer.configuration.Project;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.history.FileCollector;
+import org.opengrok.indexer.history.HistoryGuru;
+import org.opengrok.indexer.history.RepositoryFactory;
+import org.opengrok.indexer.search.QueryBuilder;
+import org.opengrok.indexer.util.IOUtils;
+import org.opengrok.indexer.util.TestRepository;
+import org.opengrok.indexer.web.Util;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * This class provides tests that verify the indexer correctly jumps over deleted documents in the index,
+ * thus not leading to weird artifacts like negative LOC counts or multiple documents with the same path
+ * returned from the search.
+ */
+class IndexerVsDeletedDocumentsTest {
+    RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+    private static String getRandomString(int numChars) {
+        Random random = new Random();
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < numChars; i++) {
+            sb.append((char) (random.nextInt(26) + 'A'));
+        }
+
+        return sb.toString();
+    }
+
+    private static class FileWork {
+        Path path;
+        WorkType workType;
+        String content = null;
+
+        FileWork(Path path, WorkType workType) {
+            this.path = path;
+            this.workType = workType;
+        }
+
+        void doIt() throws IOException {
+            switch (workType) {
+                case CREATE:
+                    Files.createFile(path);
+                    for (int i = 0; i < 16; i++) {
+                        Files.writeString(path, getRandomString(32) + " ", StandardOpenOption.APPEND);
+                    }
+                    Files.writeString(path, "\n", StandardOpenOption.APPEND);
+                    break;
+                case DELETE:
+                    Files.delete(path);
+                    break;
+                case UPDATE:
+                    if (this.content == null) {
+                        content = getRandomString(16) + " ";
+                    }
+                    Files.writeString(path, content + "\n", StandardOpenOption.APPEND);
+                    break;
+            }
+        }
+    }
+
+    private enum WorkType {
+        UPDATE,
+        DELETE,
+        CREATE,
+    }
+
+    /**
+     * IndexChangedListener derived class that records removed paths in a list.
+     * This list is then used for verification.
+     */
+    static class RecordingIndexChangedListener implements IndexChangedListener {
+        public List<String> removedPaths = new ArrayList<>();
+
+        @Override
+        public void fileAdd(String path, String analyzer) {
+            System.out.printf("Add: %s (%s)%n", path, analyzer);
+        }
+
+        @Override
+        public void fileRemove(String path) {
+            removedPaths.add(path);
+            System.out.printf("Remove file: %s%n", path);
+        }
+        @Override
+        public void fileUpdate(String path) {
+        }
+
+        @Override
+        public void fileAdded(String path, String analyzer) {
+        }
+
+        @Override
+        public void fileRemoved(String path) {
+        }
+
+        public void reset() {
+            removedPaths.clear();
+        }
+    }
+
+    /**
+     * {@link IndexWriterConfigFactory} extension that uses NoMerge* settings in order to produce
+     * an index with deleted documents.
+     */
+    static class NoMergeIndexWriterConfigFactory extends IndexWriterConfigFactory {
+        @Override
+        public IndexWriterConfig get() {
+            RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+            Analyzer analyzer = AnalyzerGuru.getAnalyzer();
+            IndexWriterConfig iwc = new IndexWriterConfig(analyzer);
+            iwc.setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND);
+            iwc.setRAMBufferSizeMB(env.getRamBufferSize());
+
+            iwc.setMergePolicy(NoMergePolicy.INSTANCE);
+            iwc.setMergeScheduler(NoMergeScheduler.INSTANCE);
+
+            return iwc;
+        }
+    }
+
+    private IndexReader getIndexReader(String projectName) throws IOException {
+        Path indexPath = Path.of(env.getDataRootPath(), IndexDatabase.INDEX_DIR,
+                env.isProjectsEnabled() ? projectName : "");
+        assertTrue(indexPath.toFile().isDirectory());
+
+        try (FSDirectory indexDirectory = FSDirectory.open(indexPath, NoLockFactory.INSTANCE)) {
+            return DirectoryReader.open(indexDirectory);
+        }
+    }
+
+    /**
+     * @param projectName project name, can be empty
+     * @return set of deleted uids in the index related to the project name
+     * @throws IOException if the index cannot be read
+     */
+    private Set<String> getDeletedUids(String projectName) throws IOException {
+        Set<String> deletedUids = new HashSet<>();
+
+        try (IndexReader indexReader = getIndexReader(projectName)) {
+            Bits liveDocs = MultiBits.getLiveDocs(indexReader);
+            if (liveDocs == null) { // the index has no deletions
+                return deletedUids;
+            }
+
+            for (int i = 0; i < indexReader.maxDoc(); i++) {
+                Document doc = indexReader.document(i);
+                // This should avoid the special LOC documents.
+                IndexableField field = doc.getField(QueryBuilder.U);
+                if (field != null) {
+                    String uid = field.stringValue();
+
+                    if (!liveDocs.get(i)) {
+                        deletedUids.add(uid);
+                    }
+                }
+            }
+        }
+
+        return deletedUids;
+    }
+
+    @BeforeEach
+    void setup() throws IOException {
+        // Create and set source and data root.
+        TestRepository testRepository = new TestRepository();
+        testRepository.createEmpty();
+        assertTrue(env.getSourceRootFile().isDirectory());
+        assertTrue(env.getDataRootFile().isDirectory());
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        IOUtils.removeRecursive(Path.of(env.getDataRootPath()));
+        IOUtils.removeRecursive(Path.of(env.getSourceRootPath()));
+    }
+
+    private static Stream<Arguments> provideAguments() {
+        return Stream.of(
+                Arguments.of(false, true),
+                Arguments.of(false, false),
+                Arguments.of(true, true),
+                Arguments.of(true, false)
+        );
+    }
+
+    /**
+     * Create index under data root that will contain:
+     * <ul>
+     * <li>updated documents (i.e. deleted and added)</li>
+     * <li>deleted documents</li>
+     * </ul>
+     * @param projectsEnabled whether projects should be enabled
+     * @param useGit whether to initialize Git repository and commit the changes
+     */
+    @ParameterizedTest
+    @MethodSource("provideAguments")
+    void testIndexTraversalWithDeletedDocuments(boolean projectsEnabled, boolean useGit) throws Exception {
+        // Setup for the indexer.
+        String projectName = "foo";
+        File projectRoot = Path.of(env.getSourceRootPath(), projectName).toFile();
+        env.setProjectsEnabled(projectsEnabled);
+        assertTrue(projectRoot.mkdir());
+        assertTrue(projectRoot.exists());
+
+        final String fooFileName = "foo.txt";
+        final Path fooPath = Path.of(env.getSourceRootPath(), projectName, fooFileName);
+        final Path barPath = Path.of(env.getSourceRootPath(), projectName, "bar.txt");
+
+        RepositoryFactory.initializeIgnoredNames(env);
+        Indexer indexer = Indexer.getInstance();
+
+        Git gitRepo = null;
+        final String authorName = "author";
+        final String authorEmail = "author@example.com";
+        if (useGit) {
+            gitRepo = Git.init().setDirectory(projectRoot).call();
+        }
+
+        // Create initial file content.
+        List<FileWork> initialWork = List.of(new FileWork(fooPath, WorkType.CREATE),
+                        new FileWork(barPath, WorkType.CREATE));
+        for (FileWork fileWork : initialWork) {
+            fileWork.doIt();
+            if (gitRepo != null) {
+                gitRepo.add().addFilepattern(fileWork.path.getFileName().toString()).call();
+            }
+        }
+        if (gitRepo != null) {
+            gitRepo.commit().setMessage("initial content").setAuthor(authorName, authorEmail).call();
+        }
+        // Add the project and optionally detect the Git repository.
+        env.setProjects(new HashMap<>());
+        HistoryGuru.getInstance().clear();
+        env.setRepositories(new ArrayList<>());
+        env.generateProjectRepositoriesMap();
+        indexer.prepareIndexer(
+                env, useGit, projectsEnabled,
+                null, null);
+        Project project = null;
+        if (projectsEnabled) {
+            project = env.getProjects().get(projectName);
+            assertNotNull(project);
+        }
+        if (useGit) {
+            // Check the Git repository was detected.
+            assertTrue(env.getRepositories().size() > 0);
+        }
+        indexer.doIndexerExecution(null, null);
+
+        /*
+         * Use IndexDatabase instead of indexer.doIndexerExecution() for fine-grained control over indexing.
+         * Specifically, use no merge index writer settings to increase the probability of creating multi-segment index
+         * with deleted documents which are necessary for the test of the update() behavior.
+         */
+        IndexDatabase indexDatabaseOrig = new IndexDatabase(project,
+                new IndexDownArgsFactory(), new NoMergeIndexWriterConfigFactory());
+        IndexDatabase indexDatabase = spy(indexDatabaseOrig);
+
+        RecordingIndexChangedListener listener = new RecordingIndexChangedListener();
+        indexDatabase.addIndexChangedListener(listener);
+
+        // Perform file work and index multiple times. Repeat this until there are deleted files in the index
+        // or maximum number of iterations is reached.
+        for (int i = 0; i < 16; i++) {
+            List<FileWork> work = List.of(new FileWork(fooPath, WorkType.UPDATE),
+                    new FileWork(barPath, WorkType.UPDATE));
+            for (FileWork fileWork : work) {
+                fileWork.doIt();
+                if (gitRepo != null) {
+                    gitRepo.add().addFilepattern(fileWork.path.getFileName().toString()).call();
+                }
+            }
+
+            // Creating a bunch of new files increases the chances of the fooPath/barPath updates resulting in
+            // deleted documents.
+            for (int j = 0; j < 8; j++) {
+                // Might as well use temporary file to avoid failures, however 32 chars is enough for now.
+                Path filePath = Path.of(env.getSourceRootPath(), projectName,
+                        getRandomString(32) + "-" + i + ".txt");
+                new FileWork(filePath, WorkType.CREATE).doIt();
+                if (gitRepo != null) {
+                    gitRepo.add().addFilepattern(filePath.getFileName().toString()).call();
+                }
+            }
+
+            if (gitRepo != null) {
+                gitRepo.commit().setMessage(String.format("iteration %d", i)).setAuthor(authorName, authorEmail).call();
+            }
+
+            listener.reset();
+            FileCollector fileCollector = env.getFileCollector(projectName);
+            if (fileCollector != null) {
+                fileCollector.reset();
+            }
+            assertEquals(0, listener.removedPaths.size());
+            System.out.printf("indexing iteration #%d%n", i);
+            indexer.prepareIndexer(
+                    env, useGit, projectsEnabled,
+                    null, null);
+            env.generateProjectRepositoriesMap();
+            indexDatabase.update();
+
+            if (useGit && projectsEnabled) {
+                // Verify the history based reindex was actually used.
+                verify(indexDatabase, atLeast(1)).processFileIncremental(any(), any(), any());
+            } else {
+                verify(indexDatabase, atLeast(1)).processFile(any(), any(), any());
+            }
+
+            // Only fooPath and barPath are updated in each cycle, hence there should be 2 removals.
+            assertEquals(2, listener.removedPaths.size());
+
+            // At most one fileRemove() should be called for each path.
+            assertEquals(new HashSet<>(listener.removedPaths).size(), listener.removedPaths.size());
+
+            if (getDeletedUids(projectName).size() > 0) {
+                break;
+            }
+        }
+
+        if (gitRepo != null) {
+            Status gitStatus = gitRepo.status().call();
+            // Check the status is clear, i.e. there are no uncommitted changes.
+            assertEquals(0, gitStatus.getUncommittedChanges().size());
+
+            int commits = 0;
+            for (RevCommit commit : gitRepo.log().call()) {
+                commits++;
+
+                // Check the commit contain fooPath.
+                RevTree tree = commit.getTree();
+                try (TreeWalk treeWalk = new TreeWalk(gitRepo.getRepository())) {
+                    treeWalk.addTree(tree);
+                    treeWalk.setRecursive(true);
+                    // Should be sufficient to check just one of the paths expected to be changed.
+                    treeWalk.setFilter(PathFilter.create(fooFileName));
+                    assertTrue(treeWalk.next());
+                }
+
+            }
+            assertTrue(commits > 0);
+        }
+
+        // Make sure there are some deleted documents.
+        try (IndexReader indexReader = getIndexReader(projectName)) {
+            assertTrue(indexReader.numDeletedDocs() > 0);
+        }
+
+        checkLiveDocs(projectName);
+
+        if (gitRepo != null) {
+            gitRepo.close();
+        }
+    }
+
+    /**
+     * Check there is at most one live document for each path by doing terms traversal,
+     * similar to what is done in {@link IndexDatabase}.
+     */
+    private void checkLiveDocs(String projectName) throws IOException {
+        try (IndexReader indexReader = getIndexReader(projectName)) {
+            Terms terms = MultiTerms.getTerms(indexReader, QueryBuilder.U);
+            TermsEnum uidIter = terms.iterator();
+            String dir = "/" + projectName;
+            String startUid = Util.path2uid(dir, "");
+            uidIter.seekCeil(new BytesRef(startUid));
+            final BytesRef emptyBR = new BytesRef("");
+            // paths of live (i.e. not deleted) documents. Must be a list for the asserts below to work.
+            List<String> livePaths = new ArrayList<>();
+            Set<String> deletedUids = getDeletedUids(projectName);
+
+            while (uidIter != null && uidIter.term() != null && uidIter.term().compareTo(emptyBR) != 0) {
+                String termValue = uidIter.term().utf8ToString();
+                String termPath = Util.uid2url(termValue);
+
+                if (deletedUids.contains(termValue)) {
+                    BytesRef next = uidIter.next();
+                    if (next == null) {
+                        uidIter = null;
+                    }
+                    continue;
+                }
+
+                livePaths.add(termPath);
+
+                BytesRef next = uidIter.next();
+                if (next == null) {
+                    uidIter = null;
+                }
+            }
+
+            assertTrue(livePaths.size() > 0);
+            assertEquals(new HashSet<>(livePaths).size(), livePaths.size());
+        }
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
@@ -246,8 +246,8 @@ class IndexerVsDeletedDocumentsTest {
 
     @AfterEach
     void cleanup() throws IOException {
-        FileUtils.deleteDirectory(env.getDataRootFile());
-        IOUtils.removeRecursive(Path.of(env.getSourceRootPath()));
+        IOUtils.removeRecursive(Path.of(env.getDataRootPath()));
+        FileUtils.deleteDirectory(env.getSourceRootFile());
     }
 
     private static Stream<Arguments> provideAguments() {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
@@ -247,6 +247,7 @@ class IndexerVsDeletedDocumentsTest {
     @AfterEach
     void cleanup() throws IOException {
         IOUtils.removeRecursive(Path.of(env.getDataRootPath()));
+        // FileUtils.deleteDirectory() avoids AccessDeniedException on Windows.
         FileUtils.deleteDirectory(env.getSourceRootFile());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 
 -->
@@ -77,6 +77,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
         <micrometer.version>1.8.2</micrometer.version>
         <mockito.version>3.12.4</mockito.version>
+        <commons-io.version>1.3.2</commons-io.version>
     </properties>
 
     <dependencyManagement>

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
 
 -->
@@ -62,9 +62,9 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
         </dependency>
 
         <dependency>
-            <groupId>commons-io</groupId>
+            <groupId>org.apache.commons</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>${commons-io.version}</version>
         </dependency>
 
         <dependency>

--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest;
 
@@ -508,7 +508,7 @@ class SuggesterProjectData implements Closeable {
         }
 
         try {
-            String str = FileUtils.readFileToString(versionFile, StandardCharsets.UTF_8);
+            String str = FileUtils.readFileToString(versionFile, StandardCharsets.UTF_8.toString());
             return Long.parseLong(str);
         } catch (IOException e) {
             logger.log(Level.WARNING, "Could not read suggester data version", e);
@@ -518,7 +518,8 @@ class SuggesterProjectData implements Closeable {
 
     private void storeDataVersion(final long version) {
         try {
-            FileUtils.writeStringToFile(getFile(VERSION_FILE_NAME), "" + version, StandardCharsets.UTF_8);
+            FileUtils.writeStringToFile(getFile(VERSION_FILE_NAME), "" + version,
+                    StandardCharsets.UTF_8.toString());
         } catch (IOException e) {
             logger.log(Level.WARNING, "Could not store version", e);
         }


### PR DESCRIPTION
This long awaited change fixes a regression in document traversal with multi-segment indexes. The main idea is to assemble the list of deleted uids and then skip them when traversing the index during indexing. For this I had to significantly change the traversal algorithm for history based reindex.

This will necessitate reindex from scratch to fix the negative LOC/Line counts and duplicate items in search results.