### PR TITLE
return correct results for configuration API calls

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ConfigurationController.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -81,7 +81,7 @@ public class ConfigurationController {
                     env.applyConfig(body, reindex, CommandTimeoutType.RESTFUL);
                     suggesterService.refresh();
                     return null;
-                }));
+                }, Response.Status.CREATED));
     }
 
     @GET
@@ -104,7 +104,7 @@ public class ConfigurationController {
                     env.applyConfig(false, CommandTimeoutType.RESTFUL);
                     suggesterService.refresh();
                     return null;
-                }));
+                }, Response.Status.NO_CONTENT));
     }
 
     @POST

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ConfigurationControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ConfigurationControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -97,7 +97,8 @@ class ConfigurationControllerTest extends OGKJerseyTest {
         Response response = target("configuration")
                 .request()
                 .put(Entity.xml(configStr));
-        ApiUtils.waitForAsyncApi(response);
+        Response finalResponse = ApiUtils.waitForAsyncApi(response);
+        assertEquals(Response.Status.CREATED.getStatusCode(), finalResponse.getStatus());
 
         assertEquals(srcRoot, env.getSourceRootPath());
 


### PR DESCRIPTION
This change fixes result codes for PUT API calls to the configuration endpoint.