### PR TITLE
replace ForkJoinPool with fixed thread pool

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1955,10 +1955,7 @@ public class IndexDatabase {
             List<Future<IndexFileWork>> futures = parallelizer.getIndexWorkExecutor().invokeAll(callables);
             for (var future : futures) {
                 IndexFileWork work = future.get();
-                bySuccess.merge(work.ret, new ArrayList<>(List.of(work)), (x, y) -> {
-                    x.addAll(y);
-                    return x;
-                });
+                bySuccess.computeIfAbsent(work.ret, key -> new ArrayList<>()).add(work);
             }
         } catch (InterruptedException | ExecutionException e) {
             interrupted = true;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -39,6 +39,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -47,9 +48,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -1902,54 +1905,61 @@ public class IndexDatabase {
         IndexerParallelizer parallelizer = RuntimeEnvironment.getInstance().getIndexerParallelizer();
         ObjectPool<Ctags> ctagsPool = parallelizer.getCtagsPool();
 
-        Map<Boolean, List<IndexFileWork>> bySuccess = null;
+        Map<Boolean, List<IndexFileWork>> bySuccess = new HashMap<>();
         try (Progress progress = new Progress(LOGGER, String.format("indexing '%s'", dir), worksCount)) {
-            bySuccess = parallelizer.getForkJoinPool().submit(() ->
-                args.works.parallelStream().collect(
-                Collectors.groupingByConcurrent((x) -> {
-                    int tries = 0;
-                    Ctags pctags = null;
-                    boolean ret;
-                    while (true) {
-                        try {
-                            if (alreadyClosedCounter.get() > 0) {
-                                ret = false;
-                            } else {
-                                pctags = ctagsPool.get();
-                                addFile(x.file, x.path, pctags);
-                                successCounter.incrementAndGet();
-                                ret = true;
+            Set<Callable<IndexFileWork>> callables = args.works.stream().
+                    <Callable<IndexFileWork>>map(x -> () -> {
+                        int tries = 0;
+                        Ctags pctags = null;
+                        while (true) {
+                            try {
+                                if (alreadyClosedCounter.get() > 0) {
+                                    x.ret = false;
+                                } else {
+                                    pctags = ctagsPool.get();
+                                    addFile(x.file, x.path, pctags);
+                                    successCounter.incrementAndGet();
+                                    x.ret = true;
+                                }
+                            } catch (AlreadyClosedException e) {
+                                alreadyClosedCounter.incrementAndGet();
+                                String errmsg = String.format("ERROR addFile(): '%s'", x.file);
+                                LOGGER.log(Level.SEVERE, errmsg, e);
+                                x.exception = e;
+                                x.ret = false;
+                            } catch (InterruptedException e) {
+                                // Allow one retry if interrupted
+                                if (++tries <= 1) {
+                                    continue;
+                                }
+                                LOGGER.log(Level.WARNING, "No retry: ''{0}''", x.file);
+                                x.exception = e;
+                                x.ret = false;
+                            } catch (RuntimeException | IOException e) {
+                                String errmsg = String.format("ERROR addFile(): '%s'", x.file);
+                                LOGGER.log(Level.WARNING, errmsg, e);
+                                x.exception = e;
+                                x.ret = false;
+                            } finally {
+                                if (pctags != null) {
+                                    pctags.reset();
+                                    ctagsPool.release(pctags);
+                                }
                             }
-                        } catch (AlreadyClosedException e) {
-                            alreadyClosedCounter.incrementAndGet();
-                            String errmsg = String.format("ERROR addFile(): '%s'", x.file);
-                            LOGGER.log(Level.SEVERE, errmsg, e);
-                            x.exception = e;
-                            ret = false;
-                        } catch (InterruptedException e) {
-                            // Allow one retry if interrupted
-                            if (++tries <= 1) {
-                                continue;
-                            }
-                            LOGGER.log(Level.WARNING, "No retry: ''{0}''", x.file);
-                            x.exception = e;
-                            ret = false;
-                        } catch (RuntimeException | IOException e) {
-                            String errmsg = String.format("ERROR addFile(): '%s'", x.file);
-                            LOGGER.log(Level.WARNING, errmsg, e);
-                            x.exception = e;
-                            ret = false;
-                        } finally {
-                            if (pctags != null) {
-                                pctags.reset();
-                                ctagsPool.release(pctags);
-                            }
-                        }
 
-                        progress.increment();
-                        return ret;
-                    }
-                }))).get();
+                            progress.increment();
+                            return x;
+                        }
+                    }).
+                    collect(Collectors.toSet());
+            List<Future<IndexFileWork>> futures = parallelizer.getIndexWorkExecutor().invokeAll(callables);
+            for (var future : futures) {
+                IndexFileWork work = future.get();
+                bySuccess.merge(work.ret, new ArrayList<>(List.of(work)), (x, y) -> {
+                    x.addAll(y);
+                    return x;
+                });
+            }
         } catch (InterruptedException | ExecutionException e) {
             interrupted = true;
             int successCount = successCounter.intValue();
@@ -1963,12 +1973,11 @@ public class IndexDatabase {
 
         // Start with failureCount=worksCount, and then subtract successes.
         int failureCount = worksCount;
-        if (bySuccess != null) {
-            List<IndexFileWork> successes = bySuccess.getOrDefault(Boolean.TRUE, null);
-            if (successes != null) {
-                failureCount -= successes.size();
-            }
+        List<IndexFileWork> successes = bySuccess.getOrDefault(Boolean.TRUE, null);
+        if (successes != null) {
+            failureCount -= successes.size();
         }
+
         if (failureCount > 0) {
             double pctFailed = 100.0 * failureCount / worksCount;
             String exmsg = String.format("%d failures (%.1f%%) while parallel-indexing", failureCount, pctFailed);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1968,13 +1968,9 @@ public class IndexDatabase {
 
         args.curCount = currentCounter.intValue();
 
-        // Start with failureCount=worksCount, and then subtract successes.
-        int failureCount = worksCount;
-        List<IndexFileWork> successes = bySuccess.getOrDefault(Boolean.TRUE, null);
-        if (successes != null) {
-            failureCount -= successes.size();
-        }
-
+        int failureCount = worksCount - Optional.ofNullable(bySuccess.get(Boolean.TRUE))
+                .map(List::size)
+                .orElse(0);
         if (failureCount > 0) {
             double pctFailed = 100.0 * failureCount / worksCount;
             String exmsg = String.format("%d failures (%.1f%%) while parallel-indexing", failureCount, pctFailed);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDownArgs.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDownArgs.java
@@ -35,6 +35,7 @@ class IndexFileWork {
     final File file;
     final String path;
     Exception exception;
+    boolean ret;
 
     IndexFileWork(File file, String path) {
         this.file = file;


### PR DESCRIPTION
This change replaces the `ForkJoinPool` used for distributing `addFile()` tasks in the 2nd phase of indexer processing with fixed thread pool. In my case:
  - Oracle OCI VM.Standard.E3.Flex with 16 OCPUs, 128 GB RAM running Solaris 11.4 SRU ~63 and storing OpenGrok data on block volume with 25,000 IOPS / Balanced (VPU/GB:10) / Throughput: 480 MB/s
  - indexer running with Java 11 with `-J=-Xmx48g -J=-server` using `--renamedHistory 'on' -r dirbased -G -m '256' --threads 48 --historyThreads 48 --historyFileThreads 32` and annotation cache enabled for all projects
  - the input data consists of bigger projects like Linux kernel, FreeBSD, AOSP, Solaris Userland (prepped) - a mix of various repository types (Git, Subversion, Teamware, Mercurial)

it shaves some 8+ hours from the total indexing time:

before:
```
2024-02-21 16:48:04.992+0000 INFO t1 Statistics.logIt: Done indexing data of all repositories (took 1 day 21:59:50)
2024-02-21 16:48:05.842+0000 INFO t1 Indexer.writeConfigToFile: Writing configuration to '/opengrok/etc/configuration.xml'
2024-02-21 16:48:06.317+0000 INFO t1 Indexer.writeConfigToFile: Done writing configuration to '/opengrok/etc/configuration.xml'
2024-02-21 16:48:06.317+0000 INFO t1 Statistics.logIt: Indexer finished (took 2 days 06:27:12)
```
after:
```
2024-02-24 08:12:22.599+0000 INFO t1 Statistics.logIt: Done indexing data of all repositories (took 1 day 13:08:41)
2024-02-24 08:12:23.127+0000 INFO t1 Indexer.writeConfigToFile: Writing configuration to '/opengrok/etc/configuration.xml'
2024-02-24 08:12:23.565+0000 INFO t1 Indexer.writeConfigToFile: Done writing configuration to '/opengrok/etc/configuration.xml'
2024-02-24 08:12:23.566+0000 INFO t1 Statistics.logIt: Indexer finished (took 1 day 22:00:52)
```

The distribution of the tasks is not as uniform - more often than not a single project occupies the fixed thread pool (while always using it to its full capacity unlike the `ForkJoin`), however the sub-optimal scheduling is gone. Also, I don't like the [hazy promise](https://stackoverflow.com/questions/24629247/where-does-official-documentation-say-that-javas-parallel-stream-operations-use) of custom `ForkJoinPool` to be used for `parallelStream()` processing.