### PR TITLE
avoid calling removeFile() twice in the same block

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1798,9 +1798,8 @@ public class IndexDatabase {
                 boolean matchOK = (isWithDirectoryCounts || isCountingDeltas) &&
                         checkSettings(termFile, termPath);
                 if (!matchOK) {
-                    removeFile(false);
-                    addWorkHistoryBased(args, termFile, termPath);
                     deletedUidsHere.add(removeFile(false));
+                    addWorkHistoryBased(args, termFile, termPath);
                 }
             } else {
                 deletedUidsHere.add(removeFile(!fileExists));


### PR DESCRIPTION
While hunting for a bug in the indexer (causing duplicate documents with history based reindex)  I realized that `processFileHistoryBased()` calls `removeFile()` twice unnecessarily in the same block. This was introduced with the changes in 520ce3b908655d5edfc0d1b019dd2a575381a34f.