### PR TITLE
handle empty Git repositories gracefully

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/GitRepository.java
@@ -481,6 +481,7 @@ public class GitRepository extends RepositoryWithHistoryTraversal {
             ObjectId objId = repository.resolve(Constants.HEAD);
             if (Objects.isNull(objId)) {
                 if (isRepositoryEmpty()) {
+                    LOGGER.log(Level.FINEST, "ignoring empty repository {}", this);
                     return;
                 }
                 throw new HistoryException("cannot resolve HEAD");
@@ -522,6 +523,7 @@ public class GitRepository extends RepositoryWithHistoryTraversal {
              RevWalk walk = new RevWalk(repository)) {
 
             if (Objects.isNull(repository.resolve(Constants.HEAD)) && isRepositoryEmpty()) {
+                LOGGER.log(Level.FINEST, "ignoring empty repository {}", this);
                 return;
             }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -866,6 +866,11 @@ class FileHistoryCacheTest {
         assertTrue(repositoryRoot.mkdir());
         Git.init().setDirectory(repositoryRoot).call();
 
+        // Create untracked file.
+        Path untrackedFile = repositoryRoot.toPath().resolve("untrackedFile");
+        Files.createFile(untrackedFile);
+        assertTrue(untrackedFile.toFile().exists());
+
         Repository repository = RepositoryFactory.getRepository(repositoryRoot);
         assertNotNull(repository);
         History history = repository.getHistory(repositoryRoot);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, 2023, Ric Harris <harrisric@users.noreply.github.com>.
  */
@@ -858,6 +858,20 @@ class FileHistoryCacheTest {
         assertTrue(barFile.isFile());
         History updatedHistory = cache.get(barFile, gitSpyRepository, false);
         assertEquals(8, updatedHistory.getHistoryEntries().size());
+    }
+
+    @Test
+    void testHistoryCacheForEmptyGitRepository() throws Exception {
+        File repositoryRoot = new File(repositories.getSourceRoot(), "emptyGit");
+        assertTrue(repositoryRoot.mkdir());
+        Git.init().setDirectory(repositoryRoot).call();
+
+        Repository repository = RepositoryFactory.getRepository(repositoryRoot);
+        assertNotNull(repository);
+        History history = repository.getHistory(repositoryRoot);
+        assertNotNull(history);
+        assertTrue(history.getHistoryEntries().isEmpty());
+        repository.createCache(cache, null);
     }
 
     /**


### PR DESCRIPTION
As mentioned on https://github.com/oracle/opengrok/discussions/4606, empty Git repositories fail history cache creation, making the indexing of related project fail. This change fixes that.