### PR TITLE
upgrade jflex version and remove workaround

### DIFF
--- a/opengrok-indexer/pom.xml
+++ b/opengrok-indexer/pom.xml
@@ -251,7 +251,7 @@ Portions Copyright (c) 2020-2020, Lubos Kosco <tarzanek@gmail.com>.
             <plugin>
                 <groupId>de.jflex</groupId>
                 <artifactId>jflex-maven-plugin</artifactId>
-                <version>1.8.2</version>
+                <version>1.9.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -343,12 +343,6 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                             <value>bar</value>
                         </property>
                     </javaApiLinks>
-                    <sourceFileExcludes>
-                        <!-- workarounds for https://github.com/jflex-de/jflex/issues/542 -->
-                        <exclude>**/HistoryLineTokenizer.java</exclude>
-                        <exclude>**/PlainLineTokenizer.java</exclude>
-                        <exclude>**/XrefSourceTransformer.java</exclude>
-                    </sourceFileExcludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,6 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                   <execution>
                     <goals>
                       <goal>javadoc</goal>
-                      <goal>test-javadoc</goal>
                     </goals>
                     <phase>verify</phase>
                   </execution>


### PR DESCRIPTION
upgrade jflex version and remove workaround added for https://github.com/jflex-de/jflex/issues/542
Removed test api-docs target since we are not pushing api docs for test classes 

Pending : Setting token_size_limit and skipping the entire line if line length is more than the limit

#4170
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
