### PR TITLE
record completed times of individual file additions

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
@@ -49,9 +49,7 @@ public class DefaultIndexChangedListener implements IndexChangedListener {
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.log(Level.FINE, "Add: ''{0}'' ({1})", new Object[]{path, analyzer});
         }
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            statMap.put(path, new Statistics());
-        }
+        statMap.put(path, new Statistics());
     }
 
     @Override
@@ -61,12 +59,12 @@ public class DefaultIndexChangedListener implements IndexChangedListener {
 
     @Override
     public void fileAdded(String path, String analyzer) {
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            Statistics stat = statMap.get(path);
-            if (stat != null) {
-                stat.report(LOGGER, Level.FINEST, String.format("Added: '%s' (%s)", path, analyzer),
-                        "indexer.file.add.latency");
-                statMap.remove(path, stat);
+        Statistics stat = statMap.get(path);
+        if (stat != null) {
+            stat.report(LOGGER, Level.FINEST, String.format("Added: '%s' (%s)", path, analyzer),
+                    "indexer.file.add.latency");
+            statMap.remove(path, stat);
+            if (LOGGER.isLoggable(Level.FINEST)) {
                 return;
             }
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
@@ -64,6 +64,8 @@ public class DefaultIndexChangedListener implements IndexChangedListener {
             stat.report(LOGGER, Level.FINEST, String.format("Added: '%s' (%s)", path, analyzer),
                     "indexer.file.add.latency");
             statMap.remove(path, stat);
+
+            // The reporting updated the meter, however might not have emitted the log message.
             if (LOGGER.isLoggable(Level.FINEST)) {
                 return;
             }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/DefaultIndexChangedListener.java
@@ -50,10 +50,6 @@ public class DefaultIndexChangedListener implements IndexChangedListener {
     public void fileRemove(String path) {
         LOGGER.log(Level.FINE, "Remove: ''{0}''", path);
     }
-    @Override
-    public void fileUpdate(String path) {
-        LOGGER.log(Level.FINE, "Update: ''{0}''", path);
-    }
 
     @Override
     public void fileAdded(String path, String analyzer) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexChangedListener.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexChangedListener.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.index;
 
@@ -50,9 +50,4 @@ public interface IndexChangedListener {
      * @param path The path to the file (absolute from source root)
      */
     void fileRemoved(String path);
-    /**
-     * A file is to be updated in the index database.
-     * @param path The path to the file (absolute from source root)
-     */
-    void fileUpdate(String path);
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1784,7 +1784,7 @@ public class IndexDatabase {
                             }
                         } catch (AlreadyClosedException e) {
                             alreadyClosedCounter.incrementAndGet();
-                            String errmsg = String.format("ERROR addFile(): %s", x.file);
+                            String errmsg = String.format("ERROR addFile(): '%s'", x.file);
                             LOGGER.log(Level.SEVERE, errmsg, e);
                             x.exception = e;
                             ret = false;
@@ -1793,11 +1793,11 @@ public class IndexDatabase {
                             if (++tries <= 1) {
                                 continue;
                             }
-                            LOGGER.log(Level.WARNING, "No retry: {0}", x.file);
+                            LOGGER.log(Level.WARNING, "No retry: ''{0}''", x.file);
                             x.exception = e;
                             ret = false;
                         } catch (RuntimeException | IOException e) {
-                            String errmsg = String.format("ERROR addFile(): %s", x.file);
+                            String errmsg = String.format("ERROR addFile(): '%s'", x.file);
                             LOGGER.log(Level.WARNING, errmsg, e);
                             x.exception = e;
                             ret = false;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1772,7 +1772,6 @@ public class IndexDatabase {
                     int tries = 0;
                     Ctags pctags = null;
                     boolean ret;
-                    Statistics stats = new Statistics();
                     while (true) {
                         try {
                             if (alreadyClosedCounter.get() > 0) {
@@ -1810,8 +1809,6 @@ public class IndexDatabase {
                         }
 
                         progress.increment();
-                        stats.report(LOGGER, Level.FINEST,
-                                String.format("file '%s' %s", x.file, ret ? "indexed" : "failed indexing"));
                         return ret;
                     }
                 }))).get();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Statistics.java
@@ -44,8 +44,8 @@ public class Statistics {
   }
 
     private void logIt(Logger logger, Level logLevel, String msg, Duration duration) {
-        String timeStr = StringUtils.getReadableTime(duration.toMillis());
         if (logger.isLoggable(logLevel)) {
+            String timeStr = StringUtils.getReadableTime(duration.toMillis());
             logger.log(logLevel, String.format("%s (took %s)", msg, timeStr));
         }
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -463,10 +463,6 @@ class IndexDatabaseTest {
         public void fileRemoved(String path) {
         }
 
-        @Override
-        public void fileUpdate(String path) {
-        }
-
         public Set<String> getRemovedFiles() {
             return removedFiles;
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerTest.java
@@ -208,10 +208,6 @@ public class IndexerTest {
         }
 
         @Override
-        public void fileUpdate(String path) {
-        }
-
-        @Override
         public void fileRemoved(String path) {
             removedFiles.add(path);
         }
@@ -290,10 +286,6 @@ public class IndexerTest {
 
         @Override
         public void fileRemove(String path) {
-        }
-
-        @Override
-        public void fileUpdate(String path) {
         }
 
         @Override

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
@@ -145,9 +145,6 @@ class IndexerVsDeletedDocumentsTest {
             removedPaths.add(path);
             System.out.printf("Remove file: %s%n", path);
         }
-        @Override
-        public void fileUpdate(String path) {
-        }
 
         @Override
         public void fileAdded(String path, String analyzer) {


### PR DESCRIPTION
This changes the way how reporting for the work of `IndexDatabase#addFile()` is done. Previously this was done in `indexParallel()` (also using full file system path and not source root relative path), now it is done via `DefaultIndexChangedListener`. Also, I added a meter for this so it can be observed in monitoring. For file removals this is not done as it is not as interesting.

In the log it looks like this:
```
14:25:53 FINEST: Added: '/lucene/lucene/analysis/common/src/test/org/apache/lucene/analysis/hunspell/breakdefault.sug' (PlainAnalyzer) (took 0:01:04)
```
A bit of a downside is that the previous way of reporting was able to record failed operations which the listener is not capable of.