### PR TITLE
add quotes to Results logging

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/Results.java
@@ -308,7 +308,7 @@ public final class Results {
                     fargs.xrefPrefix, fargs.morePrefix, rpath, tags, true,
                     isDefSearch, null, scopes);
             } catch (IOException ex) {
-                String errMsg = String.format("No context for %s", sourceFile);
+                String errMsg = String.format("No context for '%s'", sourceFile);
                 if (LOGGER.isLoggable(Level.FINE)) {
                     // WARNING but with FINE detail
                     LOGGER.log(Level.WARNING, errMsg, ex);


### PR DESCRIPTION
As is the style in OpenGrok, file paths should be logged with single quotes. Noticed this today in the webapp logs:
```
06-Jun-2023 15:38:12.482 WARNING [http-nio-8080-exec-3798] org.opengrok.indexer.search.Results.printPlain No context for /ws-local/userland-default-prepped/components/wireshark/wireshark-4.0.5/capture/capture-wpcap.c
```
This change fixes that.