### PR TITLE
refactor writeXref() code to XrefWork

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/XrefWork.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/XrefWork.java
@@ -38,8 +38,8 @@ import java.util.concurrent.TimeUnit;
 public class XrefWork {
     private Xrefer xrefer;
     private Exception exception;
-    final private WriteXrefArgs args;
-    final private AbstractAnalyzer analyzer;
+    private final WriteXrefArgs args;
+    private final AbstractAnalyzer analyzer;
 
     public XrefWork(WriteXrefArgs args, AbstractAnalyzer analyzer) {
         this.args = args;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.document;
@@ -26,6 +26,8 @@ package org.opengrok.indexer.analysis.document;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.lucene.document.Document;
 import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.opengrok.indexer.analysis.AnalyzerFactory;
@@ -35,6 +37,7 @@ import org.opengrok.indexer.analysis.OGKTextField;
 import org.opengrok.indexer.analysis.StreamSource;
 import org.opengrok.indexer.analysis.TextAnalyzer;
 import org.opengrok.indexer.analysis.WriteXrefArgs;
+import org.opengrok.indexer.analysis.XrefWork;
 import org.opengrok.indexer.analysis.Xrefer;
 import org.opengrok.indexer.search.QueryBuilder;
 
@@ -73,8 +76,7 @@ public class MandocAnalyzer extends TextAnalyzer {
     }
 
     @Override
-    public void analyze(Document doc, StreamSource src, Writer xrefOut)
-        throws IOException {
+    public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException, InterruptedException {
 
         // this is to explicitly use appropriate analyzers tokenstream to
         // workaround #1376 symbols search works like full text search
@@ -87,10 +89,15 @@ public class MandocAnalyzer extends TextAnalyzer {
             try (Reader in = getReader(src.getStream())) {
                 WriteXrefArgs args = new WriteXrefArgs(in, xrefOut);
                 args.setProject(project);
-                Xrefer xref = writeXref(args);
+                XrefWork xrefWork = new XrefWork(args, this);
 
-                String path = doc.get(QueryBuilder.PATH);
-                addNumLinesLOC(doc, new NumLinesLOC(path, xref.getLineNumber(), xref.getLOC()));
+                try {
+                    Xrefer xref = xrefWork.getXrefer();
+                    String path = doc.get(QueryBuilder.PATH);
+                    addNumLinesLOC(doc, new NumLinesLOC(path, xref.getLineNumber(), xref.getLOC()));
+                } catch (ExecutionException e) {
+                    throw new InterruptedException("failed to generate xref :" + e);
+                }
             }
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzer.java
@@ -27,9 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.Writer;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.apache.lucene.document.Document;
@@ -48,7 +46,6 @@ import org.opengrok.indexer.analysis.TextAnalyzer;
 import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.opengrok.indexer.analysis.XrefWork;
 import org.opengrok.indexer.analysis.Xrefer;
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.NullWriter;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/XMLAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/XMLAnalyzer.java
@@ -87,23 +87,12 @@ public class XMLAnalyzer extends TextAnalyzer {
             try (Reader in = getReader(src.getStream())) {
                 WriteXrefArgs args = new WriteXrefArgs(in, xrefOut);
                 args.setProject(project);
-                CompletableFuture<XrefWork> future = CompletableFuture.supplyAsync(() -> {
-                            try {
-                                return new XrefWork(writeXref(args));
-                            } catch (IOException e) {
-                                return new XrefWork(e);
-                            }
-                        }, env.getIndexerParallelizer().getXrefWatcherExecutor()).
-                        orTimeout(env.getXrefTimeout(), TimeUnit.SECONDS);
-                XrefWork xrefWork = future.get(); // Will throw ExecutionException wrapping TimeoutException on timeout.
-                Xrefer xref = xrefWork.xrefer;
+                XrefWork xrefWork = new XrefWork(args, this);
+                Xrefer xref = xrefWork.getXrefer();
 
                 if (xref != null) {
                     String path = doc.get(QueryBuilder.PATH);
                     addNumLinesLOC(doc, new NumLinesLOC(path, xref.getLineNumber(), xref.getLOC()));
-                } else {
-                    // Re-throw the exception from writeXref().
-                    throw new IOException(xrefWork.exception);
                 }
             } catch (ExecutionException e) {
                 throw new InterruptedException("failed to generate xref :" + e);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/XMLAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/XMLAnalyzer.java
@@ -26,9 +26,7 @@ package org.opengrok.indexer.analysis.plain;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.lucene.document.Document;
 import org.opengrok.indexer.analysis.AnalyzerFactory;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/uue/UuencodeAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/uue/UuencodeAnalyzer.java
@@ -38,7 +38,6 @@ import org.opengrok.indexer.analysis.StreamSource;
 import org.opengrok.indexer.analysis.TextAnalyzer;
 import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.opengrok.indexer.analysis.XrefWork;
-import org.opengrok.indexer.analysis.Xrefer;
 import org.opengrok.indexer.search.QueryBuilder;
 
 /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/uue/UuencodeAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/uue/UuencodeAnalyzer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.uue;
@@ -26,6 +26,8 @@ package org.opengrok.indexer.analysis.uue;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.lucene.document.Document;
 import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.opengrok.indexer.analysis.AnalyzerFactory;
@@ -35,6 +37,8 @@ import org.opengrok.indexer.analysis.OGKTextField;
 import org.opengrok.indexer.analysis.StreamSource;
 import org.opengrok.indexer.analysis.TextAnalyzer;
 import org.opengrok.indexer.analysis.WriteXrefArgs;
+import org.opengrok.indexer.analysis.XrefWork;
+import org.opengrok.indexer.analysis.Xrefer;
 import org.opengrok.indexer.search.QueryBuilder;
 
 /**
@@ -74,7 +78,7 @@ public class UuencodeAnalyzer extends TextAnalyzer {
     }
 
     @Override
-    public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException {
+    public void analyze(Document doc, StreamSource src, Writer xrefOut) throws IOException, InterruptedException {
         //this is to explicitly use appropriate analyzers tokenstream to workaround #1376 symbols search works like full text search
         JFlexTokenizer symbolTokenizer = symbolTokenizerFactory.get();
         OGKTextField full = new OGKTextField(QueryBuilder.FULL, symbolTokenizer);
@@ -85,7 +89,12 @@ public class UuencodeAnalyzer extends TextAnalyzer {
             try (Reader in = getReader(src.getStream())) {
                 WriteXrefArgs args = new WriteXrefArgs(in, xrefOut);
                 args.setProject(project);
-                writeXref(args);
+                XrefWork xrefWork = new XrefWork(args, this);
+                try {
+                    xrefWork.getXrefer();
+                } catch (ExecutionException e) {
+                    throw new InterruptedException("failed to generate xref :" + e);
+                }
             }
         }
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/document/TroffAnalyzerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/document/TroffAnalyzerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2009, 2011, Jens Elkner.
  */
 package org.opengrok.indexer.analysis.document;
@@ -96,7 +96,7 @@ public class TroffAnalyzerTest {
      * @throws IOException I/O exception
      */
     @Test
-    void testAnalyze() throws IOException {
+    void testAnalyze() throws Exception {
         Document doc = new Document();
         StringWriter xrefOut = new StringWriter();
         analyzer.analyze(doc, new StreamSource() {
@@ -106,5 +106,4 @@ public class TroffAnalyzerTest {
             }
         }, xrefOut);
     }
-
 }


### PR DESCRIPTION
After adding `writeXref()` timeout to `XMLAnalyzer`, IDEA detected code duplication of the `CompletableFuture` code block there and in `PlainAnalyzer`. This change moves that block to `XrefWork` and also uses it in more analyzer classes, providing better indexer robustness.