### PR TITLE
move dependency check to profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,22 +359,6 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                 <version>3.1.2</version>
             </plugin>
             <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>8.1.2</version>
-                <configuration>
-                    <skipSystemScope>true</skipSystemScope>
-                    <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>aggregate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.9.1</version>
@@ -439,6 +423,29 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                         <configuration>
                             <release>11</release>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>dependency-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>8.1.2</version>
+                        <configuration>
+                            <skipSystemScope>true</skipSystemScope>
+                            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
The dependency check negatively contributes to build stability. In particular, the macOS builds almost always fail the dependency check due to networking error for some reason. Lately, the check fails on all the other builds, usually with HTTP 503 error, possibly when downloading the CVE data. This change moves the check to a Maven profile so that it is not executed by default. The goal is to execute the profile from a periodic Github action, so that it does not impact common builds.