### PR TITLE
no need to lock configuration for ctags validation

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -628,8 +628,7 @@ public final class RuntimeEnvironment {
         }
 
         String value = syncReadConfiguration(Configuration::getCtags);
-        return value != null ? value :
-                System.getProperty(CtagsUtil.SYSTEM_CTAGS_PROPERTY, "ctags");
+        return value != null ? value : System.getProperty(CtagsUtil.SYSTEM_CTAGS_PROPERTY, "ctags");
     }
 
     /**
@@ -699,26 +698,20 @@ public final class RuntimeEnvironment {
      * Validate that there is a Universal ctags program that can actually process input files
      * under source root.
      * <br>
-     * As a side effect, this sets the set of ctags languages that is used by the ctags program.
+     * As a side effect, this sets the set of ctags languages that is used by the <code>ctags</code> program.
      *
      * @return true if success, false otherwise
      */
-    public boolean validateUniversalCtags() {
+    public synchronized boolean validateUniversalCtags() {
         if (ctagsFound == null) {
-            try (ResourceLock resourceLock = configLock.writeLockAsResource()) {
-                //noinspection ConstantConditions to avoid warning of no reference to auto-closeable
-                assert resourceLock != null;
-                if (ctagsFound == null) {
-                    String ctagsBinary = getCtags();
-                    if (ctagsLanguages.isEmpty()) {
-                        // The ctagsLanguages are necessary for the call to validate() below.
-                        Set<String> languages = CtagsUtil.getLanguages(ctagsBinary);
-                        ctagsLanguages.addAll(languages);
-                    }
-
-                    ctagsFound = CtagsUtil.validate(ctagsBinary);
-                }
+            String ctagsBinary = getCtags();
+            if (ctagsLanguages.isEmpty()) {
+                // The ctagsLanguages are necessary for the call to validate() below.
+                Set<String> languages = CtagsUtil.getLanguages(ctagsBinary);
+                ctagsLanguages.addAll(languages);
             }
+
+            ctagsFound = CtagsUtil.validate(ctagsBinary);
         }
 
         if (ctagsFound) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;


### PR DESCRIPTION
This change solves a deadlock related to ctags validation which holds the `RuntimeEnvironment#configLock` for writing vs. reading a configuration value by removing the locking and making the `RuntimeEnvironment#validateUniversalCtags()` method synchronized.

The locking in `validateUniversalCtags()` was introduced in 9c92ca95, not sure why it was deemed necessary. The method (potentially) modifies `ctagsFound` and `ctagsLanguages` which are neither part of the `Configuration`. Also, the method is called only from `prepareIndexer` which is run from `main()` at the beginning of the indexing (which means the added `synchronized` is just for a case). The `ctagsLanguages` is needed only by the `Ctags` instances (of which the validate is special case).