### PR TITLE
tools: utils: do not error during directory creation if it exists

### DIFF
--- a/tools/src/main/python/opengrok_tools/utils/utils.py
+++ b/tools/src/main/python/opengrok_tools/utils/utils.py
@@ -43,7 +43,7 @@ def check_create_dir(logger, path):
     """
     if not os.path.isdir(path):
         try:
-            os.makedirs(path)
+            os.makedirs(path, exist_ok=True)
         except OSError:
             logger.error("cannot create {} directory".format(path))
             sys.exit(FAILURE_EXITVAL)


### PR DESCRIPTION
Do not error out when creating a directory and directory already exists.

I got an error while running the sync job. There was an error during git fetch, and while reporting error sync job failed when creating the logs directory.

```
processing of project 'xxxxx' failed
  failed commands:
    'opengrok-mirror -U http://localhost:8080/source -c /etc/mirror-config.yml xxxxx': 1
      cannot create /tmp/logs directory
```