### PR TITLE
make HistoryGuru#getLastHistoryEntry more efficient

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -42,6 +42,14 @@ interface HistoryCache extends Cache {
      * @throws CacheException if the history cache cannot be fetched
      */
     History get(File file, @Nullable Repository repository, boolean withFiles) throws CacheException;
+
+    /**
+     * Retrieve last (newest) history entry for the given file from the cache.
+     *
+     * @param file The file to retrieve history for
+     * @throws CacheException if the history cache cannot be read
+     */
+    HistoryEntry getLastHistoryEntry(File file) throws CacheException;
 
     /**
      * Store the history for a repository.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/LatestRevisionUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/LatestRevisionUtil.java
@@ -113,7 +113,7 @@ public class LatestRevisionUtil {
 
     @Nullable
     private static String getLastRevFromHistory(File file) throws HistoryException {
-        HistoryEntry he = HistoryGuru.getInstance().getLastHistoryEntry(file, true);
+        HistoryEntry he = HistoryGuru.getInstance().getLastHistoryEntry(file, true, true);
         if (he != null) {
             return he.getRevision();
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -983,4 +983,23 @@ class FileHistoryCacheTest {
         retrievedHistory = cache.get(makefile, repo, true);
         assertNotNull(retrievedHistory, "history for Makefile should not be null");
     }
+
+    @Test
+    void testGetLastHistoryEntry() throws Exception {
+        File repositoryRoot = new File(repositories.getSourceRoot(), "git");
+
+        Repository repository = RepositoryFactory.getRepository(repositoryRoot);
+
+        cache.clear(repository);
+        File sourceFile = new File(repositoryRoot, "main.c");
+        assertTrue(repository.getHistory(sourceFile).getHistoryEntries().size() > 1);
+        assertTrue(sourceFile.exists());
+        assertNull(cache.getLastHistoryEntry(sourceFile));
+
+        History historyToStore = repository.getHistory(repositoryRoot);
+        cache.store(historyToStore, repository);
+        HistoryEntry historyEntry = cache.getLastHistoryEntry(sourceFile);
+        assertNotNull(historyEntry);
+        assertEquals("aa35c25882b9a60a97758e0ceb276a3f8cb4ae3a", historyEntry.getRevision());
+    }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -377,7 +377,7 @@ public class HistoryGuruTest {
     void testGetLastHistoryEntryNonexistent() throws Exception {
         HistoryGuru instance = HistoryGuru.getInstance();
         File file = new File("/nonexistent");
-        assertNull(instance.getLastHistoryEntry(file, true));
+        assertNull(instance.getLastHistoryEntry(file, true, true));
     }
 
     @ParameterizedTest
@@ -391,9 +391,9 @@ public class HistoryGuruTest {
         File file = new File(repository.getSourceRoot(), "git");
         assertTrue(file.exists());
         if (isIndexerParam) {
-            assertThrows(IllegalStateException.class, () -> instance.getLastHistoryEntry(file, true));
+            assertThrows(IllegalStateException.class, () -> instance.getLastHistoryEntry(file, true, true));
         } else {
-            assertNotNull(instance.getLastHistoryEntry(file, true));
+            assertNotNull(instance.getLastHistoryEntry(file, true, true));
         }
         env.setIndexer(isIndexer);
         env.setTagsEnabled(isTagsEnabled);
@@ -417,7 +417,7 @@ public class HistoryGuruTest {
 
         assertNotNull(repository);
         repository.setHistoryEnabled(false);
-        assertNull(instance.getLastHistoryEntry(file, false));
+        assertNull(instance.getLastHistoryEntry(file, false, true));
 
         // cleanup
         repository.setHistoryEnabled(true);


### PR DESCRIPTION
This change exploits the recent change of `FileHistoryCache` serialization method to one that allows for sequential access. Here, the retrieval of the last `HistoryEntry` for given file from cache was changed to avoid getting complete history from the cache.