### PR TITLE
always update to the correct head of Mercurial repositories

### DIFF
--- a/tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -82,6 +82,8 @@ class MercurialRepository(Repository):
         # some servers do not support it.
         if branch == "default":
             hg_command.append("--check")
+        hg_command.append("-r")
+        hg_command.append("tip")
         cmd = self.get_command(hg_command, work_dir=self.path,
                                env_vars=self.env, logger=self.logger)
         cmd.execute()

--- a/tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -78,12 +78,20 @@ class MercurialRepository(Repository):
             return 1
 
         hg_command = [self.command, "update"]
+        #
         # Avoid remote branch lookup for default branches since
         # some servers do not support it.
+        #
         if branch == "default":
             hg_command.append("--check")
+
+        #
+        # In a multi-head situation, select the head with the
+        # biggest index as this is likely the correct one.
+        #
         hg_command.append("-r")
-        hg_command.append("tip")
+        hg_command.append("'max(head() and branch(\".\"))'")
+
         cmd = self.get_command(hg_command, work_dir=self.path,
                                env_vars=self.env, logger=self.logger)
         cmd.execute()


### PR DESCRIPTION
When indexing a particular repository after a recent change, the incremental indexer run failed with:
```
org.opengrok.indexer.index.IndexDatabase$IndexerFault: attempting to add file '/on11sru-allbranch-clone/usr/man/on/en/xman8/ikeadm.8.xml' with date matching deleted document: 20171211230536714
        at org.opengrok.indexer.index.IndexDatabase.processFileHistoryBased(IndexDatabase.java:1779)
        at org.opengrok.indexer.index.IndexDatabase.indexDownUsingHistory(IndexDatabase.java:985)
        at org.opengrok.indexer.index.IndexDatabase.getIndexDownArgs(IndexDatabase.java:946)
        at org.opengrok.indexer.index.IndexDatabase.update(IndexDatabase.java:755)
        at org.opengrok.indexer.index.Indexer.lambda$doIndexerExecution$59(Indexer.java:1208)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)

```
Digging into the problem, the changeset that was added was not reflected in the file-system changes. The mirroring logs said:
```
07/18/2024 04:09:42 PM - INFO: Synchronizing repository /ws-local/on11sru-allbranch-clone/usr/man
07/18/2024 04:09:43 PM - INFO: output of /usr/bin/hg branch:
07/18/2024 04:09:43 PM - INFO: default

07/18/2024 04:09:48 PM - INFO: output of /usr/bin/hg pull:
07/18/2024 04:09:48 PM - INFO: pulling from ssh://on-gate/on-gate/usr/man
searching for changes
adding changesets
adding manifests
adding file changes
added 1 changesets with 3 changes to 3 files
new changesets 5b82d16f6f44
(run 'hg update' to get a working copy)

07/18/2024 04:09:49 PM - INFO: output of /usr/bin/hg update --check:
07/18/2024 04:09:49 PM - INFO: 0 files updated, 0 files merged, 0 files removed, 0 files unresolved
updated to "53e7d284bbb4: Added tag st_020"
1 other heads for branch "default"
```
Basically, the mirroring for the repo executed these commands:
```
hg pull
hg update --check
```
What happened was that the update was done to some historical changeset instead of the `tip` so no files were actually updated (the output showing the `0 files updated`). The incremental file detection using the changesets (history based reindex) rather than the file system traversal got the file list correctly however the time stamp was taken from the file system, hence the indexer failure.

The historical changeset 53e7d284bbb4 was actually a head (visible in the output from `hg log --graph -b .`) likely created inadvertently and later removed (it is not in a fresh clone of the repository) however it was already pulled, causing a situation with 2 heads. `hg log --rev 'head() and branch(".")'` shows two changesets - one correct one (5b82d16f6f44), one is the stub (53e7d284bbb4).

This change fixes the problem by using the head with maximum index.