### PR TITLE
do not contrain open files limit

### DIFF
--- a/docker/sync.yml
+++ b/docker/sync.yml
@@ -20,7 +20,6 @@ commands:
       --connectTimeout, '%API_TIMEOUT%',
       -r, dirbased, -G, -m, '256', --leadingWildCards, 'on',
       -c, /usr/local/bin/ctags, -U, '%URL%', -H, '%PROJECT%']
-    limits: {RLIMIT_NOFILE: 1024}
     args_subst: {"%API_TIMEOUT%": "$API_TIMEOUT"}
 - call:
     uri: '%URL%api/v1/messages?tag=%PROJECT%'


### PR DESCRIPTION
The sync configuration contained a directive to limit the number of open files for the indexer. This came from a demo configuration and should not be present.

Checking the limits of the indexer process after the change (running from `docker-compose`, no special configuration):
```
    275 ?        Sl     0:01      \_ /opt/java/openjdk/bin/java -Dorg.opengrok.indexer.history.SCCS=/usr/bin/sccs -Dorg.opengrok.indexer.history.cvs=/usr/bin/cvs -Dorg.opengrok.indexer.history.Mercurial=/usr/bin/hg -Dorg.opengrok.indexer.history.RCS=/usr/bin/blame -Dorg.opengrok.indexer.history.Perforce=/usr/bin/p4 -Dorg.opengrok.indexer.history.Bazaar=/usr/bin/bzr -Dorg.opengrok.indexer.history.Subversion=/usr/bin/svn -jar /opengrok/lib/opengrok.jar -R /tmp/tmpyf0nbbrd --connectTimeout 30 -r dirbased -G -m 256 --leadingWildCards on -c /usr/local/bin/ctags -U http://localhost:8080/ -H jdk8-b120
...

# cat /proc/275/limits 
Limit                     Soft Limit           Hard Limit           Units     
Max cpu time              unlimited            unlimited            seconds   
Max file size             unlimited            unlimited            bytes     
Max data size             unlimited            unlimited            bytes     
Max stack size            8388608              unlimited            bytes     
Max core file size        unlimited            unlimited            bytes     
Max resident set          unlimited            unlimited            bytes     
Max processes             unlimited            unlimited            processes 
Max open files            1048576              1048576              files     
Max locked memory         65536                65536                bytes     
Max address space         unlimited            unlimited            bytes     
Max file locks            unlimited            unlimited            locks     
Max pending signals       126943               126943               signals   
Max msgqueue size         819200               819200               bytes     
Max nice priority         0                    0                    
Max realtime priority     0                    0                    
Max realtime timeout      unlimited            unlimited            us        
```