### PR TITLE
shorten the lack of history error message

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -614,6 +614,26 @@ public final class HistoryGuru {
             return false;
         }
 
+        if (!repositoryHasHistory(file, repo)) {
+            return false;
+        }
+
+        // This should return true for Annotate view.
+        Configuration.RemoteSCM globalRemoteSupport = env.getRemoteScmSupported();
+        boolean remoteSupported = ((globalRemoteSupport == RemoteSCM.ON)
+                || (globalRemoteSupport == RemoteSCM.UIONLY)
+                || (globalRemoteSupport == RemoteSCM.DIRBASED)
+                || !repo.isRemote());
+
+        if (!remoteSupported) {
+            LOGGER.log(Level.FINEST, "not eligible to display history for ''{0}'' as repository {1} is remote " +
+                    "and the global setting is {2}", new Object[]{file, repo, globalRemoteSupport});
+        }
+
+        return remoteSupported;
+    }
+
+    private static boolean repositoryHasHistory(File file, Repository repo) {
         if (!repo.isWorking()) {
             LOGGER.log(Level.FINEST, "repository {0} for ''{1}'' is not working to check history presence",
                     new Object[]{repo, file});
@@ -632,19 +652,7 @@ public final class HistoryGuru {
             return false;
         }
 
-        // This should return true for Annotate view.
-        Configuration.RemoteSCM globalRemoteSupport = env.getRemoteScmSupported();
-        boolean remoteSupported = ((globalRemoteSupport == RemoteSCM.ON)
-                || (globalRemoteSupport == RemoteSCM.UIONLY)
-                || (globalRemoteSupport == RemoteSCM.DIRBASED)
-                || !repo.isRemote());
-
-        if (!remoteSupported) {
-            LOGGER.log(Level.FINEST, "not eligible to display history for ''{0}'' as repository {1} is remote " +
-                    "and the global setting is {2}", new Object[]{file, repo, globalRemoteSupport});
-        }
-
-        return remoteSupported;
+        return true;
     }
 
     /**

--- a/opengrok-web/src/main/webapp/enoent.jsp
+++ b/opengrok-web/src/main/webapp/enoent.jsp
@@ -16,7 +16,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
 
@@ -49,9 +49,8 @@ include file="/menu.jspf"
     PageConfig cfg = PageConfig.get(request);
     String configError = "";
     if (!cfg.hasHistory()) {
-        configError = "Resource lacks history info. Was remote SCM side up when indexing occurred? "
-            + "Cleanup history cache dir(or just the .gz for the file or db record) and rerun indexer making sure remote side will respond during indexing.";
-   }
+        configError = "Resource lacks history info.";
+    }
 %>
     <h3 class="error">Error: File not found!</h3>
     <p>The requested resource is not available. </p>


### PR DESCRIPTION
This change makes the "enoent" history message short. I always found the message too verbose. Also, like it was, it was meant for an administrator (related to #4411); for the end user it was rather useless. Further, it contained hints at deployment/implementation specifics, some of which are no longer existent (database for history cache).

While there, I did some refactoring of related code.