### PR TITLE
make the hasAnnotation check more precise

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerFactory.java
@@ -64,6 +64,10 @@ public abstract class AnalyzerFactory {
      * The genre for files recognized by this kind of analyzer.
      */
     protected AbstractAnalyzer.Genre genre;
+    /**
+     * Whether the files can be annotated.
+     */
+    protected boolean hasAnnotations;
 
     protected AnalyzerFactory(FileAnalyzerFactory.Matcher matcher, String contentType) {
         cachedAnalyzer = new ThreadLocal<>();
@@ -146,11 +150,15 @@ public abstract class AnalyzerFactory {
     }
 
     /**
-     * The user friendly name of this analyzer.
+     * The user-friendly name of this analyzer.
      *
      * @return a genre
      */
     public abstract String getName();
+
+    public boolean hasAnnotations() {
+        return hasAnnotations;
+    }
 
     public abstract AbstractAnalyzer getAnalyzer();
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -237,8 +237,7 @@ public class AnalyzerGuru {
      * Maps from {@link FileAnalyzer#getFileTypeName()} to
      * {@link FileAnalyzerFactory}.
      */
-    private static final Map<String, AnalyzerFactory> FILETYPE_FACTORIES =
-            new HashMap<>();
+    private static final Map<String, AnalyzerFactory> FILETYPE_FACTORIES = new HashMap<>();
 
     /**
      * Maps from {@link FileAnalyzer#getFileTypeName()} to

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -771,6 +771,7 @@ public class AnalyzerGuru {
      * @param fileTypeName a defined instance
      * @return a defined instance or {@code null}
      */
+    @Nullable
     public static AnalyzerFactory findByFileTypeName(String fileTypeName) {
         return FILETYPE_FACTORIES.get(fileTypeName);
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzerFactory.java
@@ -34,14 +34,14 @@ import java.util.List;
  */
 public class FileAnalyzerFactory extends AnalyzerFactory {
 
-    /** The user friendly name of this analyzer. */
+    /** The user-friendly name of this analyzer. */
     private final String name;
 
     /**
      * Create an instance of {@code FileAnalyzerFactory}.
      */
     FileAnalyzerFactory() {
-        this(null, null, null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null, null, false);
     }
 
     /**
@@ -56,12 +56,13 @@ public class FileAnalyzerFactory extends AnalyzerFactory {
      * @param contentType content type for this analyzer (possibly {@code null})
      * @param genre the genre for this analyzer (if {@code null}, {@code
      * Genre.DATA} is used)
-     * @param name user friendly name of this analyzer (or null if it shouldn't be listed)
+     * @param name user-friendly name of this analyzer (or null if it shouldn't be listed)
+     * @param hasAnnotations whether the files processed by the analyzers produced by this factory can be annotated
      */
     protected FileAnalyzerFactory(
             String[] names, String[] prefixes, String[] suffixes,
             String[] magics, Matcher matcher, String contentType,
-            AbstractAnalyzer.Genre genre, String name) {
+            AbstractAnalyzer.Genre genre, String name, boolean hasAnnotations) {
         super(matcher, contentType);
         this.names = asList(names);
         this.prefixes = asList(prefixes);
@@ -69,6 +70,7 @@ public class FileAnalyzerFactory extends AnalyzerFactory {
         this.magics = asList(magics);
         this.genre = (genre == null) ? AbstractAnalyzer.Genre.DATA : genre;
         this.name = name;
+        this.hasAnnotations = hasAnnotations;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/FileAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2021, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ada/AdaAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ada/AdaAnalyzerFactory.java
@@ -41,7 +41,7 @@ public class AdaAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public AdaAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ada/AdaAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ada/AdaAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.ada;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/BZip2AnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/BZip2AnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.archive;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/BZip2AnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/BZip2AnalyzerFactory.java
@@ -38,7 +38,7 @@ public class BZip2AnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public BZip2AnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, null, null, NAME);
+        super(null, null, SUFFIXES, MAGICS, null, null, null, NAME, false);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/GZIPAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/GZIPAnalyzerFactory.java
@@ -38,9 +38,8 @@ public class GZIPAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public GZIPAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, null, null, NAME);
+        super(null, null, SUFFIXES, MAGICS, null, null, null, NAME, false);
     }
-
     @Override
     protected AbstractAnalyzer newAnalyzer() {
         return new GZIPAnalyzer(this);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/GZIPAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/GZIPAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.archive;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/TarAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/TarAnalyzerFactory.java
@@ -34,7 +34,7 @@ public class TarAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public TarAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, null, AbstractAnalyzer.Genre.XREFABLE, NAME);
+        super(null, null, SUFFIXES, null, null, null, AbstractAnalyzer.Genre.XREFABLE, NAME, false);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/TarAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/TarAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.archive;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/ZipAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/ZipAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.archive;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/ZipAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/archive/ZipAnalyzerFactory.java
@@ -57,7 +57,7 @@ public final class ZipAnalyzerFactory extends FileAnalyzerFactory {
             new ZipAnalyzerFactory();
 
     private ZipAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, MATCHER, null, AbstractAnalyzer.Genre.XREFABLE, NAME);
+        super(null, null, SUFFIXES, null, MATCHER, null, AbstractAnalyzer.Genre.XREFABLE, NAME, false);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/asm/AsmAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/asm/AsmAnalyzerFactory.java
@@ -39,7 +39,7 @@ public class AsmAnalyzerFactory extends FileAnalyzerFactory {
      * ".s" with {@link AsmAnalyzer}.
      */
     public AsmAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CAnalyzerFactory.java
@@ -44,7 +44,7 @@ public class CAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public CAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.c;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CxxAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CxxAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.c;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CxxAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/c/CxxAnalyzerFactory.java
@@ -44,7 +44,7 @@ public class CxxAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public CxxAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.clojure;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/clojure/ClojureAnalyzerFactory.java
@@ -36,7 +36,7 @@ public class ClojureAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public ClojureAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzerFactory.java
@@ -35,7 +35,7 @@ public class CSharpAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public CSharpAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/csharp/CSharpAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.csharp;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/data/IgnorantAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/data/IgnorantAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.data;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/data/IgnorantAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/data/IgnorantAnalyzerFactory.java
@@ -45,7 +45,7 @@ public class IgnorantAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public IgnorantAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, null, null, null);
+        super(null, null, SUFFIXES, MAGICS, null, null, null, null, false);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/data/ImageAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/data/ImageAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.data;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/data/ImageAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/data/ImageAnalyzerFactory.java
@@ -38,7 +38,7 @@ public class ImageAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public ImageAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, null, AbstractAnalyzer.Genre.IMAGE, NAME);
+        super(null, null, SUFFIXES, null, null, null, AbstractAnalyzer.Genre.IMAGE, NAME, false);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzerFactory.java
@@ -53,7 +53,7 @@ public class MandocAnalyzerFactory extends FileAnalyzerFactory {
         new MandocAnalyzerFactory();
 
     protected MandocAnalyzerFactory() {
-        super(null, null, null, null, MATCHER, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, null, null, MATCHER, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/MandocAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.document;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/TroffAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/TroffAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.document;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/TroffAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/document/TroffAnalyzerFactory.java
@@ -50,7 +50,7 @@ public class TroffAnalyzerFactory extends FileAnalyzerFactory {
         new TroffAnalyzerFactory();
 
     protected TroffAnalyzerFactory() {
-        super(null, null, null, null, MATCHER, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, null, null, MATCHER, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/eiffel/EiffelAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/eiffel/EiffelAnalyzerFactory.java
@@ -40,7 +40,7 @@ public class EiffelAnalyzerFactory extends FileAnalyzerFactory {
      */
     public EiffelAnalyzerFactory() {
         super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN,
-            NAME);
+            NAME, true);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/erlang/ErlangAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/erlang/ErlangAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.erlang;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/erlang/ErlangAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/erlang/ErlangAnalyzerFactory.java
@@ -39,7 +39,7 @@ public class ErlangAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public ErlangAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/ELFAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/ELFAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.executables;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/ELFAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/ELFAnalyzerFactory.java
@@ -34,7 +34,8 @@ public class ELFAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public ELFAnalyzerFactory() {
-        super(null, null, null, MAGICS, null, null, AbstractAnalyzer.Genre.XREFABLE, NAME);
+        super(null, null, null, MAGICS, null, null,
+                AbstractAnalyzer.Genre.XREFABLE, NAME, false);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JarAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JarAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.executables;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JarAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JarAnalyzerFactory.java
@@ -63,7 +63,8 @@ public final class JarAnalyzerFactory extends FileAnalyzerFactory {
             new JarAnalyzerFactory();
 
     private JarAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, MATCHER, null, AbstractAnalyzer.Genre.XREFABLE, NAME);
+        super(null, null, SUFFIXES, null, MATCHER, null,
+                AbstractAnalyzer.Genre.XREFABLE, NAME, false);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JavaClassAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JavaClassAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2021, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.executables;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JavaClassAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/executables/JavaClassAnalyzerFactory.java
@@ -95,7 +95,8 @@ public class JavaClassAnalyzerFactory extends FileAnalyzerFactory {
         new JavaClassAnalyzerFactory();
 
     private JavaClassAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, MATCHER, null, AbstractAnalyzer.Genre.XREFABLE, NAME);
+        super(null, null, SUFFIXES, null, MATCHER, null,
+                AbstractAnalyzer.Genre.XREFABLE, NAME, false);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/fortran/FortranAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/fortran/FortranAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.fortran;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/fortran/FortranAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/fortran/FortranAnalyzerFactory.java
@@ -52,7 +52,7 @@ public class FortranAnalyzerFactory extends FileAnalyzerFactory {
         "F15"};
 
     public FortranAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/golang/GolangAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/golang/GolangAnalyzerFactory.java
@@ -38,7 +38,7 @@ public class GolangAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public GolangAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/golang/GolangAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/golang/GolangAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.golang;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/haskell/HaskellAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/haskell/HaskellAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.haskell;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/haskell/HaskellAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/haskell/HaskellAnalyzerFactory.java
@@ -40,7 +40,7 @@ public class HaskellAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public HaskellAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/hcl/HCLAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/hcl/HCLAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.hcl;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/hcl/HCLAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/hcl/HCLAnalyzerFactory.java
@@ -40,7 +40,7 @@ public class HCLAnalyzerFactory extends FileAnalyzerFactory {
      * Creates a new instance of {@link HCLAnalyzerFactory}.
      */
     public HCLAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/JavaAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/JavaAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.java;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/JavaAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/JavaAnalyzerFactory.java
@@ -36,7 +36,7 @@ public class JavaAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public JavaAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/javascript/JavaScriptAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/javascript/JavaScriptAnalyzerFactory.java
@@ -33,7 +33,7 @@ public class JavaScriptAnalyzerFactory extends FileAnalyzerFactory {
     private static final String[] SUFFIXES = {"JS"};
 
     public JavaScriptAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/javascript/JavaScriptAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/javascript/JavaScriptAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.javascript;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/json/JsonAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/json/JsonAnalyzerFactory.java
@@ -35,7 +35,7 @@ public class JsonAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public JsonAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/json/JsonAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/json/JsonAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.json;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/kotlin/KotlinAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/kotlin/KotlinAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.kotlin;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/kotlin/KotlinAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/kotlin/KotlinAnalyzerFactory.java
@@ -35,7 +35,7 @@ public class KotlinAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public KotlinAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lisp/LispAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lisp/LispAnalyzerFactory.java
@@ -37,7 +37,7 @@ public class LispAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public LispAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lisp/LispAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lisp/LispAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.lisp;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lua/LuaAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lua/LuaAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.lua;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lua/LuaAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/lua/LuaAnalyzerFactory.java
@@ -38,7 +38,7 @@ public class LuaAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public LuaAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzerFactory.java
@@ -39,7 +39,7 @@ public class PascalAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public PascalAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/pascal/PascalAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.pascal;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/perl/PerlAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/perl/PerlAnalyzerFactory.java
@@ -50,7 +50,7 @@ public class PerlAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public PerlAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/perl/PerlAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/perl/PerlAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.perl;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/php/PhpAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/php/PhpAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.php;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/php/PhpAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/php/PhpAnalyzerFactory.java
@@ -45,7 +45,7 @@ public class PhpAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public PhpAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2021, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.plain;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/PlainAnalyzerFactory.java
@@ -88,7 +88,7 @@ public final class PlainAnalyzerFactory extends FileAnalyzerFactory {
     public static final PlainAnalyzerFactory DEFAULT_INSTANCE = new PlainAnalyzerFactory();
 
     private PlainAnalyzerFactory() {
-        super(null, null, null, null, MATCHER, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, null, null, MATCHER, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/XMLAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/XMLAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.plain;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/XMLAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/XMLAnalyzerFactory.java
@@ -40,7 +40,7 @@ public class XMLAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public XMLAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, "text/html", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, MAGICS, null, "text/html", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/powershell/PowershellAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/powershell/PowershellAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.powershell;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/powershell/PowershellAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/powershell/PowershellAnalyzerFactory.java
@@ -35,7 +35,7 @@ public class PowershellAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public PowershellAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/python/PythonAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/python/PythonAnalyzerFactory.java
@@ -48,7 +48,7 @@ public class PythonAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public PythonAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/python/PythonAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/python/PythonAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.python;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/r/RAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/r/RAnalyzerFactory.java
@@ -41,7 +41,7 @@ public class RAnalyzerFactory extends FileAnalyzerFactory {
      * ".r", ".rdata", ".rda", and ".rds" with {@link RAnalyzer}.
      */
     public RAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/r/RAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/r/RAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.r;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/RubyAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/RubyAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.ruby;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/RubyAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ruby/RubyAnalyzerFactory.java
@@ -50,7 +50,7 @@ public class RubyAnalyzerFactory extends FileAnalyzerFactory {
      * Creates a new instance of {@link RubyAnalyzerFactory}.
      */
     public RubyAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/rust/RustAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/rust/RustAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2016, Nikolay Denev.
  */
 package org.opengrok.indexer.analysis.rust;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/rust/RustAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/rust/RustAnalyzerFactory.java
@@ -41,7 +41,7 @@ public class RustAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public RustAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/scala/ScalaAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/scala/ScalaAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.scala;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/scala/ScalaAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/scala/ScalaAnalyzerFactory.java
@@ -39,7 +39,7 @@ public class ScalaAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public ScalaAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sh/ShAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sh/ShAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.sh;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sh/ShAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sh/ShAnalyzerFactory.java
@@ -60,7 +60,7 @@ public class ShAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public ShAnalyzerFactory() {
-        super(NAMES, PREFIXES, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(NAMES, PREFIXES, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/PLSQLAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/PLSQLAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.sql;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/PLSQLAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/PLSQLAnalyzerFactory.java
@@ -39,7 +39,7 @@ public class PLSQLAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public PLSQLAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/SQLAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/SQLAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.sql;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/SQLAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/sql/SQLAnalyzerFactory.java
@@ -34,7 +34,7 @@ public class SQLAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public SQLAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/SwiftAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/SwiftAnalyzerFactory.java
@@ -34,7 +34,7 @@ public class SwiftAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public SwiftAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/SwiftAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/swift/SwiftAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.swift;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/tcl/TclAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/tcl/TclAnalyzerFactory.java
@@ -41,7 +41,7 @@ public class TclAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public TclAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/tcl/TclAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/tcl/TclAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.tcl;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/terraform/TerraformAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/terraform/TerraformAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.terraform;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/terraform/TerraformAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/terraform/TerraformAnalyzerFactory.java
@@ -40,7 +40,7 @@ public class TerraformAnalyzerFactory extends FileAnalyzerFactory {
      * Creates a new instance of {@link TerraformAnalyzerFactory}.
      */
     public TerraformAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/typescript/TypeScriptAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/typescript/TypeScriptAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.typescript;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/typescript/TypeScriptAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/typescript/TypeScriptAnalyzerFactory.java
@@ -33,7 +33,7 @@ public class TypeScriptAnalyzerFactory extends FileAnalyzerFactory {
     private static final String[] SUFFIXES = {"TS"};
 
     public TypeScriptAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/uue/UuencodeAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/uue/UuencodeAnalyzerFactory.java
@@ -51,7 +51,7 @@ public class UuencodeAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public UuencodeAnalyzerFactory() {
-        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, MAGICS, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, false);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/uue/UuencodeAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/uue/UuencodeAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013, Constantine A. Murenin &lt;C++@Cns.SU&gt;
  */
 package org.opengrok.indexer.analysis.uue;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/vb/VBAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/vb/VBAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.analysis.vb;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/vb/VBAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/vb/VBAnalyzerFactory.java
@@ -39,7 +39,7 @@ public class VBAnalyzerFactory extends FileAnalyzerFactory {
     };
 
     public VBAnalyzerFactory() {
-        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME);
+        super(null, null, SUFFIXES, null, null, "text/plain", AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/verilog/VerilogAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/verilog/VerilogAnalyzerFactory.java
@@ -41,7 +41,7 @@ public class VerilogAnalyzerFactory extends FileAnalyzerFactory {
      */
     public VerilogAnalyzerFactory() {
         super(null, null, SUFFIXES, null, null, "text/plain", Genre.PLAIN,
-                NAME);
+                NAME, true);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzerFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates.
  * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
  */
 package org.opengrok.indexer.analysis.yaml;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yaml/YamlAnalyzerFactory.java
@@ -38,7 +38,7 @@ public class YamlAnalyzerFactory extends FileAnalyzerFactory {
 
     public YamlAnalyzerFactory() {
         super(null, null, SUFFIXES, null, null, "text/plain",
-                AbstractAnalyzer.Genre.PLAIN, NAME);
+                AbstractAnalyzer.Genre.PLAIN, NAME, true);
     }
 
     @Override

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -2336,7 +2336,7 @@ public class IndexDatabase {
                 fileTypeName = doc.get(QueryBuilder.TYPE);
                 if (fileTypeName == null) {
                     // (Should not get here, but break just in case.)
-                    LOGGER.log(Level.FINEST, "Missing TYPE field: ''{0}''", path);
+                    LOGGER.log(Level.WARNING, "Missing TYPE field: ''{0}''", path);
                     break;
                 }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -46,17 +46,21 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexNotFoundException;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
@@ -151,20 +155,24 @@ class HistoryGuruTest {
         }
     }
 
+    private static Stream<Arguments> provideParamsForHasAnnotationTestWithDocument() {
+        return Stream.of(
+                Arguments.of(AbstractAnalyzer.Genre.PLAIN.typeName(), true),
+                Arguments.of(AbstractAnalyzer.Genre.DATA.typeName(), false),
+                Arguments.of(null, false)
+                );
+    }
+
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testHasAnnotationWithDocument(boolean isXrefable) {
+    @MethodSource("provideParamsForHasAnnotationTestWithDocument")
+    void testHasAnnotationWithDocument(@Nullable String typeName, boolean isXrefable) {
         File file = Paths.get(repository.getSourceRoot(), "git", "main.c").toFile();
         assertTrue(file.isFile());
         Document document = new Document();
-        String typeName;
-        if (isXrefable) {
-            typeName = AbstractAnalyzer.Genre.PLAIN.typeName();
-        } else {
-            typeName = AbstractAnalyzer.Genre.DATA.typeName();
+        if (typeName != null) {
+            document.add(new Field(QueryBuilder.T, typeName, new FieldType(StringField.TYPE_STORED)));
+            assertEquals(isXrefable, AnalyzerGuru.isXrefable(typeName));
         }
-        assertEquals(isXrefable, AnalyzerGuru.isXrefable(typeName));
-        document.add(new Field(QueryBuilder.T, typeName, new FieldType(StringField.TYPE_STORED)));
 
         /*
          * This test class does not perform the 2nd phase of indexing, therefore getDocument() for any file
@@ -177,7 +185,7 @@ class HistoryGuruTest {
 
     /**
      * Check that {@link HistoryGuru#hasAnnotation(File, Document)} falls back to repository check
-     * if the document is {@code null}. Complements the {@link #testHasAnnotationWithDocument(boolean)} test.
+     * if the document is {@code null}. Complements the {@link #testHasAnnotationWithDocument} test.
      */
     @Test
     void testHasAnnotationWithoutDocument() {


### PR DESCRIPTION
This change builds the `hasAnnotation` check on the top of xref-able. The property is part of the analyzer factory classes.