### PR TITLE
fix some nits in CtagsUtil + fix build

### DIFF
--- a/distribution/assembly.xml
+++ b/distribution/assembly.xml
@@ -20,7 +20,7 @@
         <destName>source.war</destName>
       </file>
       <file>
-        <source>${project.basedir}/../tools/${project.build.directory}/dist/opengrok-tools-${project.python.package.version}.tar.gz</source>
+        <source>${project.basedir}/../tools/${project.build.directory}/dist/opengrok_tools-${project.python.package.version}.tar.gz</source>
         <outputDirectory>tools</outputDirectory>
         <destName>opengrok-tools.tar.gz</destName>
       </file>

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/CtagsUtil.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.util;
@@ -53,6 +53,10 @@ public class CtagsUtil {
     private static final Logger LOGGER = LoggerFactory.getLogger(CtagsUtil.class);
 
     public static final String SYSTEM_CTAGS_PROPERTY = "org.opengrok.indexer.analysis.Ctags";
+
+    /** Private to enforce static. */
+    private CtagsUtil() {
+    }
 
     /**
      * Check that {@code ctags} program exists and is working.
@@ -163,7 +167,7 @@ public class CtagsUtil {
         Set<String> result = new HashSet<>();
         for (String lang : split) {
             lang = lang.trim();
-            if (lang.length() > 0) {
+            if (!lang.isEmpty()) {
                 result.add(lang);
             }
         }
@@ -192,7 +196,7 @@ public class CtagsUtil {
                 continue;
             }
 
-            LOGGER.log(Level.FINER, "deleting Ctags temporary files in directory {0}", directoryName);
+            LOGGER.log(Level.FINER, "deleting Ctags temporary files in directory ''{0}''", directoryName);
             deleteTempFiles(directory);
         }
     }
@@ -205,14 +209,18 @@ public class CtagsUtil {
             return matcher.find();
         });
 
+        if (Objects.isNull(files)) {
+            return;
+        }
+
         for (File file : files) {
-            if (file.isFile() && !file.delete()) {
-                LOGGER.log(Level.WARNING, "cannot delete file {0}", file);
+            if (file.isFile()) {
+                try {
+                    Files.delete(file.toPath());
+                } catch (IOException exception) {
+                    LOGGER.log(Level.WARNING, String.format("cannot delete file '%s'", file), exception);
+                }
             }
         }
-    }
-
-    /** Private to enforce static. */
-    private CtagsUtil() {
     }
 }

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -267,7 +267,7 @@ Portions Copyright (c) 2017-2018, 2020, Chris Fraire <cfraire@me.com>.
                                 <argument>-m</argument>
                                 <argument>pip</argument>
                                 <argument>install</argument>
-                                <argument>${outputDirectory}/opengrok-tools-${project.version}.tar.gz</argument>
+                                <argument>${outputDirectory}/opengrok_tools-${project.version}.tar.gz</argument>
                             </arguments>
                             <skip>${skipPythonTests}</skip>
                         </configuration>


### PR DESCRIPTION
This change addresses bunch of nits found in the `CtagsUtil` class.

Also, it seems something has changed in the way `setuptools` name the resulting tarball when building a package. Even though the `[project]` section in `tools/pyproject.toml` has `name = "opengrok-tools"`, the resulting name of the tar ball will now have underscore in it. This should not matter as the `distribution` module will rename it to `opengrok-tools.tar.gz` anyway. The names of the Python packages do not change - they had underscore in them before.