### PR TITLE
adapt to new Ctags (Terraform support)

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -202,7 +202,6 @@ public class Ctags implements Resettable {
         addRustSupport(command);
         addPascalSupport(command);
         addPowerShellSupport(command);
-        addTerraformSupport(command);
         //PLEASE add new languages ONLY with POSIX syntax (see above wiki link)
 
         if (langMap == null) {
@@ -441,52 +440,6 @@ public class Ctags implements Resettable {
         command.add("--regex-scala=/^[[:space:]]*((abstract|final|sealed|implicit|lazy)[[:space:]]*)*" +
                 "var[[:space:]]+([a-zA-Z0-9_]+)/\\3/v/");
         command.add("--regex-scala=/^[[:space:]]*package[[:space:]]+([a-zA-Z0-9_.]+)/\\1/p/");
-    }
-
-    private void addTerraformSupport(List<String> command) {
-        if (!ctagsLanguages.contains("Terraform")) { // Built-in would be capitalized.
-            command.add("--langdef=terraform"); // Lower-case if user-defined.
-        }
-
-        /*
-         * Ignore Terraform single-line comments with short-form (only two
-         * separators following the pattern), exclusive matches.
-         */
-        command.add("--regex-terraform=,^[[:space:]]*#,,{exclusive}");
-        command.add("--regex-terraform=,^[[:space:]]*//,,{exclusive}");
-
-        /*
-         * Terraform "resource block declares a resource of a given type ...
-         * with a given local name...." Unfortunately there is no Posix
-         * equivalent of {Identifier} from HCL.lexh, so we must approximate with
-         * the possibility of leaving out some matches.
-         */
-        command.add("--kinddef-terraform=r,resource,Resource\\ names");
-        command.add("--kinddef-terraform=d,dataSource,Data\\ sources");
-        command.add("--kinddef-terraform=m,module,Modules");
-        command.add("--kinddef-terraform=o,outputValue,Output\\ values");
-        command.add("--kinddef-terraform=p,provider,Providers");
-        command.add("--kinddef-terraform=v,variable,Variables");
-        command.add("--regex-terraform=" +
-                "/^[[:space:]]*resource[[:space:]]*\\\"([[:alpha:]][-_[:alpha:]]*)\\\"[[:space:]]*" +
-                "\\\"([[:alpha:]][-_[:alpha:]]*)\\\"[[:space:]]*\\{/" +
-                "\\1.\\2/r/");
-        command.add("--regex-terraform=" +
-                "/^[[:space:]]*data[[:space:]]*\\\"([[:alpha:]][-_[:alpha:]]*)\\\"[[:space:]]*" +
-                "\\\"([[:alpha:]][-_[:alpha:]]*)\\\"[[:space:]]*\\{/" +
-                "\\1.\\2/d/");
-        command.add("--regex-terraform=" +
-                "/^[[:space:]]*module[[:space:]]*\\\"([[:alpha:]][-_[:alpha:]]*)\\\"[[:space:]]*\\{/" +
-                "\\1/m/");
-        command.add("--regex-terraform=" +
-                "/^[[:space:]]*output[[:space:]]*\\\"([[:alpha:]][-_[:alpha:]]*)\\\"[[:space:]]*\\{/" +
-                "\\1/o/");
-        command.add("--regex-terraform=" +
-                "/^[[:space:]]*provider[[:space:]]*\\\"([[:alpha:]][-_[:alpha:]]*)\\\"[[:space:]]*\\{/" +
-                "\\1/p/");
-        command.add("--regex-terraform=" +
-                "/^[[:space:]]*variable[[:space:]]*\\\"([[:alpha:]][-_[:alpha:]]*)\\\"[[:space:]]*\\{/" +
-                "\\1/v/");
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
@@ -153,11 +153,11 @@ public class CtagsTest {
 
     private static List<SingleTagTestData> terraformTestParams() {
         return List.of(
-                new SingleTagTestData("data_source", "aws_ami.example", "dataSource"),
+                new SingleTagTestData("data_source", "example", "data"),
                 new SingleTagTestData("module", "servers", "module"),
-                new SingleTagTestData("output_value", "instance_ip_addr", "outputValue"),
+                new SingleTagTestData("output_value", "instance_ip_addr", "output"),
                 new SingleTagTestData("provider", "oci", "provider"),
-                new SingleTagTestData("resource", "oci_core_vcn.test_vcn", "resource"),
+                new SingleTagTestData("resource", "test_vcn", "resource"),
                 new SingleTagTestData("variable", "availability_zone_names", "variable")
         );
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
@@ -29,6 +29,8 @@ import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opengrok.indexer.util.TestRepository;
@@ -142,6 +144,8 @@ public class CtagsTest {
 
     @ParameterizedTest
     @MethodSource("terraformTestParams")
+    // Universal Ctags distributed via Chocolatey on Windows does not support Terraform yet.
+    @EnabledOnOs({OS.LINUX, OS.MAC})
     void testTfTags(final SingleTagTestData data) throws Exception {
         var defs = getDefs("terraform/" + data.file + ".tf");
         assertAll(


### PR DESCRIPTION
https://github.com/universal-ctags/ctags/pull/3684 includes better support for Terraform in Universal ctags so the extra definitions are no longer needed.