### PR TITLE
prevent null date in Subversion history entry

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionHistoryParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, 2023, Ric Harris <harrisric@users.noreply.github.com>.
  */
@@ -37,6 +37,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -111,12 +113,12 @@ class SubversionHistoryParser implements Executor.StreamHandler {
                 entry.setActive(true);
                 entry.setRevision(attr.getValue("revision"));
             } else if ("path".equals(qname) && attr.getIndex(COPYFROM_PATH) != -1) {
-              LOGGER.log(Level.FINER, "rename for {0}", attr.getValue(COPYFROM_PATH));
-              if ("dir".equals(attr.getValue("kind"))) {
-                isRenamedDir = true;
-              } else {
-                isRenamedFile = true;
-              }
+                LOGGER.log(Level.FINER, "rename for {0}", attr.getValue(COPYFROM_PATH));
+                if ("dir".equals(attr.getValue("kind"))) {
+                    isRenamedDir = true;
+                } else {
+                    isRenamedFile = true;
+                }
             }
             sb.setLength(0);
         }
@@ -131,8 +133,8 @@ class SubversionHistoryParser implements Executor.StreamHandler {
                     // need to strip microseconds off - assume final character is Z otherwise invalid anyway.
                     String dateString = s;
                     if (s.length() > SVN_MILLIS_DATE_LENGTH) {
-                      dateString = dateString.substring(0, SVN_MILLIS_DATE_LENGTH - 1) +
-                          dateString.charAt(dateString.length() - 1);
+                        dateString = dateString.substring(0, SVN_MILLIS_DATE_LENGTH - 1) +
+                                dateString.charAt(dateString.length() - 1);
                     }
                     entry.setDate(repository.parse(dateString));
                 } catch (ParseException ex) {
@@ -153,7 +155,7 @@ class SubversionHistoryParser implements Executor.StreamHandler {
                         renamedFiles.add(path.intern());
                     }
                     if (isRenamedDir) {
-                      renamedToDirectoryRevisions.put(path.intern(), entry.getRevision());
+                        renamedToDirectoryRevisions.put(path.intern(), entry.getRevision());
                     }
                 } else {
                     LOGGER.log(Level.FINER, "Skipping file ''{0}'' outside repository ''{1}''",
@@ -163,6 +165,11 @@ class SubversionHistoryParser implements Executor.StreamHandler {
                 entry.setMessage(s);
             }
             if ("logentry".equals(qname)) {
+                // Avoid adding incomplete history entries.
+                if (Objects.isNull(entry.getDate())) {
+                    throw new SAXException(String.format("date is null in history entry for revision %s",
+                            Optional.ofNullable(entry.getRevision()).orElse("<unknown>")));
+                }
                 entries.add(entry);
             }
             sb.setLength(0);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionHistoryParser.java
@@ -217,17 +217,15 @@ class SubversionHistoryParser implements Executor.StreamHandler {
 
         Executor executor;
         try {
-            executor = repos.getHistoryLogExecutor(file, sinceRevision,
-                    numEntries, cmdType);
+            executor = repos.getHistoryLogExecutor(file, sinceRevision, numEntries, cmdType);
         } catch (IOException e) {
-            throw new HistoryException("Failed to get history for: \"" +
-                    file.getAbsolutePath() + "\"", e);
+            throw new HistoryException(String.format("Failed to get history for '%s'", file.getAbsolutePath()), e);
         }
 
         int status = executor.exec(true, this);
         if (status != 0) {
-            throw new HistoryException("Failed to get history for: \"" +
-                    file.getAbsolutePath() + "\" Exit code: " + status);
+            throw new HistoryException(String.format("Failed to get history for '%s': Exit code: %d",
+                    file.getAbsolutePath(), status));
         }
 
         List<HistoryEntry> entries = handler.entries;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionHistoryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionHistoryParser.java
@@ -47,6 +47,7 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.logger.LoggerFactory;
@@ -273,12 +274,13 @@ class SubversionHistoryParser implements Executor.StreamHandler {
     }
 
     /**
-     * Parse the given string.
+     * Parse the given string. Only used in tests.
      *
      * @param buffer The string to be parsed
      * @return The parsed history
      * @throws IOException if we fail to parse the buffer
      */
+    @VisibleForTesting
     History parse(String buffer) throws IOException {
         handler = new Handler("/", "", 0, new SubversionRepository());
         processStream(new ByteArrayInputStream(buffer.getBytes(StandardCharsets.UTF_8)));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
@@ -517,7 +517,7 @@ public class SubversionRepository extends Repository {
                 }
             }
         } catch (HistoryException ex) {
-            LOGGER.log(Level.WARNING, "cannot get current version info for {0}",
+            LOGGER.log(Level.WARNING, "cannot get current version info for ''{0}''",
                     getDirectoryName());
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
@@ -45,6 +45,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -121,11 +122,10 @@ public class SubversionRepository extends Repository {
     }
 
     /**
-     * Get {@code Document} corresponding to the parsed XML output from
-     * {@code svn info} command.
-     * @return document with data from {@code info} or null if the {@code svn}
-     * command failed
+     * Get {@code Document} corresponding to the parsed XML output from {@code svn info} command.
+     * @return document with data from {@code info} or null if the {@code svn} command failed
      */
+    @Nullable
     private Document getInfoDocument() {
         Document document = null;
         List<String> cmd = new ArrayList<>();
@@ -147,19 +147,14 @@ public class SubversionRepository extends Repository {
                 DocumentBuilder builder = factory.newDocumentBuilder();
                 document = builder.parse(executor.getOutputStream());
             } catch (SAXException saxe) {
-                LOGGER.log(Level.WARNING,
-                        "Parser error parsing svn output", saxe);
+                LOGGER.log(Level.WARNING, "Parser error parsing svn output", saxe);
             } catch (ParserConfigurationException pce) {
-                LOGGER.log(Level.WARNING,
-                        "Parser configuration error parsing svn output", pce);
+                LOGGER.log(Level.WARNING, "Parser configuration error parsing svn output", pce);
             } catch (IOException ioe) {
-                LOGGER.log(Level.WARNING,
-                        "IOException reading from svn process", ioe);
+                LOGGER.log(Level.WARNING, "IOException reading from svn process", ioe);
             }
         } else {
-            LOGGER.log(Level.WARNING,
-                            "Failed to execute svn info for [{0}]. Repository disabled.",
-                            getDirectoryName());
+            LOGGER.log(Level.WARNING, "Failed to execute svn info for ''{0}''", getDirectoryName());
         }
 
         return document;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
@@ -373,8 +373,7 @@ public class SubversionRepository extends Repository {
         return getHistory(file, sinceRevision, 0, CommandTimeoutType.INDEXER);
     }
 
-    private History getHistory(File file, String sinceRevision, int numEntries,
-            CommandTimeoutType cmdType)
+    private History getHistory(File file, String sinceRevision, int numEntries, CommandTimeoutType cmdType)
             throws HistoryException {
         return new SubversionHistoryParser().parse(file, this, sinceRevision,
                 numEntries, cmdType);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SubversionRepository.java
@@ -161,7 +161,7 @@ public class SubversionRepository extends Repository {
     }
 
     /**
-     * Get value of given tag in 'svn info' document.
+     * Get value of given tag in @{code svn info} document.
      * @param document document object containing {@code info} contents
      * @param tagName name of the tag to return value for
      * @return value string
@@ -411,7 +411,7 @@ public class SubversionRepository extends Repository {
 
     @Override
     public boolean fileHasHistory(File file) {
-        // @TODO: Research how to cheaply test if a file in a given
+        // TODO: Research how to cheaply test if a file in a given
         // SVN repo has history.  If there is a cheap test, then this
         // code can be refined, boosting performance.
         return true;


### PR DESCRIPTION
This change prevents adding `HistoryEntry` objects with null date to the list from the `SubversionHistoryParser`. I had to make changes in the `Executor` to propagate the errors from stream processing for this to work.

It also fixes various style issues and code smells.