### PR TITLE
update Micrometer to 1.14.1

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer;
 
@@ -30,8 +30,8 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micrometer.statsd.StatsdConfig;
 import io.micrometer.statsd.StatsdMeterRegistry;
 import io.micrometer.statsd.StatsdFlavor;

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <hamcrest.version>2.2</hamcrest.version>
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>
         <apache-commons-lang3.version>3.13.0</apache-commons-lang3.version>
-        <micrometer.version>1.11.4</micrometer.version>
+        <micrometer.version>1.14.1</micrometer.version>
         <mockito.version>5.2.0</mockito.version>
         <commons-io.version>2.14.0</commons-io.version>
     </properties>


### PR DESCRIPTION
Updates the Micrometer in order to fix a vulnerability in netty libraries used by the `micrometer-registry-statsd`.