### PR TITLE
quote path in log statement

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, Aleksandr Kirillov <alexkirillovsamara@gmail.com>.
  */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -1510,7 +1510,7 @@ public final class Configuration {
     }
 
     public static Configuration read(File file) throws IOException {
-        LOGGER.log(Level.INFO, "Reading configuration from {0}", file.getCanonicalPath());
+        LOGGER.log(Level.INFO, "Reading configuration from ''{0}''", file.getCanonicalPath());
         try (FileInputStream in = new FileInputStream(file)) {
             return decodeObject(in);
         }


### PR DESCRIPTION
This change quotes the read-only configuration path logged, to align with the rest of code base.