### PR TITLE
directory listing API

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -198,7 +198,7 @@ The `Content-type` header of the reply will be set accordingly.
 
 
 
-## Directory listing [/list?path]
+## Directory listing [/list{?path}]
 
 ### get directory entries [GET]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -197,6 +197,41 @@ The `Content-type` header of the reply will be set accordingly.
             }
 
 
+
+## Directory listing [/list?path]
+
+### get directory entries [GET]
+
++ Parameters
+  + path (string) - path of file/directory to get listing for, relative to source root, starting with /
+
++ Response 200 (application/json)
+  + Body
+
+            [
+              {
+                "path": "/lucene/.github",
+                "numLines": 178,
+                "loc": 125,
+                "date": 1673456294670,
+                "description": null,
+                "pathDescription": "",
+                "isDirectory": true,
+                "size": null
+              },
+              {
+                "path": "/lucene/.asf.yaml",
+                "numLines": 25,
+                "loc": 21,
+                "date": 1673456294670,
+                "description": null,
+                "pathDescription": "",
+                "isDirectory": false,
+                "size": 574
+              }
+            ]
+
+
 ## Include files reload [/system/includes/reload]
 
 ### reloads all include files for web application [PUT]

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -712,13 +712,14 @@ public final class HistoryGuru {
     }
 
     /**
-     * Get the last modified times and descriptions for all files and subdirectories in the specified directory.
+     * Get the last modified times and descriptions for all files and subdirectories in the specified directory
+     * and set it into the entries provided.
      * @param directory the directory whose files to check
      * @param entries list of {@link DirectoryEntry} instances
      * @return whether to fall back to file system based time stamps if the date is {@code null}
      * @throws org.opengrok.indexer.history.CacheException if history cannot be retrieved
      */
