### PR TITLE
use the all-or-nothing semantics for filling directory entries

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -764,6 +764,8 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
             return false;
         }
 
+        boolean ret = true;
+
         for (DirectoryEntry directoryEntry : entries) {
             try {
                 File file = directoryEntry.getFile();
@@ -780,15 +782,23 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
                 } else {
                     LOGGER.log(Level.FINE, "cannot get last history entry for ''{0}''",
                             directoryEntry.getFile());
-                    return false;
+                    ret = false;
+                    break;
                 }
             } catch (CacheException e) {
                 LOGGER.log(Level.FINER, "cannot get last history entry for ''{0}''", directoryEntry.getFile());
-                return false;
+                ret = false;
+                break;
             }
         }
 
-        return true;
+        // Enforce the all-or-nothing semantics.
+        if (!ret) {
+            entries.forEach(e -> e.setDate(null));
+            entries.forEach(e -> e.setDescription(null));
+        }
+
+        return ret;
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -759,9 +759,9 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
     }
 
     @Override
-    public void fillLastHistoryEntries(List<DirectoryEntry> entries) {
+    public boolean fillLastHistoryEntries(List<DirectoryEntry> entries) {
         if (entries == null) {
-            return;
+            return false;
         }
 
         for (DirectoryEntry directoryEntry : entries) {
@@ -780,11 +780,15 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
                 } else {
                     LOGGER.log(Level.FINE, "cannot get last history entry for ''{0}''",
                             directoryEntry.getFile());
+                    return false;
                 }
             } catch (CacheException e) {
                 LOGGER.log(Level.FINER, "cannot get last history entry for ''{0}''", directoryEntry.getFile());
+                return false;
             }
         }
+
+        return true;
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
@@ -95,9 +95,10 @@ interface HistoryCache extends Cache {
      * specified directory.
      *
      * @param entries list of {@link DirectoryEntry} instances
+     * @return whether all directory entries were filled
      * @throws CacheException on error
      */
-    void fillLastHistoryEntries(List<DirectoryEntry> entries) throws CacheException;
+    boolean fillLastHistoryEntries(List<DirectoryEntry> entries) throws CacheException;
 
     /**
      * Clear entry for single file from history cache.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryCache.java
@@ -91,8 +91,8 @@ interface HistoryCache extends Cache {
     @Nullable String getLatestCachedRevision(Repository repository) throws CacheException;
 
     /**
-     * Get the last modified times for all files and subdirectories in the
-     * specified directory.
+     * Get the last modified times and descriptions for all files and subdirectories in the specified directory.
+     * If any of the entries cannot be filled, these properties will be reset for all entries.
      *
      * @param entries list of {@link DirectoryEntry} instances
      * @return whether all directory entries were filled

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -750,9 +750,7 @@ public final class HistoryGuru {
             return true;
         }
 
-        historyCache.fillLastHistoryEntries(entries);
-
-        return false;
+        return !historyCache.fillLastHistoryEntries(entries);
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -1032,10 +1032,8 @@ class FileHistoryCacheTest {
         assertNotNull(files);
         assertTrue(files.length > 0);
         assertTrue(Arrays.stream(files).anyMatch(File::isDirectory));
-        List<DirectoryEntry> directoryEntries = new ArrayList<>();
-        for (File file : files) {
-            directoryEntries.add(new DirectoryEntry(file));
-        }
+        List<DirectoryEntry> directoryEntries = Arrays.stream(files).map(DirectoryEntry::new).
+                collect(Collectors.toList());
 
         assertTrue(spyCache.fillLastHistoryEntries(directoryEntries));
         Mockito.verify(spyCache, never()).getLastHistoryEntry(ArgumentMatchers.eq(subDir));

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -1046,7 +1046,7 @@ class FileHistoryCacheTest {
 
     /**
      * Test {@link FileHistoryCache#fillLastHistoryEntries(List)}, in particular that it
-     * returns {@code false} if some entries cannot be filled.
+     * returns {@code false} and resets date/descriptions if some entries cannot be filled.
      */
     @Test
     void testFillLastHistoryEntriesAllOrNothing() throws Exception {
@@ -1067,6 +1067,8 @@ class FileHistoryCacheTest {
                 collect(Collectors.toList());
 
         assertFalse(spyCache.fillLastHistoryEntries(directoryEntries));
+        assertEquals(0, (int) directoryEntries.stream().filter(e -> e.getDate() != null).count());
+        assertEquals(0, (int) directoryEntries.stream().filter(e -> e.getDescription() != null).count());
 
         // Cleanup.
         cache.clear(repository);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -43,7 +43,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -1058,6 +1058,7 @@ class FileHistoryCacheTest {
         File repositoryRoot = new File(repositories.getSourceRoot(), "git");
         Repository repository = RepositoryFactory.getRepository(repositoryRoot);
         File subFile = new File(repositoryRoot, "file.txt");
+        assertFalse(subFile.exists());
         assertTrue(subFile.createNewFile());
 
         FileHistoryCache spyCache = Mockito.spy(cache);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -1017,6 +1017,9 @@ class FileHistoryCacheTest {
     void testFillLastHistoryEntries() throws Exception {
         File repositoryRoot = new File(repositories.getSourceRoot(), "git");
         Repository repository = RepositoryFactory.getRepository(repositoryRoot);
+
+        // Create non-empty directory without repository involvement. This will be used to check
+        // that fillLastHistoryEntries() does not attempt to get history entry for it.
         File subDir = new File(repositoryRoot, "subdir");
         assertTrue(subDir.mkdir());
         File subFile = new File(subDir, "subfile.txt");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -1040,6 +1040,11 @@ class FileHistoryCacheTest {
         assertTrue(spyCache.fillLastHistoryEntries(directoryEntries));
         Mockito.verify(spyCache, never()).getLastHistoryEntry(ArgumentMatchers.eq(subDir));
 
+        assertEquals(directoryEntries.size() - 3,
+                (int) directoryEntries.stream().filter(e -> e.getDate() != null).count());
+        assertEquals(directoryEntries.size(),
+                (int) directoryEntries.stream().filter(e -> e.getDescription() != null).count());
+
         // Cleanup.
         cache.clear(repository);
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -1057,6 +1057,9 @@ class FileHistoryCacheTest {
     void testFillLastHistoryEntriesAllOrNothing() throws Exception {
         File repositoryRoot = new File(repositories.getSourceRoot(), "git");
         Repository repository = RepositoryFactory.getRepository(repositoryRoot);
+
+        // This file will be created without any repository involvement, therefore it will not be possible
+        // to get history entry for it. This should make fillLastHistoryEntries() to return false.
         File subFile = new File(repositoryRoot, "file.txt");
         assertFalse(subFile.exists());
         assertTrue(subFile.createNewFile());


### PR DESCRIPTION
The comments in PR #4295 mentioned all-or-nothing semantics for getting the dates from history cache, however this is not how it works currently. This change fixes that.