### PR TITLE
rework do_sync() tests

### DIFF
--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -93,6 +93,10 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
     :return SUCCESS_EXITVAL on success, FAILURE_EXITVAL on error
     """
 
+    # Nothing to do.
+    if len(commands) == 0:
+        return SUCCESS_EXITVAL
+
     cmds_base = []
     for directory in dirs_to_process:
         cmd_base = CommandSequenceBase(directory, commands, loglevel=loglevel,
@@ -104,6 +108,11 @@ def do_sync(loglevel, commands, cleanup, dirs_to_process, ignore_errors,
         cmds_base.append(cmd_base)
 
     if check_config:
+        #
+        # The configuration check was done unconditionally in CommandSequenceBase initialization above.
+        # If there was a problem with the configuration, the CommandConfigurationException was raised,
+        # so if the code flow arrived to this very block, this means that the check had been successful.
+        #
         if not logger:
             logger = logging.getLogger(__name__)
         logger.info("Configuration check passed")

--- a/tools/src/test/python/test_sync.py
+++ b/tools/src/test/python/test_sync.py
@@ -56,7 +56,7 @@ def test_dosync_check_config(check_config, expected_times):
 
 def test_dosync_check_config_invalid():
     """
-    The commands structure should be a dictionary and the config check should recognize this
+    The commands list should contain a dictionary and the config check should recognize this
     and raise CommandConfigurationException.
     """
     commands = ["foo"]

--- a/tools/src/test/python/test_sync.py
+++ b/tools/src/test/python/test_sync.py
@@ -37,6 +37,10 @@ from opengrok_tools.utils.exitvals import SUCCESS_EXITVAL
 
 @pytest.mark.parametrize('check_config', [True, False])
 def test_dosync_empty_commands(check_config):
+    """
+    If the commands structure is empty, the do_sync() code should never make it to the Pool.map() call,
+    regardless of the check_config parameter value.
+    """
     commands = []
     with patch(pool.Pool.map, lambda x, y, z: []):
         assert do_sync(logging.INFO, commands, None, ["foo", "bar"], [],
@@ -46,7 +50,11 @@ def test_dosync_empty_commands(check_config):
 
 @pytest.mark.parametrize(['check_config', 'expected_times'], [(True, 0), (False, 1)])
 def test_dosync_check_config(check_config, expected_times):
-    # The port used in the call within the commands structure is not expected to be reachable.
+    """
+    If the check_config parameter is True, the do_sync() code should never make it to the Pool.map() call.
+    """
+    # The port used in the call within the commands structure is not expected to be reachable
+    # since there is no call made because the map() function is patched below.
     commands = [{"call": {"uri": "http://localhost:11"}}]
     with patch(pool.Pool.map, lambda x, y, z: []):
         assert do_sync(logging.INFO, commands, None, ["foo", "bar"], [],

--- a/tools/src/test/python/test_sync.py
+++ b/tools/src/test/python/test_sync.py
@@ -32,10 +32,10 @@ from mockito import verify, ANY, patch
 
 from opengrok_tools.sync import do_sync
 from opengrok_tools.utils.commandsequence import CommandConfigurationException
-from opengrok_tools.utils.exitvals import SUCCESS_EXITVAL, FAILURE_EXITVAL
+from opengrok_tools.utils.exitvals import SUCCESS_EXITVAL
 
 
-@pytest.mark.parametrize(['check_config'], [True, False])
+@pytest.mark.parametrize('check_config', [True, False])
 def test_dosync_empty_commands(check_config):
     commands = []
     with patch(pool.Pool.map, lambda x, y, z: []):
@@ -46,10 +46,11 @@ def test_dosync_empty_commands(check_config):
 
 @pytest.mark.parametrize(['check_config', 'expected_times'], [(True, 0), (False, 1)])
 def test_dosync_check_config(check_config, expected_times):
-    commands = [{"call": {"uri": "http://localhost:8888"}}]
+    # The port used in the call within the commands structure is not expected to be reachable.
+    commands = [{"call": {"uri": "http://localhost:11"}}]
     with patch(pool.Pool.map, lambda x, y, z: []):
         assert do_sync(logging.INFO, commands, None, ["foo", "bar"], [],
-                       "http://localhost:8080/source", 1, check_config=check_config) == FAILURE_EXITVAL
+                       "http://localhost:8080/source", 1, check_config=check_config) == SUCCESS_EXITVAL
         verify(pool.Pool, times=expected_times).map(ANY, ANY, ANY)
 
 


### PR DESCRIPTION
This is attempt to fix #4430 by making the `Pool.map()` to be called only on non-empty list of commands.