### PR TITLE
use a specific chronicle-analytics version to disable reporting

### DIFF
--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -93,6 +93,12 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
 
         <dependency>
             <groupId>net.openhft</groupId>
+            <artifactId>chronicle-analytics</artifactId>
+            <version>0.EMPTY</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.openhft</groupId>
             <artifactId>chronicle-map</artifactId>
             <version>3.21.85</version>
             <exclusions>

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -91,6 +91,7 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
             <artifactId>annotations</artifactId>
         </dependency>
 
+        <!-- This specific version is used to disable reporting. -->
         <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>chronicle-analytics</artifactId>

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -91,7 +91,7 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
             <artifactId>annotations</artifactId>
         </dependency>
 
-        <!-- This specific version is used to disable reporting. -->
+        <!-- This specific version is used to disable reporting via chronicle-map. -->
         <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>chronicle-analytics</artifactId>


### PR DESCRIPTION
This change should disable the Google analytics reporting done via Chronicle Map. For testing, I performed basic suggester check on web app deployed with the changes.