### PR TITLE
check webapp via API call

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -173,7 +173,8 @@ public final class Indexer {
         try {
             argv = parseOptions(argv);
 
-            if (webappURI != null && !HostUtil.isReachable(webappURI, WEBAPP_CONNECT_TIMEOUT)) {
+            if (webappURI != null && !HostUtil.isReachable(webappURI, WEBAPP_CONNECT_TIMEOUT,
+                    cfg.getIndexerAuthenticationToken())) {
                 System.err.println(webappURI + " is not reachable and the -U option was specified, exiting.");
                 System.exit(1);
             }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -149,7 +149,7 @@ public final class Indexer {
     private static final String[] LUCENE_LOCKS = {ON, OFF, "simple", "native"};
     private static final String OPENGROK_JAR = "opengrok.jar";
 
-    private static final int WEBAPP_CONNECT_TIMEOUT = 1000;  // in milliseconds
+    private static final int WEBAPP_CONNECT_TIMEOUT = 3000;  // in milliseconds
 
     public static Indexer getInstance() {
         return indexer;
@@ -174,7 +174,7 @@ public final class Indexer {
             argv = parseOptions(argv);
 
             if (webappURI != null && !HostUtil.isReachable(webappURI, WEBAPP_CONNECT_TIMEOUT)) {
-                System.err.println(webappURI + " is not reachable.");
+                System.err.println(webappURI + " is not reachable and the -U option was specified, exiting.");
                 System.exit(1);
             }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerUtil.java
@@ -46,7 +46,7 @@ public class IndexerUtil {
      */
     public static MultivaluedMap<String, Object> getWebAppHeaders() {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
-        String token = null;
+        String token;
         if ((token = RuntimeEnvironment.getInstance().getIndexerAuthenticationToken()) != null) {
             headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/HostUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/HostUtil.java
@@ -25,19 +25,11 @@ package org.opengrok.indexer.util;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 import org.opengrok.indexer.logger.LoggerFactory;
-import org.opengrok.indexer.web.ApiUtils;
 
-import java.io.IOException;
-import java.net.ConnectException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -63,32 +55,6 @@ public class HostUtil {
     public static int urlToPort(String urlStr) throws URISyntaxException {
         URI uri = new URI(urlStr);
         return uri.getPort();
-    }
-
-    /**
-     * @param urlStr URI
-     * @return hostname
-     * @throws URISyntaxException on error
-     */
-    public static String urlToHostname(String urlStr) throws URISyntaxException {
-        URI uri = new URI(urlStr);
-        return uri.getHost();
-    }
-
-    /**
-     * @param addr IP address
-     * @param port port number
-     * @param timeOutMillis timeout in milliseconds
-     * @return true if TCP connect works, false otherwise
-     */
-    public static boolean isReachable(InetAddress addr, int port, int timeOutMillis) {
-        try (Socket soc = new Socket()) {
-            soc.connect(new InetSocketAddress(addr, port), timeOutMillis);
-        } catch (IOException e) {
-            return false;
-        }
-
-        return true;
     }
 
     private static boolean isWebAppReachable(String webappURI, int timeOutMillis) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/HostUtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/HostUtilTest.java
@@ -1,0 +1,53 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Basic tests for the {@link HostUtil} class. Ideally, these should use mocking to properly verify
+ * the exceptions and code flow. Also, positive test is missing.
+ */
+public class HostUtilTest {
+    @Test
+    void testInvalidURI() {
+        assertFalse(HostUtil.isReachable("htt://localhost:8080/source/", 1000, null));
+    }
+
+    @Test
+    void testInvalidHost() {
+        assertFalse(HostUtil.isReachable("http://localhosta:8080/source/", 1000, null));
+    }
+
+    @Test
+    void testInvalidPort() {
+        assertFalse(HostUtil.isReachable("http://localhost:zzzz/source/", 1000, null));
+    }
+
+    @Test
+    void testNotReachableWebApp() {
+        assertFalse(HostUtil.isReachable("http://localhost:4444/source/", 1000, null));
+    }
+}


### PR DESCRIPTION
This change replaces the TCP port response check done when -U is specified with API check, specifically to get the configuration, which is in a scope that the indexer will need anyway.

Tested with:
  - not listening port
  - URL not pointing to the web app (otherwise valid)
  - invalid URL (unknown scheme)
  - non-existent hostname
  - token

I raised the connect timeout (which is not also read timeout) to account for situations when running many instances of indexer in parallel (for per project reindex). Still, it might be useful to introduce special "ping" API endpoint for this check, because getting configuration can be slow sometimes.