### PR TITLE
always refresh the list of repositories for projects

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -404,6 +404,8 @@ This includes also projects of any sub-groups.
 
 This will merely add the project and its repositories to the web application configuration.
 The project will not be searchable (and thus appear in the UI) until it is indexed.
+If the project is already present in the configuration, the list of its repositories will be refreshed
+if history is enabled.
 
 + Request (text/plain)
   + Body

--- a/docker/start.py
+++ b/docker/start.py
@@ -260,9 +260,9 @@ def refresh_projects(logger, uri, api_timeout):
         logger.debug("Got item {}".format(item))
         if os.path.isdir(os.path.join(src_root, item)):
             if item in webapp_projects:
-                action="Refreshing"
+                action = "Refreshing"
             else:
-                action="Adding"
+                action = "Adding"
             logger.info(f"{action} project {item}")
             add_project(logger, item, uri, timeout=api_timeout)
 

--- a/docker/start.py
+++ b/docker/start.py
@@ -270,8 +270,9 @@ def refresh_projects(logger, uri, api_timeout):
             if logger.level == logging.DEBUG:
                 repos = get_repos(logger, item, uri)
                 if repos:
-                    logger.debug("Project {} has these repositories: {}".
-                                 format(item, repos))
+                    logger.debug(
+                        "Project {} has these repositories: {}".format(item, repos)
+                    )
 
     # Remove projects that no longer have source.
     for item in webapp_projects:

--- a/docker/start.py
+++ b/docker/start.py
@@ -55,6 +55,7 @@ from opengrok_tools.utils.opengrok import (
     add_project,
     delete_project,
     get_configuration,
+    get_repos,
     list_projects,
 )
 from opengrok_tools.utils.readconfig import read_config
@@ -265,6 +266,12 @@ def refresh_projects(logger, uri, api_timeout):
                 action = "Adding"
             logger.info(f"{action} project {item}")
             add_project(logger, item, uri, timeout=api_timeout)
+
+            if logger.level == logging.DEBUG:
+                repos = get_repos(logger, item, uri)
+                if repos:
+                    logger.debug("Project {} has these repositories: {}".
+                                 format(item, repos))
 
     # Remove projects that no longer have source.
     for item in webapp_projects:

--- a/docker/start.py
+++ b/docker/start.py
@@ -255,15 +255,18 @@ def refresh_projects(logger, uri, api_timeout):
     logger.debug("Projects from the web app: {}".format(webapp_projects))
     src_root = OPENGROK_SRC_ROOT
 
-    # Add projects.
+    # Add projects for top-level directories under source root.
     for item in os.listdir(src_root):
         logger.debug("Got item {}".format(item))
         if os.path.isdir(os.path.join(src_root, item)):
-            if item not in webapp_projects:
-                logger.info("Adding project {}".format(item))
-                add_project(logger, item, uri, timeout=api_timeout)
+            if item in webapp_projects:
+                action="Refreshing"
+            else:
+                action="Adding"
+            logger.info(f"{action} project {item}")
+            add_project(logger, item, uri, timeout=api_timeout)
 
-    # Remove projects
+    # Remove projects that no longer have source.
     for item in webapp_projects:
         if not os.path.isdir(os.path.join(src_root, item)):
             logger.info("Deleting project {}".format(item))

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/ProjectsControllerTest.java
@@ -199,7 +199,9 @@ class ProjectsControllerTest extends OGKJerseyTest {
         // Add the project.
         env.setScanningDepth(3);
 
-        addProject("mercurial");
+        try (Response response = addProject("mercurial")) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
 
         // Check that the project was added properly.
         assertTrue(env.getProjects().containsKey("mercurial"));
@@ -224,7 +226,9 @@ class ProjectsControllerTest extends OGKJerseyTest {
         // At the same time, it checks that multiple projects can be added
         // with single message.
 
-        addProject("git");
+        try (Response response = addProject("git")) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
 
         assertEquals(2, env.getProjects().size());
         assertEquals(3, env.getRepositories().size());
@@ -370,7 +374,10 @@ class ProjectsControllerTest extends OGKJerseyTest {
     void testDeleteCache(boolean historyCache) throws Exception {
         final String cacheName = historyCache ? "historycache" : "annotationcache";
         final String projectName = "git";
-        addProject(projectName);
+
+        try (Response response = addProject(projectName)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
 
         Indexer.getInstance().prepareIndexer(
                 env,
@@ -424,7 +431,9 @@ class ProjectsControllerTest extends OGKJerseyTest {
         String projectName = "mercurial";
 
         // When a project is added, it should be marked as not indexed.
-        addProject(projectName);
+        try (Response response = addProject(projectName)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
 
         assertFalse(env.getProjects().get(projectName).isIndexed());
 
@@ -480,11 +489,15 @@ class ProjectsControllerTest extends OGKJerseyTest {
 
     @Test
     void testList() throws Exception {
-        addProject("mercurial");
+        try (Response response = addProject("mercurial")) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
         assertEquals(markIndexed("mercurial").getStatusInfo().getFamily(), Response.Status.Family.SUCCESSFUL);
 
         // Add another project.
-        addProject("git");
+        try (Response response = addProject("git")) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
 
         GenericType<List<String>> type = new GenericType<>() {
         };
@@ -531,7 +544,9 @@ class ProjectsControllerTest extends OGKJerseyTest {
                 "clone", mercurialRoot.getAbsolutePath(),
                 mercurialRoot.getAbsolutePath() + File.separator + "closed");
 
-        addProject("mercurial");
+        try (Response response = addProject("mercurial")) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
 
         // Get repositories of the project.
         List<String> repos = target("projects")
@@ -565,7 +580,9 @@ class ProjectsControllerTest extends OGKJerseyTest {
     @Test
     void testSetIndexed() throws Exception {
         String project = "git";
-        addProject(project);
+        try (Response response = addProject(project)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
         assertEquals(1, env.getProjectList().size());
 
         env.getProjects().get(project).setIndexed(false);
@@ -585,7 +602,9 @@ class ProjectsControllerTest extends OGKJerseyTest {
         String[] projects = new String[] {"mercurial", "git"};
 
         for (String proj : projects) {
-            addProject(proj);
+            try (Response response = addProject(proj)) {
+                assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+            }
         }
 
         assertEquals(2, env.getProjectList().size());


### PR DESCRIPTION
The Docker startup script should allow refresh of repositories for projects. This is more in line with the appliance like characteristics of the Docker image. This will make the resync slower, depending on the repositories.

While there, I did some small changes to the test.

Also, when log level is set to debug, the list of repositories for given project will be logged.