### PR TITLE
Upgrade Chronicle-Map

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -51,7 +51,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.6.0</version>
             <executions>
               <execution>
                 <id>copy-dependencies</id>
@@ -70,7 +70,7 @@
           </plugin>
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.6.0</version>
             <configuration>
               <finalName>opengrok-${project.version}</finalName>
               <appendAssemblyId>false</appendAssemblyId>

--- a/opengrok-web/pom.xml
+++ b/opengrok-web/pom.xml
@@ -68,13 +68,13 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-            <version>2.0.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
@@ -103,12 +103,12 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.4</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.npm</groupId>
             <artifactId>showdown</artifactId>
-            <version>1.9.1</version>
+            <version>2.1.0</version>
             <!-- dependencies not required -->
             <exclusions>
                 <exclusion>
@@ -132,7 +132,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <dependency>
             <groupId>org.webjars.npm</groupId>
             <artifactId>xss</artifactId>
-            <version>1.0.8</version>
+            <version>1.0.10</version>
             <!-- dependencies not required -->
             <exclusions>
                 <exclusion>
@@ -181,7 +181,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
-            <version>2.4.4</version>
+            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <jackson.version>2.15.2</jackson.version>
         <junit.version>5.10.0</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <maven-surefire.version>3.0.0-M5</maven-surefire.version>
+        <maven-surefire.version>3.1.2</maven-surefire.version>
         <apache-commons-lang3.version>3.13.0</apache-commons-lang3.version>
         <micrometer.version>1.11.4</micrometer.version>
         <mockito.version>3.12.4</mockito.version>
@@ -155,7 +155,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.10.11</version>
+                <version>1.10.14</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
@@ -171,7 +171,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <dependency>
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
-                <version>4.1.0</version>
+                <version>4.2.0</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -183,7 +183,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <dependency>
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
-                <version>22.0.0</version>
+                <version>24.0.1</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>
@@ -215,7 +215,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.4.1</version>
                 <executions>
                   <execution>
                     <id>enforce-maven</id>
@@ -238,7 +238,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.6.0</version>
                 <configuration>
                     <descriptors>
                         <descriptor>assembly.xml</descriptor>
@@ -259,7 +259,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                       <arg>-Xlint:-fallthrough</arg>
                     </compilerArgs>
                 </configuration>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
             </plugin>
             <plugin>
                 <!-- UNIT TEST RUNNER -->
@@ -283,7 +283,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.10</version>
                 <executions>
                     <!-- Prepare execution with Surefire -->
                     <execution>
@@ -353,12 +353,12 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             </plugin>
             <plugin>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.4.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.9.1</version>
+                <version>3.12.1</version>
             </plugin>
         </plugins>
         <pluginManagement>
@@ -366,12 +366,12 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.3.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>9.1</version>
+                            <version>10.12.4</version>
                         </dependency>
                     </dependencies>
                     <executions>
@@ -380,7 +380,6 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                             <phase>validate</phase>
                             <configuration>
                                 <configLocation>/dev/checkstyle/style.xml</configLocation>
-                                <encoding>UTF-8</encoding>
                                 <consoleOutput>true</consoleOutput>
                                 <failsOnError>true</failsOnError>
                                 <suppressionsLocation>/dev/checkstyle/suppressions.xml</suppressionsLocation>
@@ -398,7 +397,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <addDefaultExcludes>false</addDefaultExcludes>
                     </configuration>
@@ -415,7 +414,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>8.1.2</version>
+                        <version>8.4.0</version>
                         <configuration>
                             <skipSystemScope>true</skipSystemScope>
                             <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
@@ -446,7 +445,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
               <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
-                <version>3.9.1.2184</version>
+                <version>3.10.0.2594</version>
               </plugin>
             </plugins>
           </build>
@@ -458,7 +457,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.2.3</version>
+                <version>4.7.3.6</version>
                 <configuration>
                     <xmlOutput>true</xmlOutput>
                     <includeFilterFile>dev/findbugs_filter.xml</includeFilterFile>
@@ -521,7 +520,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.3.0</version>
             </plugin>
         </plugins>
     </reporting>

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -101,7 +101,7 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
         <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>chronicle-map</artifactId>
-            <version>3.21.85</version>
+            <version>3.22.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.java</groupId>

--- a/suggester/src/main/java/org/opengrok/suggest/popular/impl/chronicle/BytesRefDataAccess.java
+++ b/suggester/src/main/java/org/opengrok/suggest/popular/impl/chronicle/BytesRefDataAccess.java
@@ -22,7 +22,7 @@
  */
 package org.opengrok.suggest.popular.impl.chronicle;
 
-import net.openhft.chronicle.bytes.HeapBytesStore;
+import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.RandomDataInput;
 import net.openhft.chronicle.hash.AbstractData;
 import net.openhft.chronicle.hash.Data;
@@ -35,13 +35,12 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * {@link BytesRef} data serializer for {@link net.openhft.chronicle.map.ChronicleMap}.
- * Modified from https://github.com/OpenHFT/Chronicle-Map/blob/master/docs/CM_Tutorial_DataAccess.adoc
+ * Modified from <a href="https://github.com/OpenHFT/Chronicle-Map/blob/master/docs/CM_Tutorial_DataAccess.adoc">...</a>
  */
-@SuppressWarnings("deprecation")
 public class BytesRefDataAccess extends AbstractData<BytesRef> implements DataAccess<BytesRef> {
 
     /** Cache field. */
-    private transient HeapBytesStore<byte[]> bs;
+    private transient BytesStore<?, ?> bs;
 
     /** State field. */
     private transient byte[] array;
@@ -95,7 +94,7 @@ public class BytesRefDataAccess extends AbstractData<BytesRef> implements DataAc
             array = new byte[instance.length];
             System.arraycopy(instance.bytes, instance.offset, array, 0, instance.length);
         }
-        bs = HeapBytesStore.wrap(array);
+        bs = BytesStore.wrap(array);
         return this;
     }
 


### PR DESCRIPTION
Upgrade Chronicle-Map and other maven plugins
Update BytesRefDataAccess as per https://github.com/OpenHFT/Chronicle-Map/blob/ea/docs/CM_Tutorial_DataAccess.adoc
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
