### PR TITLE
indexer: add java options to indexer

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -352,7 +352,7 @@ def indexer_no_projects(logger, uri, config_path, extra_indexer_options):
             indexer_options.extend(extra_indexer_options.split())
         indexer = Indexer(
             indexer_options,
-            java_opts=indexer_java_opts,                                        
+            java_opts=indexer_java_opts,
             logger=logger,                                                      
             jar=OPENGROK_JAR,                                                   
             doprint=True,

--- a/docker/start.py
+++ b/docker/start.py
@@ -457,7 +457,7 @@ def create_bare_config(logger, use_projects, extra_indexer_options=None):
     if use_projects:
         indexer_options.append("-P")
         indexer_options,
-        java_opts=indexer_java_opts,                                            
+        java_opts=indexer_java_opts,
         jar=OPENGROK_JAR,
         logger=logger,                                                          
         doprint=True,

--- a/docker/start.py
+++ b/docker/start.py
@@ -353,7 +353,7 @@ def indexer_no_projects(logger, uri, config_path, extra_indexer_options):
         indexer = Indexer(
             indexer_options,
             java_opts=indexer_java_opts,
-            logger=logger,                                                      
+            logger=logger,
             jar=OPENGROK_JAR,                                                   
             doprint=True,
         )

--- a/docker/start.py
+++ b/docker/start.py
@@ -456,7 +456,11 @@ def create_bare_config(logger, use_projects, extra_indexer_options=None):
         indexer_options.extend(extra_indexer_options)
     if use_projects:
         indexer_options.append("-P")
-    indexer = Indexer(indexer_options, java_opts=indexer_java_opts, jar=OPENGROK_JAR, logger=logger, doprint=True)
+        indexer_options,
+        java_opts=indexer_java_opts,                                            
+        jar=OPENGROK_JAR,                                                       
+        logger=logger,                                                          
+        doprint=True,
     indexer.execute()
     ret = indexer.getretcode()
     if ret != SUCCESS_EXITVAL:

--- a/docker/start.py
+++ b/docker/start.py
@@ -458,7 +458,7 @@ def create_bare_config(logger, use_projects, extra_indexer_options=None):
         indexer_options.append("-P")
         indexer_options,
         java_opts=indexer_java_opts,                                            
-        jar=OPENGROK_JAR,                                                       
+        jar=OPENGROK_JAR,
         logger=logger,                                                          
         doprint=True,
     indexer.execute()

--- a/docker/start.py
+++ b/docker/start.py
@@ -323,6 +323,10 @@ def indexer_no_projects(logger, uri, config_path, extra_indexer_options):
     Project less indexer
     """
 
+    indexer_java_opts = os.environ.get("INDEXER_JAVA_OPTS")
+    if indexer_java_opts:
+        indexer_java_opts = indexer_java_opts.split()
+
     wait_for_tomcat(logger, uri)
 
     while True:
@@ -347,7 +351,7 @@ def indexer_no_projects(logger, uri, config_path, extra_indexer_options):
             )
             indexer_options.extend(extra_indexer_options.split())
         indexer = Indexer(
-            indexer_options, logger=logger, jar=OPENGROK_JAR, doprint=True
+            indexer_options, java_opts=indexer_java_opts, logger=logger, jar=OPENGROK_JAR, doprint=True
         )
         indexer.execute()
 
@@ -421,6 +425,10 @@ def create_bare_config(logger, use_projects, extra_indexer_options=None):
     Create bare configuration file with a few basic settings.
     """
 
+    indexer_java_opts = os.environ.get("INDEXER_JAVA_OPTS")
+    if indexer_java_opts:
+        indexer_java_opts = indexer_java_opts.split()
+
     logger.info("Creating bare configuration in {}".format(OPENGROK_CONFIG_FILE))
     indexer_options = [
         "-s",
@@ -444,7 +452,7 @@ def create_bare_config(logger, use_projects, extra_indexer_options=None):
         indexer_options.extend(extra_indexer_options)
     if use_projects:
         indexer_options.append("-P")
-    indexer = Indexer(indexer_options, jar=OPENGROK_JAR, logger=logger, doprint=True)
+    indexer = Indexer(indexer_options, java_opts=indexer_java_opts, jar=OPENGROK_JAR, logger=logger, doprint=True)
     indexer.execute()
     ret = indexer.getretcode()
     if ret != SUCCESS_EXITVAL:
@@ -473,12 +481,16 @@ def check_index_and_wipe_out(logger):
     currently running version and the CHECK_INDEX environment variable
     is non-empty, wipe out the directories under data root.
     """
+    indexer_java_opts = os.environ.get("INDEXER_JAVA_OPTS")
+    if indexer_java_opts:
+        indexer_java_opts = indexer_java_opts.split()
+
     check_index = os.environ.get("CHECK_INDEX")
     if check_index and os.path.exists(OPENGROK_CONFIG_FILE):
         logger.info("Checking if index matches current version")
         indexer_options = ["-R", OPENGROK_CONFIG_FILE, "--checkIndex", "version"]
         indexer = Indexer(
-            indexer_options, logger=logger, jar=OPENGROK_JAR, doprint=True
+            indexer_options, java_opts=indexer_java_opts, logger=logger, jar=OPENGROK_JAR, doprint=True
         )
         indexer.execute()
         if indexer.getretcode() == 1:

--- a/docker/start.py
+++ b/docker/start.py
@@ -351,7 +351,7 @@ def indexer_no_projects(logger, uri, config_path, extra_indexer_options):
             )
             indexer_options.extend(extra_indexer_options.split())
         indexer = Indexer(
-            indexer_options, 
+            indexer_options,
             java_opts=indexer_java_opts,                                        
             logger=logger,                                                      
             jar=OPENGROK_JAR,                                                   

--- a/docker/start.py
+++ b/docker/start.py
@@ -459,7 +459,7 @@ def create_bare_config(logger, use_projects, extra_indexer_options=None):
         indexer_options,
         java_opts=indexer_java_opts,
         jar=OPENGROK_JAR,
-        logger=logger,                                                          
+        logger=logger,
         doprint=True,
     indexer.execute()
     ret = indexer.getretcode()

--- a/docker/start.py
+++ b/docker/start.py
@@ -456,6 +456,7 @@ def create_bare_config(logger, use_projects, extra_indexer_options=None):
         indexer_options.extend(extra_indexer_options)
     if use_projects:
         indexer_options.append("-P")
+    indexer = Indexer(
         indexer_options,
         java_opts=indexer_java_opts,
         jar=OPENGROK_JAR,

--- a/docker/start.py
+++ b/docker/start.py
@@ -351,7 +351,11 @@ def indexer_no_projects(logger, uri, config_path, extra_indexer_options):
             )
             indexer_options.extend(extra_indexer_options.split())
         indexer = Indexer(
-            indexer_options, java_opts=indexer_java_opts, logger=logger, jar=OPENGROK_JAR, doprint=True
+            indexer_options, 
+            java_opts=indexer_java_opts,                                        
+            logger=logger,                                                      
+            jar=OPENGROK_JAR,                                                   
+            doprint=True,
         )
         indexer.execute()
 

--- a/docker/start.py
+++ b/docker/start.py
@@ -499,9 +499,9 @@ def check_index_and_wipe_out(logger):
         indexer_options = ["-R", OPENGROK_CONFIG_FILE, "--checkIndex", "version"]
         indexer = Indexer(
             indexer_options,
-            java_opts=indexer_java_opts,                                        
-            logger=logger,                                                      
-            jar=OPENGROK_JAR,                                                   
+            java_opts=indexer_java_opts,
+            logger=logger,
+            jar=OPENGROK_JAR,
             doprint=True,
         )
         indexer.execute()

--- a/docker/start.py
+++ b/docker/start.py
@@ -354,7 +354,7 @@ def indexer_no_projects(logger, uri, config_path, extra_indexer_options):
             indexer_options,
             java_opts=indexer_java_opts,
             logger=logger,
-            jar=OPENGROK_JAR,                                                   
+            jar=OPENGROK_JAR,
             doprint=True,
         )
         indexer.execute()

--- a/docker/start.py
+++ b/docker/start.py
@@ -498,7 +498,11 @@ def check_index_and_wipe_out(logger):
         logger.info("Checking if index matches current version")
         indexer_options = ["-R", OPENGROK_CONFIG_FILE, "--checkIndex", "version"]
         indexer = Indexer(
-            indexer_options, java_opts=indexer_java_opts, logger=logger, jar=OPENGROK_JAR, doprint=True
+            indexer_options,
+            java_opts=indexer_java_opts,                                        
+            logger=logger,                                                      
+            jar=OPENGROK_JAR,                                                   
+            doprint=True,
         )
         indexer.execute()
         if indexer.getretcode() == 1:

--- a/docker/start.py
+++ b/docker/start.py
@@ -461,6 +461,7 @@ def create_bare_config(logger, use_projects, extra_indexer_options=None):
         jar=OPENGROK_JAR,
         logger=logger,
         doprint=True,
+    )
     indexer.execute()
     ret = indexer.getretcode()
     if ret != SUCCESS_EXITVAL:

--- a/tools/src/main/python/opengrok_tools/reindex_project.py
+++ b/tools/src/main/python/opengrok_tools/reindex_project.py
@@ -127,8 +127,12 @@ def main():
         # Prepend the extra options because we want the arguments to end with a project.
         indexer_options = extra_options.split() + indexer_options
     java_opts = []
+    indexer_java_opts = os.environ.get("INDEXER_JAVA_OPTS")
     if args.java_opts:
         java_opts.extend(args.java_opts)
+    elif indexer_java_opts:
+        java_opts.extend(indexer_java_opts.split())
+
     if logprop_file:
         java_opts.append("-Djava.util.logging.config.file={}".
                          format(logprop_file))


### PR DESCRIPTION
add INDEXER_JAVA_OPTS environment varibale
pass java_opts to Indexer to tune jvm options

This feature is useful for docker users

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
