### PR TITLE
remove opengrok-$version.jar file from the distribution tarball

### DIFF
--- a/distribution/assembly.xml
+++ b/distribution/assembly.xml
@@ -55,6 +55,10 @@
         <fileSet>
           <directory>${project.build.directory}/dist</directory>
           <outputDirectory>lib</outputDirectory>
+          <excludes>
+            <!-- Already included above with version-less name. -->
+            <exclude>opengrok-${version}.jar</exclude>
+          </excludes>
           <includes>
             <include>*.jar</include>
           </includes>


### PR DESCRIPTION
This change removes the `opengrok-$version.jar` file from the distribution tarball. I'd say the risk of someone using the file to actually run the indexer is fairly small, as they would need to change the version on every upgrade/downgrade.