### PR TITLE
Fortran indexing broken 

### DIFF
--- a/opengrok-indexer/src/main/jflex/analysis/fortran/FortranXref.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/fortran/FortranXref.lex
@@ -93,7 +93,7 @@ File = [a-zA-Z]{FNameChar}* "." ("i"|"inc")
     onNonSymbolMatched(cmatch.substring(0, 1), yychar);
     String file = cmatch.substring(1, cmatch.length() - 1);
     onFilelikeMatched(file, yychar + 1);
-    onNonSymbolMatched(cmatch.substring(cmatch.length() - 1, 1), yychar + 1 + file.length());
+    onNonSymbolMatched(cmatch.substring(cmatch.length() - 1, cmatch.length()), yychar + 1 + file.length());
 }
 
 /*{Hier}


### PR DESCRIPTION
As of now fortran indexing is broken because of my previous change.
```
 Second argument of substring is wrong in my previous commit 

It should be 
cmatch.substring(cmatch.length() - 1, cmatch.length()) instead of  cmatch.substring(cmatch.length() - 1, 1)
```
@vladak  Please review