### PR TITLE
bump xstream to 1.4.20

### DIFF
--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -114,7 +114,7 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.19</version>
+            <version>1.4.20</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This change bumps xstream version due to vulnerabilities found in 1.4.19.