### PR TITLE
avoid NPE in LDAP authorization plugins by checking the attribute first

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapAttrPlugin.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin;
 
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.logging.Level;
@@ -43,10 +44,10 @@ import org.opengrok.indexer.configuration.Project;
 
 /**
  * Authorization plug-in to check user's LDAP attribute against whitelist.
- *
+ * <p>
  * This plugin heavily relies on the presence of the {@code LdapUserPlugin} in the stack above it,
  * since it is using the Distinguished Name of the {@code LdapUser} to perform the LDAP lookup.
- *
+ * </p>
  * @author Krystof Tulinger
  */
 public class LdapAttrPlugin extends AbstractLdapPlugin {
@@ -190,11 +191,11 @@ public class LdapAttrPlugin extends AbstractLdapPlugin {
 
     @Override
     public boolean checkEntity(HttpServletRequest request, Project project) {
-        return ((Boolean) request.getSession().getAttribute(sessionAllowed));
+        return ((Boolean) Objects.requireNonNullElse(request.getSession().getAttribute(sessionAllowed), false));
     }
 
     @Override
     public boolean checkEntity(HttpServletRequest request, Group group) {
-        return ((Boolean) request.getSession().getAttribute(sessionAllowed));
+        return ((Boolean) Objects.requireNonNullElse(request.getSession().getAttribute(sessionAllowed), false));
     }
 }

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapFilterPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapFilterPlugin.java
@@ -18,12 +18,13 @@
  */
 
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin;
 
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
@@ -196,11 +197,11 @@ public class LdapFilterPlugin extends AbstractLdapPlugin {
 
     @Override
     public boolean checkEntity(HttpServletRequest request, Project project) {
-        return ((Boolean) request.getSession().getAttribute(sessionAllowed));
+        return ((Boolean) Objects.requireNonNullElse(request.getSession().getAttribute(sessionAllowed), false));
     }
 
     @Override
     public boolean checkEntity(HttpServletRequest request, Group group) {
-        return ((Boolean) request.getSession().getAttribute(sessionAllowed));
+        return ((Boolean) Objects.requireNonNullElse(request.getSession().getAttribute(sessionAllowed), false));
     }
 }


### PR DESCRIPTION
This change avoids NPE in LDAP authorization plugins. Tested on the same system I reproduced the bug first.