### PR TITLE
tidy IndexCheck and improve its testing

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -570,8 +570,9 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     /**
      * Get the project for a specific file.
      *
-     * @param file the file to lookup
-     * @return the project that this file belongs to (or {@code null} if the file doesn't belong to a project)
+     * @param file file under source root
+     * @return the project that this file belongs to (or {@code null} if the file doesn't belong to a project,
+     * or it is a symbolic link that is not allowed)
      */
     @Nullable
     public static Project getProject(File file) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -337,10 +337,10 @@ public class IndexCheck implements AutoCloseable {
 
         switch (mode) {
             case VERSION:
-                checkVersion(indexPath);
+                checkVersion(sourcePath, indexPath);
                 break;
             case DOCUMENTS:
-                checkDuplicateDocuments(indexPath);
+                checkDuplicateDocuments(sourcePath, indexPath);
                 break;
             case DEFINITIONS:
                 checkDefinitions(sourcePath, indexPath);
@@ -503,12 +503,13 @@ public class IndexCheck implements AutoCloseable {
     }
 
     /**
+     * @param sourcePath path to the source
      * @param indexPath path to the index directory
      * @throws IOException on I/O error
      * @throws IndexVersionException if the version stored in the document does not match the version
      * used by the running program
      */
-    private void checkVersion(Path indexPath) throws IOException, IndexVersionException {
+    private void checkVersion(Path sourcePath, Path indexPath) throws IOException, IndexVersionException {
         LockFactory lockFactory = NativeFSLockFactory.INSTANCE;
         int segVersion;
 
@@ -526,7 +527,7 @@ public class IndexCheck implements AutoCloseable {
                 new Object[]{indexPath, segVersion, Version.LATEST.major});
         if (segVersion != Version.LATEST.major) {
             throw new IndexVersionException(
-                String.format("Directory '%s' has index version discrepancy", indexPath), indexPath,
+                String.format("Index for '%s' has index version discrepancy", sourcePath), sourcePath,
                     Version.LATEST.major, segVersion);
         }
     }
@@ -606,7 +607,7 @@ public class IndexCheck implements AutoCloseable {
         }
     }
 
-    private static void checkDuplicateDocuments(Path indexPath) throws IOException, IndexDocumentException {
+    private static void checkDuplicateDocuments(Path sourcePath, Path indexPath) throws IOException, IndexDocumentException {
 
         LOGGER.log(Level.FINE, "Checking duplicate documents in ''{0}''", indexPath);
         Statistics stat = new Statistics();
@@ -640,8 +641,8 @@ public class IndexCheck implements AutoCloseable {
 
         stat.report(LOGGER, Level.FINE, String.format("duplicate check in '%s' done", indexPath));
         if (!fileMap.isEmpty()) {
-            throw new IndexDocumentException(String.format("index in '%s' contains duplicate live documents",
-                    indexPath), indexPath, fileMap);
+            throw new IndexDocumentException(String.format("index for '%s' contains duplicate live documents",
+                    sourcePath), sourcePath, fileMap);
         }
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -33,7 +33,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -90,76 +89,6 @@ public class IndexCheck implements AutoCloseable {
         VERSION,
         DEFINITIONS,
         DOCUMENTS
-    }
-
-    /**
-     * Common exception for all check modes.
-     */
-    public static class IndexCheckException extends Exception {
-        private static final long serialVersionUID = 5693446916108385595L;
-
-        private final Set<Path> failedPaths = new HashSet<>();
-
-        public IndexCheckException(String s, Path path) {
-            super(s);
-            failedPaths.add(path);
-        }
-
-        public IndexCheckException(String s, Set<Path> paths) {
-            super(s);
-            failedPaths.addAll(paths);
-        }
-
-        public Set<Path> getFailedPaths() {
-            return Collections.unmodifiableSet(failedPaths);
-        }
-    }
-
-    /**
-     * Exception thrown when index version does not match Lucene version.
-     */
-    public static class IndexVersionException extends IndexCheckException {
-
-        private static final long serialVersionUID = 5693446916108385595L;
-
-        private final int luceneIndexVersion;
-        private final int indexVersion;
-
-        public IndexVersionException(String s, Path path, int luceneIndexVersion, int indexVersion) {
-            super(s, path);
-            this.indexVersion = indexVersion;
-            this.luceneIndexVersion = luceneIndexVersion;
-        }
-
-        @Override
-        public String toString() {
-            return getMessage() + ": " + String.format("Lucene version = %d", luceneIndexVersion) + ", " +
-                    String.format("index version = %d", indexVersion);
-        }
-    }
-
-    /**
-     * Exception thrown when index contains duplicate live documents.
-     */
-    public static class IndexDocumentException extends IndexCheckException {
-        private static final long serialVersionUID = 5693446916108385595L;
-
-        private final Map<String, Integer> fileMap;
-
-        public IndexDocumentException(String s, Path path) {
-            super(s, path);
-            this.fileMap = null;
-        }
-
-        public IndexDocumentException(String s, Path path, Map<String, Integer> fileMap) {
-            super(s, path);
-            this.fileMap = fileMap;
-        }
-
-        @Override
-        public String toString() {
-            return getMessage() + ": " + (fileMap == null ? "" : fileMap);
-        }
     }
 
     private final Configuration configuration;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -188,7 +188,7 @@ public class IndexCheck implements AutoCloseable {
         }
 
         executor = Executors.newFixedThreadPool(RuntimeEnvironment.getInstance().getRepositoryInvalidationParallelism(),
-                new OpenGrokThreadFactory("webapp-index-check"));
+                new OpenGrokThreadFactory("index-check"));
     }
 
     public void close() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -466,7 +466,6 @@ public class IndexCheck implements AutoCloseable {
         LOGGER.log(Level.FINE, "Checking definitions in ''{0}'' ({1} paths)",
                 new Object[]{indexPath, paths.size()});
 
-        // TODO: reconcile this with the executor used for this class
         long errors = 0;
         ExecutorService executorService = RuntimeEnvironment.getInstance().getIndexerParallelizer().getFixedExecutor();
         List<Future<Boolean>> futures = new ArrayList<>();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -33,14 +33,17 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -61,8 +64,10 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.Version;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.analysis.Definitions;
 import org.opengrok.indexer.configuration.Configuration;
+import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.search.QueryBuilder;
@@ -70,11 +75,11 @@ import org.opengrok.indexer.util.Statistics;
 import org.opengrok.indexer.web.Util;
 
 /**
- * Index checker.
+ * Index checker. Offers multiple methods of checking the index. The main method is {@link #check(IndexCheckMode)}.
  *
  * @author Vladimír Kotal
  */
-public class IndexCheck {
+public class IndexCheck implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexCheck.class);
 
     /**
@@ -88,18 +93,40 @@ public class IndexCheck {
     }
 
     /**
+     * Common exception for all check modes.
+     */
+    public static class IndexCheckException extends Exception {
+        private static final long serialVersionUID = 5693446916108385595L;
+
+        private final Set<Path> failedPaths = new HashSet<>();
+
+        public IndexCheckException(String s, Path path) {
+            super(s);
+            failedPaths.add(path);
+        }
+
+        public IndexCheckException(String s, Set<Path> paths) {
+            super(s);
+            failedPaths.addAll(paths);
+        }
+
+        public Set<Path> getFailedPaths() {
+            return Collections.unmodifiableSet(failedPaths);
+        }
+    }
+
+    /**
      * Exception thrown when index version does not match Lucene version.
      */
-    public static class IndexVersionException extends Exception {
+    public static class IndexVersionException extends IndexCheckException {
 
         private static final long serialVersionUID = 5693446916108385595L;
 
         private final int luceneIndexVersion;
         private final int indexVersion;
 
-        public IndexVersionException(String s, int luceneIndexVersion, int indexVersion) {
-            super(s);
-
+        public IndexVersionException(String s, Path path, int luceneIndexVersion, int indexVersion) {
+            super(s, path);
             this.indexVersion = indexVersion;
             this.luceneIndexVersion = luceneIndexVersion;
         }
@@ -114,20 +141,18 @@ public class IndexCheck {
     /**
      * Exception thrown when index contains duplicate live documents.
      */
-    public static class IndexDocumentException extends Exception {
+    public static class IndexDocumentException extends IndexCheckException {
         private static final long serialVersionUID = 5693446916108385595L;
 
         private final Map<String, Integer> fileMap;
 
-        public IndexDocumentException(String s) {
-            super(s);
-
+        public IndexDocumentException(String s, Path path) {
+            super(s, path);
             this.fileMap = null;
         }
 
-        public IndexDocumentException(String s, Map<String, Integer> fileMap) {
-            super(s);
-
+        public IndexDocumentException(String s, Path path, Map<String, Integer> fileMap) {
+            super(s, path);
             this.fileMap = fileMap;
         }
 
@@ -137,76 +162,169 @@ public class IndexCheck {
         }
     }
 
-    private IndexCheck() {
-        // utility class
+    private final Configuration configuration;
+    private final Set<String> projectNames = new HashSet<>();
+
+    // Common executor for parallel processing.
+    private final ExecutorService executor;
+
+    /**
+     * @param configuration configuration based on which to perform the check
+     */
+    public IndexCheck(@NotNull Configuration configuration) {
+        this(configuration, null);
     }
 
     /**
-     * Check index(es).
      * @param configuration configuration based on which to perform the check
-     * @param mode index check mode
      * @param projectNames collection of project names. If non-empty, only projects matching these paths will be checked.
      *                     Otherwise, either the sole index or all project indexes will be checked, depending
      *                     on whether projects are enabled in the configuration.
-     * @return true on success, false on failure
      */
-    public static boolean isOkay(@NotNull Configuration configuration, IndexCheckMode mode,
-                                 Collection<String> projectNames) throws IOException {
+    public IndexCheck(@NotNull Configuration configuration, Collection<String> projectNames) {
+        this.configuration = configuration;
+        if (projectNames != null) {
+            this.projectNames.addAll(projectNames);
+        }
+
+        executor = Executors.newFixedThreadPool(RuntimeEnvironment.getInstance().getRepositoryInvalidationParallelism(),
+                new OpenGrokThreadFactory("webapp-index-check"));
+    }
+
+    public void close() {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(configuration.getIndexCheckTimeout(), TimeUnit.SECONDS)) {
+                LOGGER.log(Level.WARNING, "index check took more than {0} seconds",
+                        configuration.getIndexCheckTimeout());
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            LOGGER.log(Level.WARNING, "failed to await termination of index check");
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Perform index check of given projects in parallel.
+     * @param mode index check mode
+     * @param projectNames set of project names
+     * @throws IOException on I/O error
+     */
+    private void checkProjectsParallel(IndexCheckMode mode, Set<String> projectNames)
+            throws IOException, IndexCheckException {
+
+        Path indexRoot = Path.of(configuration.getDataRoot(), IndexDatabase.INDEX_DIR);
+
+        Set<Future<Exception>> futures = new HashSet<>();
+        for (String projectName : projectNames) {
+            futures.add(executor.submit(() -> {
+                try {
+                    checkDirWithLogging(Path.of(configuration.getSourceRoot(), projectName),
+                            Path.of(indexRoot.toString(), projectName),
+                            mode);
+                } catch (Exception e) {
+                    return e;
+                }
+                return null;
+            }));
+        }
+
+        IOException ioException = null;
+        Set<Path> paths = new HashSet<>();
+        /*
+         * In case od IndexCheckExceptions, assemble all the paths so they can be returned in a single exception.
+         * For IOExceptions, log them all and throw a common one at the end.
+         */
+        for (Future<Exception> future : futures) {
+            Exception exception = null;
+            try {
+                exception = future.get();
+            } catch (InterruptedException | ExecutionException e) {
+                LOGGER.log(Level.WARNING, "failed to get future", e);
+            }
+            if (exception != null) {
+                if (exception instanceof IndexCheckException) {
+                    // The exception is logged because even though the path will be added to the common exception
+                    // at the end, the nature of the problem (i.e. specific kind of the index check and associated details)
+                    // would be lost.
+                    LOGGER.log(Level.WARNING, "index check failed", exception);
+                    paths.addAll(((IndexCheckException) exception).getFailedPaths());
+                } else if (exception instanceof IOException) {
+                    // There can be multiple IOExceptions so log them here and remember the last one.
+                    // It will be thrown once all the checks complete.
+                    LOGGER.log(Level.WARNING, "could not perform index check", exception);
+                    ioException = (IOException) exception;
+                }
+            }
+        }
+
+        // IOException trumps the IndexCheckException, so throw the last one here first.
+        if (ioException != null) {
+            throw ioException;
+        }
+
+        if (!paths.isEmpty()) {
+            throw new IndexCheckException("index check failed", paths);
+        }
+    }
+
+    /**
+     * Check index(es). If the check is successful, just return. On failure, an exception will be thrown.
+     * @param mode index check mode
+     * @throws IOException on I/O error
+     * @throws IndexCheckException if some of the indexes failed the check. The exception contains list of the paths.
+     */
+    public void check(IndexCheckMode mode) throws IOException, IndexCheckException {
 
         if (mode.equals(IndexCheckMode.NO_CHECK)) {
             LOGGER.log(Level.WARNING, "no index check mode selected");
-            return true;
+            return;
         }
 
-        Path indexRoot = Path.of(configuration.getDataRoot(), IndexDatabase.INDEX_DIR);
-        int ret = 0;
+        Statistics statistics = new Statistics();
 
         if (!projectNames.isEmpty()) {
             // Assumes projects are enabled.
-            for (String projectName : projectNames) {
-                ret |= checkDirFilterExceptions(Path.of(configuration.getSourceRoot()),
-                        Path.of(indexRoot.toString(), projectName), mode);
-            }
+            checkProjectsParallel(mode, projectNames);
         } else {
             if (configuration.isProjectsEnabled()) {
-                for (String projectName : configuration.getProjects().keySet()) {
-                    ret |= checkDirFilterExceptions(Path.of(configuration.getSourceRoot()),
-                            Path.of(indexRoot.toString(), projectName), mode);
-                }
+                checkProjectsParallel(mode, configuration.getProjects().keySet());
             } else {
-                ret |= checkDirFilterExceptions(Path.of(configuration.getSourceRoot()), indexRoot, mode);
+                checkDirWithLogging(Path.of(configuration.getSourceRoot()),
+                        Path.of(configuration.getDataRoot(), IndexDatabase.INDEX_DIR), mode);
             }
         }
 
-        return ret == 0;
+        statistics.report(LOGGER, Level.FINE, "Index check done");
     }
 
     /**
      * Perform specified check on given index directory. All exceptions except {@code IOException} are swallowed
      * and result in return value of 1.
      * @param indexPath directory with index
-     * @return 0 on success, 1 on failure (index check failed)
      * @throws IOException on I/O error
+     * @throws IndexCheckException if the index failed given check
      */
-    private static int checkDirFilterExceptions(Path sourcePath, Path indexPath, IndexCheckMode mode) throws IOException {
+    private void checkDirWithLogging(Path sourcePath, Path indexPath, IndexCheckMode mode)
+            throws IOException, IndexCheckException {
         try {
             LOGGER.log(Level.INFO, "Checking index in ''{0}'' (mode {1})", new Object[]{indexPath, mode});
             checkDir(sourcePath, indexPath, mode);
-        } catch (IOException e) {
-            throw e;
-        } catch (Exception e) {
+        } catch (IndexCheckException e) {
             LOGGER.log(Level.WARNING, String.format("Index check for directory '%s' failed", indexPath), e);
-            return 1;
+            throw e;
         }
 
         LOGGER.log(Level.INFO, "Index check for directory ''{0}'' passed", indexPath);
-        return 0;
     }
 
     /**
-     * Check index in given directory. It assumes that that all commits (if any)
+     * Check index in given directory. If the directory is empty, just return.
+     * <p>
+     * It assumes that that all commits (if any)
      * in the Lucene segment file were done with the same version.
-     *
+     * </p>
      * @param sourcePath path to source directory
      * @param indexPath directory with index to check
      * @param mode      index check mode
@@ -214,7 +332,7 @@ public class IndexCheck {
      * @throws IndexVersionException if the version of the index does not match Lucene index version
      * @throws IndexDocumentException if there are duplicate documents in the index or not matching definitions
      */
-    public static void checkDir(Path sourcePath, Path indexPath, IndexCheckMode mode)
+    void checkDir(Path sourcePath, Path indexPath, IndexCheckMode mode)
             throws IndexVersionException, IndexDocumentException, IOException {
 
         switch (mode) {
@@ -248,7 +366,7 @@ public class IndexCheck {
      * @param path path to the file being checked
      * @return okay indication
      */
-    private static boolean checkDefinitionsForFile(Path path) throws ParseException, IOException, ClassNotFoundException {
+    private boolean checkDefinitionsForFile(Path path) throws ParseException, IOException, ClassNotFoundException {
 
         // Avoid paths with certain suffixes. These exhibit some behavior that cannot be handled
         // For example, '1;' in Perl code is interpreted by Universal Ctags as 'STDOUT'.
@@ -339,7 +457,7 @@ public class IndexCheck {
      * @throws IOException on I/O error
      * @throws IndexDocumentException if there are any documents with definitions not matching definitions found by ctags
      */
-    private static void checkDefinitions(Path sourcePath, Path indexPath) throws IOException, IndexDocumentException {
+    private void checkDefinitions(Path sourcePath, Path indexPath) throws IOException, IndexDocumentException {
 
         Statistics statistics = new Statistics();
         GetFiles getFiles = new GetFiles();
@@ -348,24 +466,15 @@ public class IndexCheck {
         LOGGER.log(Level.FINE, "Checking definitions in ''{0}'' ({1} paths)",
                 new Object[]{indexPath, paths.size()});
 
+        // TODO: reconcile this with the executor used for this class
         long errors = 0;
         ExecutorService executorService = RuntimeEnvironment.getInstance().getIndexerParallelizer().getFixedExecutor();
-        final CountDownLatch latch = new CountDownLatch(paths.size());
         List<Future<Boolean>> futures = new ArrayList<>();
         for (Path path : paths) {
-            futures.add(executorService.submit(() -> {
-                try {
-                    return checkDefinitionsForFile(path);
-                } finally {
-                    latch.countDown();
-                }
-            }));
+            futures.add(executorService.submit(() -> checkDefinitionsForFile(path)));
         }
-        try {
-            latch.await();
-        } catch (InterruptedException e) {
-            LOGGER.log(Level.WARNING, "failed to await", e);
-        }
+
+        IOException ioException = null;
         for (Future<Boolean> future : futures) {
             try {
                 if (!future.get()) {
@@ -373,13 +482,23 @@ public class IndexCheck {
                 }
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "failure when checking definitions", e);
+                final Throwable cause = e.getCause();
+                if (cause instanceof IOException) {
+                    ioException = (IOException) cause;
+                }
             }
         }
         statistics.report(LOGGER, Level.FINE, String.format("checked %d files", paths.size()));
 
+        // If there were multiple cases of IOException, they were logged above.
+        // Propagate the last one so that upper layers can properly decide on how to treat the index check.
+        if (ioException != null) {
+            throw ioException;
+        }
+
         if (errors > 0) {
             throw new IndexDocumentException(String.format("document check failed for (%d documents out of %d)",
-                    errors, paths.size()));
+                    errors, paths.size()), indexPath);
         }
     }
 
@@ -389,7 +508,7 @@ public class IndexCheck {
      * @throws IndexVersionException if the version stored in the document does not match the version
      * used by the running program
      */
-    private static void checkVersion(Path indexPath) throws IOException, IndexVersionException {
+    private void checkVersion(Path indexPath) throws IOException, IndexVersionException {
         LockFactory lockFactory = NativeFSLockFactory.INSTANCE;
         int segVersion;
 
@@ -407,12 +526,13 @@ public class IndexCheck {
                 new Object[]{indexPath, segVersion, Version.LATEST.major});
         if (segVersion != Version.LATEST.major) {
             throw new IndexVersionException(
-                String.format("Directory '%s' has index version discrepancy", indexPath),
+                String.format("Directory '%s' has index version discrepancy", indexPath), indexPath,
                     Version.LATEST.major, segVersion);
         }
     }
 
-    public static IndexReader getIndexReader(Path indexPath) throws IOException {
+    @VisibleForTesting
+    static IndexReader getIndexReader(Path indexPath) throws IOException {
         try (FSDirectory indexDirectory = FSDirectory.open(indexPath, NoLockFactory.INSTANCE)) {
             return DirectoryReader.open(indexDirectory);
         }
@@ -423,7 +543,8 @@ public class IndexCheck {
      * @return set of deleted uids in the index related to the project name
      * @throws IOException if the index cannot be read
      */
-    public static Set<String> getDeletedUids(Path indexPath) throws IOException {
+    @VisibleForTesting
+    static Set<String> getDeletedUids(Path indexPath) throws IOException {
         Set<String> deletedUids = new HashSet<>();
 
         try (IndexReader indexReader = getIndexReader(indexPath)) {
@@ -456,7 +577,8 @@ public class IndexCheck {
      * @throws IOException on I/O error
      */
     @Nullable
-    public static List<String> getLiveDocumentPaths(Path indexPath) throws IOException {
+    @VisibleForTesting
+    static List<String> getLiveDocumentPaths(Path indexPath) throws IOException {
         try (IndexReader indexReader = getIndexReader(indexPath)) {
             List<String> livePaths = new ArrayList<>();
 
@@ -490,7 +612,8 @@ public class IndexCheck {
         Statistics stat = new Statistics();
         List<String> livePaths = getLiveDocumentPaths(indexPath);
         if (livePaths == null) {
-            throw new IndexDocumentException(String.format("cannot determine live paths for '%s'", indexPath));
+            throw new IndexDocumentException(String.format("cannot determine live paths for '%s'", indexPath),
+                    indexPath);
         }
         HashSet<String> pathSet = new HashSet<>(livePaths);
         Map<String, Integer> fileMap = new ConcurrentHashMap<>();
@@ -518,7 +641,7 @@ public class IndexCheck {
         stat.report(LOGGER, Level.FINE, String.format("duplicate check in '%s' done", indexPath));
         if (!fileMap.isEmpty()) {
             throw new IndexDocumentException(String.format("index in '%s' contains duplicate live documents",
-                    indexPath), fileMap);
+                    indexPath), indexPath, fileMap);
         }
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheckException.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheckException.java
@@ -1,0 +1,51 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.index;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Common exception for all check modes.
+ */
+public class IndexCheckException extends Exception {
+    private static final long serialVersionUID = 5693446916108385595L;
+
+    private final Set<Path> failedPaths = new HashSet<>();
+
+    public IndexCheckException(String s, Path path) {
+        super(s);
+        failedPaths.add(path);
+    }
+
+    public IndexCheckException(String s, Set<Path> paths) {
+        super(s);
+        failedPaths.addAll(paths);
+    }
+
+    public Set<Path> getFailedPaths() {
+        return Collections.unmodifiableSet(failedPaths);
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDocumentException.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDocumentException.java
@@ -1,0 +1,50 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.index;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Exception thrown when index contains duplicate live documents.
+ */
+public class IndexDocumentException extends IndexCheckException {
+    private static final long serialVersionUID = 5693446916108385595L;
+
+    private final Map<String, Integer> fileMap;
+
+    public IndexDocumentException(String s, Path path) {
+        super(s, path);
+        this.fileMap = null;
+    }
+
+    public IndexDocumentException(String s, Path path, Map<String, Integer> fileMap) {
+        super(s, path);
+        this.fileMap = fileMap;
+    }
+
+    @Override
+    public String toString() {
+        return getMessage() + ": " + (fileMap == null ? "" : fileMap);
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexVersionException.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexVersionException.java
@@ -1,0 +1,48 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.index;
+
+import java.nio.file.Path;
+
+/**
+ * Exception thrown when index version does not match Lucene version.
+ */
+public class IndexVersionException extends IndexCheckException {
+
+    private static final long serialVersionUID = 5693446916108385595L;
+
+    private final int luceneIndexVersion;
+    private final int indexVersion;
+
+    public IndexVersionException(String s, Path path, int luceneIndexVersion, int indexVersion) {
+        super(s, path);
+        this.indexVersion = indexVersion;
+        this.luceneIndexVersion = luceneIndexVersion;
+    }
+
+    @Override
+    public String toString() {
+        return getMessage() + ": " + String.format("Lucene version = %d", luceneIndexVersion) + ", " +
+                String.format("index version = %d", indexVersion);
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -282,7 +282,7 @@ public final class Indexer {
                     // This avoids problems with wiping out the index based on the check.
                     LOGGER.log(Level.WARNING, String.format("Could not perform index check for '%s'", subFileArgs), e);
                     System.exit(2);
-                } catch (IndexCheck.IndexCheckException e) {
+                } catch (IndexCheckException e) {
                     System.err.printf("Index check failed%n");
                     System.err.print("You might want to remove " + e.getFailedPaths());
                     System.exit(1);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -107,14 +108,14 @@ class IndexCheckTest {
         Indexer.getInstance().doIndexerExecution(null, null);
 
         try (IndexCheck indexCheck = new IndexCheck(configuration, subFiles)) {
-            indexCheck.check(mode);
+            assertDoesNotThrow(() -> indexCheck.check(mode));
         }
     }
 
     @Test
     void testIndexVersionNoIndex() throws Exception {
         try (IndexCheck indexCheck = new IndexCheck(configuration)) {
-            indexCheck.check(IndexCheck.IndexCheckMode.VERSION);
+            assertDoesNotThrow(() -> indexCheck.check(IndexCheck.IndexCheckMode.VERSION));
         }
     }
 
@@ -250,7 +251,7 @@ class IndexCheckTest {
 
         try (IndexCheck indexCheck = new IndexCheck(configuration)) {
             for (int i = 0; i < 3; i++) {
-                indexCheck.check(IndexCheck.IndexCheckMode.VERSION);
+                assertDoesNotThrow(() -> indexCheck.check(IndexCheck.IndexCheckMode.VERSION));
             }
         }
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -156,13 +156,13 @@ class IndexCheckTest {
 
         try (IndexCheck indexCheck = new IndexCheck(configuration)) {
             IndexCheck.IndexCheckMode mode = IndexCheck.IndexCheckMode.VERSION;
-            assertThrows(IndexCheck.IndexCheckException.class, () -> indexCheck.check(mode));
+            assertThrows(IndexCheckException.class, () -> indexCheck.check(mode));
 
             // Recheck to see if the exception contains the expected list of paths that failed the check.
-            IndexCheck.IndexCheckException exception = null;
+            IndexCheckException exception = null;
             try {
                 indexCheck.check(mode);
-            } catch (IndexCheck.IndexCheckException e) {
+            } catch (IndexCheckException e) {
                 exception = e;
             }
             assertNotNull(exception);

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -153,6 +153,9 @@ public final class WebappListener implements ServletContextListener, ServletRequ
                         project.setIndexed(false);
                     }
                 }
+            } else {
+                // Fail the deployment. The index check would fail only on legitimate version discrepancy.
+                throw new Error("index version check failed", e);
             }
         }
     }

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -38,6 +38,7 @@ import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.index.IndexCheck;
+import org.opengrok.indexer.index.IndexCheckException;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.web.SearchHelper;
 import org.opengrok.web.api.ApiTaskManager;
@@ -143,7 +144,7 @@ public final class WebappListener implements ServletContextListener, ServletRequ
                 indexCheck.check(IndexCheck.IndexCheckMode.VERSION);
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "could not perform index check", e);
-        } catch (IndexCheck.IndexCheckException e) {
+        } catch (IndexCheckException e) {
             if (env.isProjectsEnabled()) {
                 LOGGER.log(Level.INFO, "marking projects that failed the index check as not indexed");
 

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -34,13 +34,11 @@ import org.opengrok.indexer.Metrics;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.authorization.AuthorizationFramework;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
-import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
+import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.index.IndexCheck;
-import org.opengrok.indexer.index.IndexDatabase;
 import org.opengrok.indexer.logger.LoggerFactory;
-import org.opengrok.indexer.util.Statistics;
 import org.opengrok.indexer.web.SearchHelper;
 import org.opengrok.web.api.ApiTaskManager;
 import org.opengrok.web.api.v1.controller.ConfigurationController;
@@ -52,10 +50,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -84,12 +78,12 @@ public final class WebappListener implements ServletContextListener, ServletRequ
         LOGGER.log(Level.INFO, "Starting webapp with version {0} ({1})",
                     new Object[]{Info.getVersion(), Info.getRevision()});
 
-        String config = context.getInitParameter("CONFIGURATION");
-        if (config == null) {
+        String configPath = context.getInitParameter("CONFIGURATION");
+        if (configPath == null) {
             throw new Error("CONFIGURATION parameter missing in the web.xml file");
         } else {
             try {
-                env.readConfiguration(new File(config), CommandTimeoutType.WEBAPP_START);
+                env.readConfiguration(new File(configPath), CommandTimeoutType.WEBAPP_START);
             } catch (IOException ex) {
                 LOGGER.log(Level.WARNING, "Configuration error. Failed to read config file: ", ex);
             }
@@ -125,8 +119,7 @@ public final class WebappListener implements ServletContextListener, ServletRequ
             env.getWatchDog().start(new File(pluginDirectory));
         }
 
-        // Check index(es).
-        checkIndex(env);
+        indexCheck(configPath, env);
 
         env.startExpirationTimer();
 
@@ -141,56 +134,28 @@ public final class WebappListener implements ServletContextListener, ServletRequ
     }
 
     /**
-     * Checks the index(es). If projects are enabled then each project with invalid index
-     * is marked as not being indexed.
-     * @param env runtime environment
+     * Check index(es). If projects are enabled, those which failed the test will be marked as not indexed.
+     * @param configPath path to configuration
+     * @param env {@link RuntimeEnvironment} instance
      */
-    private void checkIndex(RuntimeEnvironment env) {
-        if (env.isProjectsEnabled()) {
-            Map<String, Project> projects = env.getProjects();
-            Path indexRoot = Path.of(env.getDataRootPath(), IndexDatabase.INDEX_DIR);
-            if (indexRoot.toFile().exists()) {
-                LOGGER.log(Level.FINE, "Checking index versions for all projects");
-                Statistics statistics = new Statistics();
-                ExecutorService executor = Executors.newFixedThreadPool(env.getRepositoryInvalidationParallelism(),
-                        new OpenGrokThreadFactory("webapp-index-check"));
-                for (Map.Entry<String, Project> projectEntry : projects.entrySet()) {
-                    executor.submit(() -> {
-                        try {
-                            IndexCheck.checkDir(Path.of(env.getSourceRootPath(), projectEntry.getKey()),
-                                    Path.of(indexRoot.toString(), projectEntry.getKey()),
-                                    IndexCheck.IndexCheckMode.VERSION);
-                        } catch (Exception e) {
-                            LOGGER.log(Level.WARNING,
-                                    String.format("Project %s index check failed, marking as not indexed",
-                                            projectEntry.getKey()), e);
-                            projectEntry.getValue().setIndexed(false);
-                        }
-                    });
-                }
-                executor.shutdown();
-                try {
-                    if (!executor.awaitTermination(env.getIndexCheckTimeout(), TimeUnit.SECONDS)) {
-                        LOGGER.log(Level.WARNING, "index version check took more than {0} seconds",
-                                env.getIndexCheckTimeout());
-                        executor.shutdownNow();
+    private static void indexCheck(String configPath, RuntimeEnvironment env) {
+        try {
+            try (IndexCheck indexCheck = new IndexCheck(Configuration.read(new File(configPath)))) {
+                indexCheck.check(IndexCheck.IndexCheckMode.VERSION);
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "could not perform index check", e);
+        } catch (IndexCheck.IndexCheckException e) {
+            if (env.isProjectsEnabled()) {
+                LOGGER.log(Level.INFO, "marking projects that failed the index check as not indexed");
+
+                for (Path path : e.getFailedPaths()) {
+                    Project project = Project.getProject(path.toFile());
+                    if (project != null) {
+                        project.setIndexed(false);
                     }
-                } catch (InterruptedException e) {
-                    LOGGER.log(Level.WARNING, "failed to await termination of index version check");
-                    executor.shutdownNow();
                 }
-                statistics.report(LOGGER, Level.FINE, "Index version check for all projects done");
             }
-        } else {
-            LOGGER.log(Level.FINE, "Checking index");
-            try {
-                IndexCheck.checkDir(Path.of(env.getSourceRootPath()),
-                        Path.of(env.getDataRootPath(), IndexDatabase.INDEX_DIR),
-                        IndexCheck.IndexCheckMode.VERSION);
-            } catch (Exception e) {
-                LOGGER.log(Level.SEVERE, "index check failed", e);
-            }
-            LOGGER.log(Level.FINE, "Index check done");
         }
     }
 

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -139,10 +139,8 @@ public final class WebappListener implements ServletContextListener, ServletRequ
      * @param env {@link RuntimeEnvironment} instance
      */
     private static void indexCheck(String configPath, RuntimeEnvironment env) {
-        try {
-            try (IndexCheck indexCheck = new IndexCheck(Configuration.read(new File(configPath)))) {
+        try (IndexCheck indexCheck = new IndexCheck(Configuration.read(new File(configPath)))) {
                 indexCheck.check(IndexCheck.IndexCheckMode.VERSION);
-            }
         } catch (IOException e) {
             LOGGER.log(Level.WARNING, "could not perform index check", e);
         } catch (IndexCheck.IndexCheckException e) {


### PR DESCRIPTION
This change primarily converts the `IndexCheck` class from static/utility class to plain class. This allowed to use Mockito for testing normally. While there, I folded the parallelized project checking done previously in `WebappListener` to the class. This resulted in reworking the way how errors are propagated. For index check errors, the result is single exception carrying the list of source root paths corresponding to the indexes that failed the test. For I/O exceptions, just one is propagated.

There are 2 main use cases for the index check:
  1. done per project in the Docker image
  1. done for all indexes (projects enabled or not) during webapp startup

The thread handling in `IndexCheck` uses common per-class-instance pool for the project parallel processing. There is another pool used when index check is done for definitions. The latter pool comes from `IndexParallelizer` so even though multiple projects are checked in parallel, the CPU utilization will be bounded by that.