### PR TITLE
current Universal ctags has const support for rust

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -254,8 +254,7 @@ public class Ctags implements Resettable {
             command.add("--langdef=rust"); // Lower-case if user-defined.
         }
 
-        // The following are not supported yet in Universal Ctags b13cb551
-        command.add("--kinddef-rust=C,const,Static\\ constants");
+        // The following are not supported yet in Universal Ctags 882b6c7
         command.add("--kinddef-rust=I,impl,Trait\\ implementation");
         command.add("--kinddef-rust=r,trait,Traits");
         command.add("--kinddef-rust=V,localVariable,Local\\ variables");


### PR DESCRIPTION
Indexing with current Universal ctags, I can see this warning:
```
2023-05-11 04:04:27.197+0200 WARNING t81 Ctags.lambda$run$0: Error from ctags: ctags: Warning: the kind for letter `C' specified in "--kinddef-rust" option is already defined.
```
Indeed, the `const` support was added in https://github.com/universal-ctags/ctags/commit/648cbe273d9454a0556e871c5406db83f8968aa3 so this change removes the extra option passed to ctags.