### PR TITLE
log the exception when LDAP connect failed

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -292,7 +292,8 @@ public class LdapServer implements Serializable {
                 LOGGER.log(Level.INFO, "Connected to LDAP server {0}", this);
                 errorTimestamp = 0;
             } catch (NamingException ex) {
-                LOGGER.log(Level.WARNING, "LDAP server {0} is not responding", env.get(Context.PROVIDER_URL));
+                LOGGER.log(Level.WARNING,
+                        String.format("LDAP server %s is not responding", env.get(Context.PROVIDER_URL)), ex);
                 errorTimestamp = System.currentTimeMillis();
                 close();
                 ctx = null;


### PR DESCRIPTION
When investigating why some of the LDAP servers are down, I noticed the `NamingException` is not logged in `connect()`. This change fixes that.