### PR TITLE
order passages in search results based strictly on file offsets

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/ContextArgs.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/ContextArgs.java
@@ -78,7 +78,7 @@ public class ContextArgs {
      * is displayed to allow the user to view full match results.
      * <p>
      * (N.b. the value is used with Lucene {@code uhighlight}, and {@code short}
-     * is safer, though syntactically inconvenient, to avoid numeric overlow
+     * is safer, though syntactically inconvenient, to avoid numeric overflow
      * that may occur with {@code int} in that library.)
      * @return a positive value
      */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/OGKUnifiedHighlighter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/OGKUnifiedHighlighter.java
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
+ */
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 
@@ -37,6 +40,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.uhighlight.PassageScorer;
 import org.apache.lucene.search.uhighlight.UHComponents;
 import org.apache.lucene.search.uhighlight.UnifiedHighlighter;
 import org.apache.lucene.util.BytesRef;
@@ -323,5 +327,10 @@ public class OGKUnifiedHighlighter extends UnifiedHighlighter {
             StandardCharsets.UTF_8.name());
         BufferedReader bufrdr = new BufferedReader(bsrdr);
         return ExpandTabsReader.wrap(bufrdr, tabSize);
+    }
+
+    @Override
+    protected PassageScorer getScorer(String field) {
+        return new OGPassageScorer();
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/OGPassageScorer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/OGPassageScorer.java
@@ -1,0 +1,50 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.search.context;
+
+import org.apache.lucene.search.uhighlight.Passage;
+import org.apache.lucene.search.uhighlight.PassageScorer;
+import org.opengrok.indexer.logger.LoggerFactory;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Custom {@link PassageScorer} used in {@link OGKUnifiedHighlighter}.
+ * The goal is to have ordering of passages based strictly on their start offsets.
+ */
+public class OGPassageScorer extends PassageScorer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OGPassageScorer.class);
+
+    public OGPassageScorer() {
+        // Use non-default values so that the scorer object is easier to identify when debugging.
+        super(1, 2, 3);
+    }
+
+    @Override
+    public float score(Passage passage, int contentLength) {
+        LOGGER.log(Level.FINEST, "{0} -> {1}", new Object[]{passage, passage.getStartOffset()});
+        return -passage.getStartOffset();
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/PassageScorerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/PassageScorerTest.java
@@ -1,0 +1,118 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.search.context;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.history.HistoryGuru;
+import org.opengrok.indexer.history.RepositoryFactory;
+import org.opengrok.indexer.index.Indexer;
+import org.opengrok.indexer.search.SearchEngine;
+import org.opengrok.indexer.util.TestRepository;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opengrok.indexer.search.context.SearchAndContextFormatterTest.getFirstFragments;
+
+/**
+ * Make sure that passages within search results are ordered strictly based on the line numbers.
+ */
+public class PassageScorerTest {
+    private static RuntimeEnvironment env;
+    private static TestRepository repository;
+
+    @BeforeAll
+    public static void setUpClass() throws Exception {
+        repository = new TestRepository();
+        repository.create(HistoryGuru.class.getResource("/sources"));
+
+        env = RuntimeEnvironment.getInstance();
+        env.setCtags(System.getProperty("org.opengrok.indexer.analysis.Ctags", "ctags"));
+        env.setSourceRoot(repository.getSourceRoot());
+        env.setDataRoot(repository.getDataRoot());
+        RepositoryFactory.initializeIgnoredNames(env);
+        env.setHistoryEnabled(false);
+
+        assertTrue(Paths.get(env.getSourceRootPath(), "c", "sdt.h").toFile().exists());
+
+        Indexer.getInstance().doIndexerExecution(null, null);
+    }
+
+    @AfterAll
+    public static void tearDownClass() {
+        repository.destroy();
+    }
+
+    @Test
+    void testSearch() throws Exception {
+        SearchEngine instance = new SearchEngine();
+        instance.setFreetext("DTRACE_PROBE4");
+        instance.setFile("sdt");
+        int noHits = instance.search();
+        assertTrue(noHits > 0, "noHits should be positive");
+        String[] frags = getFirstFragments(instance, env, new ContextArgs((short) 0, (short) 10));
+        assertNotNull(frags, "getFirstFragments() should return something");
+        assertEquals(1, frags.length, "frags should have one element");
+
+        // Create XML from the result and parse it, get the line numbers, compare.
+        String docString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<document>\n" +
+                frags[0] +
+                "\n</document>";
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        assertNotNull(factory, "DocumentBuilderFactory is null");
+
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        assertNotNull(builder, "DocumentBuilder is null");
+
+        final int[] lineNumbers = {58, 97, 155, 172, 189, 200, 232, 264, 297, 324};
+
+        Document document = builder.parse(new ByteArrayInputStream(docString.getBytes()));
+        NodeList nl = document.getElementsByTagName("a");
+        assertEquals(lineNumbers.length, nl.getLength());
+        int[] lines = new int[nl.getLength()];
+        for (int i = 0; i < nl.getLength(); i++) {
+            String href = nl.item(i).getAttributes().getNamedItem("href").getNodeValue();
+            assertNotNull(href);
+            String lineNumStr = href.substring(href.indexOf("#") + 1);
+            assertNotNull(lineNumStr);
+            int lineNum = Integer.parseInt(lineNumStr);
+            lines[i] = lineNum;
+        }
+        assertEquals(0, Arrays.compare(lineNumbers, lines));
+
+        instance.destroy();
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
@@ -100,7 +100,7 @@ class SearchAndContextFormatterTest {
         instance.setFile("bkexlib.cpp");
         int noHits = instance.search();
         assertTrue(noHits > 0, "noHits should be positive");
-        String[] frags = getFirstFragments(instance);
+        String[] frags = getFirstFragments(instance, env, new ContextArgs((short) 1, (short) 10));
         assertNotNull(frags, "getFirstFragments() should return something");
         assertEquals(1, frags.length, "frags should have one element");
 
@@ -113,9 +113,8 @@ class SearchAndContextFormatterTest {
         instance.destroy();
     }
 
-    private String[] getFirstFragments(SearchEngine instance) throws IOException {
-
-        ContextArgs args = new ContextArgs((short) 1, (short) 10);
+    static String[] getFirstFragments(SearchEngine instance, RuntimeEnvironment env, ContextArgs args)
+            throws IOException {
 
         /*
          * The following `anz' should go unused, but UnifiedHighlighter demands

--- a/opengrok-indexer/src/test/resources/sources/c/sdt.h
+++ b/opengrok-indexer/src/test/resources/sources/c/sdt.h
@@ -1,0 +1,420 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
+ */
+
+#ifndef _SYS_SDT_H
+#define	_SYS_SDT_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#ifndef _KERNEL
+
+#define	DTRACE_PROBE(provider, name) {					\
+	extern void __dtrace_##provider##___##name(void);		\
+	__dtrace_##provider##___##name();				\
+}
+
+#define	DTRACE_PROBE1(provider, name, arg1) {				\
+	extern void __dtrace_##provider##___##name(unsigned long);	\
+	__dtrace_##provider##___##name((unsigned long)arg1);		\
+}
+
+#define	DTRACE_PROBE2(provider, name, arg1, arg2) {			\
+	extern void __dtrace_##provider##___##name(unsigned long,	\
+	    unsigned long);						\
+	__dtrace_##provider##___##name((unsigned long)arg1,		\
+	    (unsigned long)arg2);					\
+}
+
+#define	DTRACE_PROBE3(provider, name, arg1, arg2, arg3) {		\
+	extern void __dtrace_##provider##___##name(unsigned long,	\
+	    unsigned long, unsigned long);				\
+	__dtrace_##provider##___##name((unsigned long)arg1,		\
+	    (unsigned long)arg2, (unsigned long)arg3);			\
+}
+
+#define	DTRACE_PROBE4(provider, name, arg1, arg2, arg3, arg4) {		\
+	extern void __dtrace_##provider##___##name(unsigned long,	\
+	    unsigned long, unsigned long, unsigned long);		\
+	__dtrace_##provider##___##name((unsigned long)arg1,		\
+	    (unsigned long)arg2, (unsigned long)arg3,			\
+	    (unsigned long)arg4);					\
+}
+
+#define	DTRACE_PROBE5(provider, name, arg1, arg2, arg3, arg4, arg5) {	\
+	extern void __dtrace_##provider##___##name(unsigned long,	\
+	    unsigned long, unsigned long, unsigned long, unsigned long);\
+	__dtrace_##provider##___##name((unsigned long)arg1,		\
+	    (unsigned long)arg2, (unsigned long)arg3,			\
+	    (unsigned long)arg4, (unsigned long)arg5);			\
+}
+
+#else /* _KERNEL */
+
+#define	DTRACE_PROBE(name)	{					\
+	extern void __dtrace_probe_##name(void);			\
+	__dtrace_probe_##name();					\
+}
+
+#define	DTRACE_PROBE1(name, type1, arg1) {				\
+	extern void __dtrace_probe_##name(uintptr_t);			\
+	__dtrace_probe_##name((uintptr_t)(arg1));			\
+}
+
+#define	DTRACE_PROBE2(name, type1, arg1, type2, arg2) {			\
+	extern void __dtrace_probe_##name(uintptr_t, uintptr_t);	\
+	__dtrace_probe_##name((uintptr_t)(arg1), (uintptr_t)(arg2));	\
+}
+
+#define	DTRACE_PROBE3(name, type1, arg1, type2, arg2, type3, arg3) {	\
+	extern void __dtrace_probe_##name(uintptr_t, uintptr_t, uintptr_t); \
+	__dtrace_probe_##name((uintptr_t)(arg1), (uintptr_t)(arg2),	\
+	    (uintptr_t)(arg3));						\
+}
+
+#define	DTRACE_PROBE4(name, type1, arg1, type2, arg2, 			\
+    type3, arg3, type4, arg4) {						\
+	extern void __dtrace_probe_##name(uintptr_t, uintptr_t,		\
+	    uintptr_t, uintptr_t);					\
+	__dtrace_probe_##name((uintptr_t)(arg1), (uintptr_t)(arg2),	\
+	    (uintptr_t)(arg3), (uintptr_t)(arg4));			\
+}
+
+#define	DTRACE_PROBE5(name, type1, arg1, type2, arg2, 			\
+    type3, arg3, type4, arg4, type5, arg5) {				\
+	extern void __dtrace_probe_##name(uintptr_t, uintptr_t,		\
+	    uintptr_t, uintptr_t, uintptr_t);				\
+	__dtrace_probe_##name((uintptr_t)(arg1), (uintptr_t)(arg2),	\
+	    (uintptr_t)(arg3), (uintptr_t)(arg4), (uintptr_t)(arg5));	\
+}
+
+#define	DTRACE_PROBE6(name, type1, arg1, type2, arg2, 			\
+    type3, arg3, type4, arg4, type5, arg5, type6, arg6) {		\
+	extern void __dtrace_probe_##name(uintptr_t, uintptr_t,		\
+	    uintptr_t, uintptr_t, uintptr_t, uintptr_t);		\
+	__dtrace_probe_##name((uintptr_t)(arg1), (uintptr_t)(arg2),	\
+	    (uintptr_t)(arg3), (uintptr_t)(arg4), (uintptr_t)(arg5),	\
+	    (uintptr_t)(arg6));						\
+}
+
+#define	DTRACE_PROBE7(name, type1, arg1, type2, arg2, type3, arg3,	\
+    type4, arg4, type5, arg5, type6, arg6, type7, arg7) {		\
+	extern void __dtrace_probe_##name(uintptr_t, uintptr_t,		\
+	    uintptr_t, uintptr_t, uintptr_t, uintptr_t, uintptr_t);	\
+	__dtrace_probe_##name((uintptr_t)(arg1), (uintptr_t)(arg2),	\
+	    (uintptr_t)(arg3), (uintptr_t)(arg4), (uintptr_t)(arg5),	\
+	    (uintptr_t)(arg6), (uintptr_t)(arg7));			\
+}
+
+#define	DTRACE_PROBE8(name, type1, arg1, type2, arg2, type3, arg3,	\
+    type4, arg4, type5, arg5, type6, arg6, type7, arg7, type8, arg8) {	\
+	extern void __dtrace_probe_##name(uintptr_t, uintptr_t,		\
+	    uintptr_t, uintptr_t, uintptr_t, uintptr_t,			\
+	    uintptr_t, uintptr_t);					\
+	__dtrace_probe_##name((uintptr_t)(arg1), (uintptr_t)(arg2),	\
+	    (uintptr_t)(arg3), (uintptr_t)(arg4), (uintptr_t)(arg5),	\
+	    (uintptr_t)(arg6), (uintptr_t)(arg7), (uintptr_t)(arg8));	\
+}
+
+#define	DTRACE_SCHED(name)						\
+	DTRACE_PROBE(__sched_##name);
+
+#define	DTRACE_SCHED1(name, type1, arg1)				\
+	DTRACE_PROBE1(__sched_##name, type1, arg1);
+
+#define	DTRACE_SCHED2(name, type1, arg1, type2, arg2)			\
+	DTRACE_PROBE2(__sched_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_SCHED3(name, type1, arg1, type2, arg2, type3, arg3)	\
+	DTRACE_PROBE3(__sched_##name, type1, arg1, type2, arg2, type3, arg3);
+
+#define	DTRACE_SCHED4(name, type1, arg1, type2, arg2, 			\
+    type3, arg3, type4, arg4)						\
+	DTRACE_PROBE4(__sched_##name, type1, arg1, type2, arg2, 	\
+	    type3, arg3, type4, arg4);
+
+#define	DTRACE_PROC(name)						\
+	DTRACE_PROBE(__proc_##name);
+
+#define	DTRACE_PROC1(name, type1, arg1)					\
+	DTRACE_PROBE1(__proc_##name, type1, arg1);
+
+#define	DTRACE_PROC2(name, type1, arg1, type2, arg2)			\
+	DTRACE_PROBE2(__proc_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_PROC3(name, type1, arg1, type2, arg2, type3, arg3)	\
+	DTRACE_PROBE3(__proc_##name, type1, arg1, type2, arg2, type3, arg3);
+
+#define	DTRACE_PROC4(name, type1, arg1, type2, arg2, 			\
+    type3, arg3, type4, arg4)						\
+	DTRACE_PROBE4(__proc_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4);
+
+#define	DTRACE_IO(name)							\
+	DTRACE_PROBE(__io_##name);
+
+#define	DTRACE_IO1(name, type1, arg1)					\
+	DTRACE_PROBE1(__io_##name, type1, arg1);
+
+#define	DTRACE_IO2(name, type1, arg1, type2, arg2)			\
+	DTRACE_PROBE2(__io_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_IO3(name, type1, arg1, type2, arg2, type3, arg3)	\
+	DTRACE_PROBE3(__io_##name, type1, arg1, type2, arg2, type3, arg3);
+
+#define	DTRACE_IO4(name, type1, arg1, type2, arg2, 			\
+    type3, arg3, type4, arg4)						\
+	DTRACE_PROBE4(__io_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4);
+
+#define	DTRACE_ISCSI_2(name, type1, arg1, type2, arg2)			\
+	DTRACE_PROBE2(__iscsi_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_ISCSI_3(name, type1, arg1, type2, arg2, type3, arg3)	\
+	DTRACE_PROBE3(__iscsi_##name, type1, arg1, type2, arg2, type3, arg3);
+
+#define	DTRACE_ISCSI_4(name, type1, arg1, type2, arg2,			\
+    type3, arg3, type4, arg4)						\
+	DTRACE_PROBE4(__iscsi_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3, type4, arg4);
+
+#define	DTRACE_ISCSI_5(name, type1, arg1, type2, arg2,			\
+    type3, arg3, type4, arg4, type5, arg5)				\
+	DTRACE_PROBE5(__iscsi_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3, type4, arg4, type5, arg5);
+
+#define	DTRACE_ISCSI_6(name, type1, arg1, type2, arg2,			\
+    type3, arg3, type4, arg4, type5, arg5, type6, arg6)			\
+	DTRACE_PROBE6(__iscsi_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3, type4, arg4, type5, arg5, type6, arg6);
+
+#define	DTRACE_ISCSI_7(name, type1, arg1, type2, arg2,			\
+    type3, arg3, type4, arg4, type5, arg5, type6, arg6, type7, arg7)	\
+	DTRACE_PROBE7(__iscsi_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3, type4, arg4, type5, arg5, type6, arg6,		\
+	    type7, arg7);
+
+#define	DTRACE_ISCSI_8(name, type1, arg1, type2, arg2,			\
+    type3, arg3, type4, arg4, type5, arg5, type6, arg6,			\
+    type7, arg7, type8, arg8)						\
+	DTRACE_PROBE8(__iscsi_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3, type4, arg4, type5, arg5, type6, arg6,		\
+	    type7, arg7, type8, arg8);
+
+#define	DTRACE_NFSV3_3(name, type1, arg1, type2, arg2, 			\
+    type3, arg3)							\
+	DTRACE_PROBE3(__nfsv3_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3);
+#define	DTRACE_NFSV3_4(name, type1, arg1, type2, arg2, 			\
+    type3, arg3, type4, arg4)						\
+	DTRACE_PROBE4(__nfsv3_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3, type4, arg4);
+
+#define	DTRACE_NFSV4_1(name, type1, arg1) \
+	DTRACE_PROBE1(__nfsv4_##name, type1, arg1);
+
+#define	DTRACE_NFSV4_2(name, type1, arg1, type2, arg2) \
+	DTRACE_PROBE2(__nfsv4_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_NFSV4_3(name, type1, arg1, type2, arg2, type3, arg3) \
+	DTRACE_PROBE3(__nfsv4_##name, type1, arg1, type2, arg2, type3, arg3);
+
+#define	DTRACE_SMB_1(name, type1, arg1) \
+	DTRACE_PROBE1(__smb_##name, type1, arg1);
+
+#define	DTRACE_SMB_2(name, type1, arg1, type2, arg2) \
+	DTRACE_PROBE2(__smb_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_IP(name)						\
+	DTRACE_PROBE(__ip_##name);
+
+#define	DTRACE_IP1(name, type1, arg1)					\
+	DTRACE_PROBE1(__ip_##name, type1, arg1);
+
+#define	DTRACE_IP2(name, type1, arg1, type2, arg2)			\
+	DTRACE_PROBE2(__ip_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_IP3(name, type1, arg1, type2, arg2, type3, arg3)	\
+	DTRACE_PROBE3(__ip_##name, type1, arg1, type2, arg2, type3, arg3);
+
+#define	DTRACE_IP4(name, type1, arg1, type2, arg2, 			\
+    type3, arg3, type4, arg4)						\
+	DTRACE_PROBE4(__ip_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4);
+
+#define	DTRACE_IP5(name, type1, arg1, type2, arg2, 			\
+    type3, arg3, type4, arg4, type5, arg5)				\
+	DTRACE_PROBE5(__ip_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4, type5, arg5);
+
+#define	DTRACE_IP6(name, type1, arg1, type2, arg2, 			\
+    type3, arg3, type4, arg4, type5, arg5, type6, arg6)			\
+	DTRACE_PROBE6(__ip_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4, type5, arg5, type6, arg6);
+
+#define	DTRACE_IP7(name, type1, arg1, type2, arg2, type3, arg3,		\
+    type4, arg4, type5, arg5, type6, arg6, type7, arg7)			\
+	DTRACE_PROBE7(__ip_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4, type5, arg5, type6, arg6,		\
+	    type7, arg7);
+
+#define	DTRACE_TCP(name)						\
+	DTRACE_PROBE(__tcp_##name);
+
+#define	DTRACE_TCP1(name, type1, arg1)					\
+	DTRACE_PROBE1(__tcp_##name, type1, arg1);
+
+#define	DTRACE_TCP2(name, type1, arg1, type2, arg2)			\
+	DTRACE_PROBE2(__tcp_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_TCP3(name, type1, arg1, type2, arg2, type3, arg3)	\
+	DTRACE_PROBE3(__tcp_##name, type1, arg1, type2, arg2, type3, arg3);
+
+#define	DTRACE_TCP4(name, type1, arg1, type2, arg2,			\
+    type3, arg3, type4, arg4)						\
+	DTRACE_PROBE4(__tcp_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3, type4, arg4);
+
+#define	DTRACE_TCP5(name, type1, arg1, type2, arg2,			\
+    type3, arg3, type4, arg4, type5, arg5)				\
+	DTRACE_PROBE5(__tcp_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3, type4, arg4, type5, arg5);
+
+#define	DTRACE_TCP6(name, type1, arg1, type2, arg2,			\
+    type3, arg3, type4, arg4, type5, arg5, type6, arg6)			\
+	DTRACE_PROBE6(__tcp_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3, type4, arg4, type5, arg5, type6, arg6);
+
+#define	DTRACE_UDP(name)						\
+	DTRACE_PROBE(__udp_##name);
+
+#define	DTRACE_UDP1(name, type1, arg1)					\
+	DTRACE_PROBE1(__udp_##name, type1, arg1);
+
+#define	DTRACE_UDP2(name, type1, arg1, type2, arg2)			\
+	DTRACE_PROBE2(__udp_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_UDP3(name, type1, arg1, type2, arg2, type3, arg3)	\
+	DTRACE_PROBE3(__udp_##name, type1, arg1, type2, arg2, type3, arg3);
+
+#define	DTRACE_UDP4(name, type1, arg1, type2, arg2,			\
+    type3, arg3, type4, arg4)						\
+	DTRACE_PROBE4(__udp_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3, type4, arg4);
+
+#define	DTRACE_UDP5(name, type1, arg1, type2, arg2,			\
+    type3, arg3, type4, arg4, type5, arg5)				\
+	DTRACE_PROBE5(__udp_##name, type1, arg1, type2, arg2,		\
+	    type3, arg3, type4, arg4, type5, arg5);
+
+
+#define	DTRACE_SYSEVENT2(name, type1, arg1, type2, arg2)		\
+	DTRACE_PROBE2(__sysevent_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_XPV(name)						\
+	DTRACE_PROBE(__xpv_##name);
+
+#define	DTRACE_XPV1(name, type1, arg1)					\
+	DTRACE_PROBE1(__xpv_##name, type1, arg1);
+
+#define	DTRACE_XPV2(name, type1, arg1, type2, arg2)			\
+	DTRACE_PROBE2(__xpv_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_XPV3(name, type1, arg1, type2, arg2, type3, arg3)	\
+	DTRACE_PROBE3(__xpv_##name, type1, arg1, type2, arg2, type3, arg3);
+
+#define	DTRACE_XPV4(name, type1, arg1, type2, arg2, type3, arg3,	\
+	    type4, arg4)						\
+	DTRACE_PROBE4(__xpv_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4);
+
+#define	DTRACE_FC_1(name, type1, arg1) \
+	DTRACE_PROBE1(__fc_##name, type1, arg1);
+
+#define	DTRACE_FC_2(name, type1, arg1, type2, arg2) \
+	DTRACE_PROBE2(__fc_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_FC_3(name, type1, arg1, type2, arg2, type3, arg3) \
+	DTRACE_PROBE3(__fc_##name, type1, arg1, type2, arg2, type3, arg3);
+
+#define	DTRACE_FC_4(name, type1, arg1, type2, arg2, type3, arg3, type4, arg4) \
+	DTRACE_PROBE4(__fc_##name, type1, arg1, type2, arg2, type3, arg3, \
+	    type4, arg4);
+
+#define	DTRACE_FC_5(name, type1, arg1, type2, arg2, type3, arg3, 	\
+	    type4, arg4, type5, arg5)					\
+	DTRACE_PROBE5(__fc_##name, type1, arg1, type2, arg2, type3, arg3, \
+	    type4, arg4, type5, arg5);
+
+#define	DTRACE_SRP_1(name, type1, arg1)					\
+	DTRACE_PROBE1(__srp_##name, type1, arg1);
+
+#define	DTRACE_SRP_2(name, type1, arg1, type2, arg2)			\
+	DTRACE_PROBE2(__srp_##name, type1, arg1, type2, arg2);
+
+#define	DTRACE_SRP_3(name, type1, arg1, type2, arg2, type3, arg3)	\
+	DTRACE_PROBE3(__srp_##name, type1, arg1, type2, arg2, type3, arg3);
+
+#define	DTRACE_SRP_4(name, type1, arg1, type2, arg2, type3, arg3,	\
+	    type4, arg4)						\
+	DTRACE_PROBE4(__srp_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4);
+
+#define	DTRACE_SRP_5(name, type1, arg1, type2, arg2, type3, arg3,	\
+	    type4, arg4, type5, arg5)					\
+	DTRACE_PROBE5(__srp_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4, type5, arg5);
+
+#define	DTRACE_SRP_6(name, type1, arg1, type2, arg2, type3, arg3,	\
+	    type4, arg4, type5, arg5, type6, arg6)			\
+	DTRACE_PROBE6(__srp_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4, type5, arg5, type6, arg6);
+
+#define	DTRACE_SRP_7(name, type1, arg1, type2, arg2, type3, arg3,	\
+	    type4, arg4, type5, arg5, type6, arg6, type7, arg7)		\
+	DTRACE_PROBE7(__srp_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4, type5, arg5, type6, arg6, type7, arg7);
+
+#define	DTRACE_SRP_8(name, type1, arg1, type2, arg2, type3, arg3,	\
+	    type4, arg4, type5, arg5, type6, arg6, type7, arg7, type8, arg8) \
+	DTRACE_PROBE8(__srp_##name, type1, arg1, type2, arg2, 		\
+	    type3, arg3, type4, arg4, type5, arg5, type6, arg6,		\
+	    type7, arg7, type8, arg8);
+
+#endif /* _KERNEL */
+
+extern const char *sdt_prefix;
+
+typedef struct sdt_probedesc {
+	char			*sdpd_name;	/* name of this probe */
+	unsigned long		sdpd_offset;	/* offset of call in text */
+	struct sdt_probedesc	*sdpd_next;	/* next static probe */
+} sdt_probedesc_t;
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _SYS_SDT_H */


### PR DESCRIPTION
This changes the way how search results are displayed. Previously the passages were scored based on [multiple criteria](https://lucene.apache.org/core/9_4_1/highlighter/org/apache/lucene/search/uhighlight/PassageScorer.html) so that it could happen that trimmed results for given file did not show initial hits within that file which I find confusing.

While I could use `UnifiedHighlighter.Builder` with `withScorer()` in `Context#getContext2()`, I decided to override the `getScorer()` method in the `OGKUnifiedHighlighter` instead as it is more robust - no need to rely on the Builder to be used at all relevant places.

Eventually this could be made tunable per user so that it is possible to choose between the standard Lucene behavior and the new default.