### PR TITLE
unify and improve logging in DefaultIndexChangedListener

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -42,28 +42,28 @@ public class DefaultIndexChangedListener implements IndexChangedListener {
     @Override
     public void fileAdd(String path, String analyzer) {
         if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.log(Level.FINE, "Add: {0} ({1})", new Object[]{path, analyzer});
+            LOGGER.log(Level.FINE, "Add: ''{0}'' ({1})", new Object[]{path, analyzer});
         }
     }
 
     @Override
     public void fileRemove(String path) {
-        LOGGER.log(Level.FINE, "Remove file:{0}", path);
+        LOGGER.log(Level.FINE, "Remove: ''{0}''", path);
     }
     @Override
     public void fileUpdate(String path) {
-        LOGGER.log(Level.FINE, "Update: {0}", path);
+        LOGGER.log(Level.FINE, "Update: ''{0}''", path);
     }
 
     @Override
     public void fileAdded(String path, String analyzer) {
         if (LOGGER.isLoggable(Level.FINER)) {
-            LOGGER.log(Level.FINER, "Added: {0} ({1})", new Object[]{path, analyzer});
+            LOGGER.log(Level.FINER, "Added: ''{0}'' ({1})", new Object[]{path, analyzer});
         }
     }
 
     @Override
     public void fileRemoved(String path) {
-        LOGGER.log(Level.FINER, "Removed file:{0}", path);
+        LOGGER.log(Level.FINER, "Removed: ''{0}''", path);
     }
 }


### PR DESCRIPTION
This change unifies the logging displayed by the indexer when adding/removing files. In particular, it wraps the file paths in quotes as is the custom throughout the code base.