### PR TITLE
Added yaml lexer for yaml file analysis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN echo 'deb https://package.perforce.com/apt/ubuntu jammy release' > /etc/apt/
 RUN apt-get update && \
     apt-get install --no-install-recommends -y git subversion mercurial cvs cssc bzr rcs rcs-blame helix-p4d \
     unzip inotify-tools python3 python3-pip \
-    python3-venv python3-setuptools openssh-client
+    python3-venv python3-setuptools openssh-client libyaml-dev
 
 # compile and install universal-ctags
 # hadolint ignore=DL3003,DL3008

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -109,6 +109,7 @@ import org.opengrok.indexer.analysis.typescript.TypeScriptAnalyzerFactory;
 import org.opengrok.indexer.analysis.uue.UuencodeAnalyzerFactory;
 import org.opengrok.indexer.analysis.vb.VBAnalyzerFactory;
 import org.opengrok.indexer.analysis.verilog.VerilogAnalyzerFactory;
+import org.opengrok.indexer.analysis.yaml.YamlAnalyzerFactory;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.Annotation;
@@ -259,6 +260,7 @@ public class AnalyzerGuru {
                 new IgnorantAnalyzerFactory(),
                 new BZip2AnalyzerFactory(),
                 new XMLAnalyzerFactory(),
+                YamlAnalyzerFactory.DEFAULT_INSTANCE,
                 MandocAnalyzerFactory.DEFAULT_INSTANCE,
                 TroffAnalyzerFactory.DEFAULT_INSTANCE,
                 new ELFAnalyzerFactory(),
@@ -340,7 +342,7 @@ public class AnalyzerGuru {
      * {@link FileAnalyzerFactory} subclasses are revised to target more or
      * different files.
      * @return a value whose lower 32-bits are a static value
-     * 20201003_00
+     * 20230921_00
      * for the current implementation and whose higher-32 bits are non-zero if
      * {@link #addExtension(java.lang.String, AnalyzerFactory)}
      * or
@@ -348,7 +350,7 @@ public class AnalyzerGuru {
      * has been called.
      */
     public static long getVersionNo() {
-        final int ver32 = 20201003_00; // Edit comment above too!
+        final int ver32 = 20230921_00; // Edit comment above too!
         long ver = ver32;
         if (customizationHashCode != 0) {
             ver |= (long) customizationHashCode << 32;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/Consts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  */
 package org.opengrok.indexer.analysis.yaml;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/Consts.java
@@ -1,0 +1,49 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.analysis.yaml;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Holds static hash set containing the Java keywords.
+ */
+public class Consts {
+
+    static final Set<String> kwd = new HashSet<>();
+    static {
+        kwd.add("true");
+        kwd.add("false");
+        kwd.add("null");
+        kwd.add("True");
+        kwd.add("False");
+        kwd.add("Null");
+        kwd.add("TRUE");
+        kwd.add("FALSE");
+        kwd.add("NULL");
+    }
+
+    private Consts() {
+    }
+
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzer.java
@@ -1,0 +1,81 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
+ */
+package org.opengrok.indexer.analysis.yaml;
+
+import org.opengrok.indexer.analysis.AbstractAnalyzer;
+import org.opengrok.indexer.analysis.AnalyzerFactory;
+import org.opengrok.indexer.analysis.JFlexTokenizer;
+import org.opengrok.indexer.analysis.JFlexXref;
+import org.opengrok.indexer.analysis.plain.AbstractSourceCodeAnalyzer;
+
+import java.io.Reader;
+
+
+/**
+ *
+ * @author Gino Augustine
+ */
+public class YamlAnalyzer extends AbstractSourceCodeAnalyzer {
+
+
+    /**
+     * Creates a new instance of YamlAnalyzer.
+     * @param factory defined instance for the analyzer
+     */
+    protected YamlAnalyzer(AnalyzerFactory factory) {
+        super(factory, () -> new JFlexTokenizer(new YamlSymbolTokenizer(
+                AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "Java"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "Yaml";
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20230919_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20230921_00; // Edit comment above too!
+    }
+
+
+    /**
+     * Create an xref for the language supported by this analyzer.
+     *
+     * @param reader the data to produce xref for
+     * @return an xref instance
+     */
+    @Override
+    protected JFlexXref newXref(Reader reader) {
+        return new JFlexXref(new YamlXref(reader));
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
  */
 package org.opengrok.indexer.analysis.yaml;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzerFactory.java
@@ -1,0 +1,51 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
+ */
+package org.opengrok.indexer.analysis.yaml;
+
+import org.opengrok.indexer.analysis.AbstractAnalyzer;
+import org.opengrok.indexer.analysis.FileAnalyzerFactory;
+
+public class YamlAnalyzerFactory extends FileAnalyzerFactory {
+
+    private static final String NAME = "Yaml";
+
+    private static final String[] SUFFIXES = {
+        "YAML",
+        "YML"
+    };
+
+    public static final YamlAnalyzerFactory DEFAULT_INSTANCE =
+            new YamlAnalyzerFactory();
+
+
+    private YamlAnalyzerFactory() {
+        super(null, null, SUFFIXES, null, null, "text/plain",
+                AbstractAnalyzer.Genre.PLAIN, NAME);
+    }
+
+    @Override
+    protected AbstractAnalyzer newAnalyzer() {
+        return new YamlAnalyzer(this);
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
  */
 package org.opengrok.indexer.analysis.yaml;

--- a/opengrok-indexer/src/main/jflex/analysis/yaml/Yaml.lexh
+++ b/opengrok-indexer/src/main/jflex/analysis/yaml/Yaml.lexh
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
  */
 

--- a/opengrok-indexer/src/main/jflex/analysis/yaml/Yaml.lexh
+++ b/opengrok-indexer/src/main/jflex/analysis/yaml/Yaml.lexh
@@ -1,0 +1,28 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
+ */
+
+
+
+Identifier = [a-zA-Z0-9_-]+
+

--- a/opengrok-indexer/src/main/jflex/analysis/yaml/YamlSymbolTokenizer.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/yaml/YamlSymbolTokenizer.lex
@@ -1,0 +1,85 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").  
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
+ */
+
+/*
+ * Gets Java symbols - ignores comments, strings, keywords
+ */
+
+package org.opengrok.indexer.analysis.yaml;
+
+import org.opengrok.indexer.analysis.JFlexSymbolMatcher;
+%%
+%public
+%class YamlSymbolTokenizer
+%extends JFlexSymbolMatcher
+%unicode
+%buffer 32766
+%int
+%include ../CommonLexer.lexh
+%include ../Common.lexh
+%include Yaml.lexh
+%char
+
+%state STRING QSTRING SCOMMENT ALIAS_ANCHOR
+
+ANCHOR_ALIAS_START = [-?:]{WhspChar}+[*\&]
+%%
+
+
+<YYINITIAL> {
+
+{ANCHOR_ALIAS_START}     { yybegin(ALIAS_ANCHOR); }
+ \"     { yybegin(STRING); }
+ \'     { yybegin(QSTRING); }
+ "#"   { yybegin(SCOMMENT); }
+}
+
+<ALIAS_ANCHOR> {
+{Identifier} {
+    String id = yytext();
+    onSymbolMatched(id, yychar);
+    return yystate();
+    }
+ [^]    {yybegin(YYINITIAL);}
+}
+
+<STRING> {
+ \\[\"\\]    {}
+ \"     { yybegin(YYINITIAL); }
+}
+
+<QSTRING> {
+ \\[\'\\]    {}
+ \'     { yybegin(YYINITIAL); }
+}
+
+
+<SCOMMENT> {
+{EOL}    { yybegin(YYINITIAL);}
+}
+
+<YYINITIAL, STRING, SCOMMENT, QSTRING> {
+{WhspChar}+    {}
+[^]    {}
+}

--- a/opengrok-indexer/src/main/jflex/analysis/yaml/YamlSymbolTokenizer.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/yaml/YamlSymbolTokenizer.lex
@@ -23,7 +23,7 @@
  */
 
 /*
- * Gets Java symbols - ignores comments, strings, keywords
+ * Gets YAML symbols - ignores comments, strings, keywords
  */
 
 package org.opengrok.indexer.analysis.yaml;

--- a/opengrok-indexer/src/main/jflex/analysis/yaml/YamlXref.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/yaml/YamlXref.lex
@@ -23,7 +23,7 @@
  */
 
 /*
- * Cross reference a Java file
+ * Cross reference a YAML file
  */
 
 package org.opengrok.indexer.analysis.yaml;

--- a/opengrok-indexer/src/main/jflex/analysis/yaml/YamlXref.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/yaml/YamlXref.lex
@@ -1,0 +1,201 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").  
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
+ */
+
+/*
+ * Cross reference a Java file
+ */
+
+package org.opengrok.indexer.analysis.yaml;
+
+import java.io.IOException;
+import org.opengrok.indexer.analysis.JFlexSymbolMatcher;
+import org.opengrok.indexer.analysis.ScopeAction;
+import org.opengrok.indexer.analysis.EmphasisHint;
+import org.opengrok.indexer.util.StringUtils;
+import org.opengrok.indexer.web.HtmlConsts;
+%%
+%public
+%class YamlXref
+%extends JFlexSymbolMatcher
+%unicode
+%int
+%char
+%include ../CommonLexer.lexh
+%include ../CommonXref.lexh
+%include ../Common.lexh
+%include ../CommonURI.lexh
+%include Yaml.lexh
+Number = (0[xX][0-9a-fA-F]+|[0-9]+\.[0-9]+|[0-9]+)(([eE][+-]?[0-9]+)?[ufdlUFDL]*)?
+KEY_VALUE_START = [-?:]{WhspChar}+
+%{
+  /* Must match {WhiteSpace} regex */
+  private final static String WHITE_SPACE = "[ \\t\\f]+";
+
+  @Override
+  public void yypop() throws IOException {
+      onDisjointSpanChanged(null, yychar);
+      super.yypop();
+  }
+
+  protected void chkLOC() {
+      switch (yystate()) {
+          case SCOMMENT:
+              break;
+          default:
+              phLOC();
+              break;
+      }
+  }
+%}
+
+
+%state STRING SCOMMENT QSTRING KEYVALUE ANCHOR ALIAS
+%%
+<YYINITIAL>{
+
+ {Identifier}  {
+    chkLOC();
+    onQueryTermMatched(yytext(), yychar);
+ }
+ #   {
+    yypush(SCOMMENT);
+    onDisjointSpanChanged(HtmlConsts.COMMENT_CLASS, yychar);
+    onNonSymbolMatched(yytext(), yychar);
+ }
+ {KEY_VALUE_START}  {
+    chkLOC();
+    yypush(KEYVALUE);
+    onNonSymbolMatched(yytext(), yychar);
+ }
+}
+<KEYVALUE>{
+ [\&]/{Identifier}    {
+            chkLOC();
+            yypush(ANCHOR);
+            onNonSymbolMatched(yytext(), yychar);
+ }
+ [*]/{Identifier}    {
+            chkLOC();
+            yypush(ALIAS);
+            onNonSymbolMatched(yytext(), yychar);
+ }
+ {Number}   {
+    chkLOC();
+    onDisjointSpanChanged(HtmlConsts.NUMBER_CLASS, yychar);
+    onNonSymbolMatched(yytext(), yychar);
+    onDisjointSpanChanged(null, yychar);
+ }
+ {Identifier}    {
+    chkLOC();
+    String id = yytext();
+    if(Consts.kwd.contains(id)){
+       onKeywordMatched(id, yychar);
+   }else{
+       onNonSymbolMatched(yytext(), yychar);
+   }
+ }
+
+ \"     {
+    chkLOC();
+    yypush(STRING);
+    onDisjointSpanChanged(HtmlConsts.STRING_CLASS, yychar);
+    onNonSymbolMatched(yytext(), yychar);
+ }
+ \'     {
+    chkLOC();
+    yypush(QSTRING);
+    onDisjointSpanChanged(HtmlConsts.STRING_CLASS, yychar);
+    onNonSymbolMatched(yytext(), yychar);
+ }
+ #   {
+    yypop();
+    yypush(SCOMMENT);
+    onDisjointSpanChanged(HtmlConsts.COMMENT_CLASS, yychar);
+    onNonSymbolMatched(yytext(), yychar);
+ }
+}
+<ANCHOR> {
+ {Identifier}    {
+    chkLOC();
+    onSymbolMatched(yytext(), yychar);
+    yypop();
+ }
+}
+<ALIAS> {
+ {Identifier}    {
+     chkLOC();
+     onLabelDefMatched(yytext(), yychar);
+     yypop();
+ }
+}
+<ANCHOR,ALIAS> {
+ [^]    { chkLOC(); onNonSymbolMatched(yytext(), yychar); yypop();}
+}
+<STRING> {
+ \\[\"\\] |
+ \" {WhspChar}+ \"    { chkLOC(); onNonSymbolMatched(yytext(), yychar); }
+ \"     {
+    chkLOC();
+    onNonSymbolMatched(yytext(), yychar);
+    yypop();
+ }
+}
+
+<QSTRING> {
+ \\[\'\\] |
+ \' {WhspChar}+ \'    { chkLOC(); onNonSymbolMatched(yytext(), yychar); }
+ \'     {
+    chkLOC();
+    onNonSymbolMatched(yytext(), yychar);
+    yypop();
+ }
+}
+
+<KEYVALUE,SCOMMENT> {
+  {WhspChar}*{EOL} {
+    yypop();
+    onEndOfLineMatched(yytext(), yychar);
+  }
+ [[\s]--[\n]]    { onNonSymbolMatched(yytext(), yychar); }
+ [^\n]    { chkLOC(); onNonSymbolMatched(yytext(), yychar); }
+}
+
+<YYINITIAL, STRING, QSTRING> {
+{WhspChar}*{EOL}    { onEndOfLineMatched(yytext(), yychar); }
+ [[\s]--[\n]]    { onNonSymbolMatched(yytext(), yychar); }
+ [^\n]    { chkLOC(); onNonSymbolMatched(yytext(), yychar); }
+}
+
+<STRING,SCOMMENT,KEYVALUE> {
+    {BrowseableURI}    {
+        chkLOC();
+        onUriMatched(yytext(), yychar);
+    }
+}
+<QSTRING> {
+    {BrowseableURI}    {
+        chkLOC();
+        onUriMatched(yytext(), yychar, StringUtils.APOS_NO_BSESC);
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yaml/YamlSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yaml/YamlSymbolTokenizerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
  */
 package org.opengrok.indexer.analysis.yaml;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yaml/YamlSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yaml/YamlSymbolTokenizerTest.java
@@ -1,0 +1,81 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
+ */
+package org.opengrok.indexer.analysis.yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.analysis.AbstractAnalyzer;
+import org.opengrok.indexer.analysis.JFlexTokenizer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/**
+ * Tests the {@link YamlSymbolTokenizer} class.
+ * @author Gino Augustine
+ */
+public class YamlSymbolTokenizerTest {
+
+    private final AbstractAnalyzer analyzer;
+
+    public YamlSymbolTokenizerTest() {
+        this.analyzer = YamlAnalyzerFactory.DEFAULT_INSTANCE.getAnalyzer();
+    }
+
+    private String[] getTermsFor(Reader r) {
+        List<String> l = new LinkedList<>();
+        JFlexTokenizer ts = (JFlexTokenizer) this.analyzer.tokenStream("refs", r);
+        ts.setReader(r);
+        CharTermAttribute term = ts.addAttribute(CharTermAttribute.class);
+        try {
+            ts.reset();
+            while (ts.incrementToken()) {
+                l.add(term.toString());
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        return l.toArray(new String[0]);
+    }
+
+    @Test
+    public void sampleTest() throws IOException {
+        try (InputStream res = getClass().getClassLoader().getResourceAsStream("analysis/yaml/sample.yml");
+             InputStreamReader r = new InputStreamReader(res, StandardCharsets.UTF_8)) {
+            String[] termsFor = getTermsFor(r);
+            assertArrayEquals(
+                    new String[] {"apiarypath", "apiarypath"
+                    },
+                    termsFor);
+        }
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yaml/YamlXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yaml/YamlXrefTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
  */
 package org.opengrok.indexer.analysis.yaml;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yaml/YamlXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yaml/YamlXrefTest.java
@@ -1,0 +1,44 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
+ */
+package org.opengrok.indexer.analysis.yaml;
+
+import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.analysis.XrefTestBase;
+import java.io.IOException;
+
+import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
+
+/**
+ * Tests the {@link YamlXref} class.
+ */
+public class YamlXrefTest extends XrefTestBase {
+
+    @Test
+    public void sampleTest() throws IOException {
+        writeAndCompare(YamlAnalyzerFactory.DEFAULT_INSTANCE,
+                "analysis/yaml/sample.yml",
+                "analysis/yaml/sample_xref.html",
+                readTagsFromResource("analysis/yaml/sampletags"), 21);
+    }
+}

--- a/opengrok-indexer/src/test/resources/analysis/yaml/sample.yml
+++ b/opengrok-indexer/src/test/resources/analysis/yaml/sample.yml
@@ -1,0 +1,23 @@
+name: Check Apiary blueprint
+
+on:
+  push:
+    paths:
+      - &apiarypath apiary.apib
+    branches:
+      - master
+  pull_request:
+    paths:
+      - *apiarypath
+
+jobs:
+  ubuntu:
+    name: Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v2
+      - name: Install drafter
+        run: npm install drafter
+      - name: Build
+        run: node dev/parse.js

--- a/opengrok-indexer/src/test/resources/analysis/yaml/sample_xref.html
+++ b/opengrok-indexer/src/test/resources/analysis/yaml/sample_xref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>sampleFile - OpenGrok cross reference for /sampleFile</title></head><body>
+<script type="text/javascript">/* <![CDATA[ */
+function get_sym_list(){return [];} /* ]]> */</script><a class="l" name="1" href="#1">1</a><a href="/source/s?full=name">name</a>: Check Apiary blueprint
+<a class="l" name="2" href="#2">2</a>
+<a class="l" name="3" href="#3">3</a><a href="/source/s?full=on">on</a>:
+<a class="l" name="4" href="#4">4</a>  <a href="/source/s?full=push">push</a>:
+<a class="l" name="5" href="#5">5</a>    <a href="/source/s?full=paths">paths</a>:
+<a class="l" name="6" href="#6">6</a>      - &amp;<a class="d" name="apiarypath"/><a href="/source/s?refs=apiarypath" class="d intelliWindow-symbol" data-definition-place="def">apiarypath</a> apiary.apib
+<a class="l" name="7" href="#7">7</a>    <a href="/source/s?full=branches">branches</a>:
+<a class="l" name="8" href="#8">8</a>      - master
+<a class="l" name="9" href="#9">9</a>  <a href="/source/s?full=pull_request">pull_request</a>:
+<a class="hl" name="10" href="#10">10</a>    <a href="/source/s?full=paths">paths</a>:
+<a class="l" name="11" href="#11">11</a>      - *<a class="d intelliWindow-symbol" href="#apiarypath" data-definition-place="defined-in-file">apiarypath</a>
+<a class="l" name="12" href="#12">12</a>
+<a class="l" name="13" href="#13">13</a><a href="/source/s?full=jobs">jobs</a>:
+<a class="l" name="14" href="#14">14</a>  <a href="/source/s?full=ubuntu">ubuntu</a>:
+<a class="l" name="15" href="#15">15</a>    <a href="/source/s?full=name">name</a>: Ubuntu
+<a class="l" name="16" href="#16">16</a>    <a href="/source/s?full=runs%5C-on">runs-on</a>: ubuntu-latest
+<a class="l" name="17" href="#17">17</a>    <a href="/source/s?full=steps">steps</a>:
+<a class="l" name="18" href="#18">18</a>      - name: Checkout master branch
+<a class="l" name="19" href="#19">19</a>        <a href="/source/s?full=uses">uses</a>: actions/checkout@v2
+<a class="hl" name="20" href="#20">20</a>      - name: Install drafter
+<a class="l" name="21" href="#21">21</a>        <a href="/source/s?full=run">run</a>: npm install drafter
+<a class="l" name="22" href="#22">22</a>      - name: Build
+<a class="l" name="23" href="#23">23</a>        <a href="/source/s?full=run">run</a>: node dev/parse.js
+<a class="l" name="24" href="#24">24</a></body>
+</html>

--- a/opengrok-indexer/src/test/resources/analysis/yaml/sampletags
+++ b/opengrok-indexer/src/test/resources/analysis/yaml/sampletags
@@ -1,0 +1,1 @@
+apiarypath	sample.yml	/^      - &apiarypath apiary.apib$/;"	anchor	line:6


### PR DESCRIPTION
resolves #4353
Added yaml lexer support
Added libyaml for ctgs to parse yaml file
Sample output
![image](https://github.com/oracle/opengrok/assets/56913861/83c86c1e-0f2e-4be2-a1cd-066e15ae8dbb)

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
