### PR TITLE
fix finalName warning and update plugins

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -47,11 +47,12 @@
   </dependencies>
 
   <build>
+      <finalName>opengrok-${project.version}</finalName>
       <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.6.1</version>
             <executions>
               <execution>
                 <id>copy-dependencies</id>
@@ -70,9 +71,8 @@
           </plugin>
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.6.0</version>
             <configuration>
-              <finalName>opengrok-${project.version}</finalName>
               <appendAssemblyId>false</appendAssemblyId>
               <descriptors>
                 <descriptor>assembly.xml</descriptor>


### PR DESCRIPTION
When trying to reproduce a Python tools build issue by running the build through `mvnw`, I got this warning when building distribution:
```
[INFO] --- assembly:3.1.0:single (create-archive) @ opengrok-dist ---
[WARNING]  Parameter 'finalName' is read-only, must not be used in configuration
[INFO] Reading assembly descriptor: assembly.xml
[INFO] Building tar: /home/user/opengrok-vladak-scratch/distribution/target/opengrok-1.13.0.tar.gz
[INFO] 
```
Interestingly this warning is not produced when building with system supplied `mvn`.
 
https://issues.apache.org/jira/browse/MJAR-217 says what needs to be done.

While there, I bumped the version of the Maven plugins used in the distribution module.