### PR TITLE
specify the path in the configuration load exception

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/AbstractLdapPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/AbstractLdapPlugin.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin;
 
@@ -133,7 +133,8 @@ public abstract class AbstractLdapPlugin implements IAuthorizationPlugin {
             cfg = getConfiguration(configurationPath);
             ldapProvider = new LdapFacade(cfg);
         } catch (IOException ex) {
-            throw new IllegalArgumentException("Unable to read the configuration", ex);
+            throw new IllegalArgumentException(
+                    String.format("Unable to read the configuration from '%s'", configurationPath), ex);
         }
     }
 


### PR DESCRIPTION
When transitioning from the XML based authnz config to YML, I noticed that the exception is missing the configuration path. This change fixes that.