### PR TITLE
change release process to avoid pushing to the master branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,10 @@
 name: Build Docker image
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  release:
+    types: [created]
 
 jobs:
   ubuntu:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,8 @@ name: Release
 
 # TODO: run this only for the oracle/opengrok repository
 on:
-  push:
-    tags:
-      - '[1-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [created]
 
 jobs:
   get_tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,23 +47,18 @@ jobs:
       run: ./dev/before
     - name: Build
       run: ./mvnw -DskipTests=true -Dmaven.javadoc.skip=false -B -V package
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
+    - name: Get upload URL
+      id: get_upload_url
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-        draft: false
-        prerelease: false
+        OPENGROK_TAG: ${{ needs.get_tag.outputs.tag }}
+      run: dev/get_upload_url.sh
     - name: Upload release tarball
       id: upload-release-asset
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
         asset_path: ./distribution/target/opengrok-${{ needs.get_tag.outputs.tag }}.tar.gz
         asset_name: opengrok-${{ needs.get_tag.outputs.tag }}.tar.gz
         asset_content_type: application/octet-stream

--- a/dev/get_upload_url.sh
+++ b/dev/get_upload_url.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# The purpose of this script is to retrieve upload URL for OpenGrok release given by the tag
+# stored in the OPENGROK_TAG environment variable.
+# The value is stored in a special file consumed by Github action so that it can be used
+# to upload assets to the related OpenGrok release on Github.
+#
+
+echo "Getting upload URL for $OPENGROK_TAG"
+upload_url=$( curl -s https://api.github.com/repos/oracle/opengrok/releases/$OPENGROK_TAG | jq -r .upload_url )
+echo "Got $upload_url"
+echo "upload_url=$upload_url" >> $GITHUB_OUTPUT"

--- a/dev/ref2tag.sh
+++ b/dev/ref2tag.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 tag=${OPENGROK_REF#"refs/tags/"}
-echo "::set-output name=tag::$tag"
+echo "tag::$tag" >> $GITHUB_OUTPUT

--- a/dev/release.sh
+++ b/dev/release.sh
@@ -48,3 +48,6 @@ git switch -c "release_${VERSION}"
 ./mvnw versions:set -DgenerateBackupPoms=false "-DnewVersion=$VERSION"
 git commit pom.xml '**/pom.xml' -m "$VERSION"
 git push
+echo
+echo "Create PR with the changes. Once it is merged in, create new release."
+echo

--- a/dev/release.sh
+++ b/dev/release.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 #
-# Trigger new release creation on Github.
-# Assumes working Maven + Git.
-#
+# Query current release or trigger new release creation on Github.
+# For the latter, it merely kick-starts the creation of new Release on Github,
 # see https://github.com/oracle/opengrok/wiki/Release-process
+#
+# Assumes working Maven + Git.
 #
 
 set -e
@@ -43,8 +44,7 @@ if [[ $ver == $VERSION ]]; then
 fi
 
 git pull --ff-only
+git switch -c "release_${VERSION}"
 ./mvnw versions:set -DgenerateBackupPoms=false "-DnewVersion=$VERSION"
 git commit pom.xml '**/pom.xml' -m "$VERSION"
 git push
-git tag "$VERSION"
-git push origin tag "$VERSION"


### PR DESCRIPTION
The rules that avoid direct pushes to the `master` branch have been put into effect recently. This change modifies the release process not to rely on this anymore. Instead, a PR will be used to bump the versions first, then after it is merged a release will be [created](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) using either Github CLI or the web.

https://github.com/oracle/opengrok/wiki/Release-process will have to be updated