### PR TITLE
Fix Github Build Action Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
 
 
 # OpenGrok - a wicked fast source browser
-[![Github actions build](https://github.com/oracle/opengrok/workflows/Build/badge.svg?branch=master)](https://github.com/oracle/opengrok/actions)
+[![Github actions build](https://github.com/oracle/opengrok/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/oracle/opengrok/actions)
 [![Coverage status](https://coveralls.io/repos/oracle/opengrok/badge.svg?branch=master)](https://coveralls.io/r/oracle/opengrok?branch=master)
 [![SonarQube status](https://sonarcloud.io/api/project_badges/measure?project=org.opengrok%3Aopengrok-top&metric=alert_status)](https://sonarcloud.io/dashboard?id=org.opengrok%3Aopengrok-top)
 [![License](https://img.shields.io/badge/License-CDDL%201.0-blue.svg)](https://opensource.org/licenses/CDDL-1.0)


### PR DESCRIPTION
Fix Github Build Action Badge as per github [documentation ](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge)
Right now we are using old format(https://github.com/actions/starter-workflows/issues/1525#issuecomment-1763431305)
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
