### PR TITLE
Docker tools timeout redux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ ENV CLASSPATH /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-j
 COPY docker/logging.properties /usr/local/tomcat/conf/logging.properties
 RUN sed -i -e 's/Valve/Disabled/' /usr/local/tomcat/conf/server.xml
 
-# add our scripts
+# add our scripts and configuration
 COPY docker /scripts
 RUN chmod -R +x /scripts
 

--- a/docker/start.py
+++ b/docker/start.py
@@ -76,6 +76,7 @@ OPENGROK_WEBAPPS_DIR = os.path.join(tomcat_root, "webapps")
 OPENGROK_JAR = os.path.join(OPENGROK_LIB_DIR, 'opengrok.jar')
 
 NOMIRROR_ENV_NAME = 'NOMIRROR'
+API_TIMEOUT_ENV_NAME = 'API_TIMEOUT'
 
 expected_token = None
 periodic_timer = None
@@ -481,16 +482,16 @@ def main():
         setup_redirect_source(logger, url_root)
 
     api_timeout = 8
-    if os.environ.get('API_TIMEOUT'):
-        api_timeout = int(os.environ.get('API_TIMEOUT'))
-    extra_indexer_options = "--connectTimeout " + str(api_timeout)
+    if os.environ.get(API_TIMEOUT_ENV_NAME):
+        api_timeout = int(os.environ.get(API_TIMEOUT_ENV_NAME))
+    else:
+        os.environ[API_TIMEOUT_ENV_NAME] = str(api_timeout)
 
     env = {}
-    indexer_opt = os.environ.get('INDEXER_OPT', '')
-    if indexer_opt:
-        extra_indexer_options += " " + indexer_opt
-    logger.info("extra indexer options: '{}'".format(extra_indexer_options))
-    env['OPENGROK_INDEXER_OPTIONAL_ARGS'] = extra_indexer_options
+    extra_indexer_options = os.environ.get('INDEXER_OPT', '')
+    if extra_indexer_options:
+        logger.info("extra indexer options: '{}'".format(extra_indexer_options))
+        env['OPENGROK_INDEXER_OPTIONAL_ARGS'] = extra_indexer_options
 
     if os.environ.get(NOMIRROR_ENV_NAME):
         env[OPENGROK_NO_MIRROR_ENV] = os.environ.get(NOMIRROR_ENV_NAME)

--- a/docker/sync.yml
+++ b/docker/sync.yml
@@ -9,10 +9,13 @@ commands:
       text: resync + reindex in progress
 - command: [opengrok-mirror, -c, '/opengrok/etc/mirror.yml', -I, -U, '%URL%', '%PROJECT%']
 - command: [opengrok-reindex-project, --printoutput,
+    --api_timeout, '%API_TIMEOUT',
     --jar, /opengrok/lib/opengrok.jar, -U, '%URL%', -P, '%PROJECT%', --,
+    --connectTimeout, '%API_TIMEOUT',
     -r, dirbased, -G, -m, '256', --leadingWildCards, 'on',
     -c, /usr/local/bin/ctags, -U, '%URL%', -H, '%PROJECT%']
   limits: {RLIMIT_NOFILE: 1024}
+  args_subst: {"%API_TIMEOUT%": $API_TIMEOUT}
 - call:
     uri: '%URL%api/v1/messages?tag=%PROJECT%'
     method: DELETE

--- a/docker/sync.yml
+++ b/docker/sync.yml
@@ -7,15 +7,17 @@ commands:
       duration: PT1H
       tags: ['%PROJECT%']
       text: resync + reindex in progress
-- command: [opengrok-mirror, -c, '/opengrok/etc/mirror.yml', -I, -U, '%URL%', '%PROJECT%']
-- command: [opengrok-reindex-project, --printoutput,
-    --api_timeout, '%API_TIMEOUT',
-    --jar, /opengrok/lib/opengrok.jar, -U, '%URL%', -P, '%PROJECT%', --,
-    --connectTimeout, '%API_TIMEOUT',
-    -r, dirbased, -G, -m, '256', --leadingWildCards, 'on',
-    -c, /usr/local/bin/ctags, -U, '%URL%', -H, '%PROJECT%']
-  limits: {RLIMIT_NOFILE: 1024}
-  args_subst: {"%API_TIMEOUT%": $API_TIMEOUT}
+- command:
+    args: [opengrok-mirror, -c, '/opengrok/etc/mirror.yml', -I, -U, '%URL%', '%PROJECT%']
+- command:
+    args: [opengrok-reindex-project, --printoutput,
+      --api_timeout, '%API_TIMEOUT%',
+      --jar, /opengrok/lib/opengrok.jar, -U, '%URL%', -P, '%PROJECT%', --,
+      --connectTimeout, '%API_TIMEOUT%',
+      -r, dirbased, -G, -m, '256', --leadingWildCards, 'on',
+      -c, /usr/local/bin/ctags, -U, '%URL%', -H, '%PROJECT%']
+    limits: {RLIMIT_NOFILE: 1024}
+    args_subst: {"%API_TIMEOUT%": "$API_TIMEOUT"}
 - call:
     uri: '%URL%api/v1/messages?tag=%PROJECT%'
     method: DELETE

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -19,7 +19,7 @@
 #
 
 #
-# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
 #
 
 """

--- a/tools/src/main/python/opengrok_tools/utils/command.py
+++ b/tools/src/main/python/opengrok_tools/utils/command.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
 #
 
 import logging
@@ -297,7 +297,7 @@ class Command:
         finally:
             if self.timeout != 0 and timeout_thread:
                 with time_condition:
-                    time_condition.notifyAll()
+                    time_condition.notify_all()
 
             # The subprocess module does not close the write pipe descriptor
             # it fetched via OutputThread's fileno() so in order to gracefully

--- a/tools/src/main/python/opengrok_tools/utils/command.py
+++ b/tools/src/main/python/opengrok_tools/utils/command.py
@@ -344,10 +344,14 @@ class Command:
                 newarg = cmdarg
                 for pattern in args_subst.keys():
                     if pattern in newarg and args_subst[pattern]:
+                        value = args_subst[pattern]
+                        if value.startswith("$"):
+                            self.logger.debug(f"treating {value} as environment variable")
+                            value = os.environ.get(value[1:], "")
                         self.logger.debug("replacing '{}' in '{}' with '{}'".
                                           format(pattern, newarg,
-                                                 args_subst[pattern]))
-                        newarg = newarg.replace(pattern, args_subst[pattern])
+                                                 value))
+                        newarg = newarg.replace(pattern, value)
                         self.logger.debug("replaced argument with {}".
                                           format(newarg))
                         subst_done = i

--- a/tools/src/main/python/opengrok_tools/utils/commandsequence.py
+++ b/tools/src/main/python/opengrok_tools/utils/commandsequence.py
@@ -148,7 +148,7 @@ class CommandSequenceBase:
 
     def __init__(self, name, commands, loglevel=logging.INFO, cleanup=None,
                  driveon=False, url=None, env=None, http_headers=None,
-                 api_timeout=None, async_api_timeout=None):
+                 api_timeout=None, async_api_timeout=None, args_subst={}):
         self.name = name
 
         if commands is None:
@@ -178,6 +178,10 @@ class CommandSequenceBase:
         self.async_api_timeout = async_api_timeout
 
         self.url = url
+
+        self.args_subst = {PROJECT_SUBST: self.name,
+                           URL_SUBST: self.url}
+        self.args_subst.extend(args_subst)
 
     def __str__(self):
         return str(self.name)
@@ -263,8 +267,7 @@ class CommandSequence(CommandSequenceBase):
                                   env_vars=command.get("env"),
                                   logger=self.logger,
                                   resource_limits=command.get("limits"),
-                                  args_subst={PROJECT_SUBST: self.name,
-                                              URL_SUBST: self.url},
+                                  args_subst=self.args_subst,
                                   args_append=[self.name], excl_subst=True)
                 ret_code = self.run_command(command)
 

--- a/tools/src/test/python/test_command.py
+++ b/tools/src/test/python/test_command.py
@@ -20,7 +20,7 @@
 #
 
 #
-# Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -73,6 +73,17 @@ def test_subst_multiple():
     cmd = Command(['foo', 'aaa%ARG%bbb%XYZ%ccc', 'bar'],
                   args_subst={"%ARG%": "blah", "%XYZ%": "xyz"})
     assert cmd.cmd == ['foo', 'aaablahbbbxyzccc', 'bar']
+
+
+def test_subst_env():
+    """
+    Test substitution with value treated as environment variable.
+    """
+    os.environ["FOO"] = "foo"
+    cmd = Command(['foo', 'aaa%ARG%bbb', 'bar'],
+                  args_subst={"%ARG%": "$FOO"})
+    assert cmd.cmd == ['foo', 'aaafoobbb', 'bar']
+    os.environ.pop("FOO")
 
 
 # On Windows the return code is actually 1.


### PR DESCRIPTION
https://github.com/oracle/opengrok/discussions/4247#discussioncomment-5468707 inspired me to allow command argument substitution to use environment variables as values.

While making the change, I realized that the command structure is broken - it needs to be a dictionary for stuff like resource limits and argument substitution to work. The [per project workflow wiki](https://github.com/oracle/opengrok/wiki/Per-project-management-and-workflow) will have to be adapted.

Command configuration in YAML now looks like this:
```yaml
- command:
    args: [cmd, "--foo", "%FOO%"]
    limits: {RLIMIT_NOFILE: 1024}
    args_subst: {"%FOO%": "$FOO"}
```
The `$` prefix in the `$FOO` value means that it will not be taken as literal; instead, the value of environment variable `FOO` will be taken.