### PR TITLE
report progress when getting boundary changesets

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
@@ -25,6 +25,7 @@ package org.opengrok.indexer.history;
 import org.jetbrains.annotations.TestOnly;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.Progress;
 import org.opengrok.indexer.util.Statistics;
 
 import java.util.ArrayList;
@@ -74,6 +75,24 @@ public class BoundaryChangesets {
         return maxCount;
     }
 
+    static class IdWithProgress {
+        final private Progress progress;
+        final private String id;
+
+        IdWithProgress(String id, Progress progress) {
+            this.id = id;
+            this.progress = progress;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public Progress getProgress() {
+            return progress;
+        }
+    }
+
     /**
      * @param sinceRevision start revision ID
      * @return immutable list of revision IDs denoting the intervals
@@ -82,25 +101,33 @@ public class BoundaryChangesets {
     public synchronized List<String> getBoundaryChangesetIDs(String sinceRevision) throws HistoryException {
         reset();
 
-        LOGGER.log(Level.FINE, "getting boundary changesets for ''{0}''", repository.getDirectoryName());
+        Level logLevel = Level.FINE;
+        if (RuntimeEnvironment.getInstance().isPrintProgress()) {
+            logLevel = Level.INFO;
+        }
+
+        LOGGER.log(logLevel, "getting boundary changesets for {0}", repository);
         Statistics stat = new Statistics();
 
-        repository.accept(sinceRevision, this::visit);
+        try (Progress progress = new Progress(LOGGER, String.format("changesets visited of %s", this.repository))) {
+            repository.accept(sinceRevision, this::visit, progress);
+        }
 
         // The changesets need to go from oldest to newest.
         Collections.reverse(result);
 
-        stat.report(LOGGER, Level.FINE,
-                String.format("Done getting boundary changesets for ''%s'' (%d entries)",
-                        repository.getDirectoryName(), result.size()));
+        stat.report(LOGGER, logLevel,
+                String.format("Done getting boundary changesets for %s (%d entries)",
+                        repository, result.size()));
 
         return List.copyOf(result);
     }
 
-    private void visit(String id) {
+    private void visit(IdWithProgress arg) {
         if (cnt != 0 && cnt % maxCount == 0) {
-            result.add(id);
+            result.add(arg.getId());
         }
         cnt++;
+        arg.getProgress().increment();
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
@@ -76,8 +76,8 @@ public class BoundaryChangesets {
     }
 
     static class IdWithProgress {
-        final private Progress progress;
-        final private String id;
+        private final Progress progress;
+        private final String id;
 
         IdWithProgress(String id, Progress progress) {
             this.id = id;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
  */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -85,6 +85,7 @@ import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
+import org.opengrok.indexer.util.Progress;
 
 import static org.opengrok.indexer.history.History.TAGS_SEPARATOR;
 
@@ -448,7 +449,9 @@ public class GitRepository extends RepositoryWithHistoryTraversal {
         return MAX_CHANGESETS;
     }
 
-    public void accept(String sinceRevision, Consumer<String> visitor) throws HistoryException {
+    public void accept(String sinceRevision, Consumer<BoundaryChangesets.IdWithProgress> visitor, Progress progress)
+            throws HistoryException {
+
         try (org.eclipse.jgit.lib.Repository repository = getJGitRepository(getDirectoryName());
              RevWalk walk = new RevWalk(repository)) {
 
@@ -459,7 +462,7 @@ public class GitRepository extends RepositoryWithHistoryTraversal {
 
             for (RevCommit commit : walk) {
                 // Do not abbreviate the Id as this could cause AmbiguousObjectException in getHistory().
-                visitor.accept(commit.getId().name());
+                visitor.accept(new BoundaryChangesets.IdWithProgress(commit.getId().name(), progress));
             }
         } catch (IOException e) {
             throw new HistoryException(e);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialHistoryParserRevisionsOnly.java
@@ -23,6 +23,7 @@
 package org.opengrok.indexer.history;
 
 import org.opengrok.indexer.util.Executor;
+import org.opengrok.indexer.util.Progress;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -33,11 +34,15 @@ import java.util.function.Consumer;
 
 class MercurialHistoryParserRevisionsOnly implements Executor.StreamHandler {
     private final MercurialRepository repository;
-    private final Consumer<String> visitor;
+    private final Consumer<BoundaryChangesets.IdWithProgress> visitor;
 
-    MercurialHistoryParserRevisionsOnly(MercurialRepository repository, Consumer<String> visitor) {
+    private final Progress progress;
+
+    MercurialHistoryParserRevisionsOnly(MercurialRepository repository,
+                                        Consumer<BoundaryChangesets.IdWithProgress> visitor, Progress progress) {
         this.repository = repository;
         this.visitor = visitor;
+        this.progress = progress;
     }
 
     void parse(File file, String sinceRevision) throws HistoryException {
@@ -61,7 +66,7 @@ class MercurialHistoryParserRevisionsOnly implements Executor.StreamHandler {
         try (BufferedReader in = new BufferedReader(new InputStreamReader(input))) {
             String s;
             while ((s = in.readLine()) != null) {
-                visitor.accept(s);
+                visitor.accept(new BoundaryChangesets.IdWithProgress(s, progress));
             }
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -47,6 +47,7 @@ import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.BufferSink;
 import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.LazilyInstantiate;
+import org.opengrok.indexer.util.Progress;
 
 /**
  * Access to a Mercurial repository.
@@ -566,8 +567,10 @@ public class MercurialRepository extends RepositoryWithHistoryTraversal {
         return getHistory(file, null);
     }
 
-    public void accept(String sinceRevision, Consumer<String> visitor) throws HistoryException {
-        new MercurialHistoryParserRevisionsOnly(this, visitor).
+    public void accept(String sinceRevision, Consumer<BoundaryChangesets.IdWithProgress> visitor, Progress progress)
+            throws HistoryException {
+
+        new MercurialHistoryParserRevisionsOnly(this, visitor, progress).
                 parse(new File(getDirectoryName()), sinceRevision);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryWithPerPartesHistory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryWithPerPartesHistory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryWithPerPartesHistory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryWithPerPartesHistory.java
@@ -66,7 +66,7 @@ public abstract class RepositoryWithPerPartesHistory extends Repository {
      * Traverse the changesets using the visitor pattern.
      * @param sinceRevision start revision
      * @param visitor consumer of revisions
-     * @praram progress {@link Progress} instance
+     * @param progress {@link Progress} instance
      * @throws HistoryException on error during history retrieval
      */
     public abstract void accept(String sinceRevision, Consumer<BoundaryChangesets.IdWithProgress> visitor,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryWithPerPartesHistory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryWithPerPartesHistory.java
@@ -24,6 +24,7 @@ package org.opengrok.indexer.history;
 
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.Progress;
 import org.opengrok.indexer.util.Statistics;
 
 import java.io.File;
@@ -65,12 +66,17 @@ public abstract class RepositoryWithPerPartesHistory extends Repository {
      * Traverse the changesets using the visitor pattern.
      * @param sinceRevision start revision
      * @param visitor consumer of revisions
+     * @praram progress {@link Progress} instance
      * @throws HistoryException on error during history retrieval
      */
-    public abstract void accept(String sinceRevision, Consumer<String> visitor) throws HistoryException;
+    public abstract void accept(String sinceRevision, Consumer<BoundaryChangesets.IdWithProgress> visitor,
+                                Progress progress)
+            throws HistoryException;
 
     @Override
-    protected void doCreateCache(HistoryCache cache, String sinceRevision, File directory) throws HistoryException, CacheException {
+    protected void doCreateCache(HistoryCache cache, String sinceRevision, File directory)
+            throws HistoryException, CacheException {
+
         if (!RuntimeEnvironment.getInstance().isHistoryCachePerPartesEnabled()) {
             LOGGER.log(Level.INFO, "repository {0} supports per partes history cache creation however " +
                     "it is disabled in the configuration. Generating history cache as whole.", this);


### PR DESCRIPTION
This change reports the progress when getting boundary changesets when the `--progress` indexer option is in effect. This is not optimal as the level used to report start/end messages is `FINE`, #3736 would have helped here.