### PR TITLE
unlock the filelock package

### DIFF
--- a/tools/setup.py
+++ b/tools/setup.py
@@ -35,7 +35,7 @@ setup(
         'pyyaml',
         'requests>=2.20.0',
         'resource',
-        'filelock<3.3.0',
+        'filelock',
         'setuptools>=36.7.2',
     ],
     setup_requires=[


### PR DESCRIPTION
After fixing the locking logic in `sync.py` in e4b30323, the program started emitting logs via the filelock package in DEBUG mode even though it was running with log level INFO:
```
DEBUG:filelock:Attempting to acquire lock 140503852943824 on /tmp/opengrok-sync.lock
DEBUG:filelock:Lock 140503852943824 acquired on /tmp/opengrok-sync.lock
DEBUG:filelock:Attempting to release lock 140503852943824 on /tmp/opengrok-sync.lock
DEBUG:filelock:Lock 140503852943824 released on /tmp/opengrok-sync.lock
```
This change should fix this.