### PR TITLE
wait for all the futures in fillLastHistoryEntries() to complete

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -804,11 +804,9 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
             try {
                 if (!future.get()) {
                     ret = false;
-                    break;
                 }
             } catch (Exception e) {
                 ret = false;
-                break;
             }
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -761,6 +761,12 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
         return rev;
     }
 
+    /**
+     * Attempt to fill the date and description for the input instances from pertaining last history entries.
+     * @param entries list of {@link DirectoryEntry} instances
+     * @return true if all of them were filled, false otherwise in which case the date/description field
+     * for the entries will be zeroed.
+     */
     @Override
     public boolean fillLastHistoryEntries(List<DirectoryEntry> entries) {
         if (entries == null) {
@@ -800,6 +806,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
             }));
         }
 
+        // Wait for all the futures to complete. This is important as they are modifying the input parameter.
         for (Future<Boolean> future : futures) {
             try {
                 if (!future.get()) {


### PR DESCRIPTION
This is an attempt to fix #4333. When the method returns, some of the futures might be still running. This might change the input entries, hence the discrepancy. I contemplated using `cancel()` on the futures which returned false or resulted in an exception, however this is more robust as the cancelled futures would have to be still checked via `isCancelled()`.