### PR TITLE
skip inactive history entries when generating history context

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
@@ -24,6 +24,7 @@
 package org.opengrok.indexer.history;
 
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -65,7 +66,8 @@ public class History implements Serializable {
         this(new ArrayList<>());
     }
 
-    History(List<HistoryEntry> entries) {
+    @VisibleForTesting
+    public History(List<HistoryEntry> entries) {
         this(entries, Collections.emptyList());
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
@@ -127,12 +127,12 @@ public class HistoryContext {
      * @param out to write matched context
      * @param path path to the file
      * @param hits list of {@link Hit} instances
-     * @param wcontext web context - beginning of url
+     * @param urlPrefix URL prefix
      * @return whether there was at least one line that matched
      */
     @VisibleForTesting
     boolean getHistoryContext(History history, String path, @Nullable Writer out, @Nullable List<Hit> hits,
-                                      String wcontext) {
+                                      String urlPrefix) {
         if (history == null) {
             throw new IllegalArgumentException("`in' is null");
         }
@@ -193,11 +193,11 @@ public class HistoryContext {
                             } else if (out == null) {
                                 StringBuilder sb = new StringBuilder();
                                 writeMatch(sb, line, (int) start, (int) end,
-                                        true, path, wcontext, nrev, rev);
+                                        true, path, urlPrefix, nrev, rev);
                                 hits.add(new Hit(path, sb.toString(), "", false, false));
                             } else {
                                 writeMatch(out, line, (int) start, (int) end,
-                                        false, path, wcontext, nrev, rev);
+                                        false, path, urlPrefix, nrev, rev);
                             }
                             matchedLines++;
                             break;
@@ -226,24 +226,23 @@ public class HistoryContext {
      * @param end position of the first char after the match
      * @param flatten should multi-line log entries be flattened to a single
      * @param path path to the file
-     * @param wcontext web context (begin of URL)
+     * @param urlPrefix URL prefix
      * @param nrev old revision
      * @param rev current revision
-     * line? If {@code true}, replace newline with space.
      * @throws IOException IO exception
      */
     protected static void writeMatch(Appendable out, String line,
                             int start, int end, boolean flatten, String path,
-                            String wcontext, String nrev, String rev)
+                            String urlPrefix, String nrev, String rev)
             throws IOException {
 
         String prefix = line.substring(0, start);
         String match = line.substring(start, end);
         String suffix = line.substring(end);
 
-        if (wcontext != null && nrev != null && !wcontext.isEmpty()) {
+        if (urlPrefix != null && nrev != null && !urlPrefix.isEmpty()) {
             out.append("<a href=\"");
-            printHTML(out, wcontext + Prefix.DIFF_P +
+            printHTML(out, urlPrefix + Prefix.DIFF_P +
                     Util.uriEncodePath(path) +
                     "?" + QueryParameters.REVISION_2_PARAM_EQ + Util.uriEncodePath(path) + "@" +
                     rev + "&" + QueryParameters.REVISION_1_PARAM_EQ + Util.uriEncodePath(path) +

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
@@ -189,20 +189,14 @@ public class HistoryContext {
         }
 
         int matchedLines = 0;
-        Iterator<HistoryEntry> it = history.getHistoryEntries().iterator();
+        Iterator<HistoryEntry> it = history.getHistoryEntries().stream().filter(HistoryEntry::isActive).iterator();
         try {
             HistoryEntry he;
             HistoryEntry nhe = null;
             String nrev;
             while ((it.hasNext() || (nhe != null)) && matchedLines < 10) {
                 if (nhe == null) {
-                    do {
-                        he = it.next();
-                    } while (!he.isActive() && it.hasNext());
-                    if (!he.isActive()) {
-                        // No sense to continue if the (next) base entry cannot be used.
-                        break;
-                    }
+                    he = it.next();
                 } else {
                     he = nhe;  // nhe is the lookahead revision
                 }
@@ -210,12 +204,7 @@ public class HistoryContext {
                 String rev = he.getRevision();
 
                 if (it.hasNext()) {
-                    do {
-                        nhe = it.next();
-                    } while (!nhe.isActive() && it.hasNext());
-                    if (!nhe.isActive()) {
-                        nhe = null;
-                    }
+                    nhe = it.next();
                 } else {
                     // this prefetch mechanism is here because of the diff link generation
                     // we currently generate the diff to previous revision

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
@@ -154,20 +154,18 @@ public class HistoryContext {
             String nrev;
             while ((it.hasNext() || (nhe != null)) && matchedLines < 10) {
                 if (nhe == null) {
-                    he = it.next();
-                    while (!he.isActive() && it.hasNext()) {
+                    do {
                         he = it.next();
-                    }
+                    } while (!he.isActive() && it.hasNext());
                 } else {
                     he = nhe;  //nhe is the lookahead revision
                 }
                 String line = he.getLine();
                 String rev = he.getRevision();
                 if (it.hasNext()) {
-                    nhe = it.next();
-                    while (!nhe.isActive() && it.hasNext()) {
+                    do {
                         nhe = it.next();
-                    }
+                    } while (!nhe.isActive() && it.hasNext());
                 } else {
                     // this prefetch mechanism is here because of the diff link generation
                     // we currently generate the diff to previous revision

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/HistoryContext.java
@@ -199,6 +199,10 @@ public class HistoryContext {
                     do {
                         he = it.next();
                     } while (!he.isActive() && it.hasNext());
+                    if (!he.isActive()) {
+                        // No sense to continue if the (next) base entry cannot be used.
+                        break;
+                    }
                 } else {
                     he = nhe;  // nhe is the lookahead revision
                 }
@@ -209,6 +213,9 @@ public class HistoryContext {
                     do {
                         nhe = it.next();
                     } while (!nhe.isActive() && it.hasNext());
+                    if (!nhe.isActive()) {
+                        nhe = null;
+                    }
                 } else {
                     // this prefetch mechanism is here because of the diff link generation
                     // we currently generate the diff to previous revision

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
@@ -210,8 +210,8 @@ class HistoryContextTest {
                         "Totoro",
                         "Uaaah\n", true, filePaths),
                 new HistoryEntry("1.2", "1.2", new Date(1485438706000L),
-                        "Totoro",
-                        "Trrrr\n", false, filePaths),
+                        "Catbus",
+                        "Miau\n", false, filePaths),
                 new HistoryEntry("1.1", "1.1", new Date(1485438705000L),
                         "Totoro",
                         "Hmmm\n", true, filePaths)

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
@@ -205,18 +205,17 @@ class HistoryContextTest {
     @Test
     void testGetHistoryContextVsInactiveHistoryEntries() {
         Set<String> filePaths = Set.of(File.separator + Paths.get("teamware", "foo.c"));
-        final List<HistoryEntry> entries = List.of(
+        History history = new History(List.of(
                 new HistoryEntry("1.2", "1.2", new Date(1485438707000L),
-                "Totoro",
-                "Uaaah\n", true, filePaths),
+                        "Totoro",
+                        "Uaaah\n", true, filePaths),
                 new HistoryEntry("1.2", "1.2", new Date(1485438706000L),
                         "Totoro",
                         "Trrrr\n", false, filePaths),
                 new HistoryEntry("1.1", "1.1", new Date(1485438705000L),
                         "Totoro",
                         "Hmmm\n", true, filePaths)
-                );
-        History history = new History(entries);
+        ));
 
         ArrayList<Hit> hits = new ArrayList<>();
         BooleanQuery.Builder query = new BooleanQuery.Builder();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
@@ -18,16 +18,21 @@
  */
 
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
@@ -37,11 +42,14 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opengrok.indexer.condition.EnabledForRepository;
+import org.opengrok.indexer.history.History;
+import org.opengrok.indexer.history.HistoryEntry;
 import org.opengrok.indexer.search.Hit;
 import org.opengrok.indexer.util.TestRepository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
 
@@ -189,5 +197,39 @@ class HistoryContextTest {
         assertEquals("<a href=\"ctx/diff/foo%20bar/haf%2Bhaf?r2=/foo%20bar/haf%2Bhaf@2&amp;" +
                 "r1=/foo%20bar/haf%2Bhaf@1\" title=\"diff to previous version\">diff</a> <b>foo</b>",
                 sb.toString());
+    }
+
+    /**
+     * Test that inactive history entries are skipped when generating history context.
+     */
+    @Test
+    void testGetHistoryContextVsInactiveHistoryEntries() {
+        Set<String> filePaths = Set.of(File.separator + Paths.get("teamware", "foo.c"));
+        final List<HistoryEntry> entries = List.of(
+                new HistoryEntry("1.2", "1.2", new Date(1485438707000L),
+                "Totoro",
+                "Uaaah\n", true, filePaths),
+                new HistoryEntry("1.2", "1.2", new Date(1485438706000L),
+                        "Totoro",
+                        "Trrrr\n", false, filePaths),
+                new HistoryEntry("1.1", "1.1", new Date(1485438705000L),
+                        "Totoro",
+                        "Hmmm\n", true, filePaths)
+                );
+        History history = new History(entries);
+
+        ArrayList<Hit> hits = new ArrayList<>();
+        BooleanQuery.Builder query = new BooleanQuery.Builder();
+        HistoryEntry lastHistoryEntry = history.getLastHistoryEntry();
+        assertNotNull(lastHistoryEntry);
+        query.add(new TermQuery(new Term("hist", lastHistoryEntry.getMessage().trim())), Occur.MUST);
+        HistoryContext historyContext = new HistoryContext(query.build());
+        final String path = "/foo/bar";
+        final String prefix = "prefix";
+        assertTrue(historyContext.getHistoryContext(history,path, null, hits, prefix));
+        assertEquals(1, hits.size());
+        assertTrue(hits.get(0).getLine().
+                startsWith(String.format("<a href=\"%s/diff%s?r2=%s@1.2&amp;r1=%s@1.1\"",
+                        prefix, path, path, path)));
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
@@ -225,7 +225,7 @@ class HistoryContextTest {
         HistoryContext historyContext = new HistoryContext(query.build());
         final String path = "/foo/bar";
         final String prefix = "prefix";
-        assertTrue(historyContext.getHistoryContext(history,path, null, hits, prefix));
+        assertTrue(historyContext.getHistoryContext(history, path, null, hits, prefix));
         assertEquals(1, hits.size());
         assertTrue(hits.get(0).getLine().
                 startsWith(String.format("<a href=\"%s/diff%s?r2=%s@1.2&amp;r1=%s@1.1\"",


### PR DESCRIPTION
This change fixes diff link generation for histories that contain inactive history entries.