### PR TITLE
handle PRs gracefully for Docker image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,6 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         OPENGROK_REPO_SLUG: ${{ github.repository }}
-        OPENGROK_PULL_REQUEST: ${{ github.head_ref }}
         OPENGROK_REF: ${{ github.ref }}
       run: ./dev/docker.sh
     - name: Install Python pre-requisites
@@ -46,7 +45,6 @@ jobs:
     - name: Optionally update README on Docker hub
       env:
         OPENGROK_REPO_SLUG: ${{ github.repository }}
-        OPENGROK_PULL_REQUEST: ${{ github.head_ref }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: ./dev/dockerhub_readme.py

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -61,6 +61,8 @@ echo "Running the image in container"
 docker run -d $IMAGE
 docker ps -a
 
+env
+
 # This can only work on home repository since it needs encrypted variables.
 if [[ "$GITHUB_EVENT_TYPE" == "pull_request" ]]; then
 	echo "Not pushing Docker image for pull requests"

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -62,7 +62,7 @@ docker run -d $IMAGE
 docker ps -a
 
 # This can only work on home repository since it needs encrypted variables.
-if [[ -n "$OPENGROK_PULL_REQUEST" ]]; then
+if [[ "$GITHUB_EVENT_TYPE" == "pull_request" ]]; then
 	echo "Not pushing Docker image for pull requests"
 	exit 0
 fi
@@ -75,12 +75,12 @@ fi
 
 if [[ -z $DOCKER_USERNAME ]]; then
 	echo "DOCKER_USERNAME is empty, exiting"
-	exit 0
+	exit 1
 fi
 
 if [[ -z $DOCKER_PASSWORD ]]; then
 	echo "DOCKER_PASSWORD is empty, exiting"
-	exit 0
+	exit 1
 fi
 
 # Publish the image to Docker hub.

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -61,10 +61,8 @@ echo "Running the image in container"
 docker run -d $IMAGE
 docker ps -a
 
-env
-
 # This can only work on home repository since it needs encrypted variables.
-if [[ "$GITHUB_EVENT_TYPE" == "pull_request" ]]; then
+if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
 	echo "Not pushing Docker image for pull requests"
 	exit 0
 fi

--- a/dev/dockerhub_readme.py
+++ b/dev/dockerhub_readme.py
@@ -85,7 +85,7 @@ def check_push_env():
         logger.info("Not updating Docker hub README for non main repo")
         sys.exit(0)
 
-    event_type = os.environ.get("GITHUB_EVENT_TYPE")
+    event_type = os.environ.get("GITHUB_EVENT_NAME")
     if event_type and event_type == "pull_request":
         logger.info("Not updating Docker hub README for pull requests")
         sys.exit(0)

--- a/dev/dockerhub_readme.py
+++ b/dev/dockerhub_readme.py
@@ -85,8 +85,8 @@ def check_push_env():
         logger.info("Not updating Docker hub README for non main repo")
         sys.exit(0)
 
-    pull_request = os.environ.get("OPENGROK_PULL_REQUEST")
-    if pull_request and len(pull_request) > 0:
+    event_type = os.environ.get("GITHUB_EVENT_TYPE")
+    if event_type and event_type == "pull_request":
         logger.info("Not updating Docker hub README for pull requests")
         sys.exit(0)
 


### PR DESCRIPTION
This change should avoid uploading Docker image/README for all PRs, esp. including those raised by Dependabot.

For the README handling, the alternative would be to equip the corresponding action with `if: ${{ github.event_name != 'pull_request' }}` however the handling is already in the scripts.