### PR TITLE
History based reindex vs. git revert

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1921,6 +1921,13 @@ public final class RuntimeEnvironment {
         stat.report(LOGGER, "Done refreshing searcher managers");
     }
 
+    @VisibleForTesting
+    public void releaseIndexSearchers() throws IOException {
+        for (SearcherManager sm : searcherManagerMap.values()) {
+            sm.close();
+        }
+    }
+
     /**
      * Get IndexSearcher for given project or global IndexSearcher.
      * Wrapper of {@link #getSuperIndexSearcher(String)}. Make sure to release the returned

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1926,6 +1926,7 @@ public final class RuntimeEnvironment {
         for (SearcherManager sm : searcherManagerMap.values()) {
             sm.close();
         }
+        searcherManagerMap.clear();
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -39,6 +39,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -960,6 +961,37 @@ public class IndexDatabase {
     }
 
     /**
+     * @param file file under source root
+     * @return false if the document date is newer or equal to the last modified time stamp of the file, otherwise true
+     */
+    private static boolean isStrictlyNewerThanDocument(File file) {
+        if (!file.exists()) {
+            // Case of delete/renamed file.
+            return true;
+        }
+        try {
+            Document doc = IndexDatabase.getDocument(file);
+            if (Objects.isNull(doc)) {
+                return true;
+            }
+            IndexableField field = doc.getField(QueryBuilder.DATE);
+            try {
+                Date docDate = DateTools.stringToDate(field.stringValue());
+                long lastModified = file.lastModified();
+                if (lastModified <= docDate.getTime()) {
+                    return false;
+                }
+            } catch (java.text.ParseException e) {
+                return true;
+            }
+        } catch (ParseException | IOException e) {
+            LOGGER.log(Level.FINEST, "cannot get document for ''{0}''", file);
+        }
+
+        return true;
+    }
+
+    /**
      * Executes the first, serial stage of indexing, by going through set of files assembled from history.
      * @param sourceRoot path to the source root (same as {@link RuntimeEnvironment#getSourceRootPath()})
      * @param args {@link IndexDownArgs} instance where the resulting files to be indexed will be stored
@@ -982,8 +1014,18 @@ public class IndexDatabase {
                     return;
                 }
                 File file = new File(sourceRoot, path.toString());
-                processFileHistoryBased(args, file, path.toString());
                 progress.increment();
+                //
+                // If the changes to the file were nullified across a sequence of changesets, the repository
+                // might not have updated the file. The history collector is not that smart however,
+                // so handle such situation here.
+                //
+                if (!isStrictlyNewerThanDocument(file)) {
+                    LOGGER.log(Level.FINEST, "file ''{0}'' is not newer than its document, skipping",
+                            new Object[]{file});
+                    continue;
+                }
+                processFileHistoryBased(args, file, path.toString());
             }
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -977,6 +977,7 @@ public class IndexDatabase {
             IndexableField field = doc.getField(QueryBuilder.DATE);
             try {
                 Date docDate = DateTools.stringToDate(field.stringValue());
+                // Assumes millisecond precision.
                 long lastModified = file.lastModified();
                 if (lastModified <= docDate.getTime()) {
                     return false;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -1030,6 +1030,7 @@ class IndexDatabaseTest {
         // cleanup
         gitProject.setHistoryBasedReindex(projectUseAnnotationOrig);
         env.setDataRoot(dataRootOrig);
+        env.releaseIndexSearchers();
         IOUtils.removeRecursive(dataRoot);
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -317,6 +317,8 @@ class IndexDatabaseTest {
 
     @Test
     void testGetLastRev() throws IOException, ParseException {
+        // IndexDatabase.getDocument() searches the index, so refresh the IndexSearcher objects
+        // to get fresh results.
         env.maybeRefreshIndexSearchers();
         Document doc = IndexDatabase.getDocument(Paths.get(repository.getSourceRoot(),
                 "git", "main.c").toFile());

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -142,6 +142,8 @@ class IndexDatabaseTest {
         IOUtils.removeRecursive(gitRepositoryRootPath);
         Files.move(gitCheckoutPath, gitRepositoryRootPath);
 
+        env.releaseIndexSearchers();
+
         env.setSourceRoot(repository.getSourceRoot());
         env.setDataRoot(repository.getDataRoot());
         env.setHistoryEnabled(true);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -142,8 +142,6 @@ class IndexDatabaseTest {
         IOUtils.removeRecursive(gitRepositoryRootPath);
         Files.move(gitCheckoutPath, gitRepositoryRootPath);
 
-        env.releaseIndexSearchers();
-
         env.setSourceRoot(repository.getSourceRoot());
         env.setDataRoot(repository.getDataRoot());
         env.setHistoryEnabled(true);
@@ -177,6 +175,7 @@ class IndexDatabaseTest {
 
     @AfterEach
     void tearDownClass() throws Exception {
+        env.releaseIndexSearchers();
         repository.destroy();
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -316,6 +316,7 @@ class IndexDatabaseTest {
 
     @Test
     void testGetLastRev() throws IOException, ParseException {
+        env.maybeRefreshIndexSearchers();
         Document doc = IndexDatabase.getDocument(Paths.get(repository.getSourceRoot(),
                 "git", "main.c").toFile());
         assertNotNull(doc);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -1114,6 +1114,8 @@ class IndexDatabaseTest {
         File parentRepositoryRoot = new File(env.getSourceRootPath(), "gitNoChangeParent");
         assertTrue(parentRepositoryRoot.mkdir());
 
+        env.setHistoryBasedReindex(true);
+
         final String repoName = "gitNoChange";
         List<String> projectList = List.of(File.separator + repoName);
         try (Git gitParent = Git.init().setDirectory(parentRepositoryRoot).call()) {
@@ -1192,5 +1194,6 @@ class IndexDatabaseTest {
         idb.update();
         // Verify history based reindex was used.
         checkIndexDown(true, idb);
+        // TODO: check that the document for bar.txt was updated
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
@@ -199,6 +199,8 @@ class IndexerVsDeletedDocumentsTest {
 
     @AfterEach
     void cleanup() throws IOException {
+        // Release any references to index files.
+        env.releaseIndexSearchers();
         IOUtils.removeRecursive(Path.of(env.getDataRootPath()));
         // FileUtils.deleteDirectory() avoids AccessDeniedException on Windows.
         FileUtils.deleteDirectory(env.getSourceRootFile());

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
@@ -199,7 +199,8 @@ class IndexerVsDeletedDocumentsTest {
 
     @AfterEach
     void cleanup() throws IOException {
-        // Release any references to index files.
+        // Release any references to index files so that it is actually possible to
+        // remove the index files (under data root) on Windows.
         env.releaseIndexSearchers();
         IOUtils.removeRecursive(Path.of(env.getDataRootPath()));
         // FileUtils.deleteDirectory() avoids AccessDeniedException on Windows.


### PR DESCRIPTION
This fixes the failing incremental reindex in the face of sequence of changes to a file that in the end nullify each other by checking the last modified date of the file to the date stored in the corresponding document. The first idea was to simply "`touch`" the files however that would cause unneeded churn.

While there, the changes to the `IndexDatabaseTest` somehow made the Windows builds failing due to pending references to index files (with `AccessDenied` exception thrown from `IOutils.removeRecursive()`), also even in different test classes due to the intertwined nature of indexing and `RuntimeEnvironment`. Hence the index searcher related changes.