### PR TITLE
enforce Java version

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2011, Jens Elkner.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
@@ -85,6 +85,8 @@ import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.HostUtil;
 import org.opengrok.indexer.util.OptionParser;
 import org.opengrok.indexer.util.Statistics;
+
+import static org.opengrok.indexer.util.RuntimeUtil.checkJavaVersion;
 
 /**
  * Creates and updates an inverted source index as well as generates Xref, file
@@ -371,7 +373,9 @@ public final class Indexer {
             }
 
             LOGGER.log(Level.INFO, "Indexer version {0} ({1}) running on Java {2}",
-                    new Object[]{Info.getVersion(), Info.getRevision(), System.getProperty("java.version")});
+                    new Object[]{Info.getVersion(), Info.getRevision(), Runtime.version()});
+
+            checkJavaVersion();
 
             // Create history cache first.
             if (searchRepositories) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/RuntimeUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/RuntimeUtil.java
@@ -33,6 +33,10 @@ public class RuntimeUtil {
     static final int JAVA_VERSION_MIN = 11;
     static final int JAVA_VERSION_MAX = 21;
 
+    /**
+     * @throws RuntimeException if the Java runtime version is outside
+     * {@link #JAVA_VERSION_MIN} and {@link #JAVA_VERSION_MAX}.
+     */
     public static void checkJavaVersion() throws RuntimeException {
         Runtime.Version javaVersion = Runtime.version();
         int majorVersion = javaVersion.version().get(0);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/RuntimeUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/RuntimeUtil.java
@@ -1,0 +1,44 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.util;
+
+public class RuntimeUtil {
+    private RuntimeUtil() {
+        // private for static
+    }
+
+    /*
+     * interval of supported Java versions
+     */
+    static final int JAVA_VERSION_MIN = 11;
+    static final int JAVA_VERSION_MAX = 17;
+
+    public static void checkJavaVersion() throws RuntimeException {
+        Runtime.Version javaVersion = Runtime.version();
+        int majorVersion = javaVersion.version().get(0);
+        if (majorVersion < JAVA_VERSION_MIN || majorVersion > JAVA_VERSION_MAX) {
+            throw new RuntimeException(String.format("unsupported Java version %d [%d,%d)",
+                    majorVersion, JAVA_VERSION_MIN, JAVA_VERSION_MAX));
+        }
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/RuntimeUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/RuntimeUtil.java
@@ -31,7 +31,7 @@ public class RuntimeUtil {
      * interval of supported Java versions
      */
     static final int JAVA_VERSION_MIN = 11;
-    static final int JAVA_VERSION_MAX = 17;
+    static final int JAVA_VERSION_MAX = 21;
 
     public static void checkJavaVersion() throws RuntimeException {
         Runtime.Version javaVersion = Runtime.version();

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web;
@@ -55,6 +55,8 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static org.opengrok.indexer.util.RuntimeUtil.checkJavaVersion;
+
 /**
  * Initialize webapp context.
  *
@@ -77,8 +79,10 @@ public final class WebappListener implements ServletContextListener, ServletRequ
         ServletContext context = servletContextEvent.getServletContext();
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
-        LOGGER.log(Level.INFO, "Starting webapp with version {0} ({1})",
-                    new Object[]{Info.getVersion(), Info.getRevision()});
+        LOGGER.log(Level.INFO, "Starting webapp with version {0} ({1}) on Java {2}",
+                    new Object[]{Info.getVersion(), Info.getRevision(), Runtime.version()});
+
+        checkJavaVersion();
 
         String configPath = Optional.ofNullable(context.getInitParameter("CONFIGURATION"))
                 .orElseThrow(() -> new WebappError("CONFIGURATION parameter missing in the web.xml file"));


### PR DESCRIPTION
Inspired by https://github.com/oracle/opengrok/discussions/4675, I resurrected an old branch to enforce Java version range for the runtime of the indexer and webapp.

Next to the Oracle Java 11, I also tried with Amazon Corretto 11.0.25.