### PR TITLE
do not log stack trace for CacheException reporting disabled cache an…

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -643,10 +643,10 @@ public class Ctags implements Resettable {
             StreamSource src = StreamSource.fromFile(new File(filename));
             splitter.reset(src);
         } catch (NullPointerException | IOException ex) {
-            LOGGER.log(Level.WARNING, "Failed to re-read {0}", filename);
+            LOGGER.log(Level.WARNING, "Failed to re-read ''{0}''", filename);
             return null;
         }
-        LOGGER.log(Level.FINEST, "Re-read {0}", filename);
+        LOGGER.log(Level.FINEST, "Re-read ''{0}''", filename);
         return splitter;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CacheException.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CacheException.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -32,6 +32,7 @@ public class CacheException extends Exception {
     private static final long serialVersionUID = 1L;
 
     private final Level level;
+    private final boolean logTrace;
 
     /**
      * Construct a {@code CacheException} with the specified message.
@@ -50,6 +51,20 @@ public class CacheException extends Exception {
     public CacheException(String msg, Level level) {
         super(msg);
         this.level = level;
+        this.logTrace = true;
+    }
+
+    /**
+     * Construct a {@code CacheException} with the specified message and log level
+     * and whether to log stack trace.
+     * @param msg message
+     * @param level suggested log level
+     * @param logTrace whether to log stack trace
+     */
+    public CacheException(String msg, Level level, boolean logTrace) {
+        super(msg);
+        this.level = level;
+        this.logTrace = logTrace;
     }
 
     /**
@@ -60,6 +75,7 @@ public class CacheException extends Exception {
     public CacheException(Throwable cause) {
         super(cause);
         this.level = Level.WARNING;
+        this.logTrace = true;
     }
 
     /**
@@ -71,6 +87,7 @@ public class CacheException extends Exception {
     public CacheException(String msg, Throwable cause) {
         super(msg, cause);
         this.level = Level.WARNING;
+        this.logTrace = true;
     }
 
     /**
@@ -78,5 +95,9 @@ public class CacheException extends Exception {
      */
     public Level getLevel() {
         return level;
+    }
+
+    public boolean isLogTrace() {
+        return this.logTrace;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CacheException.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CacheException.java
@@ -49,9 +49,7 @@ public class CacheException extends Exception {
      * @param level suggested log level
      */
     public CacheException(String msg, Level level) {
-        super(msg);
-        this.level = level;
-        this.logTrace = true;
+        this(msg, level, true);
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -715,6 +715,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
         Path newPath = Path.of(getRepositoryCachedRevPath(repository));
         try (Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(newPath.toFile())))) {
             writer.write(rev);
+            LOGGER.finest(() -> String.format("stored latest cached revision %s for repository %s", rev, repository));
         } catch (IOException ex) {
             LOGGER.log(Level.WARNING,
                     String.format("Cannot write latest cached revision to file for repository %s", repository), ex);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -239,7 +239,6 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
         smileFactory.configure(SmileGenerator.Feature.CHECK_SHARED_STRING_VALUES, false);
 
         ObjectMapper mapper = new SmileMapper(smileFactory);
-        // ObjectMapper mapper = new JsonMapper();
         ObjectWriter objectWriter = mapper.writer().forType(HashMap.class);
 
         try (OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(outputFile))) {
@@ -255,7 +254,6 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
         smileFactory.configure(SmileGenerator.Feature.CHECK_SHARED_STRING_VALUES, false);
 
         ObjectMapper mapper = new SmileMapper(smileFactory);
-        // ObjectMapper mapper = new JsonMapper();
         return mapper.writer().forType(HistoryEntry.class);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -1180,7 +1180,7 @@ public final class HistoryGuru {
         if (!repository.isWorking() || !repository.isAnnotationCacheEnabled()) {
             throw new CacheException(
                     String.format("repository %s does not allow to create annotation cache for '%s'",
-                            repository, file), Level.FINER);
+                            repository, file), Level.FINER, false);
         }
 
         LOGGER.finest(() -> String.format("creating annotation cache for '%s'", launderLog(file.toString())));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1306,7 +1306,7 @@ public class IndexDatabase {
                 // call above) directly.
                 HistoryGuru.getInstance().createAnnotationCache(file, lastRev);
             } catch (CacheException e) {
-                LOGGER.log(e.getLevel(), "failed to create annotation", e);
+                LOGGER.log(e.getLevel(), "failed to create annotation", e.isLogTrace() ? e : e.getMessage());
             }
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1306,7 +1306,12 @@ public class IndexDatabase {
                 // call above) directly.
                 HistoryGuru.getInstance().createAnnotationCache(file, lastRev);
             } catch (CacheException e) {
-                LOGGER.log(e.getLevel(), "failed to create annotation", e.isLogTrace() ? e : e.getMessage());
+                final String logPrefix = "failed to create annotation";
+                if (e.isLogTrace()) {
+                    LOGGER.log(e.getLevel(), logPrefix, e);
+                } else {
+                    LOGGER.log(e.getLevel(), String.format("%s: %s", logPrefix, e.getMessage()));
+                }
             }
         }
     }


### PR DESCRIPTION
This change removes superfluous stack trace from the log entry in the case of disabled annotation cache by adding a property to `CacheException` and performing the logging based on this property.

The alternative would be to change the code in `HistoryGuru#createAnnotationCache()` and avoid throwing the exception in such case however that would impact testability. Or, try to use a hack and set the elements of the exception object via `setStackTrace()` which seems fragile (if it actually works in this case).

Example of the changed log entry:
```
15:06:23 FINER: failed to create annotation: repository {dir='/var/opengrok/src.linux/linux',type=git,historyCache=on,renamed=false,merge=true,annotationCache=off} does not allow to create annotation cache for '/var/opengrok/src.linux/linux/Documentation/devicetree/bindings/dma/brcm,bcm2835-dma.yaml'
15:06:23 FINEST: Added: '/linux/Documentation/devicetree/bindings/dma/brcm,bcm2835-dma.yaml' (YamlAnalyzer) (took 8 ms)
```

While there, I fixed some related and not so related nits.