### PR TITLE
do not call getSCCSFile() twice

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSHistoryParser.java
@@ -82,7 +82,7 @@ final class SCCSHistoryParser {
             return null;
         }
 
-        in = new BufferedReader(new FileReader(getSCCSFile(file)));
+        in = new BufferedReader(new FileReader(f));
         pass = sep = false;
         passRecord = true;
         active = true;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SCCSHistoryParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 


### PR DESCRIPTION
This change fixes a small nit I found when traversing the code of `SCCSHistoryParser`.