### PR TITLE
add TreeMap for Groups serialization

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationClassLoader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigurationClassLoader.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.configuration;
 
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -70,6 +71,7 @@ public class ConfigurationClassLoader extends ClassLoader {
             StatsdFlavor.class,
             String.class,
             SuggesterConfig.class,
+            TreeMap.class,
             TreeSet.class,
             XMLDecoder.class
     ).stream().map(Class::getName).collect(Collectors.toSet());


### PR DESCRIPTION
After deploying 1.12.1 with the groups changed to map, the indexer failed due to `TreeMap` not being included in the white list of classed allowed for `Configuration` serialization. This likely surfaced only after configuration merge.