### PR TITLE
fix annotation regression

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -624,15 +624,25 @@ public class AnalyzerGuru {
         }
 
         if (fa != null) {
-            AbstractAnalyzer.Genre g = fa.getGenre();
-            if (g == AbstractAnalyzer.Genre.PLAIN || g == AbstractAnalyzer.Genre.XREFABLE || g == AbstractAnalyzer.Genre.HTML) {
-                doc.add(new Field(QueryBuilder.T, g.typeName(), string_ft_stored_nanalyzed_norms));
+            AbstractAnalyzer.Genre genre = fa.getGenre();
+            if (isXrefable(genre.typeName())) {
+                doc.add(new Field(QueryBuilder.T, genre.typeName(), string_ft_stored_nanalyzed_norms));
             }
             fa.analyze(doc, StreamSource.fromFile(file), xrefOut);
 
             String type = fa.getFileTypeName();
             doc.add(new StringField(QueryBuilder.TYPE, type, Store.YES));
         }
+    }
+
+    /**
+     * @param genreName genre name
+     * @return whether it is possible to produce xref for the genre
+     */
+    public static boolean isXrefable(String genreName) {
+        return (genreName.equals(AbstractAnalyzer.Genre.PLAIN.typeName())
+                || genreName.equals(AbstractAnalyzer.Genre.XREFABLE.typeName())
+                || genreName.equals(AbstractAnalyzer.Genre.HTML.typeName()));
     }
 
     private static void populateDocumentHistory(Document doc, File file) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2021, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -686,7 +686,7 @@ public final class HistoryGuru {
 
     /**
      * Check if we can annotate the specified file.
-     *
+     * TODO: how is this called from the indexer ?
      * @param file the file to check
      * @return whether the file can be annotated
      */
@@ -697,6 +697,7 @@ public final class HistoryGuru {
             return false;
         }
 
+        // call this only in the webapp ?
         Boolean docIsEligible = null;
         try {
             Document doc;
@@ -711,6 +712,7 @@ public final class HistoryGuru {
         }
 
         if (docIsEligible == null) {
+            // TODO: how come this does not perform magic bytes matching ?
             AbstractAnalyzer.Genre genre = AnalyzerGuru.getGenre(file.toString());
             if (genre == null) {
                 LOGGER.log(Level.INFO, "will not produce annotation for ''{0}'' with unknown genre", file);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -68,8 +68,6 @@ import org.opengrok.indexer.util.PathUtils;
 import org.opengrok.indexer.util.Progress;
 import org.opengrok.indexer.util.Statistics;
 
-import static org.opengrok.indexer.index.IndexDatabase.getDocument;
-
 /**
  * The HistoryGuru is used to implement an transparent layer to the various
  * source control systems.
@@ -707,7 +705,7 @@ public final class HistoryGuru {
                 return !AbstractAnalyzer.Genre.IMAGE.typeName().equals(fileType)
                         && !AbstractAnalyzer.Genre.DATA.typeName().equals(fileType);
             }
-        } catch (ParseException|IOException e) {
+        } catch (ParseException | IOException e) {
             // pass
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -697,26 +697,29 @@ public final class HistoryGuru {
             return false;
         }
 
+        Boolean docIsEligible = null;
         try {
             Document doc;
             if ((doc = IndexDatabase.getDocument(file)) != null) {
                 String fileType = doc.get(QueryBuilder.T);
                 // Consistent with the genre check below
-                return !AbstractAnalyzer.Genre.IMAGE.typeName().equals(fileType)
+                docIsEligible = !AbstractAnalyzer.Genre.IMAGE.typeName().equals(fileType)
                         && !AbstractAnalyzer.Genre.DATA.typeName().equals(fileType);
             }
         } catch (ParseException | IOException e) {
             // pass
         }
 
-        AbstractAnalyzer.Genre genre = AnalyzerGuru.getGenre(file.toString());
-        if (genre == null) {
-            LOGGER.log(Level.INFO, "will not produce annotation for ''{0}'' with unknown genre", file);
-            return false;
-        }
-        if (genre.equals(AbstractAnalyzer.Genre.DATA) || genre.equals(AbstractAnalyzer.Genre.IMAGE)) {
-            LOGGER.log(Level.INFO, "no sense to produce annotation for binary file ''{0}''", file);
-            return false;
+        if (docIsEligible == null) {
+            AbstractAnalyzer.Genre genre = AnalyzerGuru.getGenre(file.toString());
+            if (genre == null) {
+                LOGGER.log(Level.INFO, "will not produce annotation for ''{0}'' with unknown genre", file);
+                return false;
+            }
+            if (genre.equals(AbstractAnalyzer.Genre.DATA) || genre.equals(AbstractAnalyzer.Genre.IMAGE)) {
+                LOGGER.log(Level.INFO, "no sense to produce annotation for binary file ''{0}''", file);
+                return false;
+            }
         }
 
         Repository repo = getRepository(file);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -201,7 +201,6 @@ class HistoryGuruTest {
     void testHasAnnotationSmokeTest() {
         // If hasAnnotation() returns true for a file, it should be possible to actually construct the annotation.
         List<File> filesWithAnnotation = FILES.stream().filter(instance::hasAnnotation).collect(Collectors.toList());
-        assertTrue(filesWithAnnotation.size() > 10);
         assertAll(filesWithAnnotation.stream().map(f -> () -> assertNotNull(instance.annotate(f, null))));
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -201,7 +201,7 @@ class HistoryGuruTest {
     void testHasAnnotationSmokeTest() {
         // If hasAnnotation() returns true for a file, it should be possible to actually construct the annotation.
         List<File> filesWithAnnotation = FILES.stream().filter(instance::hasAnnotation).collect(Collectors.toList());
-        assertEquals(11, filesWithAnnotation.size());
+        assertTrue(filesWithAnnotation.size() > 10);
         assertAll(filesWithAnnotation.stream().map(f -> () -> assertNotNull(instance.annotate(f, null))));
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -18,11 +18,12 @@
  */
 
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -46,15 +47,24 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexNotFoundException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opengrok.indexer.analysis.AbstractAnalyzer;
+import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.condition.EnabledForRepository;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.index.IndexDatabase;
 import org.opengrok.indexer.search.DirectoryEntry;
+import org.opengrok.indexer.search.QueryBuilder;
 import org.opengrok.indexer.util.FileUtilities;
 import org.opengrok.indexer.util.TestRepository;
 
@@ -70,6 +80,8 @@ class HistoryGuruTest {
     private static RuntimeEnvironment env;
 
     private static int savedNestingMaximum;
+
+    HistoryGuru instance = HistoryGuru.getInstance();
 
     @BeforeAll
     static void setUpClass() throws Exception {
@@ -139,14 +151,58 @@ class HistoryGuruTest {
         }
     }
 
-    @Test
-    void testAnnotationSmokeTest() throws Exception {
-        HistoryGuru instance = HistoryGuru.getInstance();
-        for (File f : FILES) {
-            if (instance.hasAnnotation(f)) {
-                assertNotNull(instance.annotate(f, null));
-            }
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testHasAnnotationWithDocument(boolean isXrefable) {
+        File file = Paths.get(repository.getSourceRoot(), "git", "main.c").toFile();
+        assertTrue(file.isFile());
+        Document document = new Document();
+        String typeName;
+        if (isXrefable) {
+            typeName = AbstractAnalyzer.Genre.PLAIN.typeName();
+        } else {
+            typeName = AbstractAnalyzer.Genre.DATA.typeName();
         }
+        assertEquals(isXrefable, AnalyzerGuru.isXrefable(typeName));
+        document.add(new Field(QueryBuilder.T, typeName, new FieldType(StringField.TYPE_STORED)));
+
+        /*
+         * This test class does not perform the 2nd phase of indexing, therefore getDocument() for any file
+         * should result in exception. This differentiates the two hasAnnotation() implementations.
+         */
+        assertThrows(IndexNotFoundException.class, () -> IndexDatabase.getDocument(file));
+        assertTrue(instance.hasAnnotation(file));
+        assertEquals(isXrefable, instance.hasAnnotation(file, document));
+    }
+
+    /**
+     * Check that {@link HistoryGuru#hasAnnotation(File, Document)} falls back to repository check
+     * if the document is {@code null}. Complements the {@link #testHasAnnotationWithDocument(boolean)} test.
+     */
+    @Test
+    void testHasAnnotationWithoutDocument() {
+        File file = Paths.get(repository.getSourceRoot(), "git", "main.c").toFile();
+        assertTrue(file.isFile());
+        Repository repositoryForGit = HistoryGuru.getInstance().getRepository(file);
+        assertNotNull(repositoryForGit);
+        assertTrue(repositoryForGit.isWorking());
+        var repoHasAnnotation = repositoryForGit.fileHasAnnotation(file);
+        assertAll(() -> assertEquals(repoHasAnnotation, instance.hasAnnotation(file, null)),
+                () -> assertEquals(repoHasAnnotation, instance.hasAnnotation(file)));
+    }
+
+    /**
+     * Simple smoke test for hasAnnotation(). Because of the way how {@link HistoryGuru#hasAnnotation(File)}
+     * works and given this test class does not perform 2nd phase of the indexing, there will be some binary
+     * files in the list. These should not be included if the 2nd indexing phase was done as the
+     * {@link HistoryGuru#hasAnnotation(File)} should use the index document for negative check.
+     */
+    @Test
+    void testHasAnnotationSmokeTest() {
+        // If hasAnnotation() returns true for a file, it should be possible to actually construct the annotation.
+        List<File> filesWithAnnotation = FILES.stream().filter(instance::hasAnnotation).collect(Collectors.toList());
+        assertEquals(11, filesWithAnnotation.size());
+        assertAll(filesWithAnnotation.stream().map(f -> () -> assertNotNull(instance.annotate(f, null))));
     }
 
     /**
@@ -184,6 +240,7 @@ class HistoryGuruTest {
         assertNotNull(latestRev);
         instance.createAnnotationCache(file, latestRev);
         Repository repository = instance.getRepository(file);
+        assertNotNull(repository);
 
         // Ensure the annotation is loaded from the cache by moving the dot git directory away.
         final String tmpDirName = "gitdisabled";

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2011, Jens Elkner.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
@@ -735,13 +735,11 @@ public final class PageConfig {
     }
 
     /**
-     * Check, whether annotations are available for the related resource.
-     *
-     * @return {@code true} if annotations are available.
+     * @return whether annotations are available for the related resource.
      */
     public boolean hasAnnotations() {
         if (hasAnnotation == null) {
-            hasAnnotation = !isDir() && HistoryGuru.getInstance().hasAnnotation(getResourceFile());
+            hasAnnotation = HistoryGuru.getInstance().hasAnnotation(getResourceFile());
         }
         return hasAnnotation;
     }
@@ -753,7 +751,7 @@ public final class PageConfig {
      */
     public boolean annotate() {
         if (annotate == null) {
-            annotate = hasAnnotations() && Boolean.parseBoolean(req.getParameter(QueryParameters.ANNOTATION_PARAM));
+            annotate = Boolean.parseBoolean(req.getParameter(QueryParameters.ANNOTATION_PARAM)) && hasAnnotations();
         }
         return annotate;
     }


### PR DESCRIPTION
This change restores the ability to get annotations for xref-able files in the UI. The way it works with this change is that if there is a document for given file, it is used for negative check, i.e. if there is no type in the document or the type is not xref-able, the file is considered not eligible for annotation. If no document can be found for the file, the repository will be checked. This way, with some refactoring, it should work for both the UI and the indexer (when annotation cache is created). Using the "xrefable" property as "annotatable" property (not considering the missing document caveat) is not entirely correct, however it is better to leave this for a subsequent PR; the focus of this PR should be the regression fix.