### PR TITLE
add tests for Mercurial tag parsing

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -635,6 +635,11 @@ public class MercurialRepository extends RepositoryWithHistoryTraversal {
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         argv.add(RepoCommand);
         argv.add("tags");
+        argv.add("--template");
+        // Use '|' as a revision separator rather than ':' to avoid collision with the commonly used
+        // separator within the revision string (which is not used in the 'hg tags' output but better
+        // safe than sorry).
+        argv.add("{rev}|{tag}\\n");
 
         Executor executor = new Executor(argv, directory,
                 RuntimeEnvironment.getInstance().getCommandTimeout(cmdType));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialTagParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialTagParser.java
@@ -26,6 +26,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.NavigableSet;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -49,7 +50,7 @@ public class MercurialTagParser implements Executor.StreamHandler {
      *
      * @return entries a set of tag entries
      */
-    public TreeSet<TagEntry> getEntries() {
+    public NavigableSet<TagEntry> getEntries() {
         return entries;
     }
 
@@ -59,7 +60,7 @@ public class MercurialTagParser implements Executor.StreamHandler {
             try (BufferedReader in = new BufferedReader(new InputStreamReader(input))) {
                 String line;
                 while ((line = in.readLine()) != null) {
-                    String[] parts = line.split("  *");
+                    String[] parts = line.split("\\|");
                     if (parts.length < 2) {
                         LOGGER.log(Level.WARNING,
                                 "Failed to parse tag list: {0}",
@@ -67,27 +68,15 @@ public class MercurialTagParser implements Executor.StreamHandler {
                         entries = null;
                         break;
                     }
-                    // Grrr, how to parse tags with spaces inside?
-                    // This solution will lose multiple spaces ;-/
-                    String tag = parts[0];
-                    for (int i = 1; i < parts.length - 1; ++i) {
-                        tag = tag.concat(" ");
-                        tag = tag.concat(parts[i]);
-                    }
+                    String rev = parts[0];
+                    String tag = parts[1];
+
                     // The implicit 'tip' tag only causes confusion so ignore it.
                     if (tag.contentEquals("tip")) {
                         continue;
                     }
-                    String[] revParts = parts[parts.length - 1].split(":");
-                    if (revParts.length != 2) {
-                        LOGGER.log(Level.WARNING,
-                                "Failed to parse tag list: {0}",
-                                "Mercurial revision parsing error: "
-                                        + parts[parts.length - 1]);
-                        entries = null;
-                        break;
-                    }
-                    TagEntry tagEntry = new MercurialTagEntry(Integer.parseInt(revParts[0]), tag);
+
+                    TagEntry tagEntry = new MercurialTagEntry(Integer.parseInt(rev), tag);
                     // Reverse the order of the list.
                     entries.add(tagEntry);
                 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialTagParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialTagParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -56,8 +56,7 @@ public class MercurialTagParser implements Executor.StreamHandler {
     @Override
     public void processStream(InputStream input) throws IOException {
         try {
-            try (BufferedReader in = new BufferedReader(
-                    new InputStreamReader(input))) {
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(input))) {
                 String line;
                 while ((line = in.readLine()) != null) {
                     String[] parts = line.split("  *");
@@ -88,16 +87,13 @@ public class MercurialTagParser implements Executor.StreamHandler {
                         entries = null;
                         break;
                     }
-                    TagEntry tagEntry
-                            = new MercurialTagEntry(Integer.parseInt(revParts[0]),
-                                    tag);
-                    // Reverse the order of the list
+                    TagEntry tagEntry = new MercurialTagEntry(Integer.parseInt(revParts[0]), tag);
+                    // Reverse the order of the list.
                     entries.add(tagEntry);
                 }
             }
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING,
-                    "Failed to read tag list: {0}", e.getMessage());
+            LOGGER.log(Level.WARNING, "Failed to read tag list: {0}", e.getMessage());
             entries = null;
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -283,7 +283,7 @@ public abstract class Repository extends RepositoryInfo {
         return false;
     }
 
-    NavigableSet<TagEntry> getTagList() {
+    @Nullable NavigableSet<TagEntry> getTagList() {
         return this.tagList;
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/TagEntry.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/TagEntry.java
@@ -83,6 +83,10 @@ public abstract class TagEntry implements Comparable<TagEntry> {
         this.tags = tags;
     }
 
+    public int getRevision() {
+        return revision;
+    }
+
     public String getTags() {
         return this.tags;
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -449,6 +449,9 @@ public class MercurialRepositoryTest {
         assertEquals(pair.getValue(), revisions);
     }
 
+    /**
+     * Test special case of repository with no tags, in this case empty repository.
+     */
     @Test
     void testBuildTagListEmpty() throws Exception {
         Path repositoryRootPath = Files.createDirectory(Path.of(RuntimeEnvironment.getInstance().getSourceRootPath(),
@@ -463,6 +466,9 @@ public class MercurialRepositoryTest {
         IOUtils.removeRecursive(repositoryRootPath);
     }
 
+    /**
+     * Extract the tags from the original repository. It already contains one tag.
+     */
     @Test
     void testBuildTagListInitial() throws Exception {
         MercurialRepository hgRepo = (MercurialRepository) RepositoryFactory.getRepository(repositoryRoot);
@@ -476,6 +482,10 @@ public class MercurialRepositoryTest {
         assertEquals(expectedTags, tags);
     }
 
+    /**
+     * Clone the original repository, add new tag, check that the extracted tags contain the pre-existing
+     * and new one.
+     */
     @Test
     void testBuildTagListOneMore() throws Exception {
         Path repositoryRootPath = Files.createDirectory(Path.of(RuntimeEnvironment.getInstance().getSourceRootPath(),

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -47,7 +47,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -474,6 +473,20 @@ public class MercurialRepositoryTest {
         Set<TagEntry> expectedTags = new TreeSet<>();
         TagEntry tagEntry = new MercurialTagEntry(7, "start_of_novel");
         expectedTags.add(tagEntry);
+        assertEquals(expectedTags, tags);
+    }
+
+    @Test
+    void testBuildTagListOneMore() throws Exception {
+        MercurialRepository hgRepo = (MercurialRepository) RepositoryFactory.getRepository(repositoryRoot);
+        assertNotNull(hgRepo);
+        runHgCommand(repositoryRoot, "tag", "foo");
+        hgRepo.buildTagList(new File(hgRepo.getDirectoryName()), CommandTimeoutType.INDEXER);
+        var tags = hgRepo.getTagList();
+        assertNotNull(tags);
+        assertEquals(2, tags.size());
+        Set<TagEntry> expectedTags = Set.of(new MercurialTagEntry(7, "start_of_novel"),
+                new MercurialTagEntry(9, "foo"));
         assertEquals(expectedTags, tags);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -478,6 +478,10 @@ public class MercurialRepositoryTest {
 
     @Test
     void testBuildTagListOneMore() throws Exception {
+        Path repositoryRootPath = Files.createDirectory(Path.of(RuntimeEnvironment.getInstance().getSourceRootPath(),
+                "addedTagTest"));
+        File repositoryRoot = repositoryRootPath.toFile();
+        runHgCommand(this.repositoryRoot, "clone", this.repositoryRoot.toString(), repositoryRootPath.toString());
         MercurialRepository hgRepo = (MercurialRepository) RepositoryFactory.getRepository(repositoryRoot);
         assertNotNull(hgRepo);
         runHgCommand(repositoryRoot, "tag", "foo");
@@ -488,5 +492,6 @@ public class MercurialRepositoryTest {
         Set<TagEntry> expectedTags = Set.of(new MercurialTagEntry(7, "start_of_novel"),
                 new MercurialTagEntry(9, "foo"));
         assertEquals(expectedTags, tags);
+        IOUtils.removeRecursive(repositoryRootPath);
     }
 }


### PR DESCRIPTION
This change introduces test coverage for the `MercurialTagParser` class. While there, I fixed issue with parsing tags containing multiple spaces.