### PR TITLE
Handle history cache failures

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -467,7 +467,11 @@ public class GitRepository extends RepositoryWithHistoryTraversal {
             if (sinceRevision != null) {
                 walk.markUninteresting(walk.lookupCommit(repository.resolve(sinceRevision)));
             }
-            walk.markStart(walk.parseCommit(repository.resolve(Constants.HEAD)));
+            ObjectId objId = repository.resolve(Constants.HEAD);
+            if (objId == null) {
+                throw new HistoryException("cannot resolve HEAD");
+            }
+            walk.markStart(walk.parseCommit(objId));
 
             for (RevCommit commit : walk) {
                 // Do not abbreviate the Id as this could cause AmbiguousObjectException in getHistory().

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -465,7 +465,11 @@ public class GitRepository extends RepositoryWithHistoryTraversal {
              RevWalk walk = new RevWalk(repository)) {
 
             if (sinceRevision != null) {
-                walk.markUninteresting(walk.lookupCommit(repository.resolve(sinceRevision)));
+                ObjectId objId = repository.resolve(sinceRevision);
+                if (objId == null) {
+                    throw new HistoryException("cannot resolve " + sinceRevision);
+                }
+                walk.markUninteresting(walk.lookupCommit(objId));
             }
             ObjectId objId = repository.resolve(Constants.HEAD);
             if (objId == null) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -1050,7 +1050,7 @@ public final class HistoryGuru {
      */
     public Map<Repository, Optional<Exception>> createHistoryCache(Collection<String> repositories) {
         if (!useHistoryCache()) {
-            return null;
+            return Collections.emptyMap();
         }
         return createHistoryCacheReal(getReposFromString(repositories));
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -1001,9 +1001,9 @@ public final class HistoryGuru {
                 futures.put(entry.getKey(), executor.submit(() -> {
                     try {
                         createHistoryCache(entry.getKey(), entry.getValue());
-                    } catch (Exception ex) {
-                        // We want to catch any exception since we are in thread.
-                        LOGGER.log(Level.WARNING, "createHistoryCacheReal() got exception", ex);
+                    } catch (Exception ex) {    // We want to catch any exception since we are in thread.
+                        LOGGER.log(Level.WARNING,
+                                String.format("failed to create history cache for %s", entry.getKey()), ex);
                         return Optional.of(ex);
                     } finally {
                         progress.increment();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -1022,7 +1022,7 @@ public final class HistoryGuru {
         for (Map.Entry<Repository, Future<Optional<Exception>>> entry : futures.entrySet()) {
             try {
                 results.put(entry.getKey(), entry.getValue().get());
-            } catch (InterruptedException|ExecutionException ex) {
+            } catch (InterruptedException | ExecutionException ex) {
                 results.put(entry.getKey(), Optional.of(ex));
             }
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -42,7 +42,9 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -50,6 +52,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -247,23 +250,57 @@ public class IndexDatabase {
         LIVE_CHECK_FIELDS.add(QueryBuilder.PATH);
     }
 
+    public static void addIndexDatabaseForProject(@Nullable IndexDatabase db, Project project, List<IndexDatabase> dbs,
+                                           Map<Repository, Optional<Exception>> historyCacheResults) throws IOException {
+
+        Map<Repository, Optional<Exception>> projectReposWithException = historyCacheResults.entrySet().
+                stream().
+                filter(e -> e.getValue().isPresent()).
+                filter(e -> e.getKey().getDirectoryNameRelative().startsWith(project.getName())).
+                collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        if (projectReposWithException.isEmpty()) {
+            dbs.add(db != null ? db : new IndexDatabase(project));
+        } else {
+            LOGGER.log(Level.SEVERE, "Failed to create history cache for some repositories of project {0}: {1}",
+                    new Object[]{project, projectReposWithException});
+        }
+    }
+
+    public static void addIndexDatabase(@Nullable IndexDatabase db, List<IndexDatabase> dbs,
+                                        Map<Repository, Optional<Exception>> historyCacheResults) throws IOException {
+
+        Map<Repository, Optional<Exception>> reposWithException = historyCacheResults.entrySet().stream().
+                filter(e -> e.getValue().isPresent()).
+                collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        if (reposWithException.isEmpty()) {
+            dbs.add(db != null ? db : new IndexDatabase());
+        } else {
+            LOGGER.log(Level.SEVERE, "Failed to create history cache for some repositories: {0}",
+                    reposWithException);
+        }
+    }
+
     /**
      * Update the index database for all the projects.
      *
      * @param listener where to signal the changes to the database
+     * @param historyCacheResults map of repository to optional exception
      * @throws IOException if an error occurs
      */
-    static CountDownLatch updateAll(IndexChangedListener listener) throws IOException {
+    static CountDownLatch updateAll(IndexChangedListener listener,
+                                    Map<Repository, Optional<Exception>> historyCacheResults) throws IOException {
 
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         List<IndexDatabase> dbs = new ArrayList<>();
 
         if (env.hasProjects()) {
             for (Project project : env.getProjectList()) {
-                dbs.add(new IndexDatabase(project));
+                addIndexDatabaseForProject(null, project, dbs, historyCacheResults);
             }
         } else {
-            dbs.add(new IndexDatabase());
+            addIndexDatabase(null, dbs, historyCacheResults);
         }
 
         IndexerParallelizer parallelizer = RuntimeEnvironment.getInstance().getIndexerParallelizer();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -52,7 +52,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -255,7 +255,7 @@ public class IndexDatabase {
         Map<Repository, Optional<Exception>> projectReposWithException = historyCacheResults.entrySet().
                 stream().
                 filter(e -> e.getValue().isPresent()).
-                filter(e -> e.getKey().getDirectoryNameRelative().startsWith(project.getName())).
+                filter(e -> project.equals(Project.getProject(e.getKey().getDirectoryNameRelative()))).
                 collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
         if (projectReposWithException.isEmpty()) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -398,7 +398,7 @@ public final class Indexer {
             // prepareIndexer() populated the list of projects so now default projects can be set.
             env.setDefaultProjectsFromNames(defaultProjects);
 
-            // And now index it all.
+            // With the history cache results in hand, head over to the 2nd phase of the indexing.
             if (runIndex) {
                 IndexChangedListener progress = new DefaultIndexChangedListener();
                 if (ignoreHistoryCacheFailures) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -402,7 +402,7 @@ public final class Indexer {
             if (runIndex) {
                 IndexChangedListener progress = new DefaultIndexChangedListener();
                 if (ignoreHistoryCacheFailures) {
-                    if (historyCacheResults.entrySet().stream().anyMatch(e -> e.getValue().isPresent())) {
+                    if (historyCacheResults.values().stream().anyMatch(Optional::isPresent)) {
                         LOGGER.log(Level.INFO, "There have been history cache creation failures, " +
                                 "however --ignoreHistoryCacheFailures was used, hence ignoring them: {0}",
                                 historyCacheResults);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -711,10 +711,11 @@ public final class Indexer {
                     cfg.getIgnoredNames().add((String) pattern));
 
             parser.on("--ignoreHistoryCacheFailures",
-                    "Ignore history cache creation failures. By default if there is a history cache",
-                    "creation failure for a repository that corresponds to the source being indexed,",
-                    "the indexer will not proceed, because it will result either in indexing slow down",
-                    "or incomplete index. This option overrides the failure. Assumes -H.").execute(v ->
+                    "Ignore history cache creation failures. By default if there is ",
+                    "a history cache creation failure for a repository that corresponds ",
+                    "to the source being indexed, the indexer will not proceed, ",
+                    "because it will result either in indexing slow down or incomplete index.",
+                    "This option overrides the failure. Assumes -H.").execute(v ->
                     ignoreHistoryCacheFailures = true);
 
             parser.on("-l", "--lock", "=on|off|simple|native", LUCENE_LOCKS,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -59,6 +59,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
 import org.opengrok.indexer.Info;
 import org.opengrok.indexer.Metrics;
@@ -1167,11 +1168,11 @@ public final class Indexer {
      * by passing source code files through ctags, generating xrefs
      * and storing data from the source files in the index (along with history, if any).
      *
-     * @param subFiles index just some subdirectories
-     * @param progress object to receive notifications as indexer progress is made
+     * @param subFiles if not {@code null}, index just some subdirectories
+     * @param progress if not {@code null}, an object to receive notifications as indexer progress is made
      * @throws IOException if I/O exception occurred
      */
-    public void doIndexerExecution(List<String> subFiles, IndexChangedListener progress,
+    public void doIndexerExecution(@Nullable List<String> subFiles, @Nullable IndexChangedListener progress,
                                    Map<Repository, Optional<Exception>> historyCacheResults) throws IOException {
 
         Statistics elapsed = new Statistics();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryCacheResultsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryCacheResultsTest.java
@@ -1,0 +1,117 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.history;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.index.Indexer;
+import org.opengrok.indexer.util.TestRepository;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Writer;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HistoryCacheResultsTest {
+
+    private static TestRepository repository = new TestRepository();
+
+    private static RuntimeEnvironment env;
+
+    @BeforeAll
+    static void setUpClass() throws Exception {
+        env = RuntimeEnvironment.getInstance();
+        env.setHistoryEnabled(true);
+
+        repository = new TestRepository();
+        repository.create(HistoryGuru.class.getResource("/repositories"));
+        RepositoryFactory.initializeIgnoredNames(env);
+    }
+
+    @AfterAll
+    static void tearDownClass() {
+        repository.destroy();
+    }
+
+    private void corruptGitRepo(File root, final String repoName) throws Exception {
+        GitRepository gitrepo = (GitRepository) RepositoryFactory.getRepository(root);
+        assertNotNull(gitrepo);
+
+        Path localPath = Path.of(repository.getSourceRoot(), repoName);
+        Path l = Path.of(".git", "refs", "heads", "master");
+        Path objPath = localPath.resolve(l);
+        assertTrue(objPath.toFile().exists());
+        try (Writer writer = new FileWriter(objPath.toFile())) {
+            writer.write("corrupt");
+        }
+    }
+
+    /**
+     * Test that the return value of {@link Indexer#prepareIndexer(RuntimeEnvironment, boolean, boolean, List, List)}
+     * contains the repository for which history cache cannot be generated and associated exception.
+     */
+    @Test
+    void testCorruptRepository() throws Exception {
+        Map<Repository, Optional<Exception>> results = Indexer.getInstance().prepareIndexer(
+                env,
+                true, // search for repositories
+                true, // scan and add projects
+                null, // subFiles
+                null); // repositories
+
+        assertEquals(0, results.values().stream().filter(Optional::isPresent).count());
+
+        File root = new File(repository.getSourceRoot(), "git");
+        assertTrue(root.isDirectory());
+        final String repoName = "git";
+        corruptGitRepo(root, repoName);
+
+        results = Indexer.getInstance().prepareIndexer(
+                env,
+                true, // search for repositories
+                true, // scan and add projects
+                null, // subFiles
+                null); // repositories
+
+        assertEquals(1, results.values().stream().filter(Optional::isPresent).count());
+        List<Repository> repos = results.entrySet().stream().filter(e -> e.getValue().isPresent()).
+                map(Map.Entry::getKey).collect(Collectors.toList());
+        assertEquals(1, repos.size());
+        Repository repo = repos.get(0);
+        assertTrue(repo.getDirectoryName().contains(repoName));
+        Optional<Exception> repoResult = results.get(repo);
+        assertTrue(repoResult.isPresent());
+        Exception exception = repoResult.get();
+        assertTrue(exception instanceof HistoryException);
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -92,7 +92,7 @@ class HistoryGuruTest {
         // a bit incomprehensible, it does not make sense to run the rest of tests
         // if the basic functionality does not work.
         env.setRepositories(repository.getSourceRoot());
-        assertTrue(histGuru.getRepositories().size() > 0);
+        assertFalse(histGuru.getRepositories().isEmpty());
         assertEquals(histGuru.getRepositories().size(),
                 env.getRepositories().size());
 
@@ -169,7 +169,7 @@ class HistoryGuruTest {
         History history = instance.getHistory(file);
         assertNotNull(history);
         assertNotNull(history.getHistoryEntries());
-        assertTrue(history.getHistoryEntries().size() > 0);
+        assertFalse(history.getHistoryEntries().isEmpty());
         String revision = history.getHistoryEntries().get(1).getRevision();
         annotation = instance.annotate(file, revision, false);
         assertNull(annotation);


### PR DESCRIPTION
This change addresses long standing issue where the 2nd phase of indexing goes through even though history cache creation/update for one of the repositories failed. If projects are enabled and one of the repositories for given project failed history cache creation/update, that project will not be indexed; the projects with all their repositories being fine w.r.t. history cache are allowed to progress to 2nd phase of indexing. If projects are disabled, history cache creation failure of a repository results in the 2nd phase of indexing being skipped altogether.

Obviously, this relies on the individual repository implementations to properly report the history cache operation failure via `HistoryException`.

To suppress the new behavior, one can use the `--ignoreHistoryCacheFailures` indexer option.