### PR TITLE
fix(sec): upgrade commons-io:commons-io to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <apache-commons-lang3.version>3.12.0</apache-commons-lang3.version>
         <micrometer.version>1.8.2</micrometer.version>
         <mockito.version>3.12.4</mockito.version>
-        <commons-io.version>1.3.2</commons-io.version>
+        <commons-io.version>2.7</commons-io.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in commons-io:commons-io 1.3.2
- [CVE-2021-29425](https://www.oscs1024.com/hd/CVE-2021-29425)


### What did I do？
Upgrade commons-io:commons-io from 1.3.2 to 2.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS