### PR TITLE
do not set default async API timeout in opengrok-projadm

### DIFF
--- a/tools/src/main/python/opengrok_tools/projadm.py
+++ b/tools/src/main/python/opengrok_tools/projadm.py
@@ -18,7 +18,7 @@
 # CDDL HEADER END
 
 #
-# Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 #
 
 """
@@ -54,7 +54,7 @@ if (MAJOR_VERSION < 3):
     print("Need Python 3, you are running {}".format(MAJOR_VERSION))
     sys.exit(1)
 
-__version__ = "0.6"
+__version__ = "0.7"
 
 
 def exec_command(doit, logger, cmd, msg):
@@ -265,7 +265,7 @@ def main():
     add_http_headers(parser)
     parser.add_argument('--api_timeout', type=int, default=3,
                         help='Set response timeout in seconds for RESTful API calls')
-    parser.add_argument('--async_api_timeout', type=int, default=300,
+    parser.add_argument('--async_api_timeout', type=int, default=None,
                         help='Set timeout in seconds for asynchronous RESTful API calls')
 
     group = parser.add_mutually_exclusive_group()

--- a/tools/src/main/python/opengrok_tools/projadm.py
+++ b/tools/src/main/python/opengrok_tools/projadm.py
@@ -265,7 +265,7 @@ def main():
     add_http_headers(parser)
     parser.add_argument('--api_timeout', type=int, default=3,
                         help='Set response timeout in seconds for RESTful API calls')
-    parser.add_argument('--async_api_timeout', type=int, default=None,
+    parser.add_argument('--async_api_timeout', type=int,
                         help='Set timeout in seconds for asynchronous RESTful API calls')
 
     group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
There should be a way to set indefinite async API timeout for `opengrok-projadm` to have the ability to wait for the API call completion no matter how long it takes. This is currently not possible (`None` value is needed for that and there is positive default) and this change fixes that by making it the default which I think makes sense; one rarely wants to let the API result slip away, esp. when doing reindex from scratch (a case of back-to-back index deletion which is done via async API call and project addition).