### PR TITLE
make Tomcat use temporary directory under OpenGrok data root

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -654,6 +654,10 @@ def main():
 
     # Start Tomcat last.
     logger.info("Starting Tomcat")
+    tomcat_temp = os.path.join(OPENGROK_DATA_ROOT, "tomcat_temp")
+    os.makedirs(tomcat_temp, exist_ok=True)
+    tomcat_env = os.environ
+    tomcat_env["CATALINA_TMPDIR"] = tomcat_temp
     tomcat_popen = subprocess.Popen(
         [os.path.join(tomcat_root, "bin", "catalina.sh"), "run"]
     )

--- a/docker/start.py
+++ b/docker/start.py
@@ -656,10 +656,10 @@ def main():
     logger.info("Starting Tomcat")
     tomcat_temp = os.path.join(OPENGROK_DATA_ROOT, "tomcat_temp")
     os.makedirs(tomcat_temp, exist_ok=True)
-    tomcat_env = os.environ
+    tomcat_env = dict(os.environ)
     tomcat_env["CATALINA_TMPDIR"] = tomcat_temp
     tomcat_popen = subprocess.Popen(
-        [os.path.join(tomcat_root, "bin", "catalina.sh"), "run"]
+        [os.path.join(tomcat_root, "bin", "catalina.sh"), "run"], env=tomcat_env
     )
 
     sigset = set()


### PR DESCRIPTION
As suggested in https://github.com/oracle/opengrok/discussions/4252#discussioncomment-5479257, Tomcat temporary directory should reside under OpenGrok data root in Docker container.
