### PR TITLE
add documents argument to --indexCheck

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -106,9 +107,9 @@ public class IndexCheck {
     public static class IndexDocumentException extends Exception {
         private static final long serialVersionUID = 5693446916108385595L;
 
-        private final HashMap<String, Integer> fileMap;
+        private final Map<String, Integer> fileMap;
 
-        public IndexDocumentException(String s, HashMap<String, Integer> fileMap) {
+        public IndexDocumentException(String s, Map<String, Integer> fileMap) {
             super(s);
 
             this.fileMap = fileMap;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -18,27 +18,45 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexNotFoundException;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.MultiBits;
+import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.LockFactory;
 import org.apache.lucene.store.NativeFSLockFactory;
+import org.apache.lucene.store.NoLockFactory;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Version;
 import org.jetbrains.annotations.NotNull;
 import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.search.QueryBuilder;
+import org.opengrok.indexer.util.Statistics;
+import org.opengrok.indexer.web.Util;
 
 /**
  * Index checker.
@@ -77,13 +95,15 @@ public class IndexCheck {
     }
 
     /**
-     * Check if version of index(es) matches major Lucene version.
+     * Check index(es).
      * @param configuration configuration based on which to perform the check
      * @param subFilesList collection of paths. If non-empty, only projects matching these paths will be checked.
+     *                     Otherwise, either the sole index or all project indexes will be checked, depending
+     *                     on whether projects are enabled in the configuration.
      * @return true on success, false on failure
      */
     public static boolean check(@NotNull Configuration configuration, Collection<String> subFilesList) {
-        File indexRoot = new File(configuration.getDataRoot(), IndexDatabase.INDEX_DIR);
+        Path indexRoot = Path.of(configuration.getDataRoot(), IndexDatabase.INDEX_DIR);
         LOGGER.log(Level.FINE, "Checking for Lucene index version mismatch in {0}", indexRoot);
         int ret = 0;
 
@@ -93,7 +113,7 @@ public class IndexCheck {
                 LOGGER.log(Level.FINER,
                         "Checking Lucene index version in project {0}",
                         projectName);
-                ret |= checkDirNoExceptions(new File(indexRoot, projectName));
+                ret |= checkDirNoExceptions(Path.of(indexRoot.toString(), projectName), projectName);
             }
         } else {
             if (configuration.isProjectsEnabled()) {
@@ -101,23 +121,27 @@ public class IndexCheck {
                     LOGGER.log(Level.FINER,
                             "Checking Lucene index version in project {0}",
                             projectName);
-                    ret |= checkDirNoExceptions(new File(indexRoot, projectName));
+                    ret |= checkDirNoExceptions(Path.of(indexRoot.toString(), projectName), projectName);
                 }
             } else {
                 LOGGER.log(Level.FINER, "Checking Lucene index version in {0}",
                         indexRoot);
-                ret |= checkDirNoExceptions(indexRoot);
+                ret |= checkDirNoExceptions(indexRoot, "");
             }
         }
 
         return ret == 0;
     }
 
-    private static int checkDirNoExceptions(File dir) {
+    /**
+     * @param indexPath directory with index
+     * @return 0 on success, 1 on failure
+     */
+    private static int checkDirNoExceptions(Path indexPath, String projectName) {
         try {
-            checkDir(dir);
+            checkDir(indexPath, projectName);
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Index check for directory " + dir + " failed", e);
+            LOGGER.log(Level.WARNING, String.format("Index check for directory '%s' failed", indexPath), e);
             return 1;
         }
 
@@ -128,15 +152,15 @@ public class IndexCheck {
      * Check index in given directory. It assumes that that all commits (if any)
      * in the Lucene segment file were done with the same version.
      *
-     * @param dir directory with index
+     * @param indexPath directory with index to check
      * @throws IOException if the directory cannot be opened
      * @throws IndexVersionException if the version of the index does not match Lucene index version
      */
-    public static void checkDir(File dir) throws IndexVersionException, IOException {
+    public static void checkDir(Path indexPath, String projectName) throws IndexVersionException, IOException {
         LockFactory lockFactory = NativeFSLockFactory.INSTANCE;
         int segVersion;
 
-        try (Directory indexDirectory = FSDirectory.open(dir.toPath(), lockFactory)) {
+        try (Directory indexDirectory = FSDirectory.open(indexPath, lockFactory)) {
             try {
                 SegmentInfos segInfos = SegmentInfos.readLatestCommit(indexDirectory);
                 segVersion = segInfos.getIndexCreatedVersionMajor();
@@ -148,8 +172,107 @@ public class IndexCheck {
 
         if (segVersion != Version.LATEST.major) {
             throw new IndexVersionException(
-                String.format("Directory %s has index version discrepancy", dir),
+                String.format("Directory '%s' has index version discrepancy", indexPath),
                     Version.LATEST.major, segVersion);
         }
+
+        // TODO: make this optional (based on configuration/CLI switch ?)
+        LOGGER.log(Level.FINE, "checking duplicate documents in ''{0}''", indexPath);
+        Statistics stat = new Statistics();
+        if (hasDuplicateDocuments(indexPath, projectName)) {
+            LOGGER.log(Level.WARNING, "index in ''{0}'' contains duplicate live documents", indexPath);
+        }
+        stat.report(LOGGER, Level.FINE, String.format("duplicate check in '%s' done", indexPath));
+    }
+
+    public static IndexReader getIndexReader(Path indexPath) throws IOException {
+        try (FSDirectory indexDirectory = FSDirectory.open(indexPath, NoLockFactory.INSTANCE)) {
+            return DirectoryReader.open(indexDirectory);
+        }
+    }
+
+    /**
+     * @param indexPath path to the index
+     * @return set of deleted uids in the index related to the project name
+     * @throws IOException if the index cannot be read
+     */
+    public static Set<String> getDeletedUids(Path indexPath) throws IOException {
+        Set<String> deletedUids = new HashSet<>();
+
+        try (IndexReader indexReader = getIndexReader(indexPath)) {
+            Bits liveDocs = MultiBits.getLiveDocs(indexReader);
+            if (liveDocs == null) { // the index has no deletions
+                return deletedUids;
+            }
+
+            for (int i = 0; i < indexReader.maxDoc(); i++) {
+                Document doc = indexReader.storedFields().document(i);
+                // This should avoid the special LOC documents.
+                IndexableField field = doc.getField(QueryBuilder.U);
+                if (field != null) {
+                    String uid = field.stringValue();
+
+                    if (!liveDocs.get(i)) {
+                        deletedUids.add(uid);
+                    }
+                }
+            }
+        }
+
+        return deletedUids;
+    }
+
+    public static List<String> getLiveDocumentPaths(Path indexPath, String projectName) throws IOException {
+        try (IndexReader indexReader = getIndexReader(indexPath)) {
+            Terms terms = MultiTerms.getTerms(indexReader, QueryBuilder.U);
+            TermsEnum uidIter = terms.iterator();
+            String dir = "/" + projectName;
+            String startUid = Util.path2uid(dir, "");
+            uidIter.seekCeil(new BytesRef(startUid));
+            final BytesRef emptyBR = new BytesRef("");
+            // paths of live (i.e. not deleted) documents. Must be a list so that duplicate documents can be checked.
+            List<String> livePaths = new ArrayList<>();
+            Set<String> deletedUids = getDeletedUids(indexPath);
+
+            while (uidIter != null && uidIter.term() != null && uidIter.term().compareTo(emptyBR) != 0) {
+                String termValue = uidIter.term().utf8ToString();
+                String termPath = Util.uid2url(termValue);
+
+                if (deletedUids.contains(termValue)) {
+                    BytesRef next = uidIter.next();
+                    if (next == null) {
+                        uidIter = null;
+                    }
+                    continue;
+                }
+
+                livePaths.add(termPath);
+
+                BytesRef next = uidIter.next();
+                if (next == null) {
+                    uidIter = null;
+                }
+            }
+
+            return livePaths;
+        }
+    }
+
+    private static boolean hasDuplicateDocuments(Path indexPath, String projectName) throws IOException {
+        List<String> livePaths = getLiveDocumentPaths(indexPath, projectName);
+        HashSet<String> pathSet = new HashSet<>(livePaths);
+        if (pathSet.size() != livePaths.size()) {
+            LOGGER.log(Level.WARNING, "index in ''{0}'' has document path set ({1}) vs document list ({2}) discrepancy",
+                    new Object[]{indexPath, pathSet.size(), livePaths.size()});
+            for (String path : livePaths) {
+                if (pathSet.contains(path)) {
+                    LOGGER.log(Level.WARNING, "duplicate path: ''{0}''", path);
+                }
+            }
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -138,7 +138,7 @@ public class IndexCheck {
                                 Collection<String> projectNames) {
 
         if (mode.equals(IndexCheckMode.NO_CHECK)) {
-            LOGGER.log(Level.WARNING, "no check mode selected");
+            LOGGER.log(Level.WARNING, "no index check mode selected");
             return true;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -311,7 +311,7 @@ public class IndexCheck {
                     new Object[]{indexPath, pathSet.size(), livePaths.size()});
             for (String path : livePaths) {
                 if (pathSet.contains(path)) {
-                    LOGGER.log(Level.FINE, "duplicate path: ''{0}''", path);
+                    LOGGER.log(Level.FINER, "duplicate path: ''{0}''", path);
                     fileMap.putIfAbsent(path, 0);
                     fileMap.put(path, fileMap.get(path) + 1);
                 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -239,6 +239,12 @@ public class IndexCheck {
         return deletedUids;
     }
 
+    /**
+     * @param indexPath path to index
+     * @param projectName project name, can be empty
+     * @return list of live document paths
+     * @throws IOException on I/O error
+     */
     public static List<String> getLiveDocumentPaths(Path indexPath, String projectName) throws IOException {
         try (IndexReader indexReader = getIndexReader(indexPath)) {
             Terms terms = MultiTerms.getTerms(indexReader, QueryBuilder.U);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -169,12 +169,14 @@ public class IndexCheck {
      */
     private static int checkDirNoExceptions(Path indexPath, IndexCheckMode mode, String projectName) {
         try {
+            LOGGER.log(Level.INFO, "Checking index in ''{0}''", indexPath);
             checkDir(indexPath, mode, projectName);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, String.format("Index check for directory '%s' failed", indexPath), e);
             return 1;
         }
 
+        LOGGER.log(Level.INFO, "Index check for directory ''{0}'' passed", indexPath);
         return 0;
     }
 
@@ -199,7 +201,7 @@ public class IndexCheck {
                 SegmentInfos segInfos = SegmentInfos.readLatestCommit(indexDirectory);
                 segVersion = segInfos.getIndexCreatedVersionMajor();
             } catch (IndexNotFoundException e) {
-                LOGGER.log(Level.FINE, "no index found in ''{0}''", indexDirectory);
+                LOGGER.log(Level.WARNING, "no index found in ''{0}''", indexDirectory);
                 return;
             }
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -802,7 +802,7 @@ public class IndexDatabase {
     }
 
     private void logIgnoredUid(String uid) {
-        LOGGER.log(Level.FINEST, "ignoring deleted document for {0} at {1}",
+        LOGGER.log(Level.FINEST, "ignoring deleted document for ''{0}'' at {1}",
                 new Object[]{Util.uid2url(uid), Util.uid2date(uid)});
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -117,7 +117,7 @@ public final class Indexer {
 
     private static final Indexer indexer = new Indexer();
     private static Configuration cfg = null;
-    private static boolean checkIndex = false;
+    private static IndexCheck.IndexCheckMode indexCheckMode = IndexCheck.IndexCheckMode.NO_CHECK;
     private static boolean runIndex = true;
     private static boolean reduceSegmentCount = false;
     private static boolean addProjects = false;
@@ -167,7 +167,8 @@ public final class Indexer {
 
         Executor.registerErrorHandler();
         List<String> subFiles = RuntimeEnvironment.getInstance().getSubFiles();
-        Set<String> subFilesArgs = new HashSet<>();
+        Set<String> subFilePaths = new HashSet<>();
+        Set<String> subFileArgs = new HashSet<>();
 
         try {
             argv = parseOptions(argv);
@@ -246,7 +247,8 @@ public final class Indexer {
             // called from the setConfiguration() below.
             for (String arg : argv) {
                 String path = Paths.get(cfg.getSourceRoot(), arg).toString();
-                subFilesArgs.add(path);
+                subFilePaths.add(path);
+                subFileArgs.add(arg);
             }
 
             // If a user used customizations for projects he perhaps just
@@ -260,16 +262,16 @@ public final class Indexer {
             }
 
             // Check index(es). Exit with return code upon failure.
-            if (checkIndex) {
+            if (indexCheckMode.ordinal() > IndexCheck.IndexCheckMode.NO_CHECK.ordinal()) {
                 if (cfg.getDataRoot() == null || cfg.getDataRoot().isEmpty()) {
                     System.err.println("Need data root in configuration for index check (use -R)");
                     System.exit(1);
                 }
 
-                if (!IndexCheck.check(cfg, subFilesArgs)) {
+                if (!IndexCheck.check(cfg, indexCheckMode, subFileArgs)) {
                     System.err.printf("Index check failed%n");
                     System.err.print("You might want to remove " +
-                            (!subFilesArgs.isEmpty() ? "data for projects " + String.join(",", subFilesArgs) :
+                            (!subFilePaths.isEmpty() ? "data for projects " + String.join(",", subFilePaths) :
                                     "all data") + " under the data root and reindex\n");
                     System.exit(1);
                 }
@@ -279,7 +281,7 @@ public final class Indexer {
 
             // Set updated configuration in RuntimeEnvironment. This is called so that the tunables set
             // via command line options are available.
-            env.setConfiguration(cfg, subFilesArgs, CommandTimeoutType.INDEXER);
+            env.setConfiguration(cfg, subFilePaths, CommandTimeoutType.INDEXER);
 
             // Let repository types to add items to ignoredNames.
             // This changes env so is called after the setConfiguration()
@@ -288,7 +290,7 @@ public final class Indexer {
 
             if (bareConfig) {
                 // Set updated configuration in RuntimeEnvironment.
-                env.setConfiguration(cfg, subFilesArgs, CommandTimeoutType.INDEXER);
+                env.setConfiguration(cfg, subFilePaths, CommandTimeoutType.INDEXER);
 
                 getInstance().sendToConfigHost(env, webappURI);
                 writeConfigToFile(env, configFilename);
@@ -303,7 +305,7 @@ public final class Indexer {
              * directory and not per project data root directory).
              * For the check we need to have 'env' already set.
              */
-            for (String path : subFilesArgs) {
+            for (String path : subFilePaths) {
                 String srcPath = env.getSourceRootPath();
                 if (srcPath == null) {
                     System.err.println("Error getting source root from environment. Exiting.");
@@ -330,7 +332,7 @@ public final class Indexer {
                 }
             }
 
-            if (!subFilesArgs.isEmpty() && subFiles.isEmpty()) {
+            if (!subFilePaths.isEmpty() && subFiles.isEmpty()) {
                 System.err.println("None of the paths were added, exiting");
                 System.exit(1);
             }
@@ -385,7 +387,7 @@ public final class Indexer {
 
             // Set updated configuration in RuntimeEnvironment. This is called so that repositories discovered
             // in prepareIndexer() are stored in the Configuration used by RuntimeEnvironment.
-            env.setConfiguration(cfg, subFilesArgs, CommandTimeoutType.INDEXER);
+            env.setConfiguration(cfg, subFilePaths, CommandTimeoutType.INDEXER);
 
             // prepareIndexer() populated the list of projects so now default projects can be set.
             env.setDefaultProjectsFromNames(defaultProjects);
@@ -568,8 +570,24 @@ public final class Indexer {
                 canonicalRoots.add(root);
             });
 
-            parser.on("--checkIndex", "Check index, exit with 0 on success,",
-                    "with 1 on failure.").execute(v -> checkIndex = true);
+            parser.on("--checkIndex", "=[mode]",
+                    "Check index, exit with 0 on success,",
+                    "with 1 on failure.",
+                    "With no mode specified, performs basic index check.",
+                    "Selectable modes (performs given test on top of the basic check):",
+                    "  documents - checks duplicate documents in the index"
+                    ).execute(v -> {
+                        indexCheckMode = IndexCheck.IndexCheckMode.VERSION;
+                        String mode = (String) v;
+                        if (mode != null && !mode.isEmpty()) {
+                            if (mode.equals("documents")) {
+                                indexCheckMode = IndexCheck.IndexCheckMode.DOCUMENTS;
+                            } else {
+                                die("mode '" + mode + "' is not valid.");
+                            }
+                        }
+                    }
+            );
 
             parser.on("-d", "--dataRoot", "=/path/to/data/root",
                 "The directory where OpenGrok stores the generated data.").

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -259,8 +259,7 @@ public final class Indexer {
                 }
             }
 
-            // Check version of index(es) versus current Lucene version and exit
-            // with return code upon failure.
+            // Check index(es). Exit with return code upon failure.
             if (checkIndex) {
                 if (cfg.getDataRoot() == null || cfg.getDataRoot().isEmpty()) {
                     System.err.println("Need data root in configuration for index check (use -R)");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -99,12 +99,12 @@ class IndexCheckTest {
                 null, null);
         Indexer.getInstance().doIndexerExecution(null, null);
 
-        IndexCheck.check(configuration, subFiles);
+        IndexCheck.check(configuration, IndexCheck.IndexCheckMode.VERSION, subFiles);
     }
 
     @Test
     void testIndexVersionNoIndex() {
-        IndexCheck.check(configuration, new ArrayList<>());
+        IndexCheck.check(configuration, IndexCheck.IndexCheckMode.VERSION, new ArrayList<>());
     }
 
     @Test
@@ -138,14 +138,15 @@ class IndexCheckTest {
         configuration.setDataRoot(oldIndexDataDir.toString());
         env.setProjectsEnabled(false);
         configuration.setProjectsEnabled(false);
-        assertFalse(IndexCheck.check(configuration, new ArrayList<>()));
+        assertFalse(IndexCheck.check(configuration, IndexCheck.IndexCheckMode.VERSION, new ArrayList<>()));
 
-        assertThrows(IndexCheck.IndexVersionException.class, () -> IndexCheck.checkDir(indexPath, ""));
+        assertThrows(IndexCheck.IndexVersionException.class, () ->
+                IndexCheck.checkDir(indexPath, IndexCheck.IndexCheckMode.VERSION, ""));
     }
 
     @Test
     void testEmptyDir(@TempDir Path tempDir) throws Exception {
         assertEquals(0, tempDir.toFile().list().length);
-        IndexCheck.checkDir(tempDir, "");
+        IndexCheck.checkDir(tempDir, IndexCheck.IndexCheckMode.VERSION, "");
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -140,12 +140,12 @@ class IndexCheckTest {
         configuration.setProjectsEnabled(false);
         assertFalse(IndexCheck.check(configuration, new ArrayList<>()));
 
-        assertThrows(IndexCheck.IndexVersionException.class, () -> IndexCheck.checkDir(indexDir));
+        assertThrows(IndexCheck.IndexVersionException.class, () -> IndexCheck.checkDir(indexPath, ""));
     }
 
     @Test
     void testEmptyDir(@TempDir Path tempDir) throws Exception {
         assertEquals(0, tempDir.toFile().list().length);
-        IndexCheck.checkDir(tempDir.toFile());
+        IndexCheck.checkDir(tempDir, "");
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
@@ -24,21 +24,10 @@ package org.opengrok.indexer.index;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.MultiBits;
-import org.apache.lucene.index.MultiTerms;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.NoMergeScheduler;
-import org.apache.lucene.index.Terms;
-import org.apache.lucene.index.TermsEnum;
-import org.apache.lucene.store.FSDirectory;
-import org.apache.lucene.store.NoLockFactory;
-import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.BytesRef;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.lib.Repository;
@@ -57,10 +46,8 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.FileCollector;
 import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.history.RepositoryFactory;
-import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.IOUtils;
 import org.opengrok.indexer.util.TestRepository;
-import org.opengrok.indexer.web.Util;
 
 import java.io.File;
 import java.io.IOException;
@@ -72,7 +59,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -82,6 +68,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.opengrok.indexer.index.IndexCheck.getDeletedUids;
+import static org.opengrok.indexer.index.IndexCheck.getIndexReader;
+import static org.opengrok.indexer.index.IndexCheck.getLiveDocumentPaths;
 
 /**
  * This class provides tests that verify the indexer correctly jumps over deleted documents in the index,
@@ -194,45 +183,11 @@ class IndexerVsDeletedDocumentsTest {
         }
     }
 
-    private IndexReader getIndexReader(String projectName) throws IOException {
+    private Path getIndexPath(String projectName) throws IOException {
         Path indexPath = Path.of(env.getDataRootPath(), IndexDatabase.INDEX_DIR,
                 env.isProjectsEnabled() ? projectName : "");
         assertTrue(indexPath.toFile().isDirectory());
-
-        try (FSDirectory indexDirectory = FSDirectory.open(indexPath, NoLockFactory.INSTANCE)) {
-            return DirectoryReader.open(indexDirectory);
-        }
-    }
-
-    /**
-     * @param projectName project name, can be empty
-     * @return set of deleted uids in the index related to the project name
-     * @throws IOException if the index cannot be read
-     */
-    private Set<String> getDeletedUids(String projectName) throws IOException {
-        Set<String> deletedUids = new HashSet<>();
-
-        try (IndexReader indexReader = getIndexReader(projectName)) {
-            Bits liveDocs = MultiBits.getLiveDocs(indexReader);
-            if (liveDocs == null) { // the index has no deletions
-                return deletedUids;
-            }
-
-            for (int i = 0; i < indexReader.maxDoc(); i++) {
-                Document doc = indexReader.storedFields().document(i);
-                // This should avoid the special LOC documents.
-                IndexableField field = doc.getField(QueryBuilder.U);
-                if (field != null) {
-                    String uid = field.stringValue();
-
-                    if (!liveDocs.get(i)) {
-                        deletedUids.add(uid);
-                    }
-                }
-            }
-        }
-
-        return deletedUids;
+        return indexPath;
     }
 
     @BeforeEach
@@ -390,7 +345,7 @@ class IndexerVsDeletedDocumentsTest {
             // At most one fileRemove() should be called for each path.
             assertEquals(new HashSet<>(listener.removedPaths).size(), listener.removedPaths.size());
 
-            if (getDeletedUids(projectName).size() > 0) {
+            if (getDeletedUids(getIndexPath(projectName)).size() > 0) {
                 break;
             }
         }
@@ -418,7 +373,7 @@ class IndexerVsDeletedDocumentsTest {
         }
 
         // Make sure there are some deleted documents.
-        try (IndexReader indexReader = getIndexReader(projectName)) {
+        try (IndexReader indexReader = getIndexReader(getIndexPath(projectName))) {
             assertTrue(indexReader.numDeletedDocs() > 0);
         }
 
@@ -431,42 +386,12 @@ class IndexerVsDeletedDocumentsTest {
 
     /**
      * Check there is at most one live document for each path by doing terms traversal,
-     * similar to what is done in {@link IndexDatabase}.
+     * similar to what is done in {@link IndexDatabase#update()}.
      */
     private void checkLiveDocs(String projectName) throws IOException {
-        try (IndexReader indexReader = getIndexReader(projectName)) {
-            Terms terms = MultiTerms.getTerms(indexReader, QueryBuilder.U);
-            TermsEnum uidIter = terms.iterator();
-            String dir = "/" + projectName;
-            String startUid = Util.path2uid(dir, "");
-            uidIter.seekCeil(new BytesRef(startUid));
-            final BytesRef emptyBR = new BytesRef("");
-            // paths of live (i.e. not deleted) documents. Must be a list for the asserts below to work.
-            List<String> livePaths = new ArrayList<>();
-            Set<String> deletedUids = getDeletedUids(projectName);
+        List<String> livePaths = getLiveDocumentPaths(getIndexPath(projectName), projectName);
 
-            while (uidIter != null && uidIter.term() != null && uidIter.term().compareTo(emptyBR) != 0) {
-                String termValue = uidIter.term().utf8ToString();
-                String termPath = Util.uid2url(termValue);
-
-                if (deletedUids.contains(termValue)) {
-                    BytesRef next = uidIter.next();
-                    if (next == null) {
-                        uidIter = null;
-                    }
-                    continue;
-                }
-
-                livePaths.add(termPath);
-
-                BytesRef next = uidIter.next();
-                if (next == null) {
-                    uidIter = null;
-                }
-            }
-
-            assertTrue(livePaths.size() > 0);
-            assertEquals(new HashSet<>(livePaths).size(), livePaths.size());
-        }
+        assertTrue(livePaths.size() > 0);
+        assertEquals(new HashSet<>(livePaths).size(), livePaths.size());
     }
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web;
@@ -148,7 +148,8 @@ public final class WebappListener implements ServletContextListener, ServletRequ
                 LOGGER.log(Level.FINE, "Checking indexes for all projects");
                 for (Map.Entry<String, Project> projectEntry : projects.entrySet()) {
                     try {
-                        IndexCheck.checkDir(Path.of(indexRoot.toString(), projectEntry.getKey()), projectEntry.getKey());
+                        IndexCheck.checkDir(Path.of(indexRoot.toString(), projectEntry.getKey()),
+                                IndexCheck.IndexCheckMode.VERSION, projectEntry.getKey());
                     } catch (Exception e) {
                         LOGGER.log(Level.WARNING,
                                 String.format("Project %s index check failed, marking as not indexed",
@@ -161,7 +162,8 @@ public final class WebappListener implements ServletContextListener, ServletRequ
         } else {
             LOGGER.log(Level.FINE, "Checking index");
             try {
-                IndexCheck.checkDir(Path.of(env.getDataRootPath(), IndexDatabase.INDEX_DIR), "");
+                IndexCheck.checkDir(Path.of(env.getDataRootPath(), IndexDatabase.INDEX_DIR),
+                        IndexCheck.IndexCheckMode.VERSION, "");
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, "index check failed", e);
             }

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -47,6 +47,7 @@ import org.opengrok.web.api.v1.suggester.provider.service.SuggesterServiceFactor
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
@@ -142,12 +143,12 @@ public final class WebappListener implements ServletContextListener, ServletRequ
     private void checkIndex(RuntimeEnvironment env) {
         if (env.isProjectsEnabled()) {
             Map<String, Project> projects = env.getProjects();
-            File indexRoot = new File(env.getDataRootPath(), IndexDatabase.INDEX_DIR);
-            if (indexRoot.exists()) {
+            Path indexRoot = Path.of(env.getDataRootPath(), IndexDatabase.INDEX_DIR);
+            if (indexRoot.toFile().exists()) {
                 LOGGER.log(Level.FINE, "Checking indexes for all projects");
                 for (Map.Entry<String, Project> projectEntry : projects.entrySet()) {
                     try {
-                        IndexCheck.checkDir(new File(indexRoot, projectEntry.getKey()));
+                        IndexCheck.checkDir(Path.of(indexRoot.toString(), projectEntry.getKey()), projectEntry.getKey());
                     } catch (Exception e) {
                         LOGGER.log(Level.WARNING,
                                 String.format("Project %s index check failed, marking as not indexed",
@@ -160,7 +161,7 @@ public final class WebappListener implements ServletContextListener, ServletRequ
         } else {
             LOGGER.log(Level.FINE, "Checking index");
             try {
-                IndexCheck.checkDir(new File(env.getDataRootPath(), IndexDatabase.INDEX_DIR));
+                IndexCheck.checkDir(Path.of(env.getDataRootPath(), IndexDatabase.INDEX_DIR), "");
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, "index check failed", e);
             }


### PR DESCRIPTION
Inspired by https://github.com/oracle/opengrok/issues/4180#issuecomment-1447625787 , I thought there could be a way how to check index(es) for live documents with the same path, within the indexer. By refactoring the test added in PR #4182, the indexer can now run the same check.