### PR TITLE
parallelize filling directory entries

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -270,6 +270,12 @@ public final class Configuration {
     private int MaxRevisionThreadCount;
 
     /**
+     * Upper bound for number of threads used for getting directory entries.
+     * This is total for the whole webapp.
+     */
+    private int MaxDirectoryListingThreadCount;
+
+    /**
      * If false, do not display listing or projects/repositories on the index page.
      */
     private boolean displayRepositories;
@@ -586,6 +592,7 @@ public final class Configuration {
         //mandoc is default(String)
         setMaxSearchThreadCount(2 * Runtime.getRuntime().availableProcessors());
         setMaxRevisionThreadCount(Runtime.getRuntime().availableProcessors());
+        setMaxDirectoryListingThreadCount(Runtime.getRuntime().availableProcessors());
         setMergeCommitsEnabled(true);
         setMessageLimit(500);
         setNavigateWindowEnabled(false);
@@ -1351,6 +1358,14 @@ public final class Configuration {
 
     public void setMaxRevisionThreadCount(int count) {
         this.MaxRevisionThreadCount = count;
+    }
+
+    public int getMaxDirectoryListingThreadCount() {
+        return MaxDirectoryListingThreadCount;
+    }
+
+    public void setMaxDirectoryListingThreadCount(int count) {
+        this.MaxDirectoryListingThreadCount = count;
     }
 
     public boolean isProjectsEnabled() {

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -204,6 +204,7 @@ public final class WebappListener implements ServletContextListener, ServletRequ
         try {
             env.shutdownRevisionExecutor();
             env.shutdownSearchExecutor();
+            env.shutdownDirectoryListingExecutor();
         } catch (InterruptedException e) {
             LOGGER.log(Level.WARNING, "Could not shutdown revision executor", e);
         }


### PR DESCRIPTION
This change should speed up getting directory listing when history cache is used to get the dates/descriptions for files.