-    public boolean getLastHistoryEntries(File directory, List<DirectoryEntry> entries) throws CacheException {
+    public boolean fillLastHistoryEntries(File directory, List<DirectoryEntry> entries) throws CacheException {
 
         if (!env.isUseHistoryCacheForDirectoryListing()) {
             LOGGER.log(Level.FINEST, "using history cache to retrieve last modified times for ''{0}}'' is disabled",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryEntry.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryEntry.java
@@ -35,9 +35,11 @@ import java.util.Date;
 public class DirectoryEntry {
 
     private final File file;
-    private final NullableNumLinesLOC extra;
+    private NullableNumLinesLOC extra;
 
     private String description;
+
+    private String pathDescription;
 
     private Date date;
 
@@ -77,6 +79,10 @@ public class DirectoryEntry {
         return extra;
     }
 
+    public void setExtra(NullableNumLinesLOC extra) {
+        this.extra = extra;
+    }
+
     public String getDescription() {
         return description;
     }
@@ -91,5 +97,13 @@ public class DirectoryEntry {
 
     public void setDate(Date date) {
         this.date = date;
+    }
+
+    public String getPathDescription() {
+        return pathDescription;
+    }
+
+    public void setPathDescription(String pathDescription) {
+        this.pathDescription = pathDescription;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryExtraReader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/DirectoryExtraReader.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search;
@@ -59,8 +59,7 @@ public class DirectoryExtraReader {
      * @return a list of results, limited to 2000 values
      * @throws IOException if an error occurs searching the index
      */
-    public List<NullableNumLinesLOC> search(IndexSearcher searcher, String path)
-            throws IOException {
+    public List<NullableNumLinesLOC> search(IndexSearcher searcher, String path) throws IOException {
         if (searcher == null) {
             throw new IllegalArgumentException("`searcher' is null");
         }
@@ -87,9 +86,7 @@ public class DirectoryExtraReader {
                 "search.latency", new String[]{"category", "extra",
                         "outcome", hits.scoreDocs.length > 0 ? "success" : "empty"});
 
-        List<NullableNumLinesLOC> results = processHits(searcher, hits);
-
-        return results;
+        return processHits(searcher, hits);
     }
 
     private List<NullableNumLinesLOC> processHits(IndexSearcher searcher, TopDocs hits)

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/FileExtraZipper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/FileExtraZipper.java
@@ -18,16 +18,15 @@
  */
 
 /*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.util;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.opengrok.indexer.analysis.NullableNumLinesLOC;
 import org.opengrok.indexer.search.DirectoryEntry;
@@ -41,29 +40,23 @@ public class FileExtraZipper {
 
     /**
      * Merge the specified lists by looking up a possible entry in
-     * {@code extras} for every element in {@code files}.
-     * @param dir the files' directory
-     * @param files the file names
-     * @param extras some OpenGrok-analyzed extra metadata
-     * @return a list of the same size as {@code files}
+     * {@code extras} for every element in {@code entries}.
+     *
+     * @param entries list of {@link DirectoryEntry} instances
+     * @param extras  some OpenGrok-analyzed extra metadata
      */
-    public List<DirectoryEntry> zip(File dir, List<String> files, List<NullableNumLinesLOC> extras) {
+    public void zip(List<DirectoryEntry> entries, List<NullableNumLinesLOC> extras) {
 
         if (extras == null) {
-            return files.stream().map(f -> new DirectoryEntry(new File(dir, f))).collect(Collectors.toList());
+            return;
         }
 
         Map<String, NullableNumLinesLOC> byName = indexExtraByName(extras);
 
-        List<DirectoryEntry> result = new ArrayList<>(files.size());
-        for (String file : files) {
-            File fileobj = new File(dir, file);
-            NullableNumLinesLOC extra = findExtra(byName, fileobj);
-            DirectoryEntry entry = new DirectoryEntry(fileobj, extra);
-            result.add(entry);
+        for (DirectoryEntry entry : entries) {
+            NullableNumLinesLOC extra = findExtra(byName, entry.getFile());
+            entry.setExtra(extra);
         }
-
-        return result;
     }
 
     private NullableNumLinesLOC findExtra(Map<String, NullableNumLinesLOC> byName, File fileobj) {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -452,7 +452,7 @@ public class HistoryGuruTest {
         }
         boolean useHistoryCacheForDirectoryListingOrig = env.isUseHistoryCacheForDirectoryListing();
         env.setUseHistoryCacheForDirectoryListing(true);
-        boolean fallback = instance.getLastHistoryEntries(repositoryRoot, directoryEntries);
+        boolean fallback = instance.fillLastHistoryEntries(repositoryRoot, directoryEntries);
         if (isMergeCommitsEnabled) {
             assertFalse(fallback);
         } else {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/DummyHttpServletRequest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/DummyHttpServletRequest.java
@@ -182,8 +182,17 @@ public class DummyHttpServletRequest implements HttpServletRequest {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
+    private String contextPath;
+
+    public void setContextPath(String contextPath) {
+        this.contextPath = contextPath;
+    }
+
     @Override
     public String getContextPath() {
+        if (contextPath != null) {
+            return contextPath;
+        }
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
@@ -224,7 +233,16 @@ public class DummyHttpServletRequest implements HttpServletRequest {
 
     @Override
     public String getServletPath() {
+        if (servletPath != null) {
+            return servletPath;
+        }
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    private String servletPath;
+
+    public void setServletPath(String path) {
+        this.servletPath = path;
     }
 
     @Override

--- a/opengrok-web/src/main/java/org/opengrok/web/DirectoryListing.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/DirectoryListing.java
@@ -151,7 +151,8 @@ public class DirectoryListing {
      * @param dir the directory to list
      * @param path virtual path of the directory (usually the path name of
      *        <var>dir</var> with the source root directory stripped off).
-     * @return list of {@link DirectoryEntry} instances
+     * @param files list of file paths
+     * @return list of {@link DirectoryEntry} instances, filtered via {@link PathAccepter}
      * @throws CacheException if history cache operation failed
      */
     public List<DirectoryEntry> createDirectoryEntries(File dir, String path, List<String> files) throws CacheException {
@@ -220,7 +221,6 @@ public class DirectoryListing {
      * @param entries basenames of potential children of the directory to list,
      *  assuming that these were filtered by {@link PathAccepter}.
      * @throws IOException when cannot write to the {@code out} parameter
-     * @throws CacheException when failed to get last modified time for files in directory
      */
     public void extraListTo(String contextPath, File dir, Writer out,
                                     String path, @Nullable List<DirectoryEntry> entries) throws IOException {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/ApiTaskManager.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/ApiTaskManager.java
@@ -139,6 +139,7 @@ public final class ApiTaskManager {
 
     /**
      * Shutdown all executor services and wait 60 seconds for pending tasks.
+     * @throws InterruptedException on termination
      */
     public synchronized void shutdown() throws InterruptedException {
         for (ExecutorService executorService : queues.values()) {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/DirectoryListingController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/DirectoryListingController.java
@@ -1,0 +1,194 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.api.v1.controller;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import org.jetbrains.annotations.VisibleForTesting;
+import org.opengrok.indexer.analysis.NullableNumLinesLOC;
+import org.opengrok.indexer.configuration.Project;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.history.CacheException;
+import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.search.DirectoryEntry;
+import org.opengrok.indexer.util.FileExtraZipper;
+import org.opengrok.indexer.util.ForbiddenSymlinkException;
+import org.opengrok.indexer.web.messages.JSONable;
+import org.opengrok.web.DirectoryListing;
+import org.opengrok.web.PageConfig;
+import org.opengrok.web.api.v1.filter.CorsEnable;
+import org.opengrok.web.api.v1.filter.PathAuthorized;
+import org.opengrok.web.util.NoPathParameterException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.opengrok.web.util.FileUtil.toFile;
+
+@Path(DirectoryListingController.PATH)
+public class DirectoryListingController {
+
+    public static final String PATH = "/list";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DirectoryListingController.class);
+
+    static class DirectoryEntryDTO implements JSONable {
+        @JsonProperty
+        String path;
+        @JsonProperty
+        Long numLines;
+        @JsonProperty
+        Long loc;
+        @JsonProperty
+        Date date;
+        @JsonProperty
+        String description;
+        @JsonProperty
+        String pathDescription;
+        @JsonProperty
+        boolean isDirectory;
+        @JsonProperty
+        Long size;
+
+        // Needed for deserialization when testing.
+        DirectoryEntryDTO() {
+        }
+
+        DirectoryEntryDTO(DirectoryEntry entry) throws ForbiddenSymlinkException, IOException {
+            path = RuntimeEnvironment.getInstance().getPathRelativeToSourceRoot(entry.getFile());
+            NullableNumLinesLOC extra = entry.getExtra();
+            if (extra != null) {
+                loc = entry.getExtra().getLOC();
+                numLines = entry.getExtra().getNumLines();
+            }
+            date = entry.getDate();
+            description = entry.getDescription();
+            pathDescription = entry.getPathDescription();
+            isDirectory = entry.getFile().isDirectory();
+            if (isDirectory) {
+                size = null;
+            } else {
+                size = entry.getFile().length();
+            }
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final DirectoryEntryDTO other = (DirectoryEntryDTO) obj;
+
+            if (!Objects.equals(this.path, other.path)) {
+                return false;
+            }
+            if (!Objects.equals(this.date, other.date)) {
+                return false;
+            }
+            if (!Objects.equals(this.numLines, other.numLines)) {
+                return false;
+            }
+            if (!Objects.equals(this.loc, other.loc)) {
+                return false;
+            }
+            if (!Objects.equals(this.description, other.description)) {
+                return false;
+            }
+            if (!Objects.equals(this.pathDescription, other.pathDescription)) {
+                return false;
+            }
+            if (this.isDirectory != other.isDirectory) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(path, date, numLines, loc, description, pathDescription, isDirectory);
+        }
+
+        @Override
+        public String toString() {
+            return "{" + "path=" + path + ",date=" + date + ",numLines=" + numLines + ",loc=" + loc +
+                    ",description=" + description + ",pathDescription=" + pathDescription +
+                    ",isDirectory=" + isDirectory + "}";
+        }
+    }
+
+    @VisibleForTesting
+    static List<DirectoryEntryDTO> getDirectoryEntriesDTO(List<DirectoryEntry> entries) {
+        List<DirectoryEntryDTO> result = new ArrayList<>(entries.size());
+        for (DirectoryEntry entry : entries) {
+            DirectoryEntryDTO directoryEntryDTO = null;
+            try {
+                directoryEntryDTO = new DirectoryEntryDTO(entry);
+            } catch (IOException | ForbiddenSymlinkException e) {
+                LOGGER.log(Level.WARNING, "TODO");
+            }
+            result.add(directoryEntryDTO);
+        }
+        return result;
+    }
+
+    @GET
+    @CorsEnable
+    @PathAuthorized
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<DirectoryEntryDTO> getDirectoryListing(@Context HttpServletRequest request,
+                                             @Context HttpServletResponse response,
+                                             @QueryParam("path") final String path)
+            throws IOException, NoPathParameterException, CacheException {
+
+        File file = toFile(path);
+        PageConfig cfg = PageConfig.get(path, request);
+        DirectoryListing dl = new DirectoryListing();
+        List<String> files = cfg.getResourceFileList();
+
+        List<DirectoryEntry> entries = dl.createDirectoryEntries(file, path, files);
+
+        Project project = Project.getProject(path);
+        List<NullableNumLinesLOC> extras = cfg.getExtras(project, request);
+        FileExtraZipper zipper = new FileExtraZipper();
+        zipper.zip(entries, extras);
+
+        return getDirectoryEntriesDTO(entries);
+    }
+}

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/DirectoryListingController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/DirectoryListingController.java
@@ -40,6 +40,7 @@ import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.search.DirectoryEntry;
 import org.opengrok.indexer.util.FileExtraZipper;
 import org.opengrok.indexer.util.ForbiddenSymlinkException;
+import org.opengrok.indexer.web.Util;
 import org.opengrok.indexer.web.messages.JSONable;
 import org.opengrok.web.DirectoryListing;
 import org.opengrok.web.PageConfig;
@@ -88,7 +89,7 @@ public class DirectoryListingController {
         }
 
         DirectoryEntryDTO(DirectoryEntry entry) throws ForbiddenSymlinkException, IOException {
-            path = RuntimeEnvironment.getInstance().getPathRelativeToSourceRoot(entry.getFile());
+            path = Util.fixPathIfWindows(RuntimeEnvironment.getInstance().getPathRelativeToSourceRoot(entry.getFile()));
             NullableNumLinesLOC extra = entry.getExtra();
             if (extra != null) {
                 loc = entry.getExtra().getLOC();

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/suggester/provider/service/SuggesterService.java
@@ -66,6 +66,7 @@ public interface SuggesterService {
      * Wait for rebuild. For testing.
      * @param timeout timeout to wait for
      * @param unit timeout unit
+     * @throws InterruptedException on termination
      */
     void waitForRebuild(long timeout, TimeUnit unit) throws InterruptedException;
 

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -169,9 +169,9 @@ document.pageReady.push(function() { pageReadyList();});
 
             List<String> readMes = null;
             if (entries != null) {
-                // TODO: startsWith || endsWith
                 readMes = entries.stream().
-                        filter(e -> e.getFile().getName().toLowerCase(Locale.ROOT).contains("readme")).
+                        filter(e -> e.getFile().getName().toLowerCase(Locale.ROOT).startsWith("readme") ||
+                                e.getFile().getName().toLowerCase(Locale.ROOT).endsWith("readme")).
                         map(e -> e.getFile().getName()).
                         collect(Collectors.toList());
             }

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -26,16 +26,13 @@ java.io.BufferedInputStream,
 java.io.File,
 java.io.FileInputStream,
 java.io.InputStreamReader,
-java.io.IOException,
 java.io.Reader,
 java.net.URLEncoder,
 java.nio.charset.StandardCharsets,
 java.util.List,
 java.util.Locale,
-java.util.logging.Level,
 java.util.logging.Logger,
 java.util.Set,
-java.util.TreeSet,
 org.opengrok.indexer.analysis.AnalyzerGuru,
 org.opengrok.indexer.analysis.Definitions,
 org.opengrok.indexer.analysis.AbstractAnalyzer,
@@ -45,17 +42,19 @@ org.opengrok.indexer.history.Annotation,
 org.opengrok.indexer.index.IndexDatabase,
 org.opengrok.indexer.logger.LoggerFactory,
 org.opengrok.indexer.search.DirectoryEntry,
-org.opengrok.indexer.search.DirectoryExtraReader,
 org.opengrok.indexer.util.FileExtraZipper,
-org.opengrok.indexer.util.ForbiddenSymlinkException,
 org.opengrok.indexer.util.IOUtils,
-org.opengrok.web.DirectoryListing,
-org.opengrok.indexer.web.SearchHelper"
+org.opengrok.web.DirectoryListing"
 %>
 <%@ page import="static org.opengrok.web.PageConfig.DUMMY_REVISION" %>
 <%@ page import="static org.opengrok.indexer.history.LatestRevisionUtil.getLatestRevision" %>
 <%@ page import="org.opengrok.indexer.web.SortOrder" %>
 <%@ page import="jakarta.servlet.http.Cookie" %>
+<%@ page import="java.util.stream.Collectors" %>
+<%@ page import="org.opengrok.indexer.configuration.PathAccepter" %>
+<%@ page import="org.opengrok.indexer.configuration.RuntimeEnvironment" %>
+<%@ page import="java.text.Format" %>
+<%@ page import="java.text.SimpleDateFormat" %>
 <%
 {
     // need to set it here since requesting parameters
@@ -124,8 +123,6 @@ document.pageReady.push(function() { pageReadyList();});
 <%
 /* ---------------------- list.jsp start --------------------- */
 {
-    final Logger LOGGER = LoggerFactory.getLogger(getClass());
-
     PageConfig cfg = PageConfig.get(request);
     String rev = cfg.getRequestedRevision();
     Project project = cfg.getProject();
@@ -161,38 +158,23 @@ document.pageReady.push(function() { pageReadyList();});
         DirectoryListing dl = new DirectoryListing(cfg.getEftarReader());
         List<String> files = cfg.getResourceFileList();
         if (!files.isEmpty()) {
-            List<NullableNumLinesLOC> extras = null;
-            SearchHelper searchHelper = cfg.prepareInternalSearch(SortOrder.RELEVANCY);
-            /*
-             * N.b. searchHelper.destroy() is called via
-             * WebappListener.requestDestroyed() on presence of the following
-             * REQUEST_ATTR.
-             */
-            request.setAttribute(SearchHelper.REQUEST_ATTR, searchHelper);
-            if (project != null) {
-                searchHelper.prepareExec(project);
-            } else {
-                //noinspection Convert2Diamond
-                searchHelper.prepareExec(new TreeSet<String>());
-            }
+            List<DirectoryEntry> entries = dl.createDirectoryEntries(resourceFile, path, files);
 
-            if (searchHelper.getSearcher() != null) {
-                DirectoryExtraReader extraReader = new DirectoryExtraReader();
-                String primePath = path;
-                try {
-                    primePath = searchHelper.getPrimeRelativePath(projectName, path);
-                } catch (IOException | ForbiddenSymlinkException ex) {
-                    LOGGER.log(Level.WARNING, String.format(
-                            "Error getting prime relative for %s", path), ex);
-                }
-                extras = extraReader.search(searchHelper.getSearcher(), primePath);
-            }
-
+            List<NullableNumLinesLOC> extras = cfg.getExtras(project, request);
             FileExtraZipper zipper = new FileExtraZipper();
-            List<DirectoryEntry> entries = zipper.zip(resourceFile, files, extras);
+            zipper.zip(entries, extras);
 
-            List<String> readMes = dl.extraListTo(Util.uriEncodePath(request.getContextPath()),
+            dl.extraListTo(Util.uriEncodePath(request.getContextPath()),
                     resourceFile, out, path, entries);
+
+            List<String> readMes = null;
+            if (entries != null) {
+                // TODO: startsWith || endsWith
+                readMes = entries.stream().
+                        filter(e -> e.getFile().getName().toLowerCase(Locale.ROOT).contains("readme")).
+                        map(e -> e.getFile().getName()).
+                        collect(Collectors.toList());
+            }
 
             File[] catfiles = cfg.findDataFiles(readMes);
             for (int i = 0; i < catfiles.length; i++) {

--- a/opengrok-web/src/main/webapp/xref.jspf
+++ b/opengrok-web/src/main/webapp/xref.jspf
@@ -52,6 +52,8 @@ org.opengrok.indexer.web.QueryParameters"
     Genre g = AnalyzerGuru.getGenre(a);
     String error = null;
 
+    final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
     if (g == Genre.PLAIN || g == Genre.HTML || g == null) {
         InputStream in = null;
         File tempf = null;

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -248,7 +248,7 @@ public class PageConfigTest {
         assertTrue(file.isFile());
 
         // Make sure the regular file is last.
-        List<String> entries = pageConfig.getSortedFiles(sourceRootFile.listFiles());
+        List<String> entries = PageConfig.getSortedFiles(sourceRootFile.listFiles());
         assertNotNull(entries);
         assertFalse(entries.isEmpty());
         int numEntries = entries.size();
@@ -260,7 +260,7 @@ public class PageConfigTest {
         Files.createSymbolicLink(link, target);
 
         // Check the symlink was sorted as file.
-        entries = pageConfig.getSortedFiles(sourceRootFile.listFiles());
+        entries = PageConfig.getSortedFiles(sourceRootFile.listFiles());
         assertNotNull(entries);
         assertFalse(entries.isEmpty());
         assertEquals(numEntries + 1, entries.size());

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/DirectoryListingControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/DirectoryListingControllerTest.java
@@ -1,0 +1,206 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.api.v1.controller;
+
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.analysis.NullableNumLinesLOC;
+import org.opengrok.indexer.configuration.Project;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.history.HistoryGuru;
+import org.opengrok.indexer.history.RepositoryFactory;
+import org.opengrok.indexer.index.Indexer;
+import org.opengrok.indexer.search.DirectoryEntry;
+import org.opengrok.indexer.util.FileExtraZipper;
+import org.opengrok.indexer.util.TestRepository;
+import org.opengrok.indexer.web.DummyHttpServletRequest;
+import org.opengrok.indexer.web.SearchHelper;
+import org.opengrok.indexer.web.SortOrder;
+import org.opengrok.web.DirectoryListing;
+import org.opengrok.web.PageConfig;
+import org.opengrok.web.api.v1.RestApp;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opengrok.web.api.v1.controller.DirectoryListingController.getDirectoryEntriesDTO;
+
+public class DirectoryListingControllerTest extends OGKJerseyTest {
+    private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+    private TestRepository repository;
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
+    }
+
+    @Override
+    protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
+        return new GrizzlyWebTestContainerFactory();
+    }
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        repository = new TestRepository();
+        repository.create(HistoryGuru.class.getResource("/repositories"));
+
+        env.setSourceRoot(repository.getSourceRoot());
+        env.setDataRoot(repository.getDataRoot());
+        env.setProjectsEnabled(true);
+        env.setHistoryEnabled(true);
+        RepositoryFactory.initializeIgnoredNames(env);
+
+        Indexer.getInstance().prepareIndexer(
+                env,
+                true, // search for repositories
+                true, // scan and add projects
+                // don't create dictionary
+                null, // subFiles - needed when refreshing history partially
+                null); // repositories - needed when refreshing history partially
+
+        // Run the indexer so that LOC fields are populated.
+        Indexer.getInstance().doIndexerExecution(Collections.singletonList("/git"), null);
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        // This should match Configuration constructor.
+        env.setProjects(new ConcurrentHashMap<>());
+        env.setRepositories(new ArrayList<>());
+        env.getProjectRepositoriesMap().clear();
+
+        repository.destroy();
+    }
+
+    /**
+     * Basic negative test that two {@link DirectoryListingController.DirectoryEntryDTO}
+     * instances are not equal if their paths are not equal.
+     * Also makes a nice test for
+     * {@link DirectoryListingController.DirectoryEntryDTO#DirectoryEntryDTO(DirectoryEntry)}
+     * in the case when the 'extra' field carrying LOC is {@code null}.
+     * Ideally, all the fields should be tested like this.
+     */
+    @Test
+    void testDirectoryEntryDTONotEquals() throws Exception {
+        File file1 = Path.of(repository.getSourceRoot(), "git", "main.c").toFile();
+        DirectoryEntry entry1 = new DirectoryEntry(file1);
+        assertNull(entry1.getExtra());
+        DirectoryListingController.DirectoryEntryDTO entryDTO1 = new DirectoryListingController.DirectoryEntryDTO(entry1);
+
+        File file2 = Path.of(repository.getSourceRoot(), "git", "header.h").toFile();
+        DirectoryEntry entry2 = new DirectoryEntry(file2);
+        assertNull(entry2.getExtra());
+        DirectoryListingController.DirectoryEntryDTO entryDTO2 = new DirectoryListingController.DirectoryEntryDTO(entry2);
+
+        assertNotEquals(entryDTO1, entryDTO2);
+    }
+
+    /**
+     * Basic positive test of {@link DirectoryListingController.DirectoryEntryDTO#DirectoryEntryDTO(DirectoryEntry)}.
+     */
+    @Test
+    void testDirectoryEntryDTOConstruction() throws Exception {
+        File file = Path.of(repository.getSourceRoot(), "git", "main.c").toFile();
+        DirectoryEntry entry = new DirectoryEntry(file);
+        final Date date = new Date(123000000);
+        entry.setDate(date);
+        final String description = "foo";
+        entry.setDescription(description);
+        final String pathDescription = "bar";
+        entry.setPathDescription(pathDescription);
+        NullableNumLinesLOC extra = new NullableNumLinesLOC("/git/main.c", 42L, 24L);
+        entry.setExtra(extra);
+        DirectoryListingController.DirectoryEntryDTO entryDTO = new DirectoryListingController.DirectoryEntryDTO(entry);
+
+        DirectoryListingController.DirectoryEntryDTO entryDTOexp = new DirectoryListingController.DirectoryEntryDTO();
+        entryDTOexp.path = "/git/main.c";
+        entryDTOexp.date = date;
+        entryDTOexp.description = description;
+        entryDTOexp.pathDescription = pathDescription;
+        entryDTOexp.numLines = 42L;
+        entryDTOexp.loc = 24L;
+
+        assertEquals(entryDTOexp, entryDTO);
+    }
+
+    @Test
+    void testDirectoryListing() throws Exception {
+        final String path = "git";
+        int size = 6;
+        Response response = target("list")
+                .queryParam("path", "/" + path)
+                .request()
+                .get();
+        List<DirectoryListingController.DirectoryEntryDTO> entriesResp = response.readEntity(new GenericType<>() {
+        });
+        assertNotNull(entriesResp);
+        assertEquals(size, entriesResp.size());
+
+        File file = new File(repository.getSourceRoot(), path);
+        assertTrue(file.isDirectory());
+        DirectoryListing dl = new DirectoryListing();
+        File[] files = file.listFiles();
+        List<DirectoryEntry> entries = dl.createDirectoryEntries(file, path, PageConfig.getSortedFiles(files));
+
+        Project project = Project.getProject("/" + path);
+        assertNotNull(project);
+        DummyHttpServletRequest request = new DummyHttpServletRequest();
+        request.setContextPath("foo");
+        request.setServletPath("bar");
+        PageConfig pageConfig = PageConfig.get(path, request);
+        SearchHelper searchHelper = pageConfig.prepareInternalSearch(SortOrder.RELEVANCY);
+        searchHelper.prepareExec(project);
+        List<NullableNumLinesLOC> extras = pageConfig.getNullableNumLinesLOCS(project, searchHelper);
+        FileExtraZipper zipper = new FileExtraZipper();
+        zipper.zip(entries, extras);
+
+        List<DirectoryListingController.DirectoryEntryDTO> entriesDTO = getDirectoryEntriesDTO(entries);
+        assertEquals(entriesDTO.size(), entriesResp.size());
+        assertEquals(entriesDTO, entriesResp);
+    }
+}


### PR DESCRIPTION
This change introduces directory listing API.

There are couple of limitations:
  - only directories are supported at the moment, i.e. one cannot get the properties of individual file
  - not possible to list source root directly
  - There is no paging (like for the `/history` API endpoint); it is assumed that the number of entries in a directory is fairly low (hundreds of files).
  - the tests ought to have bigger coverage (DTO entry comparison, with/without extras, with path descriptions, authorization test, etc.)

At one point I contemplated moving the HTML production to a JSP, like it is mentioned in the comment in `DirectoryListing#extraListTo()`, however decided not to because the tests rely on the HTML/XML parsing.