### PR TITLE
adapt IndexDatabase to Lucene 9.x

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -784,7 +784,8 @@ public class IndexDatabase {
                 indexDirectory);
         for (int i = 0; i < reader.maxDoc(); i++) {
             if (!liveDocs.get(i)) {
-                Document doc = reader.document(i, LIVE_CHECK_FIELDS);  // use limited-field version
+                StoredFields storedFields = reader.storedFields();
+                Document doc = storedFields.document(i, LIVE_CHECK_FIELDS);  // use limited-field version
                 IndexableField field = doc.getField(QueryBuilder.U);
                 if (field != null) {
                     if (LOGGER.isLoggable(Level.FINEST)) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
@@ -219,7 +219,7 @@ class IndexerVsDeletedDocumentsTest {
             }
 
             for (int i = 0; i < indexReader.maxDoc(); i++) {
-                Document doc = indexReader.document(i);
+                Document doc = indexReader.storedFields().document(i);
                 // This should avoid the special LOC documents.
                 IndexableField field = doc.getField(QueryBuilder.U);
                 if (field != null) {


### PR DESCRIPTION
This change avoids deprecation warnings in `IndexDatabase` and related classes after the recent Lucene 9.x upgrade. These were introduced by #4182.