### PR TITLE
rescan the repositories in testListFiles()

### DIFF
--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
@@ -645,7 +645,7 @@ class ProjectsControllerTest extends OGKJerseyTest {
 
         Indexer.getInstance().prepareIndexer(
                 env,
-                false, // don't search for repositories
+                true, // don't search for repositories
                 true, // add projects
                 // don't create dictionary
                 new ArrayList<>(), // subFiles - needed when refreshing history partially


### PR DESCRIPTION
This is more of a hot fix as the proper fix would be to remove the `/mercurial/usr/closed` repository at the end of each test that added it.