### PR TITLE
parallelize projects index check

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -302,6 +302,8 @@ public final class Configuration {
     private int connectTimeout = -1;    // connect timeout in seconds
     private int apiTimeout = -1;    // API timeout in seconds
 
+    private int indexCheckTimeout;
+
     private boolean historyBasedReindex;
 
     /**
@@ -414,6 +416,25 @@ public final class Configuration {
                     String.format(NEGATIVE_NUMBER_ERROR, "restfulCommandTimeout", timeout));
         }
         this.restfulCommandTimeout = timeout;
+    }
+
+    public int getIndexCheckTimeout() {
+        return indexCheckTimeout;
+    }
+
+    /**
+     * Set the index check timeout (performed by the webapp on startup) to a new value.
+     *
+     * @see org.opengrok.indexer.index.IndexCheck
+     * @param timeout the new value
+     * @throws IllegalArgumentException when the timeout is negative
+     */
+    public void setIndexCheckTimeout(int timeout) throws IllegalArgumentException {
+        if (timeout < 0) {
+            throw new IllegalArgumentException(
+                    String.format(NEGATIVE_NUMBER_ERROR, "indexCheckTimeout", timeout));
+        }
+        this.indexCheckTimeout = timeout;
     }
 
     public int getWebappStartCommandTimeout() {
@@ -552,6 +573,7 @@ public final class Configuration {
         setHitsPerPage(25);
         setIgnoredNames(new IgnoredNames());
         setIncludedNames(new Filter());
+        setIndexCheckTimeout(60);
         setIndexVersionedFilesOnly(false);
         setLastEditedDisplayMode(true);
         //luceneLocking default is OFF

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -325,6 +325,14 @@ public final class RuntimeEnvironment {
         syncWriteConfiguration(timeout, Configuration::setWebappStartCommandTimeout);
     }
 
+    public int getIndexCheckTimeout() {
+        return syncReadConfiguration(Configuration::getIndexCheckTimeout);
+    }
+
+    public void setIndexCheckTimeout(int timeout) {
+        syncWriteConfiguration(timeout, Configuration::setIndexCheckTimeout);
+    }
+
     public int getIndexerCommandTimeout() {
         return syncReadConfiguration(Configuration::getIndexerCommandTimeout);
     }

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -150,7 +150,7 @@ public final class WebappListener implements ServletContextListener, ServletRequ
             Map<String, Project> projects = env.getProjects();
             Path indexRoot = Path.of(env.getDataRootPath(), IndexDatabase.INDEX_DIR);
             if (indexRoot.toFile().exists()) {
-                LOGGER.log(Level.FINE, "Checking indexes for all projects");
+                LOGGER.log(Level.FINE, "Checking index versions for all projects");
                 Statistics statistics = new Statistics();
                 ExecutorService executor = Executors.newFixedThreadPool(env.getRepositoryInvalidationParallelism(),
                         new OpenGrokThreadFactory("webapp-index-check"));
@@ -169,16 +169,16 @@ public final class WebappListener implements ServletContextListener, ServletRequ
                 }
                 executor.shutdown();
                 try {
-                    // TODO: make the timeout tunable
-                    if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
-                        LOGGER.log(Level.WARNING, "index check took more than 60 seconds");
+                    if (!executor.awaitTermination(env.getIndexCheckTimeout(), TimeUnit.SECONDS)) {
+                        LOGGER.log(Level.WARNING, "index version check took more than {0} seconds",
+                                env.getIndexCheckTimeout());
                         executor.shutdownNow();
                     }
                 } catch (InterruptedException e) {
-                    LOGGER.log(Level.WARNING, "failed to await termination of index check");
+                    LOGGER.log(Level.WARNING, "failed to await termination of index version check");
                     executor.shutdownNow();
                 }
-                statistics.report(LOGGER, Level.FINE, "Index check for all projects done");
+                statistics.report(LOGGER, Level.FINE, "Index version check for all projects done");
             }
         } else {
             LOGGER.log(Level.FINE, "Checking index");


### PR DESCRIPTION
This change parallelizes the index check performed by webapp on startup. The parallelism level is set to `getRepositoryInvalidationParallelism()` given the sort of similar task and considering that the repository invalidation is already done at that stage (when reading the configuration).

By default the newly introduced `indexCheckTimeout` tunable is set to 60 seconds.

The wiki with webapp configuration will have to be updated.