### PR TITLE
add directory listing statistics

### DIFF
--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -31,7 +31,6 @@ java.net.URLEncoder,
 java.nio.charset.StandardCharsets,
 java.util.List,
 java.util.Locale,
-java.util.logging.Logger,
 java.util.Set,
 org.opengrok.indexer.analysis.AnalyzerGuru,
 org.opengrok.indexer.analysis.Definitions,
@@ -40,7 +39,6 @@ org.opengrok.indexer.analysis.AnalyzerFactory,
 org.opengrok.indexer.analysis.NullableNumLinesLOC,
 org.opengrok.indexer.history.Annotation,
 org.opengrok.indexer.index.IndexDatabase,
-org.opengrok.indexer.logger.LoggerFactory,
 org.opengrok.indexer.search.DirectoryEntry,
 org.opengrok.indexer.util.FileExtraZipper,
 org.opengrok.indexer.util.IOUtils,
@@ -48,13 +46,8 @@ org.opengrok.web.DirectoryListing"
 %>
 <%@ page import="static org.opengrok.web.PageConfig.DUMMY_REVISION" %>
 <%@ page import="static org.opengrok.indexer.history.LatestRevisionUtil.getLatestRevision" %>
-<%@ page import="org.opengrok.indexer.web.SortOrder" %>
 <%@ page import="jakarta.servlet.http.Cookie" %>
 <%@ page import="java.util.stream.Collectors" %>
-<%@ page import="org.opengrok.indexer.configuration.PathAccepter" %>
-<%@ page import="org.opengrok.indexer.configuration.RuntimeEnvironment" %>
-<%@ page import="java.text.Format" %>
-<%@ page import="java.text.SimpleDateFormat" %>
 <%
 {
     // need to set it here since requesting parameters

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -48,6 +48,9 @@ org.opengrok.web.DirectoryListing"
 <%@ page import="static org.opengrok.indexer.history.LatestRevisionUtil.getLatestRevision" %>
 <%@ page import="jakarta.servlet.http.Cookie" %>
 <%@ page import="java.util.stream.Collectors" %>
+<%@ page import="org.opengrok.indexer.util.Statistics" %>
+<%@ page import="org.opengrok.indexer.logger.LoggerFactory" %>
+<%@ page import="java.util.logging.Logger" %>
 <%
 {
     // need to set it here since requesting parameters
@@ -116,6 +119,8 @@ document.pageReady.push(function() { pageReadyList();});
 <%
 /* ---------------------- list.jsp start --------------------- */
 {
+    final Logger LOGGER = LoggerFactory.getLogger(getClass());
+
     PageConfig cfg = PageConfig.get(request);
     String rev = cfg.getRequestedRevision();
     Project project = cfg.getProject();
@@ -128,6 +133,8 @@ document.pageReady.push(function() { pageReadyList();});
     String rawPath = request.getContextPath() + Prefix.DOWNLOAD_P + path;
     Reader r = null;
     if (cfg.isDir()) {
+        Statistics statistics = new Statistics();
+
         // valid resource is requested
         // mast.jsp assures, that resourceFile is valid and not /
         // see cfg.resourceNotAvailable()
@@ -201,6 +208,8 @@ document.pageReady.push(function() { pageReadyList();});
 
             }
         }
+
+        statistics.report(LOGGER, Level.FINE, "directory listing done", "dir.list.latency");
     } else if (rev.length() != 0) {
         // requesting a revision
         File xrefFile;

--- a/opengrok-web/src/main/webapp/xref.jspf
+++ b/opengrok-web/src/main/webapp/xref.jspf
@@ -52,8 +52,6 @@ org.opengrok.indexer.web.QueryParameters"
     Genre g = AnalyzerGuru.getGenre(a);
     String error = null;
 
-    final Logger LOGGER = LoggerFactory.getLogger(getClass());
-
     if (g == Genre.PLAIN || g == Genre.HTML || g == null) {
         InputStream in = null;
         File tempf = null;


### PR DESCRIPTION
The directory listing latency falls under the `xref` thanks to how the path is constructed and to `StatisticsFilter`. This change adds a separate log and mater for directory listing. This might be useful to track down the latencies, esp. when using history cache to display dates/titles.