### PR TITLE
Junit error in Suggester Controller Test

### DIFF
--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
@@ -315,7 +315,7 @@ class SuggesterProjectData implements Closeable {
                 m = new ChronicleMapAdapter(field, conf.getAverageKeySize(), conf.getEntries(), f);
             } catch (IllegalArgumentException e) {
                 logger.log(Level.SEVERE, String.format("Could not create ChronicleMap for field %s in directory " +
-                        "'%s' due to invalid key size (%f) or number of entries: (%d):",
+                                "'%s' due to invalid key size (%f) or number of entries: (%d):",
                         field, suggesterDir,  conf.getAverageKeySize(), conf.getEntries()), e);
                 return;
             } catch (Throwable t) {
@@ -324,8 +324,14 @@ class SuggesterProjectData implements Closeable {
                                 +  " , most popular completion disabled, if you are using "
                                 + "JDK9+ make sure to specify: "
                                 + "--add-exports java.base/jdk.internal.ref=ALL-UNNAMED "
-                                + "--add-exports java.base/jdk.internal.misc=ALL-UNNAMED "
-                                + "--add-exports java.base/sun.nio.ch=ALL-UNNAMED", field, suggesterDir), t);
+                                + "--add-exports java.base/sun.nio.ch=ALL-UNNAMED "
+                                + "--add-exports jdk.unsupported/sun.misc=ALL-UNNAMED "
+                                + "--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED "
+                                + "--add-opens jdk.compiler/com.sun.tools.javac=ALL-UNNAMED "
+                                + "--add-opens java.base/java.lang=ALL-UNNAMED "
+                                + "--add-opens java.base/java.lang.reflect=ALL-UNNAMED "
+                                + "--add-opens java.base/java.io=ALL-UNNAMED "
+                                + "--add-opens java.base/java.util=ALL-UNNAMED", field, suggesterDir), t);
                 return;
             }
 

--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterSearcher.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterSearcher.java
@@ -293,7 +293,7 @@ class SuggesterSearcher extends IndexSearcher {
         while (postingsEnum.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
             int docId = postingsEnum.docID();
             if (data.documentIds.has(docBase + docId)) {
-                IntsHolder positions = data.scorer.getPositions(docBase + docId);
+                IntsHolder positions = data.scorer.getPositions(docId);
                 if (positions == null) {
                     continue;
                 }


### PR DESCRIPTION
Junit error was coming up when suggester results are from second Lucene segment(docbase>0).
Document ID map inside Complex data was populated with key as docbase +docID , but documentToPositionsMap inside phrase scorer is considering only doc id. 
Junit was passing mostly since the data will be in one segment and docbase will be zero for this usecase.
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
