### PR TITLE
do not attempt to get history cache for directories

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -655,6 +655,10 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
     @Override
     public History get(File file, Repository repository, boolean withFiles) throws CacheException {
 
+        if (file.isDirectory()) {
+            return null;
+        }
+
         if (isUpToDate(file)) {
             File cacheFile = getCachedFile(file);
             try {


### PR DESCRIPTION
This change avoids exception to be thrown when getting history for a directory.