### PR TITLE
fix units for the connect timeout

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/HostUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/HostUtil.java
@@ -71,6 +71,8 @@ public class HostUtil {
             headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
         }
 
+        LOGGER.log(Level.FINE, "checking reachability of {0} with connect/read timeout of {1} seconds",
+                new Object[]{webappURI, timeOutSeconds});
         try (Client client = clientBuilder.build()) {
             Response response = client
                 .target(webappURI)

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/HostUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/HostUtil.java
@@ -59,10 +59,10 @@ public class HostUtil {
         return uri.getPort();
     }
 
-    private static boolean isWebAppReachable(String webappURI, int timeOutMillis, @Nullable String token) {
+    private static boolean isWebAppReachable(String webappURI, int timeOutSeconds, @Nullable String token) {
         ClientBuilder clientBuilder = ClientBuilder.newBuilder();
-        clientBuilder.connectTimeout(timeOutMillis, TimeUnit.MILLISECONDS);
-        clientBuilder.readTimeout(timeOutMillis, TimeUnit.MILLISECONDS);
+        clientBuilder.connectTimeout(timeOutSeconds, TimeUnit.SECONDS);
+        clientBuilder.readTimeout(timeOutSeconds, TimeUnit.SECONDS);
 
         // Here, IndexerUtil#getWebAppHeaders() is not used because at the point this method is called,
         // the RuntimeEnvironment configuration used by getWebAppHeaders() is not set yet.
@@ -97,11 +97,11 @@ public class HostUtil {
     /**
      *
      * @param webappURI URI of the web app
-     * @param timeOutMillis connect/read timeout in milliseconds
+     * @param timeOutSeconds connect/read timeout in seconds
      * @param token authentication token, can be {@code null}
      * @return whether web app is reachable within given timeout on given URI
      */
-    public static boolean isReachable(String webappURI, int timeOutMillis, @Nullable String token) {
+    public static boolean isReachable(String webappURI, int timeOutSeconds, @Nullable String token) {
         boolean connectWorks = false;
 
         try {
@@ -111,7 +111,7 @@ public class HostUtil {
                 return false;
             }
 
-            return isWebAppReachable(webappURI, timeOutMillis, token);
+            return isWebAppReachable(webappURI, timeOutSeconds, token);
         } catch (URISyntaxException e) {
             LOGGER.log(Level.SEVERE, String.format("URI not valid: %s", webappURI), e);
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/HostUtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/HostUtilTest.java
@@ -33,21 +33,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class HostUtilTest {
     @Test
     void testInvalidURI() {
-        assertFalse(HostUtil.isReachable("htt://localhost:8080/source/", 1000, null));
+        assertFalse(HostUtil.isReachable("htt://localhost:8080/source/", 10, null));
     }
 
     @Test
     void testInvalidHost() {
-        assertFalse(HostUtil.isReachable("http://localhosta:8080/source/", 1000, null));
+        assertFalse(HostUtil.isReachable("http://localhosta:8080/source/", 10, null));
     }
 
     @Test
     void testInvalidPort() {
-        assertFalse(HostUtil.isReachable("http://localhost:zzzz/source/", 1000, null));
+        assertFalse(HostUtil.isReachable("http://localhost:zzzz/source/", 10, null));
     }
 
     @Test
     void testNotReachableWebApp() {
-        assertFalse(HostUtil.isReachable("http://localhost:4444/source/", 1000, null));
+        assertFalse(HostUtil.isReachable("http://localhost:4444/source/", 10, null));
     }
 }


### PR DESCRIPTION
This change fixes the confusion in connect timeout units for performing webapp live check when using the -U indexer option.