### PR TITLE
avoid setting global log level

### DIFF
--- a/logging.properties
+++ b/logging.properties
@@ -30,7 +30,7 @@ handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
 # Available logging levels: OFF, SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL
 # OFF will give no output, SEVERE will give very little output, FINEST and ALL will give lots of output.
 #
-.level= ALL
+# .level= ALL
 
 ############################################################
 # Handler specific properties.

--- a/tools/logging.properties.template
+++ b/tools/logging.properties.template
@@ -5,7 +5,10 @@
 handlers= java.util.logging.FileHandler
 
 # Default global logging level.
-.level= FINE
+#.level= FINE
+
+# OpenGrok log level
+org.opengrok.level = FINE
 
 # The '%PROJ%' pattern will be expanded by the the opengrok-reindex-project script 
 # and therefore needs to match the argument to the -p option.


### PR DESCRIPTION
This change normalizes the log level setting in the example files.