### PR TITLE
Replace deprecated sonar login parameter in GH Action

### DIFF
--- a/dev/main
+++ b/dev/main
@@ -23,7 +23,7 @@ if [[ "x$OPENGROK_REPO_SLUG" == "xoracle/opengrok" &&
 	#
 	if [[ "$RUNNER_OS" == "Linux" ]]; then
 		echo "Enabling Sonar"
-		extra_args="$extra_args -P sonar -Dsonar.login=$OPENGROK_SONAR_TOKEN sonar:sonar"
+		extra_args="$extra_args -P sonar -Dsonar.token=$OPENGROK_SONAR_TOKEN -Dsonar.python.version=3.9 sonar:sonar"
 	fi
 fi
 


### PR DESCRIPTION
1. Replace deprecated sonar login parameter in GH Action
2. Pass python version to sonar scanner

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
