### PR TITLE
avoid annotations for binary files

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -723,7 +723,7 @@ public class AnalyzerGuru {
      * Get the genre of a file.
      *
      * @param file The file to inspect
-     * @return The genre suitable to decide how to display the file (or {@code null} if not found)
+     * @return The genre suitable to decide how to display the file or {@code null} if not found
      */
     @Nullable
     public static AbstractAnalyzer.Genre getGenre(String file) {
@@ -734,9 +734,10 @@ public class AnalyzerGuru {
      * Get the genre of a bulk of data.
      *
      * @param in A stream containing the data
-     * @return The genre suitable to decide how to display the file
+     * @return The genre suitable to decide how to display the file or {@code null} if not found
      * @throws java.io.IOException If an error occurs while getting the content
      */
+    @Nullable
     public static AbstractAnalyzer.Genre getGenre(InputStream in) throws IOException {
         return getGenre(find(in));
     }
@@ -744,7 +745,7 @@ public class AnalyzerGuru {
     /**
      * Get the genre for a named class (this is most likely an analyzer).
      *
-     * @param factory the analyzer factory to get the genre for
+     * @param factory the analyzer factory to get the genre for or {@code null} if not found
      * @return The genre of this class (or {@code null} if not found)
      */
     @Nullable

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -723,8 +723,9 @@ public class AnalyzerGuru {
      * Get the genre of a file.
      *
      * @param file The file to inspect
-     * @return The genre suitable to decide how to display the file
+     * @return The genre suitable to decide how to display the file (or {@code null} if not found)
      */
+    @Nullable
     public static AbstractAnalyzer.Genre getGenre(String file) {
         return getGenre(find(file));
     }
@@ -744,8 +745,9 @@ public class AnalyzerGuru {
      * Get the genre for a named class (this is most likely an analyzer).
      *
      * @param factory the analyzer factory to get the genre for
-     * @return The genre of this class (null if not found)
+     * @return The genre of this class (or {@code null} if not found)
      */
+    @Nullable
     public static AbstractAnalyzer.Genre getGenre(AnalyzerFactory factory) {
         if (factory != null) {
             return factory.getGenre();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -750,10 +751,7 @@ public class AnalyzerGuru {
      */
     @Nullable
     public static AbstractAnalyzer.Genre getGenre(AnalyzerFactory factory) {
-        if (factory != null) {
-            return factory.getGenre();
-        }
-        return null;
+        return Optional.ofNullable(factory).map(AnalyzerFactory::getGenre).orElse(null);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -684,7 +684,7 @@ public final class HistoryGuru {
      * Check if we can annotate the specified file.
      *
      * @param file the file to check
-     * @return <code>true</code> if the file is under version control and the
+     * @return whether the file is under version control, can be annotated and the
      * version control system supports annotation
      */
     public boolean hasAnnotation(File file) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialAnnotationParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -37,18 +37,18 @@ import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.web.Util;
 
 /**
- * handles parsing the output of the {@code hg annotate} command
- * into an annotation object.
+ * Handles parsing the output of the {@code hg annotate} command
+ * into an {@link Annotation} object.
  */
 class MercurialAnnotationParser implements Executor.StreamHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(MercurialAnnotationParser.class);
 
     private Annotation annotation = null;
-    HashMap<String, HistoryEntry> revs;
-    File file;
+    private final HashMap<String, HistoryEntry> revs;
+    private final File file;
 
     /**
-     * Pattern used to extract author/revision from {@code hg annotate}.
+     * Pattern used to extract author/revision from the {@code hg annotate} command.
      */
     private static final Pattern ANNOTATION_PATTERN = Pattern.compile("^\\s*(\\d+):");
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSRepositoryAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSRepositoryAnnotationParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -42,11 +42,13 @@ public class SCCSRepositoryAnnotationParser implements Executor.StreamHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(SCCSRepositoryAnnotationParser.class);
 
     /**
-     * Store annotation created by processStream.
+     * Store annotation created by {@link #processStream(InputStream)}.
      */
     private final Annotation annotation;
 
     private final Map<String, String> authors;
+
+    private final File file;
 
     /**
      * Pattern used to extract revision from the {@code sccs get} command.
@@ -54,6 +56,7 @@ public class SCCSRepositoryAnnotationParser implements Executor.StreamHandler {
     private static final Pattern ANNOTATION_PATTERN = Pattern.compile("^([\\d.]+)\\s+");
 
     SCCSRepositoryAnnotationParser(File file, Map<String, String> authors) {
+        this.file = file;
         this.annotation = new Annotation(file.getName());
         this.authors = authors;
     }
@@ -69,8 +72,7 @@ public class SCCSRepositoryAnnotationParser implements Executor.StreamHandler {
 
     @Override
     public void processStream(InputStream input) throws IOException {
-        try (BufferedReader in = new BufferedReader(
-                new InputStreamReader(input))) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(input))) {
             String line;
             int lineno = 0;
             while ((line = in.readLine()) != null) {
@@ -86,8 +88,8 @@ public class SCCSRepositoryAnnotationParser implements Executor.StreamHandler {
                     annotation.addLine(rev, author, true);
                 } else {
                     LOGGER.log(Level.SEVERE,
-                            "Error: did not find annotations in line {0}: [{1}]",
-                            new Object[]{lineno, line});
+                            "Error: did not find annotations in line {0} for ''{2}'': [{1}]",
+                            new Object[]{lineno, line, file});
                 }
             }
         }

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -360,6 +360,9 @@ public final class PageConfig {
         for (int i = 0; i < 2 && data.genre == null; i++) {
             try {
                 data.genre = AnalyzerGuru.getGenre(inArray[i]);
+                if (data.genre == null) {
+                    data.errorMsg = "Unable to determine the file type";
+                }
             } catch (IOException e) {
                 data.errorMsg = "Unable to determine the file type: "
                         + Util.htmlize(e.getMessage());


### PR DESCRIPTION
This change prevents getting annotations for data/image files or genre-less files.