### PR TITLE
Docker vs pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && \
 # hadolint ignore=DL3008,DL3059
 RUN architecture=$(uname -m) && if [[ "$architecture" == "aarch64" ]]; then \
         echo "aarch64: do not install helix-p4d."; else \
-        apt-get install --no-install-recommends -y helix-p4d; fi
+        apt-get install --no-install-recommends -y helix-p4d || echo "Failed to install Perforce"; fi
 
 # compile and install universal-ctags
 # hadolint ignore=DL3003,DL3008

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,10 @@ COPY --from=build opengrok.tar.gz /opengrok.tar.gz
 RUN mkdir -p /opengrok /opengrok/etc /opengrok/data /opengrok/src && \
     tar -zxvf /opengrok.tar.gz -C /opengrok --strip-components 1 && \
     rm -f /opengrok.tar.gz && \
-    python3 -m pip install --no-cache-dir /opengrok/tools/opengrok-tools.tar.gz && \
-    python3 -m pip install --no-cache-dir Flask Flask-HTTPAuth waitress # for /reindex REST endpoint handled by start.py
+    python3 -m venv /venv
+ENV PATH=/venv/bin:$PATH
+RUN /venv/bin/python3 -m pip install --no-cache-dir /opengrok/tools/opengrok-tools.tar.gz && \
+     /venv/bin/python3 -m pip install --no-cache-dir Flask Flask-HTTPAuth waitress # for /reindex REST endpoint handled by start.py
 
 COPY --from=build /mvn/VERSION /opengrok/VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,10 +77,6 @@ RUN apt-get install --no-install-recommends -y pkg-config automake build-essenti
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Update the Python tooling in order to successfully install the opengrok-tools package.
-# hadolint ignore=DL3013
-RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools
-
 # prepare OpenGrok binaries and directories
 # hadolint ignore=DL3010
 COPY --from=build opengrok.tar.gz /opengrok.tar.gz

--- a/docker/README.md
+++ b/docker/README.md
@@ -168,7 +168,7 @@ If you want to do your own development, you can build the image yourself:
 
     git clone https://github.com/oracle/opengrok.git
     cd opengrok
-    docker build -t opengrok-dev .
+    docker buildx build -t opengrok-dev .
 
 Then run the container:
 


### PR DESCRIPTION
The Docker builds have started failing recently due to the run of pip trying to install packages globally. This change provides remedy by using Python virtual environment.

While there, I made Perforce installation optional because it is failing in my local environment.