### PR TITLE
add --nolock option to indexer.py

### DIFF
--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -160,7 +160,7 @@ def main():
     parser.add_argument('-f', '--driveon', action='store_true', default=False,
                         help='continue command sequence processing even '
                         'if one of the commands requests break')
-    parser.add_argument('--nolock', action='store_false', default=True,
+    parser.add_argument('--nolock', action='store_true', default=False,
                         help='do not acquire lock that prevents multiple '
                         'instances from running')
     parser.add_argument('--api_timeout', type=int, default=3,


### PR DESCRIPTION
https://github.com/oracle/opengrok/discussions/4361 describes a use case for `--nolock` option in the `opengrok-indexer` Python tool. This makes it on par with the `opengrok-sync` tool (which had the nolock logic wrong).