### PR TITLE
bump dependency check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.4.4</version>
+                <version>8.1.2</version>
                 <configuration>
                     <skipSystemScope>true</skipSystemScope>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>


### PR DESCRIPTION
Upgrades the dependency-check Maven plugin to the latest version, hoping that the macOS Github Actions runner problems with downloading artifacts will go away.