### PR TITLE
use HistoryGuru#getLastHistoryEntry() in AnalyzerGuru

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -112,7 +112,6 @@ import org.opengrok.indexer.analysis.verilog.VerilogAnalyzerFactory;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.Annotation;
-import org.opengrok.indexer.history.History;
 import org.opengrok.indexer.history.HistoryEntry;
 import org.opengrok.indexer.history.HistoryException;
 import org.opengrok.indexer.history.HistoryGuru;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -637,13 +637,9 @@ public class AnalyzerGuru {
             HistoryReader hr = histGuru.getHistoryReader(file);
             if (hr != null) {
                 doc.add(new TextField(QueryBuilder.HIST, hr));
-                History history;
-                if ((history = histGuru.getHistory(file)) != null) {
-                    List<HistoryEntry> historyEntries = history.getHistoryEntries(1, 0);
-                    if (!historyEntries.isEmpty()) {
-                        HistoryEntry histEntry = historyEntries.get(0);
-                        doc.add(new TextField(QueryBuilder.LASTREV, histEntry.getRevision(), Store.YES));
-                    }
+                HistoryEntry histEntry = histGuru.getLastHistoryEntry(file, false, true);
+                if (histEntry != null) {
+                    doc.add(new TextField(QueryBuilder.LASTREV, histEntry.getRevision(), Store.YES));
                 }
             }
         } catch (HistoryException e) {


### PR DESCRIPTION
This change should make the indexer more efficient when history cache is enabled.