### PR TITLE
Search results debugging

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
@@ -122,15 +122,13 @@ public final class Results {
         } catch (Exception e) {
             String fnm = compressed ? TandemPath.join(basedir + path, ".gz") :
                     basedir + path;
-            LOGGER.log(Level.WARNING, "An error reading tags from " + fnm, e);
+            LOGGER.log(Level.WARNING, String.format("An error reading tags from '%s'", fnm), e);
         }
         return "";
     }
 
     /** Return a reader for the specified xref file. */
-    private static Reader getXrefReader(
-                    File basedir, String path, boolean compressed)
-            throws IOException {
+    private static Reader getXrefReader(File basedir, String path, boolean compressed) throws IOException {
         /*
          * For backward compatibility, read the OpenGrok-produced document
          * using the system default charset.
@@ -165,9 +163,9 @@ public final class Results {
      * @throws IOException I/O exception
      * @throws ClassNotFoundException class not found
      */
-    public static void prettyPrint(Writer out, SearchHelper sh, int start,
-            long end)
+    public static void prettyPrint(Writer out, SearchHelper sh, int start, long end)
             throws HistoryException, IOException, ClassNotFoundException {
+
         Project p;
         String contextPath = sh.getContextPath();
         String ctxE = Util.uriEncodePath(contextPath);


### PR DESCRIPTION
Inspired by https://github.com/oracle/opengrok/issues/4180#issuecomment-1453765351, this change will log the documents found by a search at the `FINEST` level. The document ID and path will be logged so that one can see whether there are multiple documents with the same path and different ID.

Here's example of the output (for the second page of search results, hence the 25-37) range:
```
03-Mar-2023 17:48:01.868 FINEST [http-nio-8080-exec-124] org.opengrok.indexer.search.Results.createMap directory hash contents for search hits (25,37):
03-Mar-2023 17:48:01.875 FINEST [http-nio-8080-exec-124] org.opengrok.indexer.search.Results.createMap 5,631: /lucene/lucene/core/src/java/org/apache/lucene/index/PointValues.java
03-Mar-2023 17:48:01.876 FINEST [http-nio-8080-exec-124] org.opengrok.indexer.search.Results.createMap 6,403: /lucene/lucene/analysis/common/src/java/org/apache/lucene/analysis/email/UAX29URLEmailTokenizerImpl.jflex
```
It does not display the actual search query, that would require some sort of representation of the `SearchHelper` instance. Also, this is meant for very specific debugging, so it's not actually needed.