### PR TITLE
do not constrain the output of the Groups command in opengrok-groups

### DIFF
--- a/dev/before_install
+++ b/dev/before_install
@@ -28,12 +28,6 @@ if [[ "$RUNNER_OS" == "Linux" ]]; then
 	# Bitkeeper install failure is not critical, so exit code is not checked.
 	sudo ./dev/install-bitkeeper.sh
 
-	sudo -H ./dev/install-python-packages.sh
-	if [[ $? != 0 ]]; then
-		echo "cannot install Python packages"
-		exit 1
-	fi
-
 	sudo ./dev/install-universal_ctags.sh
 	if [[ $? != 0 ]]; then
 		echo "cannot install Universal ctags"

--- a/tools/src/main/python/opengrok_tools/groups.py
+++ b/tools/src/main/python/opengrok_tools/groups.py
@@ -18,7 +18,7 @@
 # CDDL HEADER END
 
 #
-# Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
 #
 
 import argparse
@@ -51,7 +51,8 @@ def main():
     cmd = Java(args.options, classpath=args.jar, java=args.java,
                java_opts=args.java_opts, redirect_stderr=False,
                main_class='org.opengrok.indexer.configuration.Groups',
-               logger=logger, doprint=args.doprint)
+               logger=logger, doprint=args.doprint,
+               max_line_length=-1, max_lines=-1)
     cmd.execute()
     ret = cmd.getretcode()
     if ret is None or ret != SUCCESS_EXITVAL:

--- a/tools/src/main/python/opengrok_tools/utils/java.py
+++ b/tools/src/main/python/opengrok_tools/utils/java.py
@@ -37,7 +37,8 @@ class Java(Command):
 
     def __init__(self, command, logger=None, main_class=None, java=None,
                  jar=None, java_opts=None, classpath=None, env_vars=None,
-                 redirect_stderr=True, doprint=False):
+                 redirect_stderr=True, doprint=False,
+                 max_line_length=None, max_lines=None):
 
         if not java:
             java = self.FindJava(logger)
@@ -72,7 +73,8 @@ class Java(Command):
         logger.debug("Java command: {}".format(java_command))
 
         super().__init__(java_command, logger=logger, env_vars=env,
-                         redirect_stderr=redirect_stderr, doprint=doprint)
+                         redirect_stderr=redirect_stderr, doprint=doprint,
+                         max_line_length=max_line_length, max_lines=max_lines)
 
     def FindJava(self, logger):
         """


### PR DESCRIPTION
Fixes a problem with long lines/output generated by the `Groups` command where previously `opengrok-groups` (the wrapper) would truncat it, leading to invalid XML.

While working on this, the Linux build failed on me due to the Python packages (pip) being externally managed, so this change fixes this (for the time being leaving the script behind).