### PR TITLE
name the ForkJoinPool threads

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/OpenGrokThreadFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/OpenGrokThreadFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.configuration;
 
@@ -33,6 +33,8 @@ import java.util.concurrent.ThreadFactory;
 public class OpenGrokThreadFactory implements ThreadFactory {
     private final String threadPrefix;
 
+    public static final String PREFIX = "OpenGrok-";
+
     public OpenGrokThreadFactory(String name) {
         if (!name.endsWith("-")) {
             threadPrefix = name + "-";
@@ -44,7 +46,7 @@ public class OpenGrokThreadFactory implements ThreadFactory {
     @Override
     public Thread newThread(@NotNull Runnable runnable) {
         Thread thread = Executors.defaultThreadFactory().newThread(runnable);
-        thread.setName("OpenGrok-" + threadPrefix + thread.getId());
+        thread.setName(PREFIX + threadPrefix + thread.getId());
         return thread;
     }
 }


### PR DESCRIPTION
This change gives names to thread created by the `ForkJoinPool` in `IndexerParallelizer`. These threads look like this:
```
"OpenGrok-ForkJoinPool-46" #46 daemon prio=5 os_prio=0 cpu=467,38ms elapsed=2,20s tid=0x00007f206c003800 nid=0x3ca62 runnable  [0x00007f20d1aee000]
   java.lang.Thread.State: RUNNABLE
	at sun.nio.cs.UTF_8$Decoder.decodeArrayLoop(java.base@11.0.18/UTF_8.java:320)
	at sun.nio.cs.UTF_8$Decoder.decodeLoop(java.base@11.0.18/UTF_8.java:414)
	at java.nio.charset.CharsetDecoder.decode(java.base@11.0.18/CharsetDecoder.java:576)
	at sun.nio.cs.StreamDecoder.implRead(java.base@11.0.18/StreamDecoder.java:318)
	at sun.nio.cs.StreamDecoder.read(java.base@11.0.18/StreamDecoder.java:178)
	- locked <0x000000063d607bd0> (a java.io.InputStreamReader)
	at java.io.InputStreamReader.read(java.base@11.0.18/InputStreamReader.java:181)
	at org.opengrok.indexer.analysis.ZeroReader.read(ZeroReader.java:58)
	at org.opengrok.indexer.analysis.plain.PlainFullTokenizer.zzRefill(PlainFullTokenizer.java:572)
	at org.opengrok.indexer.analysis.plain.PlainFullTokenizer.yylex(PlainFullTokenizer.java:819)
	at org.opengrok.indexer.analysis.JFlexTokenizer.incrementToken(JFlexTokenizer.java:106)
	at org.apache.lucene.index.IndexingChain$PerField.invert(IndexingChain.java:1128)
	at org.apache.lucene.index.IndexingChain.processField(IndexingChain.java:690)
	at org.apache.lucene.index.IndexingChain.processDocument(IndexingChain.java:575)
	at org.apache.lucene.index.DocumentsWriterPerThread.updateDocuments(DocumentsWriterPerThread.java:242)
	at org.apache.lucene.index.DocumentsWriter.updateDocuments(DocumentsWriter.java:432)
	at org.apache.lucene.index.IndexWriter.updateDocuments(IndexWriter.java:1532)
	at org.apache.lucene.index.IndexWriter.updateDocument(IndexWriter.java:1817)
	at org.apache.lucene.index.IndexWriter.addDocument(IndexWriter.java:1470)
...
```