### PR TITLE
Add null guards

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/OpenGrokThreadFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/OpenGrokThreadFactory.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.Objects;
 
 /**
  * ThreadFactory to be used throughout OpenGrok to make sure all threads have common prefix.
@@ -45,7 +46,7 @@ public class OpenGrokThreadFactory implements ThreadFactory {
 
     @Override
     public Thread newThread(@NotNull Runnable runnable) {
-        Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+        Thread thread = Executors.defaultThreadFactory().newThread(Objects.requireNonNull(runnable, "runnable"));
         thread.setName(PREFIX + threadPrefix + thread.getId());
         return thread;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryReader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryReader.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.List;
+import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
 import org.opengrok.indexer.util.IOUtils;
@@ -47,7 +48,7 @@ public class HistoryReader extends Reader {
         if (input == null) {
             input = createInternalReader();
         }
-        return input.read(cbuf, off, len);
+        return input.read(Objects.requireNonNull(cbuf, "cbuf"), off, len);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheck.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -101,7 +102,7 @@ public class IndexCheck implements AutoCloseable {
      * @param configuration configuration based on which to perform the check
      */
     public IndexCheck(@NotNull Configuration configuration) {
-        this(configuration, null);
+        this(configuration, null); // configuration is guarded against null inside this constructor
     }
 
     /**
@@ -111,7 +112,7 @@ public class IndexCheck implements AutoCloseable {
      *                     on whether projects are enabled in the configuration.
      */
     public IndexCheck(@NotNull Configuration configuration, Collection<String> projectNames) {
-        this.configuration = configuration;
+        this.configuration = Objects.requireNonNull(configuration, "configuration");
         if (projectNames != null) {
             this.projectNames.addAll(projectNames);
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -2105,7 +2105,7 @@ public class IndexDatabase {
 
         @Override
         public void write(@NotNull char[] chars, int off, int len) throws IOException {
-            out.write(chars, off, len);
+            out.write(Objects.requireNonNull(chars), off, len);
             count += len;
         }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/OpenGrokThreadFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/OpenGrokThreadFactoryTest.java
@@ -1,0 +1,15 @@
+package org.opengrok.indexer.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class OpenGrokThreadFactoryTest {
+    @Test
+    void testNullRunnable() throws Exception {
+        assertThrows(NullPointerException.class, () -> {
+            OpenGrokThreadFactory factory = new OpenGrokThreadFactory("");
+            factory.newThread(null);
+        });
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/OpenGrokThreadFactoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/OpenGrokThreadFactoryTest.java
@@ -1,3 +1,26 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2024, Heewon Lee <heewon.lee@kaist.ac.kr>.
+ */
 package org.opengrok.indexer.configuration;
 
 import org.junit.jupiter.api.Test;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryReaderTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryReaderTest.java
@@ -1,3 +1,26 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2024, Heewon Lee <heewon.lee@kaist.ac.kr>.
+ */
 package org.opengrok.indexer.history;
 
 import org.junit.jupiter.api.Test;
@@ -5,11 +28,11 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HistoryReaderTest {
-	@Test
-	void testNullCbuf() throws Exception {
-		assertThrows(NullPointerException.class, () -> {
-			HistoryReader historyReader = new HistoryReader(new History());
-			historyReader.read(null, 0, 0);
-		});
-	}
+    @Test
+    void testNullCbuf() throws Exception {
+        assertThrows(NullPointerException.class, () -> {
+            HistoryReader historyReader = new HistoryReader(new History());
+            historyReader.read(null, 0, 0);
+        });
+    }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryReaderTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryReaderTest.java
@@ -1,0 +1,15 @@
+package org.opengrok.indexer.history;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HistoryReaderTest {
+	@Test
+	void testNullCbuf() throws Exception {
+		assertThrows(NullPointerException.class, () -> {
+			HistoryReader historyReader = new HistoryReader(new History());
+			historyReader.read(null, 0, 0);
+		});
+	}
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -258,6 +258,9 @@ class IndexCheckTest {
 
     @Test
     void testNullConfiguration() throws Exception {
-        assertThrows(NullPointerException.class, () -> {new IndexCheck(null);});
+        assertThrows(NullPointerException.class, () -> {
+            new IndexCheck(null);
+            }
+        );
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexCheckTest.java
@@ -255,4 +255,9 @@ class IndexCheckTest {
             }
         }
     }
+
+    @Test
+    void testNullConfiguration() throws Exception {
+        assertThrows(NullPointerException.class, () -> {new IndexCheck(null);});
+    }
 }


### PR DESCRIPTION
While the `@NotNull` decorator informs developers that the correct usage is that the decorated variables should not be `null`, it does not enforce such in any way.
This leads to cases where an incorrectly fed `null` could propagate far away before being detected (such as via `NullPointerException`s).
This commit implements some `null` guards where needed for a fail-fast treatment of `null` inputs.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
