### PR TITLE
fall back to the default temporary directory for ctags check

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -711,7 +711,7 @@ public final class RuntimeEnvironment {
                 ctagsLanguages.addAll(languages);
             }
 
-            ctagsFound = CtagsUtil.validate(ctagsBinary);
+            ctagsFound = CtagsUtil.isValid(ctagsBinary);
         }
 
         if (ctagsFound) {

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>
         <apache-commons-lang3.version>3.13.0</apache-commons-lang3.version>
         <micrometer.version>1.11.4</micrometer.version>
-        <mockito.version>3.12.4</mockito.version>
+        <mockito.version>5.2.0</mockito.version>
         <commons-io.version>2.14.0</commons-io.version>
     </properties>
 


### PR DESCRIPTION
This change relaxes the ctags check so that it works also for non-writable source root which is legit.

In order to test that, I had to bump Mockito in order to be able to use static method mocking. I contemplated a bit about making `CtagsUtil` non-static however turned the idea down as it would be too big change for such small change and generally it seems that the static methods have their own place for this use case.