### PR TITLE
enable merge commits by default

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -585,7 +585,7 @@ public final class Configuration {
         //mandoc is default(String)
         setMaxSearchThreadCount(2 * Runtime.getRuntime().availableProcessors());
         setMaxRevisionThreadCount(Runtime.getRuntime().availableProcessors());
-        setMergeCommitsEnabled(false);
+        setMergeCommitsEnabled(true);
         setMessageLimit(500);
         setNavigateWindowEnabled(false);
         setNestingMaximum(1);


### PR DESCRIPTION
This change enables merge commits by default. The reason being is that they are frequently used and the view would be incomplete without these. Also, the default mode of operation should not be tailored for big deployments where it might matter performance wise.

Will require reindex from scratch due to history cache contents being changed.

As a side effect, the dates in directory listing will be taken from history cache by default.