### PR TITLE
fix nits in Python tests causing build failure

### DIFF
--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/CtagsUtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/CtagsUtilTest.java
@@ -48,8 +48,6 @@ class CtagsUtilTest {
         assertNotNull(result, "getLanguages() should always return non null");
         assertFalse(result.isEmpty(), "should get Ctags languages");
         assertTrue(result.contains("C++"), "Ctags languages should contain C++");
-        // Test that the [disabled] tag is stripped for OldC.
-        assertTrue(result.contains("OldC"), "Ctags languages should contain OldC");
     }
 
     @Test

--- a/tools/src/test/python/test_readconfig.py
+++ b/tools/src/test/python/test_readconfig.py
@@ -20,7 +20,7 @@
 #
 
 #
-# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
 #
 import os
 import tempfile
@@ -37,5 +37,5 @@ def test_read_config_empty_yaml():
     res = read_config(mock(spec=logging.Logger, strict=False), tmpf.name)
     os.remove(tmpf.name)
     assert res is not None
-    assert type(res) == dict
+    assert type(res) is dict
     assert len(res) == 0

--- a/tools/src/test/python/test_restful.py
+++ b/tools/src/test/python/test_restful.py
@@ -20,7 +20,7 @@
 #
 
 #
-# Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
 #
 
 import pytest
@@ -30,7 +30,7 @@ from requests.exceptions import HTTPError
 
 from mockito import verify, patch, mock
 
-from opengrok_tools.utils.restful import call_rest_api,\
+from opengrok_tools.utils.restful import call_rest_api, \
     CONTENT_TYPE, APPLICATION_JSON, do_api_call
 from opengrok_tools.utils.commandsequence import ApiCall
 


### PR DESCRIPTION
Fixes the problem recently surfacing during Linux builds:
```
[INFO] --- exec:1.6.0:exec (Python flake8) @ tools ---
flake8.checker            MainProcess     93 INFO     Making checkers
flake8.main.application   MainProcess    756 INFO     Finished running
flake8.main.application   MainProcess    756 INFO     Reporting errors
flake8.main.application   MainProcess    757 INFO     Found a total of 13 violations and reported 2
/home/runner/work/opengrok/opengrok/tools/src/test/python/test_readconfig.py:40:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
/home/runner/work/opengrok/opengrok/tools/src/test/python/test_restful.py:33:55: E231 missing whitespace after ','
Error:  Command execution failed.
```

Also, remove the `OldC` ctags test. That parser was removed in Universal ctags in https://github.com/universal-ctags/ctags/commit/4c7738d9edcc751cafefd55bf9898c0df94d58c8