### PR TITLE
check command state before accessing return value

### DIFF
--- a/tools/src/main/python/opengrok_tools/scm/cvs.py
+++ b/tools/src/main/python/opengrok_tools/scm/cvs.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -44,7 +44,7 @@ class CVSRepository(Repository):
         cmd.execute()
         self.logger.info("output of {}:".format(cmd))
         self.logger.info(cmd.getoutputstr())
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
+        if cmd.getstate() != Command.FINISHED or cmd.getretcode() != 0:
             self.logger.error("failed to perform update: command {}"
                               "in directory {} exited with {}".
                               format(hg_command, self.path, cmd.getretcode()))

--- a/tools/src/main/python/opengrok_tools/scm/git.py
+++ b/tools/src/main/python/opengrok_tools/scm/git.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -44,7 +44,7 @@ class GitRepository(Repository):
         cmd = self.get_command(git_command, work_dir=self.path,
                                env_vars=self.env, logger=self.logger)
         cmd.execute()
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
+        if cmd.getstate() != Command.FINISHED or cmd.getretcode() != 0:
             cmd.log_error("failed to configure git pull.ff")
 
     def reposync(self):

--- a/tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -157,7 +157,7 @@ class MercurialRepository(Repository):
         # If the 'hg out' command fails for some reason, it will return 255.
         # Hence, check for positive value as bail out indication.
         #
-        if status > 0:
+        if cmd.getstate() != Command.FINISHED or status > 0:
             return False
 
         revisions = list(filter(None, cmd.getoutputstr().split("\n")))

--- a/tools/src/main/python/opengrok_tools/scm/mercurial.py
+++ b/tools/src/main/python/opengrok_tools/scm/mercurial.py
@@ -45,7 +45,7 @@ class MercurialRepository(Repository):
         cmd.execute()
         self.logger.info("output of {}:".format(cmd))
         self.logger.info(cmd.getoutputstr())
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
+        if cmd.getstate() != Command.FINISHED or cmd.getretcode() != 0:
             cmd.log_error("failed to get branch")
             return None
         else:
@@ -73,7 +73,7 @@ class MercurialRepository(Repository):
         cmd.execute()
         self.logger.info("output of {}:".format(cmd))
         self.logger.info(cmd.getoutputstr())
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
+        if cmd.getstate() != Command.FINISHED or cmd.getretcode() != 0:
             cmd.log_error("failed to perform pull")
             return 1
 
@@ -98,7 +98,7 @@ class MercurialRepository(Repository):
         cmd.execute()
         self.logger.info("output of {}:".format(cmd))
         self.logger.info(cmd.getoutputstr())
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
+        if cmd.getstate() != Command.FINISHED or cmd.getretcode() != 0:
             cmd.log_error("failed to perform pull and update")
             return 1
 

--- a/tools/src/main/python/opengrok_tools/scm/repository.py
+++ b/tools/src/main/python/opengrok_tools/scm/repository.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Krystof Tulinger <k.tulinger@seznam.cz>
 #
 
@@ -161,7 +161,7 @@ class Repository:
         cmd = self.get_command(command, work_dir=self.path,
                                env_vars=self.env, logger=self.logger)
         cmd.execute()
-        if cmd.getretcode() != 0 or cmd.getstate() != Command.FINISHED:
+        if cmd.getstate() != Command.FINISHED or cmd.getretcode() != 0:
             cmd.log_error("failed to perform command {}".format(command))
             status = cmd.getretcode()
             if status == 0 and cmd.getstate() != Command.FINISHED:


### PR DESCRIPTION
When mirroring a JDK project with unresponsive Mercurial parent, the `opengrok-mirror` command failed due to timeout which caused `TypeError` exception due to the `status` value being  `None`:
```
processing of project 'jdk8' failed
  failed commands:
    'sudo -u wsmirror /opengrok/dist/bin/venv/bin/opengrok-mirror --api_timeout 16 --backupcount 120 --workers 3 --strip-outgoing -I -b -c /opengrok/etc/mirror-config.yml jdk8': 1
      multiprocessing.pool.RemoteTraceback:      """      Traceback (most recent call last):        
File "/usr/lib/python3.9/multiprocessing/pool.py", line 125, in worker        
  result = (True, func(*args, **kwds))        
File "/usr/lib/python3.9/multiprocessing/pool.py", line 48, in mapstar        
  return list(map(*args))        
File "/opengrok/dist/bin/venv/lib/python3.9/site-packages/opengrok_tools/mirror.py", line 77, in worker        
  return mirror_project(config, project_name,        
File "/opengrok/dist/bin/venv/lib/python3.9/site-packages/opengrok_tools/utils/mirror.py", line 545, in mirror_project        
  r = process_outgoing(repos, project_name)        
File "/opengrok/dist/bin/venv/lib/python3.9/site-packages/opengrok_tools/utils/mirror.py", line 431, in process_outgoing        
  if repo.strip_outgoing():        
File "/opengrok/dist/bin/venv/lib/python3.9/site-packages/opengrok_tools/scm/mercurial.py", line 158, in strip_outgoing        
  if status > 0:      
TypeError: '>' not supported between instances of 'NoneType' and 'int'      """        
    The above exception was the direct cause of the following exception:        
    Traceback (most recent call last):        
File "/opengrok/dist/bin/venv/bin/opengrok-mirror", line 8, in <module>        
  sys.exit(main())        
File "/opengrok/dist/bin/venv/lib/python3.9/site-packages/opengrok_tools/mirror.py", line 227, in main        
  project_results = pool.map(worker, worker_args, 1)        
File "/usr/lib/python3.9/multiprocessing/pool.py", line 364, in map        
  return self._map_async(func, iterable, mapstar, chunksize).get()        
File "/usr/lib/python3.9/multiprocessing/pool.py", line 771, in get        
  raise self._value      TypeError: '>' not supported between instances of 'NoneType' and 'int'
```
This change fixes that.