### PR TITLE
treat IOException in index check as success

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -173,7 +173,7 @@ public class IndexCheck {
     private static int checkDirNoExceptions(Path indexPath, IndexCheckMode mode, String projectName) {
         try {
             LOGGER.log(Level.INFO, "Checking index in ''{0}''", indexPath);
-            checkDir(indexPath, mode, projectName);
+            checkDir(indexPath, mode);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, String.format("Index check for directory '%s' failed", indexPath), e);
             return 1;
@@ -188,12 +188,11 @@ public class IndexCheck {
      * in the Lucene segment file were done with the same version.
      *
      * @param indexPath directory with index to check
-     * @param mode index check mode
-     * @param projectName name of the project, can be empty
-     * @throws IOException if the directory cannot be opened
+     * @param mode      index check mode
+     * @throws IOException           if the directory cannot be opened
      * @throws IndexVersionException if the version of the index does not match Lucene index version
      */
-    public static void checkDir(Path indexPath, IndexCheckMode mode, String projectName)
+    public static void checkDir(Path indexPath, IndexCheckMode mode)
             throws IndexVersionException, IndexDocumentException, IOException {
 
         LockFactory lockFactory = NativeFSLockFactory.INSTANCE;
@@ -293,8 +292,7 @@ public class IndexCheck {
         }
     }
 
-    private static void checkDuplicateDocuments(Path indexPath)
-            throws IOException, IndexDocumentException {
+    private static void checkDuplicateDocuments(Path indexPath) throws IOException, IndexDocumentException {
 
         LOGGER.log(Level.FINE, "Checking duplicate documents in ''{0}''", indexPath);
         Statistics stat = new Statistics();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -268,7 +268,7 @@ public final class Indexer {
                     System.exit(1);
                 }
 
-                if (!IndexCheck.check(cfg, indexCheckMode, subFileArgs)) {
+                if (!IndexCheck.isOkay(cfg, indexCheckMode, subFileArgs)) {
                     System.err.printf("Index check failed%n");
                     System.err.print("You might want to remove " +
                             (!subFilePaths.isEmpty() ? "data for projects " + String.join(",", subFilePaths) :

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -141,12 +141,12 @@ class IndexCheckTest {
         assertFalse(IndexCheck.check(configuration, IndexCheck.IndexCheckMode.VERSION, new ArrayList<>()));
 
         assertThrows(IndexCheck.IndexVersionException.class, () ->
-                IndexCheck.checkDir(indexPath, IndexCheck.IndexCheckMode.VERSION, ""));
+                IndexCheck.checkDir(indexPath, IndexCheck.IndexCheckMode.VERSION));
     }
 
     @Test
     void testEmptyDir(@TempDir Path tempDir) throws Exception {
         assertEquals(0, tempDir.toFile().list().length);
-        IndexCheck.checkDir(tempDir, IndexCheck.IndexCheckMode.VERSION, "");
+        IndexCheck.checkDir(tempDir, IndexCheck.IndexCheckMode.VERSION);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -43,6 +43,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -152,10 +154,15 @@ class IndexCheckTest {
 
     /**
      * Check that {@link IOException} thrown during index check is treated as success.
+     * Runs only on Unix systems because the {@link IOException} is not thrown on Windows
+     * for non-existent directories.
      */
     @Test
+    @EnabledOnOs({OS.LINUX, OS.MAC})
     void testIndexCheckIOException() {
+        // This is set to simulate IOException in IndexCheck.checkDir().
         configuration.setDataRoot("/nonexistent");
+
         configuration.setProjectsEnabled(false);
 
         IndexCheck.IndexCheckMode mode = IndexCheck.IndexCheckMode.VERSION;

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -158,7 +158,7 @@ public final class WebappListener implements ServletContextListener, ServletRequ
                     executor.submit(() -> {
                         try {
                             IndexCheck.checkDir(Path.of(indexRoot.toString(), projectEntry.getKey()),
-                                    IndexCheck.IndexCheckMode.VERSION, projectEntry.getKey());
+                                    IndexCheck.IndexCheckMode.VERSION);
                         } catch (Exception e) {
                             LOGGER.log(Level.WARNING,
                                     String.format("Project %s index check failed, marking as not indexed",
@@ -184,7 +184,7 @@ public final class WebappListener implements ServletContextListener, ServletRequ
             LOGGER.log(Level.FINE, "Checking index");
             try {
                 IndexCheck.checkDir(Path.of(env.getDataRootPath(), IndexDatabase.INDEX_DIR),
-                        IndexCheck.IndexCheckMode.VERSION, "");
+                        IndexCheck.IndexCheckMode.VERSION);
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, "index check failed", e);
             }


### PR DESCRIPTION
As suggested in https://github.com/oracle/opengrok/discussions/4401#discussioncomment-6802657, the index check should treat `IOException` as success.

For the test, I tried using static method mocking (had to update to Mockito v5 first), however had no luck with that, so the test is based on `IOException` being thrown for non-existent directory.