### PR TITLE
compile Universal ctags with XML support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN architecture=$(uname -m) && if [[ "$architecture" == "aarch64" ]]; then \
 
 # compile and install universal-ctags
 # hadolint ignore=DL3003,DL3008
-RUN apt-get install --no-install-recommends -y pkg-config automake build-essential && \
+RUN apt-get install --no-install-recommends -y pkg-config automake build-essential libxml2-dev && \
     git clone https://github.com/universal-ctags/ctags /root/ctags && \
     cd /root/ctags && ./autogen.sh && ./configure && make && make install && \
     apt-get remove -y automake build-essential && \


### PR DESCRIPTION
Install `libxml2-dev` to support XML in Universal ctags built for the Docker image.

docker build excerpt:
```
checking for libxml-2.0 >= 2.7.7... yes
checking libxml-2.0 CRLF handling bug... good
```
Previously the answer was `no`.

Checking languages support in the container built with these changes:
```
$ docker exec opengrok-dev /usr/local/bin/ctags --list-languages | grep XML
PlistXML
XML
```