### PR TITLE
fix(sec): upgrade org.webjars.npm:xss to 

### DIFF
--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -132,7 +132,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <dependency>
             <groupId>org.webjars.npm</groupId>
             <artifactId>xss</artifactId>
-            <version>1.0.8</version>
+            <version>1.0.10</version>
             <!-- dependencies not required -->
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.webjars.npm:xss 1.0.8
- [MPS-2022-11773](https://www.oscs1024.com/hd/MPS-2022-11773)


### What did I do？
Upgrade org.webjars.npm:xss from 1.0.8 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS