### PR TITLE
avoid truncation when merging config files

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigMerge.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigMerge.java
@@ -18,13 +18,15 @@
  */
 
  /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.configuration;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -140,7 +142,7 @@ public class ConfigMerge {
         }
 
         int optind = getopt.getOptind();
-        if (optind < 0 || argv.length - optind != 2) {
+        if (optind < 0 || argv.length - optind != 3) {
             aUsage(System.err);
             System.exit(1);
         }
@@ -168,14 +170,18 @@ public class ConfigMerge {
             System.exit(1);
         }
 
-        // Write the resulting XML representation to standard output.
-        OutputStream os = System.out;
-        cfgNew.encodeObject(os);
+        // Write the resulting XML representation to the output file.
+        try (OutputStream os = new FileOutputStream(argv[optind + 2])) {
+            cfgNew.encodeObject(os);
+        } catch (IOException ex) {
+            System.err.print(ex);
+            System.exit(1);
+        }
     }
 
     private static void aUsage(PrintStream out) {
         out.println("Usage:");
-        out.println(NAME + " [-h] <config_file_base> <config_file_new>");
+        out.println(NAME + " [-h] <config_file_base> <config_file_new> <output_file>");
         out.println();
         out.println("OPTIONS:");
         out.println("Help");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigMerge.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/ConfigMerge.java
@@ -25,7 +25,6 @@ package org.opengrok.indexer.configuration;
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/tools/src/main/python/opengrok_tools/config_merge.py
+++ b/tools/src/main/python/opengrok_tools/config_merge.py
@@ -18,7 +18,7 @@
 # CDDL HEADER END
 
 #
-# Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
 #
 
 import argparse
@@ -33,20 +33,20 @@ from .utils.exitvals import (
     SUCCESS_EXITVAL
 )
 """
- Wrapper for Java program merging OpenGrok configuration.
+ Wrapper for the ConfigMerge Java program merging OpenGrok configuration files.
 """
 
 
 def merge_config_files(read_only, current, out_file, jar,
                        loglevel=logging.INFO):
 
-    return config_merge_wrapper([read_only, current], jar=jar,
-                                out_file=out_file, loglevel=loglevel)
+    return config_merge_wrapper([read_only, current, out_file], jar=jar,
+                                loglevel=loglevel)
 
 
 def config_merge_wrapper(options, loglevel=logging.INFO,
                          jar=None, java=None, java_opts=None,
-                         doprint=False, out_file=None):
+                         doprint=False):
 
     # Avoid using utils.log.get_console_level() since the stdout of the program
     # is interpreted as data.
@@ -63,11 +63,6 @@ def config_merge_wrapper(options, loglevel=logging.INFO,
         logger.error(cmd.geterroutput())
         logger.error("command failed (return code {})".format(ret))
         return FAILURE_EXITVAL
-    else:
-        if out_file:
-            out_file.write(cmd.getoutputstr())
-        else:
-            print(cmd.getoutputstr())
 
     return SUCCESS_EXITVAL
 


### PR DESCRIPTION
This change introduces output file mandatory parameter to the `ConfigMerge` utility. As a result the tools will no longer consume its output in order to produce new configuration file, avoiding truncation.