### PR TITLE
log the full repository representation

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -23,9 +23,6 @@
  */
 package org.opengrok.indexer.history;
 
-import java.beans.Encoder;
-import java.beans.Expression;
-import java.beans.PersistenceDelegate;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -136,15 +136,6 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
         storeFile(history, file, repository, !renamed);
     }
 
-    static class FilePersistenceDelegate extends PersistenceDelegate {
-        @Override
-        protected Expression instantiate(Object oldInstance, Encoder out) {
-            File f = (File) oldInstance;
-            return new Expression(oldInstance, f.getClass(), "new",
-                new Object[] {f.toString()});
-        }
-    }
-
     @Override
     public void initialize() {
         MeterRegistry meterRegistry = Metrics.getRegistry();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -523,7 +523,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
          * The renamed files will be handled separately.
          */
         Level logLevel = Level.FINE;
-        LOGGER.log(logLevel, "Storing history for {0} regular files in repository ''{1}'' till {2}",
+        LOGGER.log(logLevel, "Storing history for {0} regular files in repository {1} till {2}",
                 new Object[]{regularFiles.size(), repository, getRevisionString(tillRevision)});
         final File root = env.getSourceRootFile();
 
@@ -554,7 +554,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
             } catch (InterruptedException ex) {
                 LOGGER.log(Level.SEVERE, "latch exception", ex);
             }
-            LOGGER.log(logLevel, "Stored history for {0} regular files in repository ''{1}''",
+            LOGGER.log(logLevel, "Stored history for {0} regular files in repository {1}",
                     new Object[]{fileHistoryCount, repository});
         }
 
@@ -583,7 +583,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
         renamedFiles = renamedFiles.stream().filter(f -> new File(env.getSourceRootPath() + f).exists()).
                 collect(Collectors.toSet());
         Level logLevel = Level.FINE;
-        LOGGER.log(logLevel, "Storing history for {0} renamed files in repository ''{1}'' till {2}",
+        LOGGER.log(logLevel, "Storing history for {0} renamed files in repository {1} till {2}",
                 new Object[]{renamedFiles.size(), repository, getRevisionString(tillRevision)});
 
         createDirectoriesForFiles(renamedFiles, repository, "renamed files for history " +
@@ -645,7 +645,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
             File dir = cache.getParentFile();
 
             if (!dir.isDirectory() && !dir.mkdirs()) {
-                LOGGER.log(Level.WARNING, "Unable to create cache directory ''{0}''.", dir);
+                LOGGER.log(Level.WARNING, "Unable to create cache directory ''{0}''", dir);
             }
         }
         elapsed.report(LOGGER, Level.FINE, String.format("Done creating directories for %s (%s)", repository, label));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -821,8 +821,7 @@ public final class HistoryGuru {
                         }
                     }
                 } else {
-                    LOGGER.log(Level.CONFIG, "Adding <{0}> repository for ''{1}''",
-                            new Object[]{repository.getClass().getName(), path});
+                    LOGGER.log(Level.CONFIG, "Adding repository {0}", repository);
 
                     repoList.add(new RepositoryInfo(repository));
                     putRepository(repository);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -780,10 +780,7 @@ public final class HistoryGuru {
                 continue;
             }
 
-            String path;
             try {
-                path = file.getCanonicalPath();
-
                 Repository repository = null;
                 try {
                     repository = RepositoryFactory.getRepository(file, CommandTimeoutType.INDEXER, isNested);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -942,29 +942,26 @@ public final class HistoryGuru {
 
         if (!repository.isHistoryEnabled()) {
             LOGGER.log(Level.INFO,
-                    "Skipping history cache creation of {0} repository in ''{1}'' and its subdirectories",
-                    new Object[]{type, path});
+                    "Skipping history cache creation for {0} and its subdirectories", repository);
             return;
         }
 
         if (repository.isWorking()) {
             Statistics elapsed = new Statistics();
 
-            LOGGER.log(Level.INFO, "Creating history cache for ''{0}'' ({1}) {2} renamed file handling",
-                    new Object[]{path, type, repository.isHandleRenamedFiles() ? "with" : "without"});
+            LOGGER.log(Level.INFO, "Creating history cache for {0}", repository);
 
             try {
                 repository.createCache(historyCache, sinceRevision);
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING,
-                        String.format("An error occurred while creating cache for '%s' (%s)", path, type), e);
+                        String.format("An error occurred while creating cache for %s", repository), e);
             }
 
-            elapsed.report(LOGGER, String.format("Done history cache for '%s'", path));
+            elapsed.report(LOGGER, String.format("Done history cache for %s", repository));
         } else {
             LOGGER.log(Level.WARNING,
-                    "Skipping creation of history cache of {0} repository in ''{1}'': Missing SCM dependencies?",
-                    new Object[]{type, path});
+                    "Skipping creation of history cache for {0}: Missing SCM dependencies?", repository);
         }
     }
 
@@ -993,10 +990,7 @@ public final class HistoryGuru {
                 latestRev = historyCache.getLatestCachedRevision(repo);
                 repos2process.put(repo, latestRev);
             } catch (CacheException he) {
-                LOGGER.log(Level.WARNING,
-                        String.format(
-                                "Failed to retrieve latest cached revision for %s",
-                                repo.getDirectoryName()), he);
+                LOGGER.log(Level.WARNING, String.format("Failed to retrieve latest cached revision for %s", repo), he);
             }
         }
 
@@ -1033,8 +1027,7 @@ public final class HistoryGuru {
         try {
             historyCache.optimize();
         } catch (CacheException he) {
-            LOGGER.log(Level.WARNING,
-                    "Failed optimizing the history cache database", he);
+            LOGGER.log(Level.WARNING, "Failed optimizing the history cache database", he);
         }
         elapsed.report(LOGGER, "Done history cache for all repositories", "indexer.history.cache");
         setHistoryIndexDone();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -936,8 +936,6 @@ public final class HistoryGuru {
     }
 
     private void createHistoryCache(Repository repository, String sinceRevision) {
-        String path = repository.getDirectoryName();
-        String type = repository.getClass().getSimpleName();
 
         if (!repository.isHistoryEnabled()) {
             LOGGER.log(Level.INFO,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -936,7 +936,6 @@ public final class HistoryGuru {
     }
 
     private void createHistoryCache(Repository repository, String sinceRevision) {
-
         if (!repository.isHistoryEnabled()) {
             LOGGER.log(Level.INFO,
                     "Skipping history cache creation for {0} and its subdirectories", repository);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -425,9 +425,9 @@ public class RepositoryInfo implements Serializable {
     public String toString() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("{");
-        stringBuilder.append("dir=");
+        stringBuilder.append("dir='");
         stringBuilder.append(this.getDirectoryName());
-        stringBuilder.append(",");
+        stringBuilder.append("',");
         stringBuilder.append("type=");
         stringBuilder.append(getType());
         stringBuilder.append(",");


### PR DESCRIPTION
This change alters the logging of repository information when creating history cache. The current logging merely reports repository type/path and whether renamed file handling is on, however all of this can be gotten from the `toString()` repository method with other useful fields, such as merge changeset handling.

While at it, I also performed some cleanup in related areas.