### PR TITLE
Parallelism zero fix

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -23,6 +23,7 @@
  */
 package org.opengrok.indexer.configuration;
 
+import static java.lang.Integer.max;
 import static org.opengrok.indexer.configuration.Configuration.makeXMLStringAsConfiguration;
 import static org.opengrok.indexer.index.IndexerUtil.getWebAppHeaders;
 
@@ -1177,7 +1178,7 @@ public final class RuntimeEnvironment {
      */
     public int getRepositoryInvalidationParallelism() {
         int parallelism = syncReadConfiguration(Configuration::getRepositoryInvalidationParallelism);
-        return parallelism < 1 ? (Runtime.getRuntime().availableProcessors() / 2) : parallelism;
+        return parallelism < 1 ? (max(Runtime.getRuntime().availableProcessors() / 2, 1)) : parallelism;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1178,7 +1178,7 @@ public final class RuntimeEnvironment {
      */
     public int getRepositoryInvalidationParallelism() {
         int parallelism = syncReadConfiguration(Configuration::getRepositoryInvalidationParallelism);
-        return parallelism < 1 ? (max(Runtime.getRuntime().availableProcessors() / 2, 1)) : parallelism;
+        return parallelism < 1 ? max(Runtime.getRuntime().availableProcessors() / 2, 1) : parallelism;
     }
 
     /**


### PR DESCRIPTION
Fixes broken repository invalidation when number of CPUs is set to 1. This bug is is a tribute to how omnipresent multi-core/CPU systems are nowadays, I think.