### PR TITLE
introduce more /system endpoints

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -296,6 +296,25 @@ The paths are relative to source root, starting with /.
 
 + Response 204
 
+## Web app version [/system/version]
+
+### get web app version as string [GET]
+
++ Request (text/plain)
+  + Body
+
+            1.9.0 (a5ac05426bc5029158fedffee1cd44abf033bb61)
+
++ Response 200
+
+## Ping the webapp [/system/ping]
+
+This endpoint is used by the indexer when running with the -U option.
+
+### Check if web app is deployed and alive [GET]
+
++ Response 200
+
 ## Groups [/groups]
 
 ### returns a list of all groups [GET]

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -588,7 +588,7 @@ public final class Configuration {
         // webappCtags is default(boolean)
         setXrefTimeout(30);
         setApiTimeout(300); // 5 minutes
-        setConnectTimeout(3);
+        setConnectTimeout(10);
     }
 
     public String getRepoCmd(String clazzName) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/HostUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/HostUtil.java
@@ -78,7 +78,8 @@ public class HostUtil {
                 .target(webappURI)
                     .path("api")
                     .path("v1")
-                    .path("configuration")
+                    .path("system")
+                    .path("ping")
                     .request()
                     .headers(headers)
                     .get();

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.controller;
 import jakarta.inject.Inject;
@@ -33,6 +33,7 @@ import jakarta.ws.rs.core.MediaType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
+import org.opengrok.indexer.Info;
 import org.opengrok.indexer.configuration.IndexTimestamp;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.web.EftarFile;
@@ -80,5 +81,18 @@ public class SystemController {
         // StdDateFormat is ISO8601 since jackson 2.9
         mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
         return mapper.writeValueAsString(date);
+    }
+
+    @GET
+    @Path("/version")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getVersion() {
+        return String.format("%s (%s)", Info.getVersion(), Info.getRevision());
+    }
+
+    @GET
+    @Path("/ping")
+    public String ping() {
+        return "";
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -118,7 +118,7 @@ class SystemControllerTest extends OGKJerseyTest {
         // The output file will be located in a directory under data root so create it first.
         Path dataRoot = Files.createTempDirectory("api_dtags_test");
         env.setDataRoot(dataRoot.toString());
-        Paths.get(dataRoot.toString(), "index").toFile().mkdir();
+        assertTrue(Paths.get(dataRoot.toString(), "index").toFile().mkdir());
 
         // Create path descriptions string.
         StringBuilder sb = new StringBuilder();
@@ -128,10 +128,11 @@ class SystemControllerTest extends OGKJerseyTest {
         };
 
         // Reload the contents via API call.
-        Response r = target("system")
+        try (Response r = target("system")
                 .path("pathdesc")
-                .request().post(Entity.json(descriptions));
-        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), r.getStatus());
+                .request().post(Entity.json(descriptions))) {
+            assertEquals(Response.Status.NO_CONTENT.getStatusCode(), r.getStatus());
+        }
 
         // Check
         Path eftarPath = env.getDtagsEftarPath();

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -32,6 +32,7 @@ import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.Info;
 import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.IOUtils;
@@ -70,7 +71,7 @@ class SystemControllerTest extends OGKJerseyTest {
 
     /**
      * This method tests include files reload by testing it for one specific file out of the whole set.
-     * @throws IOException
+     * @throws IOException on error
      */
     @Test
     public void testIncludeReload() throws IOException {
@@ -165,5 +166,27 @@ class SystemControllerTest extends OGKJerseyTest {
 
         // Cleanup
         IOUtils.removeRecursive(dataRoot);
+    }
+
+    @Test
+    void testVersion() {
+        Response r = target("system")
+                .path("version")
+                .request().get();
+        String result = r.readEntity(String.class);
+
+        assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
+        assertEquals(String.format("%s (%s)", Info.getVersion(), Info.getRevision()), result);
+    }
+
+    @Test
+    void testPing() {
+        Response r = target("system")
+                .path("ping")
+                .request().get();
+        String result = r.readEntity(String.class);
+
+        assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
+        assertTrue(result.isEmpty());
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -99,10 +99,11 @@ class SystemControllerTest extends OGKJerseyTest {
         }
 
         // Reload the contents via API call.
-        Response r = target("system")
+        try (Response r = target("system")
                 .path("includes").path("reload")
-                .request().put(Entity.text(""));
-        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), r.getStatus());
+                .request().put(Entity.text(""))) {
+            assertEquals(Response.Status.NO_CONTENT.getStatusCode(), r.getStatus());
+        }
 
         // Check that the content was reloaded.
         String after = env.getIncludeFiles().getFooterIncludeFileContent(false);
@@ -121,7 +122,6 @@ class SystemControllerTest extends OGKJerseyTest {
         assertTrue(Paths.get(dataRoot.toString(), "index").toFile().mkdir());
 
         // Create path descriptions string.
-        StringBuilder sb = new StringBuilder();
         PathDescription[] descriptions = {
                 new PathDescription("/path1", "foo foo"),
                 new PathDescription("/path2", "bar bar")


### PR DESCRIPTION
This change introduces new /system endpoints for getting the version and pinging the webapp. The latter is now used when the indexer checks whether the webapp is alive. Also, I raised the default connect/read timeout to 10 seconds.