### PR TITLE
make sure HistoryException is thrown for all problems in storeFile()

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -294,14 +294,14 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
      * @param file file to store the history object into
      * @param repo repository for the file
      * @param mergeHistory whether to merge the history with existing or store the histNew as is
+     * @throws HistoryException if there was any problem with history cache generation
      */
     private void storeFile(History histNew, File file, Repository repo, boolean mergeHistory) throws HistoryException {
         File cacheFile;
         try {
             cacheFile = getCachedFile(file);
         } catch (CacheException e) {
-            LOGGER.log(Level.FINER, e.getMessage());
-            return;
+            throw new HistoryException(e);
         }
 
         File dir = cacheFile.getParentFile();


### PR DESCRIPTION
As noted in https://github.com/oracle/opengrok/discussions/4145#discussioncomment-7100494, the fidelity of history cache creation reporting of file counts relies on `HistoryException` to be thrown for all problems in functions responsible for history cache entry creation/modification. This change fixes one (last ?) place where this was not done.