### PR TITLE
chore: fix 'Too many open files in system' error(#872) when indexing AOSP

### DIFF
--- a/docker/sync.yml
+++ b/docker/sync.yml
@@ -20,7 +20,7 @@ commands:
       --connectTimeout, '%API_TIMEOUT%',
       -r, dirbased, -G, -m, '256', --leadingWildCards, 'on',
       -c, /usr/local/bin/ctags, -U, '%URL%', -H, '%PROJECT%']
-    limits: {RLIMIT_NOFILE: 1024}
+    limits: {RLIMIT_NOFILE: 102400}
     args_subst: {"%API_TIMEOUT%": "$API_TIMEOUT"}
 - call:
     uri: '%URL%api/v1/messages?tag=%PROJECT%'


### PR DESCRIPTION
fix 'opengrok java.io.FileNotFoundException Too many open files' when using opengrok docker with large git repo (eg. aosp)

Change-Id: I955be229827a837f6990cb29b095c46be62e8078

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
