### PR TITLE
Progress log level shifting

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BoundaryChangesets.java
@@ -102,14 +102,12 @@ public class BoundaryChangesets {
         reset();
 
         Level logLevel = Level.FINE;
-        if (RuntimeEnvironment.getInstance().isPrintProgress()) {
-            logLevel = Level.INFO;
-        }
 
         LOGGER.log(logLevel, "getting boundary changesets for {0}", repository);
         Statistics stat = new Statistics();
 
-        try (Progress progress = new Progress(LOGGER, String.format("changesets visited of %s", this.repository))) {
+        try (Progress progress = new Progress(LOGGER, String.format("changesets visited of %s", this.repository),
+                logLevel)) {
             repository.accept(sinceRevision, this::visit, progress);
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -471,7 +471,8 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
          * (saved in the value of the hash map entry for the file) in a file.
          * The renamed files will be handled separately.
          */
-        LOGGER.log(Level.FINE, "Storing history for {0} regular files in repository ''{1}'' till {2}",
+        Level logLevel = Level.FINE;
+        LOGGER.log(logLevel, "Storing history for {0} regular files in repository ''{1}'' till {2}",
                 new Object[]{regularFiles.size(), repository, getRevisionString(tillRevision)});
         final File root = env.getSourceRootFile();
 
@@ -480,7 +481,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
         try (Progress progress = new Progress(LOGGER,
                 String.format("history cache for regular files of %s till %s", repository,
                         getRevisionString(tillRevision)),
-                regularFiles.size())) {
+                regularFiles.size(), logLevel)) {
             for (String file : regularFiles) {
                 env.getIndexerParallelizer().getHistoryFileExecutor().submit(() -> {
                     try {
@@ -502,7 +503,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
             } catch (InterruptedException ex) {
                 LOGGER.log(Level.SEVERE, "latch exception", ex);
             }
-            LOGGER.log(Level.FINE, "Stored history for {0} regular files in repository ''{1}''",
+            LOGGER.log(logLevel, "Stored history for {0} regular files in repository ''{1}''",
                     new Object[]{fileHistoryCount, repository});
         }
 
@@ -530,7 +531,8 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
 
         renamedFiles = renamedFiles.stream().filter(f -> new File(env.getSourceRootPath() + f).exists()).
                 collect(Collectors.toSet());
-        LOGGER.log(Level.FINE, "Storing history for {0} renamed files in repository ''{1}'' till {2}",
+        Level logLevel = Level.FINE;
+        LOGGER.log(logLevel, "Storing history for {0} renamed files in repository ''{1}'' till {2}",
                 new Object[]{renamedFiles.size(), repository, getRevisionString(tillRevision)});
 
         createDirectoriesForFiles(renamedFiles, repository, "renamed files for history " +
@@ -542,7 +544,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
         try (Progress progress = new Progress(LOGGER,
                 String.format("history cache for renamed files of %s till %s", repository,
                         getRevisionString(tillRevision)),
-                renamedFiles.size())) {
+                renamedFiles.size(), logLevel)) {
             for (final String file : renamedFiles) {
                 env.getIndexerParallelizer().getHistoryFileExecutor().submit(() -> {
                     try {
@@ -568,7 +570,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
                 LOGGER.log(Level.SEVERE, "latch exception", ex);
             }
         }
-        LOGGER.log(Level.FINE, "Stored history for {0} renamed files in repository {1}",
+        LOGGER.log(logLevel, "Stored history for {0} renamed files in repository {1}",
                 new Object[]{renamedFileHistoryCount.intValue(), repository});
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -150,6 +150,7 @@ public class IndexDatabase {
     private final Map<String, IndexedSymlink> indexedSymlinks = new TreeMap<>(
             Comparator.comparingInt(String::length).thenComparing(o -> o));
 
+    @Nullable
     private final Project project;
     private FSDirectory indexDirectory;
     private IndexReader reader;
@@ -2125,7 +2126,7 @@ public class IndexDatabase {
             hasPendingCommit = true;
 
             Statistics completerStat = new Statistics();
-            int n = completer.complete();
+            int n = completer.complete(this.project != null ? " for project " + this.project : "");
             completerStat.report(LOGGER, Level.FINE, String.format("completed %d object(s)", n));
 
             // Just before commit(), reset the `hasPendingCommit' flag,
@@ -2144,7 +2145,7 @@ public class IndexDatabase {
     }
 
     /**
-     * Verify TABSIZE, and evaluate AnalyzerGuru version together with ZVER --
+     * Verify {@code TABSIZE}, and evaluate AnalyzerGuru version together with {@code ZVER} --
      * or return a value to indicate mismatch.
      * @param file the source file object
      * @param path the source file path

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -2126,8 +2126,9 @@ public class IndexDatabase {
             hasPendingCommit = true;
 
             Statistics completerStat = new Statistics();
-            int n = completer.complete(this.project != null ? " for project " + this.project : "");
-            completerStat.report(LOGGER, Level.FINE, String.format("completed %d object(s)", n));
+            final String logSuffix = this.project != null ? " for project " + this.project : "";
+            int n = completer.complete(logSuffix);
+            completerStat.report(LOGGER, Level.FINE, String.format("completed %d object(s)%s", n, logSuffix));
 
             // Just before commit(), reset the `hasPendingCommit' flag,
             // since after commit() is called, there is no need for

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -41,6 +41,7 @@ import java.util.logging.Logger;
  * to go through, it will ping an instance of this class for each item completed.
  * This class will then log based on the number of pings. The bigger the progress,
  * the higher log level ({@link Level} value) will be used. The default base level is {@code Level.INFO}.
+ * Regardless of the base level, maximum 4 log levels will be used.
  */
 public class Progress implements AutoCloseable {
     private final Logger logger;
@@ -99,7 +100,7 @@ public class Progress implements AutoCloseable {
             this.totalCount = totalCount;
         }
 
-        // Note: Level.CONFIG is missing
+        // Note: Level.CONFIG is missing as it does not make too much sense for progress reporting semantically.
         final List<Level> standardLevels = Arrays.asList(Level.OFF, Level.SEVERE, Level.WARNING, Level.INFO,
                 Level.FINE, Level.FINER, Level.FINEST, Level.ALL);
         int i = standardLevels.indexOf(baseLogLevel);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -555,11 +555,11 @@ class IndexDatabaseTest {
         // hence it should be called just once.
         if (historyBased) {
             verify(idb, times(1)).indexDownUsingHistory(any(), any());
-            verify(idb, times(0)).indexDown(any(), any(), any());
+            verify(idb, times(0)).indexDown(any(), any(), any(), any());
         } else {
             // indexDown() is recursive, so it will be called more than once.
             verify(idb, times(0)).indexDownUsingHistory(any(), any());
-            verify(idb, atLeast(1)).indexDown(any(), any(), any());
+            verify(idb, atLeast(1)).indexDown(any(), any(), any(), any());
         }
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ProgressTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.util;
 
@@ -33,12 +33,14 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.times;
 
@@ -47,6 +49,14 @@ public class ProgressTest {
     public static void setup() {
         // needed to spawn logger thread in Progress
         RuntimeEnvironment.getInstance().setPrintProgress(true);
+    }
+
+    @Test
+    void testShifting() {
+        final Logger logger = Mockito.mock(Logger.class);
+        try (Progress progress = new Progress(logger, "xxx")) {
+            assertNotNull(progress);
+        }
     }
 
     @Test
@@ -85,6 +95,10 @@ public class ProgressTest {
         assertSame(loggerThread.getState(), Thread.State.TERMINATED);
 
         Mockito.verify(logger, times(totalCount)).log(any(), anyString());
+        Mockito.verify(logger, atLeast(1)).log(same(Level.INFO), anyString());
+        Mockito.verify(logger, atLeast(2)).log(same(Level.FINE), anyString());
+        Mockito.verify(logger, atLeast(10)).log(same(Level.FINER), anyString());
+        Mockito.verify(logger, atLeast(50)).log(same(Level.FINEST), anyString());
     }
 
     @Test


### PR DESCRIPTION
This change allows to set base log level for `Progress`. This is specifically handy for code that goes like this:
```java
LOGGER.log(Level.FINE, "starting operation foo", ...);
try (Progress = new Progress(...)) {
    ...
    progress.increment();
}
LOGGER.log(Level.FINE, "operation foo finished", ...);
```
Previously, the `Progress` logged the messages with `INFO` etc. level which might be confusing.

With this change, when a log level is supplied as argument to the `Progress` constructor, it will be used as a base log level. For the above example:
```java
Level logLevel = Level.FINE;
LOGGER.log(logLevel, "starting operation foo", ...);
try (Progress = new Progress(..., logLevel)) {
    ...
    progress.increment();
}
LOGGER.log(logLevel, "operation foo finished", ...);
```
the "buckets" used will correspond to the `FINE`, `FINER`, `FINEST`, `ALL` log levels.

While at it, I added progress reporting to more areas of the indexer.