### PR TITLE
use connectTimeout for all API calls

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerUtil.java
@@ -36,6 +36,8 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
+import java.util.concurrent.TimeUnit;
+
 public class IndexerUtil {
 
     private IndexerUtil() {
@@ -70,7 +72,8 @@ public class IndexerUtil {
             ProcessingException,
             WebApplicationException {
 
-        try (Client client = ClientBuilder.newClient()) {
+        try (Client client = ClientBuilder.newBuilder().
+                connectTimeout(RuntimeEnvironment.getInstance().getConnectTimeout(), TimeUnit.SECONDS).build()) {
             final Invocation.Builder request = client.target(host)
                     .path("api")
                     .path("v1")

--- a/plugins/src/main/java/opengrok/auth/plugin/util/RestfulClient.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/util/RestfulClient.java
@@ -29,7 +29,9 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -52,7 +54,8 @@ public class RestfulClient {
     public static int postIt(String uri, String input) {
         int result;
         try {
-            try (Client client = ClientBuilder.newClient()) {
+            try (Client client = ClientBuilder.newBuilder().
+                    connectTimeout(RuntimeEnvironment.getInstance().getConnectTimeout(), TimeUnit.SECONDS).build()) {
                 LOGGER.log(Level.FINEST, "sending REST POST request to {0}: {1}",
                         new Object[]{uri, input});
                 try (Response response = client.target(uri)


### PR DESCRIPTION
This change ensures that the `connectTimeout` is used everywhere. Also, I converted some `Response` uses to try-with-resources.