### PR TITLE
Fix : NPE when displaying a diff

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -349,12 +349,11 @@ public final class PageConfig {
                     .forEach(IOUtils::close);
         }
         if (Objects.isNull(data.errorMsg)) {
-            return;
+            populateRevisionData(data);
+            populateRevisionURLDetails(data, filepath);
+            data.full = fullDiff();
+            data.type = getDiffType();
         }
-        populateRevisionData(data);
-        populateRevisionURLDetails(data, filepath);
-        data.full = fullDiff();
-        data.type = getDiffType();
     }
 
     private void populateGenreIfEmpty(DiffData data, InputStream[] inArray) {

--- a/opengrok-web/src/test/java/org/opengrok/web/DiffTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/DiffTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
-import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.history.RepositoryFactory;
 import org.opengrok.indexer.index.Indexer;
 import org.opengrok.indexer.util.TestRepository;
@@ -35,6 +34,7 @@ import org.opengrok.indexer.web.QueryParameters;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,7 +50,7 @@ class DiffTest {
     @BeforeAll
     static void setUp() throws Exception {
         repository = new TestRepository();
-        repository.create(HistoryGuru.class.getResource("/repositories"));
+        repository.create(DiffTest.class.getResource("/repositories"));
 
         env.setSourceRoot(repository.getSourceRoot());
         env.setDataRoot(repository.getDataRoot());
@@ -98,6 +98,12 @@ class DiffTest {
         assertNotNull(diffData);
         assertNotNull(diffData.getErrorMsg());
         assertTrue(diffData.getErrorMsg().startsWith("Unable to get revision"));
+        assertAll(
+                () -> assertNull(diffData.getRevision()),
+                () -> assertNull(diffData.getParam(0)),
+                () -> assertNull(diffData.getParam(1)),
+                () -> assertNull(diffData.getType())
+        );
     }
 
     @Test
@@ -119,7 +125,12 @@ class DiffTest {
         assertAll(() -> assertEquals(rev1, diffData.getRev(0)),
                 () -> assertEquals(rev2, diffData.getRev(1)),
                 () -> assertTrue(diffData.getFile(0).length > 0),
-                () -> assertTrue(diffData.getFile(1).length > 0)
+                () -> assertTrue(diffData.getFile(1).length > 0),
+                () -> assertNotNull(diffData.getRevision()),
+                () -> assertEquals("/git/main.c@bb74b7e", diffData.getParam(0)),
+                () -> assertEquals("/git/main.c@aa35c25", diffData.getParam(1)),
+                () -> assertEquals(DiffType.SIDEBYSIDE, diffData.getType()),
+                () -> assertFalse(diffData.isFull())
         );
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -49,7 +49,6 @@ import org.opengrok.indexer.condition.EnabledForRepository;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.Annotation;
-import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.history.LatestRevisionUtil;
 import org.opengrok.indexer.history.RepositoryFactory;
 import org.opengrok.indexer.index.Indexer;
@@ -77,7 +76,7 @@ class PageConfigTest {
     @BeforeAll
     public static void setUpClass() throws Exception {
         repository = new TestRepository();
-        repository.create(HistoryGuru.class.getResource("/repositories"));
+        repository.create(PageConfigTest.class.getResource("/repositories"));
         RuntimeEnvironment.getInstance().setRepositories(repository.getSourceRoot());
     }
 


### PR DESCRIPTION
Populated the revision data if there is no error message.
Added additional assertions to confirm revision data is populated while created diff for valid versions
closes #4468
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
