### PR TITLE
Use Ubuntu Jammy (22.04) as base for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3059
 RUN curl -sS https://package.perforce.com/perforce.pubkey | gpg --dearmor > /etc/apt/trusted.gpg.d/perforce.gpg
 # hadolint ignore=DL3059
-RUN echo 'deb http://package.perforce.com/apt/ubuntu bionic release' > /etc/apt/sources.list.d/perforce.list
+RUN echo 'deb https://package.perforce.com/apt/ubuntu focal release' > /etc/apt/sources.list.d/perforce.list
 
 # install dependencies and Python tools
 # hadolint ignore=DL3008,DL3009

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
 
-FROM ubuntu:bionic as build
+FROM ubuntu:jammy as build
 
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install --no-install-recommends -y maven python3 python3-venv && \
@@ -50,7 +50,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3059
 RUN curl -sS https://package.perforce.com/perforce.pubkey | gpg --dearmor > /etc/apt/trusted.gpg.d/perforce.gpg
 # hadolint ignore=DL3059
-RUN echo 'deb https://package.perforce.com/apt/ubuntu focal release' > /etc/apt/sources.list.d/perforce.list
+RUN echo 'deb https://package.perforce.com/apt/ubuntu jammy release' > /etc/apt/sources.list.d/perforce.list
 
 # install dependencies and Python tools
 # hadolint ignore=DL3008,DL3009

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@
 
 Built from official source: https://github.com/oracle/opengrok/releases/
 
-You can learn more about OpenGrok at http://oracle.github.io/opengrok/
+You can learn more about OpenGrok at https://oracle.github.io/opengrok/
 
 The container is available from DockerHub at https://hub.docker.com/r/opengrok/docker/
 


### PR DESCRIPTION
Bionic was released in 2018, Jammy is a bit more up-to-date. The later used `tomcat:10.1-jdk11` image is based on Jammy as well, so we update the Perforce repo, too, and make it use HTTPS.