### PR TITLE
add tests for MercurialRepository.annotate()

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -457,6 +458,7 @@ public class MercurialRepository extends RepositoryWithHistoryTraversal {
      * @throws java.io.IOException if I/O exception occurred
      */
     @Override
+    @Nullable
     public Annotation annotate(File file, String revision) throws IOException {
         ArrayList<String> argv = new ArrayList<>();
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
@@ -483,6 +485,11 @@ public class MercurialRepository extends RepositoryWithHistoryTraversal {
         // needed later to get user string for particular revision.
         try {
             History hist = HistoryGuru.getInstance().getHistory(file, false);
+            if (Objects.isNull(hist)) {
+                LOGGER.log(Level.SEVERE,
+                        "Error: cannot get history for file ''{0}''", file);
+                return null;
+            }
             for (HistoryEntry e : hist.getHistoryEntries()) {
                 // Chop out the colon and all hexadecimal what follows.
                 // This is because the whole changeset identification is
@@ -492,7 +499,7 @@ public class MercurialRepository extends RepositoryWithHistoryTraversal {
             }
         } catch (HistoryException he) {
             LOGGER.log(Level.SEVERE,
-                    "Error: cannot get history for file {0}", file);
+                    "Error: cannot get history for file ''{0}''", file);
             return null;
         }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -422,13 +422,13 @@ public class MercurialRepositoryTest {
         assertNull(annotation);
     }
 
-    private static Stream<Pair<String, List<String>>> provideParametersForNegativeAnnotationTest() {
+    private static Stream<Pair<String, List<String>>> provideParametersForPositiveAnnotationTest() {
         return Stream.of(Pair.of("8:6a8c423f5624", List.of("7", "8")),
                 Pair.of("7:db1394c05268", List.of("7")));
     }
 
     @ParameterizedTest
-    @MethodSource("provideParametersForNegativeAnnotationTest")
+    @MethodSource("provideParametersForPositiveAnnotationTest")
     void testAnnotationPositive(Pair<String, List<String>> pair) throws Exception {
         MercurialRepository hgRepo = (MercurialRepository) RepositoryFactory.getRepository(repositoryRoot);
         assertNotNull(hgRepo);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -44,7 +44,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -18,15 +18,17 @@
  */
 
 /*
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opengrok.indexer.condition.EnabledForRepository;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -42,12 +44,16 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
@@ -255,7 +261,7 @@ public class MercurialRepositoryTest {
      * Test that it is possible to get contents of multiple revisions of a file.
      */
     @Test
-    void testgetHistoryGetForAll() throws Exception {
+    void testGetHistoryGetForAll() throws Exception {
         MercurialRepository mr = (MercurialRepository) RepositoryFactory.getRepository(repositoryRoot);
 
         for (String rev : REVISIONS_novel) {
@@ -405,5 +411,35 @@ public class MercurialRepositoryTest {
 
         // Cleanup.
         env.setMergeCommitsEnabled(isMergeCommitsEnabledOrig);
+    }
+
+    @Test
+    void testAnnotationNegative() throws Exception {
+        MercurialRepository hgRepo = (MercurialRepository) RepositoryFactory.getRepository(repositoryRoot);
+        File file = new File(repositoryRoot, "nonexistent");
+        assertFalse(file.exists());
+        Annotation annotation = hgRepo.annotate(file, null);
+        assertNull(annotation);
+    }
+
+    private static Stream<Pair<String, List<String>>> provideParametersForNegativeAnnotationTest() {
+        return Stream.of(Pair.of("8:6a8c423f5624", List.of("7", "8")),
+                Pair.of("7:db1394c05268", List.of("7")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParametersForNegativeAnnotationTest")
+    void testAnnotationPositive(Pair<String, List<String>> pair) throws Exception {
+        MercurialRepository hgRepo = (MercurialRepository) RepositoryFactory.getRepository(repositoryRoot);
+        assertNotNull(hgRepo);
+        File file = new File(repositoryRoot, "novel.txt");
+        assertTrue(file.exists());
+        // The annotate() method calls uses HistoryGuru's getHistory() method which requires the RepositoryLookup
+        // to be initialized. Do so via setRepositories().
+        RuntimeEnvironment.getInstance().setRepositories(repository.getSourceRoot());
+        Annotation annotation = hgRepo.annotate(file, pair.getKey());
+        assertNotNull(annotation);
+        List<String> revisions = new ArrayList<>(annotation.getRevisions());
+        assertEquals(pair.getValue(), revisions);
     }
 }


### PR DESCRIPTION
This change increases coverage of `MercurialRepository`, in particular `MercurialAnnotationParser`. This is a basic test, ideally all the `Annotation` members should be verified in the positive case.