### PR TITLE
improve suggester throughput

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuggesterConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuggesterConfig.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuggesterConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuggesterConfig.java
@@ -51,6 +51,7 @@ public class SuggesterConfig {
     public static final int BUILD_TERMINATION_TIME_DEFAULT = 1800; // half an hour should be enough
     public static final int TIME_THRESHOLD_DEFAULT = 2000; // 2 sec
     public static final int REBUILD_THREAD_POOL_PERCENT_NCPUS_DEFAULT = 80;
+    public static final int SEARCH_THREAD_POOL_PERCENT_NCPUS_DEFAULT = 90;
 
     private static final Set<String> allowedProjectsDefault = null;
     private static final Set<String> allowedFieldsDefault = Set.of(
@@ -141,6 +142,11 @@ public class SuggesterConfig {
      */
     private int rebuildThreadPoolSizeInNcpuPercent;
 
+    /**
+     * Number of threads used for search pool expressed in percent of available CPUs in the system.
+     */
+    private int searchThreadPoolSizeInNcpuPercent;
+
     public SuggesterConfig() {
         setEnabled(ENABLED_DEFAULT);
         setMaxResults(MAX_RESULTS_DEFAULT);
@@ -157,6 +163,7 @@ public class SuggesterConfig {
         setRebuildCronConfig(REBUILD_CRON_CONFIG_DEFAULT);
         setBuildTerminationTime(BUILD_TERMINATION_TIME_DEFAULT);
         setRebuildThreadPoolSizeInNcpuPercent(REBUILD_THREAD_POOL_PERCENT_NCPUS_DEFAULT);
+        setSearchThreadPoolSizeInNcpuPercent(SEARCH_THREAD_POOL_PERCENT_NCPUS_DEFAULT);
     }
 
     public boolean isEnabled() {
@@ -302,6 +309,17 @@ public class SuggesterConfig {
         return rebuildThreadPoolSizeInNcpuPercent;
     }
 
+    public void setSearchThreadPoolSizeInNcpuPercent(final int percent) {
+        if (percent < 0 || percent > 100) {
+            throw new IllegalArgumentException("Need percentage value");
+        }
+        this.searchThreadPoolSizeInNcpuPercent = percent;
+    }
+
+    public int getSearchThreadPoolSizeInNcpuPercent() {
+        return searchThreadPoolSizeInNcpuPercent;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -355,6 +373,8 @@ public class SuggesterConfig {
         res.setRebuildCronConfig("1 0 * * *");
         res.setBuildTerminationTime(1 + res.getBuildTerminationTime());
         res.setRebuildThreadPoolSizeInNcpuPercent(1 + res.getRebuildThreadPoolSizeInNcpuPercent());
+        res.setSearchThreadPoolSizeInNcpuPercent(1 + res.getSearchThreadPoolSizeInNcpuPercent());
+
         return res;
     }
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opengrok.suggest.Suggester;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.configuration.SuggesterConfig;
 import org.opengrok.indexer.index.Indexer;
@@ -43,13 +42,10 @@ import org.opengrok.web.api.v1.RestApp;
 import org.opengrok.web.api.v1.suggester.provider.service.impl.SuggesterServiceImpl;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -102,7 +102,7 @@ class SuggesterControllerProjectsDisabledTest extends OGKJerseyTest {
         f.setAccessible(true);
         Suggester suggester = (Suggester) f.get(SuggesterServiceImpl.getInstance());
 
-        Field f2 = Suggester.class.getDeclaredField("projectData");
+        Field f2 = Suggester.class.getDeclaredField("projectDataMap");
         f2.setAccessible(true);
 
         return ((Map) f2.get(suggester)).size();

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerProjectsDisabledTest.java
@@ -91,21 +91,10 @@ class SuggesterControllerProjectsDisabledTest extends OGKJerseyTest {
     }
 
     @BeforeEach
-    void before() {
-        await().atMost(15, TimeUnit.SECONDS).until(() -> getSuggesterProjectDataSize() == 1);
+    void before() throws Exception {
+        SuggesterServiceImpl.getInstance().waitForInit(15, TimeUnit.SECONDS);
 
         env.setSuggesterConfig(new SuggesterConfig());
-    }
-
-    private static int getSuggesterProjectDataSize() throws Exception {
-        Field f = SuggesterServiceImpl.class.getDeclaredField("suggester");
-        f.setAccessible(true);
-        Suggester suggester = (Suggester) f.get(SuggesterServiceImpl.getInstance());
-
-        Field f2 = Suggester.class.getDeclaredField("projectDataMap");
-        f2.setAccessible(true);
-
-        return ((Map) f2.get(suggester)).size();
     }
 
     @Test

--- a/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
+++ b/suggester/src/main/java/org/opengrok/suggest/SuggesterProjectData.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest;
 
@@ -105,6 +105,8 @@ class SuggesterProjectData implements Closeable {
 
     private final Directory tempDir;
 
+    private boolean initialized;    // Whether init() was called.
+
     SuggesterProjectData(
             final Directory indexDir,
             final Path suggesterDir,
@@ -163,6 +165,8 @@ class SuggesterProjectData implements Closeable {
             }
 
             storeDataVersion(commitVersion);
+
+            initialized = true;
         } finally {
             lock.writeLock().unlock();
         }
@@ -244,6 +248,15 @@ class SuggesterProjectData implements Closeable {
             }
 
             storeDataVersion(getCommitVersion());
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public boolean isInitialized() {
+        lock.writeLock().lock();
+        try {
+            return initialized;
         } finally {
             lock.writeLock().unlock();
         }

--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
@@ -136,7 +136,7 @@ class SuggesterTest {
         }
     }
 
-    private SuggesterTestData initSuggester() throws IOException {
+    private SuggesterTestData initSuggester() throws Exception {
         Path tempIndexDir = Files.createTempDirectory("opengrok");
         Directory dir = FSDirectory.open(tempIndexDir);
 
@@ -152,8 +152,7 @@ class SuggesterTest {
                 registry, false);
 
         s.init(Collections.singleton(new Suggester.NamedIndexDir("test", tempIndexDir)));
-
-        await().atMost(2, TimeUnit.SECONDS).until(() -> getSuggesterProjectDataSize(s) == 1);
+        s.waitForInit(2, TimeUnit.SECONDS);
 
         SuggesterTestData testData = new SuggesterTestData();
         testData.s = s;
@@ -172,15 +171,8 @@ class SuggesterTest {
         }
     }
 
-    private static int getSuggesterProjectDataSize(final Suggester suggester) throws Exception {
-        java.lang.reflect.Field f2 = Suggester.class.getDeclaredField("projectDataMap");
-        f2.setAccessible(true);
-
-        return ((Map) f2.get(suggester)).size();
-    }
-
     @Test
-    void testSimpleSuggestions() throws IOException {
+    void testSimpleSuggestions() throws Exception {
         SuggesterTestData t = initSuggester();
 
         Suggester.NamedIndexReader ir = t.getNamedIndexReader();
@@ -195,7 +187,7 @@ class SuggesterTest {
     }
 
     @Test
-    void testRefresh() throws IOException {
+    void testRefresh() throws Exception {
         SuggesterTestData t = initSuggester();
 
         addText(t.getIndexDirectory(), "a1 a2");
@@ -214,7 +206,7 @@ class SuggesterTest {
     }
 
     @Test
-    void testIndexChangedWhileOffline() throws IOException {
+    void testIndexChangedWhileOffline() throws Exception {
         SuggesterTestData t = initSuggester();
 
         t.s.close();
@@ -227,8 +219,7 @@ class SuggesterTest {
                 registry, false);
 
         t.s.init(Collections.singleton(t.getNamedIndexDir()));
-
-        await().atMost(2, TimeUnit.SECONDS).until(() -> getSuggesterProjectDataSize(t.s) == 1);
+        t.s.waitForInit(2, TimeUnit.SECONDS);
 
         Suggester.NamedIndexReader ir = t.getNamedIndexReader();
 
@@ -242,7 +233,7 @@ class SuggesterTest {
     }
 
     @Test
-    void testRemove() throws IOException {
+    void testRemove() throws Exception {
         SuggesterTestData t = initSuggester();
 
         t.s.remove(Collections.singleton("test"));
@@ -254,7 +245,7 @@ class SuggesterTest {
     }
 
     @Test
-    void testComplexQuerySearch() throws IOException {
+    void testComplexQuerySearch() throws Exception {
         SuggesterTestData t = initSuggester();
 
         List<LookupResultItem> res = t.s.search(Collections.singletonList(t.getNamedIndexReader()),
@@ -268,7 +259,7 @@ class SuggesterTest {
 
     @Test
     @SuppressWarnings("unchecked") // for contains()
-    void testOnSearch() throws IOException {
+    void testOnSearch() throws Exception {
         SuggesterTestData t = initSuggester();
 
         Query q = new BooleanQuery.Builder()
@@ -287,7 +278,7 @@ class SuggesterTest {
     }
 
     @Test
-    void testGetSearchCountsForUnknown() throws IOException {
+    void testGetSearchCountsForUnknown() throws Exception {
         SuggesterTestData t = initSuggester();
 
         assertTrue(t.s.getSearchCounts("unknown", "unknown", 0, 10).isEmpty());
@@ -297,7 +288,7 @@ class SuggesterTest {
 
     @Test
     @SuppressWarnings("unchecked") // for contains()
-    void testIncreaseSearchCount() throws IOException {
+    void testIncreaseSearchCount() throws Exception {
         SuggesterTestData t = initSuggester();
 
         t.s.increaseSearchCount("test", new Term("test", "term2"), 100, true);

--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
@@ -51,13 +51,11 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;

--- a/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
+++ b/suggester/src/test/java/org/opengrok/suggest/SuggesterTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest;
 
@@ -108,7 +108,7 @@ class SuggesterTest {
         var terminationDuration = Duration.ofMinutes(5);
         assertThrows(IllegalArgumentException.class,
                 () -> new Suggester(null, 10, terminationDuration, false,
-                        true, null, Integer.MAX_VALUE, 1, registry,
+                        true, null, Integer.MAX_VALUE, 1, 1, registry,
                         false));
     }
 
@@ -129,7 +129,7 @@ class SuggesterTest {
                                         .orElse(null);
         try {
             new Suggester(tempFile.toFile(), 10, objDuration, false,
-                    true, null, Integer.MAX_VALUE, 1, registry,
+                    true, null, Integer.MAX_VALUE, 1, 1, registry,
                     false);
         } finally {
             tempFile.toFile().delete();
@@ -148,7 +148,8 @@ class SuggesterTest {
 
         Suggester s = new Suggester(tempSuggesterDir.toFile(), 10, Duration.ofMinutes(1), true,
                 true, Collections.singleton("test"), Integer.MAX_VALUE,
-                Runtime.getRuntime().availableProcessors(), registry, false);
+                Runtime.getRuntime().availableProcessors(), Runtime.getRuntime().availableProcessors(),
+                registry, false);
 
         s.init(Collections.singleton(new Suggester.NamedIndexDir("test", tempIndexDir)));
 
@@ -172,7 +173,7 @@ class SuggesterTest {
     }
 
     private static int getSuggesterProjectDataSize(final Suggester suggester) throws Exception {
-        java.lang.reflect.Field f2 = Suggester.class.getDeclaredField("projectData");
+        java.lang.reflect.Field f2 = Suggester.class.getDeclaredField("projectDataMap");
         f2.setAccessible(true);
 
         return ((Map) f2.get(suggester)).size();
@@ -222,7 +223,8 @@ class SuggesterTest {
 
         t.s = new Suggester(t.suggesterDir.toFile(), 10, Duration.ofMinutes(1), false,
                 true, Collections.singleton("test"), Integer.MAX_VALUE,
-                Runtime.getRuntime().availableProcessors(), registry, false);
+                Runtime.getRuntime().availableProcessors(), Runtime.getRuntime().availableProcessors(),
+                registry, false);
 
         t.s.init(Collections.singleton(t.getNamedIndexDir()));
 


### PR DESCRIPTION
This change addresses 2 problems with suggester:
  - per class lock held inside the `Suggester` class for init/rebuild/remove operations prevented API calls to proceed for a long time. Together with `SuggesterServiceImpl` and `SuggesterProjectData`, there were 3 layers of locking, making this confusing.
  - init/rebuild done as a result of reindexing multiple projects in parallel, resulting in potentially long queue of rebuild operations, executed serially. 

The locking part of the change is done with the assumption that the `lock` object based synchronization in the `Suggester` class was primarily used to protect the insertions/queries to the `projectData` map. I addressed this using `computeIfAbsent` which is atomic for the `ConcurrentHashMap` used.

The rebuild execution part of the change was done by introducing a thread pool that is reused for the init/rebuild operations.

In general this should improve the throughput of the suggester.

While there, I added tunable for the search pool parallelism level and addressed a few nits in the code.

Also, changed the latency meters to record per suggester data times rather than aggregates as the latter makes limited sense, I think.