### PR TITLE
add links to file revisions in side diff view

### DIFF
--- a/opengrok-web/src/main/webapp/diff.jsp
+++ b/opengrok-web/src/main/webapp/diff.jsp
@@ -212,11 +212,12 @@ action=download">download diff</a></span><%
         if (type == DiffType.SIDEBYSIDE || type == DiffType.UNIFIED) {
         %><table class="plain" aria-label="table with old and new content"><%
             if (type == DiffType.SIDEBYSIDE) {
-                String linkPrefix = request.getContextPath() + Prefix.XREF_P + Util.htmlize(cfg.getPath());
+                String linkPrefix = request.getContextPath() + Prefix.XREF_P + Util.htmlize(cfg.getPath()) +
+                        "?" + QueryParameters.REVISION_PARAM_EQ;
             %>
             <thead><tr>
-                <th><a href="<%= linkPrefix %>?<%= QueryParameters.REVISION_PARAM_EQ %><%= data.getRev(0) %>"><%= data.getFilename() %> (<%= data.getRev(0) %>)</a></th>
-                <th><a href="<%= linkPrefix %>?<%= QueryParameters.REVISION_PARAM_EQ %><%= data.getRev(1) %>"><%= data.getFilename() %> (<%= data.getRev(1) %>)</a></th>
+                <th><a href="<%= linkPrefix %><%= data.getRev(0) %>"><%= data.getFilename() %> (<%= data.getRev(0) %>)</a></th>
+                <th><a href="<%= linkPrefix %><%= data.getRev(1) %>"><%= data.getFilename() %> (<%= data.getRev(1) %>)</a></th>
             </tr></thead><%
             }
             %>

--- a/opengrok-web/src/main/webapp/diff.jsp
+++ b/opengrok-web/src/main/webapp/diff.jsp
@@ -212,10 +212,11 @@ action=download">download diff</a></span><%
         if (type == DiffType.SIDEBYSIDE || type == DiffType.UNIFIED) {
         %><table class="plain" aria-label="table with old and new content"><%
             if (type == DiffType.SIDEBYSIDE) {
+                String linkPrefix = request.getContextPath() + Prefix.XREF_P + Util.htmlize(cfg.getPath());
             %>
             <thead><tr>
-                <th><%= data.getFilename() %> (<%= data.getRev(0) %>)</th>
-                <th><%= data.getFilename() %> (<%= data.getRev(1) %>)</th>
+                <th><a href="<%= linkPrefix %>?<%= QueryParameters.REVISION_PARAM_EQ %><%= data.getRev(0) %>"><%= data.getFilename() %> (<%= data.getRev(0) %>)</a></th>
+                <th><a href="<%= linkPrefix %>?<%= QueryParameters.REVISION_PARAM_EQ %><%= data.getRev(1) %>"><%= data.getFilename() %> (<%= data.getRev(1) %>)</a></th>
             </tr></thead><%
             }
             %>


### PR DESCRIPTION
When trying to identify a change, I often use annotate view, then click the 'S' link to search for changes in particular changeset, then use the diff view for a file. To pinpoint the change, I often need to display annotations for older revision of the file (and repeat the cycle). To aid this, I added links to file revisions in diff view:
![image](https://user-images.githubusercontent.com/2934284/232493598-c2a3c5d4-92bf-4166-b170-393dc635ef0e.png)

Not sure whether to shorten the revision IDs (in the parens), so leaving them as they are for now.