### PR TITLE
Added system/ping endpoint to the list of apis accesible outside localhost

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4,7 +4,7 @@ HIFORMAT: 1A
 
 OpenGrok RESTful API documentation. The following endpoints are accessible under `/api/v1` with the exception of `/metrics`.
 
-Besides `/suggester`, `/search`, `/system/ping`  and `/metrics` endpoints, everything is accessible from `localhost` only
+Besides `/suggester`, `/search`, `/system/ping` and `/metrics` endpoints, everything is accessible from `localhost` only
 unless authentication bearer tokens are configured in the web application and used via the 'Authorization' HTTP header
 (within HTTPS connection).
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -4,7 +4,7 @@ HIFORMAT: 1A
 
 OpenGrok RESTful API documentation. The following endpoints are accessible under `/api/v1` with the exception of `/metrics`.
 
-Besides `/suggester`, `/search` and `/metrics` endpoints, everything is accessible from `localhost` only
+Besides `/suggester`, `/search`, `/system/ping`  and `/metrics` endpoints, everything is accessible from `localhost` only
 unless authentication bearer tokens are configured in the web application and used via the 'Authorization' HTTP header
 (within HTTPS connection).
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SystemController.java
@@ -47,8 +47,10 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@Path("/system")
+@Path(SystemController.PATH)
 public class SystemController {
+
+    public static final String PATH = "system";
 
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
@@ -39,6 +39,7 @@ import org.opengrok.web.api.v1.controller.FileController;
 import org.opengrok.web.api.v1.controller.HistoryController;
 import org.opengrok.web.api.v1.controller.SearchController;
 import org.opengrok.web.api.v1.controller.SuggesterController;
+import org.opengrok.web.api.v1.controller.SystemController;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -70,7 +71,8 @@ public class IncomingFilter implements ContainerRequestFilter, ConfigurationChan
      */
     private static final Set<String> allowedPaths = new HashSet<>(Arrays.asList(
             SearchController.PATH, SuggesterController.PATH, SuggesterController.PATH + "/config",
-            HistoryController.PATH, FileController.PATH, AnnotationController.PATH));
+            HistoryController.PATH, FileController.PATH, AnnotationController.PATH,
+            SystemController.PATH + "/ping"));
 
     @Context
     private HttpServletRequest request;
@@ -136,7 +138,7 @@ public class IncomingFilter implements ContainerRequestFilter, ConfigurationChan
         }
 
         if (allowedPaths.contains(path)) {
-            LOGGER.log(Level.FINEST, "allowing request to {0} based on whitelisted path", path);
+            LOGGER.log(Level.FINEST, "allowing request to {0} based on allow listed path", path);
             return;
         }
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/filter/IncomingFilterTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/filter/IncomingFilterTest.java
@@ -198,13 +198,13 @@ public class IncomingFilterTest {
 
     @Test
     public void localhostTest() throws Exception {
-        assertFilterDoesNotBlockAddress("127.0.0.1");
+        assertFilterDoesNotBlockAddress("127.0.0.1","test");
     }
 
-    private void assertFilterDoesNotBlockAddress(final String remoteAddr) throws Exception {
+    private void assertFilterDoesNotBlockAddress(final String remoteAddr, final String url) throws Exception {
         IncomingFilter filter = mockWithRemoteAddress(remoteAddr);
 
-        ContainerRequestContext context = mockContainerRequestContext("test");
+        ContainerRequestContext context = mockContainerRequestContext(url);
 
         ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
 
@@ -215,19 +215,32 @@ public class IncomingFilterTest {
 
     @Test
     public void localhostIPv6Test() throws Exception {
-        assertFilterDoesNotBlockAddress("0:0:0:0:0:0:0:1");
+        assertFilterDoesNotBlockAddress("0:0:0:0:0:0:0:1","test");
     }
 
     @Test
     public void searchTest() throws Exception {
-        IncomingFilter filter = mockWithRemoteAddress("10.0.0.1");
+        assertFilterDoesNotBlockAddress("10.0.0.1","search");
+    }
 
-        ContainerRequestContext context = mockContainerRequestContext("search");
+    @Test
+    public void systemPingRemoteWithoutTokenTest() throws Exception {
+        assertFilterDoesNotBlockAddress("10.0.0.1","system/ping");
+    }
+
+    @Test
+    public void systemPathDescWithoutTokenTest() throws Exception {
+
+        IncomingFilter filter = mockWithRemoteAddress("192.168.1.1");
+
+        ContainerRequestContext context = mockContainerRequestContext("system/pathdesc");
 
         ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
 
         filter.filter(context);
 
-        verify(context, never()).abortWith(captor.capture());
+        verify(context).abortWith(captor.capture());
+
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), captor.getValue().getStatus());
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/filter/IncomingFilterTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/filter/IncomingFilterTest.java
@@ -198,7 +198,7 @@ public class IncomingFilterTest {
 
     @Test
     public void localhostTest() throws Exception {
-        assertFilterDoesNotBlockAddress("127.0.0.1","test");
+        assertFilterDoesNotBlockAddress("127.0.0.1", "test");
     }
 
     private void assertFilterDoesNotBlockAddress(final String remoteAddr, final String url) throws Exception {
@@ -215,17 +215,17 @@ public class IncomingFilterTest {
 
     @Test
     public void localhostIPv6Test() throws Exception {
-        assertFilterDoesNotBlockAddress("0:0:0:0:0:0:0:1","test");
+        assertFilterDoesNotBlockAddress("0:0:0:0:0:0:0:1", "test");
     }
 
     @Test
     public void searchTest() throws Exception {
-        assertFilterDoesNotBlockAddress("10.0.0.1","search");
+        assertFilterDoesNotBlockAddress("10.0.0.1", "search");
     }
 
     @Test
     public void systemPingRemoteWithoutTokenTest() throws Exception {
-        assertFilterDoesNotBlockAddress("10.0.0.1","system/ping");
+        assertFilterDoesNotBlockAddress("10.0.0.1", "system/ping");
     }
 
     @Test


### PR DESCRIPTION
Resolves https://github.com/oracle/opengrok/issues/4397
Added system/ping endpoint to the list of apis accessible outside localhost without bearer token. Exposing this api outside localhost helps to use this endpoint as readiness probe for k8s based deployment

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
