### PR TITLE
let the indexParallel() exceptions bubble up + removal of per directory reindex

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -35,12 +35,12 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micrometer.statsd.StatsdConfig;
 import io.micrometer.statsd.StatsdMeterRegistry;
 import io.micrometer.statsd.StatsdFlavor;
+import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
-import org.opengrok.indexer.index.Indexer;
 import org.opengrok.indexer.logger.LoggerFactory;
 
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -108,13 +108,12 @@ public final class Metrics {
     private Metrics() {
     }
 
-    public static void updateSubFiles(List<String> subFiles) {
+    public static void updateProjects(Set<Project> projects) {
         // Add tag for per-project reindex.
-        if (statsdRegistry != null && !subFiles.isEmpty()) {
-            String projects = subFiles.stream().
-                    map(s -> s.startsWith(Indexer.PATH_SEPARATOR_STRING) ? s.substring(1) : s).
+        if (statsdRegistry != null && !projects.isEmpty()) {
+            String projectNames = projects.stream().map(Project::getName).
                     collect(Collectors.joining(","));
-            Tag commonTag = Tag.of("projects", projects);
+            Tag commonTag = Tag.of("projects", projectNames);
             LOGGER.log(Level.FINE, "updating statsdRegistry with common tag: {}", commonTag);
             statsdRegistry.config().commonTags(Collections.singleton(commonTag));
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -143,12 +143,6 @@ public final class RuntimeEnvironment {
 
     private final Set<ConfigurationChangedListener> listeners = new CopyOnWriteArraySet<>();
 
-    public List<String> getSubFiles() {
-        return subFiles;
-    }
-
-    private final List<String> subFiles = new ArrayList<>();
-
     /**
      * Maps project name to FileCollector object. This is used to pass the list of files acquired when
      * generating history cache in the first phase of indexing to the second phase of indexing.
@@ -507,17 +501,15 @@ public final class RuntimeEnvironment {
             return maybeRelPath;
         }
 
-        throw new FileNotFoundException("Failed to resolve [" + file.getPath()
-                + "] relative to source root [" + sourceRoot + "]");
+        throw new FileNotFoundException(String.format("Failed to resolve '%s' relative to source root '%s'",
+                file.getPath(), sourceRoot));
     }
 
     /**
-     * Do we have any projects ?
-     *
-     * @return true if we have projects
+     * @return true if projects are enabled and there are some projects present
      */
     public boolean hasProjects() {
-        return (this.isProjectsEnabled() && getProjects().size() > 0);
+        return (this.isProjectsEnabled() && !getProjects().isEmpty());
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1727,7 +1727,7 @@ public class IndexDatabase {
 
         File[] files = dir.listFiles();
         if (files == null) {
-            LOGGER.log(Level.SEVERE, "Failed to get file listing for: ''{0}''", dir.getPath());
+            LOGGER.log(Level.SEVERE, "Failed to get file listing for ''{0}''", dir.getPath());
             return;
         }
         Arrays.sort(files, FILENAME_COMPARATOR);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -338,10 +338,11 @@ public final class Indexer {
                                     stream().map(RepositoryInfo::getDirectoryNameRelative).collect(Collectors.toSet()));
                         }
                     } else {
-                        System.err.println("The path " + path
-                                + " does not correspond to a project");
+                        System.err.println(String.format("The path '%s' does not correspond to a project", path));
+                        System.exit(1);
                     }
                 } else {
+                    // TODO: does this assume projects are enabled ?
                     subFiles.add(path);
                 }
             }
@@ -1257,7 +1258,7 @@ public final class Indexer {
                 }
             }
         } else {
-            LOGGER.log(Level.WARNING, "Directory does not exist \"{0}\"", path);
+            LOGGER.log(Level.WARNING, "Directory ''{0}'' does not exist", path);
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -84,6 +84,7 @@ import org.opengrok.indexer.util.CtagsUtil;
 import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.HostUtil;
 import org.opengrok.indexer.util.OptionParser;
+import org.opengrok.indexer.util.RuntimeUtil;
 import org.opengrok.indexer.util.Statistics;
 
 import static org.opengrok.indexer.util.RuntimeUtil.checkJavaVersion;
@@ -372,8 +373,9 @@ public final class Indexer {
                 }
             }
 
-            LOGGER.log(Level.INFO, "Indexer version {0} ({1}) running on Java {2}",
-                    new Object[]{Info.getVersion(), Info.getRevision(), Runtime.version()});
+            LOGGER.log(Level.INFO, "Indexer version {0} ({1}) running on Java {2} with properties: {3}",
+                    new Object[]{Info.getVersion(), Info.getRevision(), RuntimeUtil.getJavaVersion(),
+                            RuntimeUtil.getJavaProperties()});
 
             checkJavaVersion();
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerException.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerException.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.index;
 
@@ -30,8 +30,15 @@ public class IndexerException extends Exception {
 
    private static final long serialVersionUID = -3009093549932264215L;
 
+   IndexerException() {
+      super();
+   }
+
    IndexerException(String string) {
       super(string);
    }
 
+   IndexerException(Exception e) {
+      super(e);
+   }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/RuntimeUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/RuntimeUtil.java
@@ -22,6 +22,7 @@
  */
 package org.opengrok.indexer.util;
 
+
 public class RuntimeUtil {
     private RuntimeUtil() {
         // private for static
@@ -44,5 +45,44 @@ public class RuntimeUtil {
             throw new RuntimeException(String.format("unsupported Java version %d [%d,%d)",
                     majorVersion, JAVA_VERSION_MIN, JAVA_VERSION_MAX));
         }
+    }
+
+    /**
+     * @return string representing Java version and some properties
+     */
+    public static String getJavaVersion() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("version: ").append(Runtime.version());
+        stringBuilder.append(", name: ").append(System.getProperty("java.vm.name"));
+        stringBuilder.append(", vendor: ").append(System.getProperty("java.vendor"));
+        stringBuilder.append(", arch: ").append(System.getProperty("os.arch"));
+        return stringBuilder.toString();
+    }
+
+    private static String bytesToHumanReadable(long size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("Invalid size: " + size);
+        }
+        if (size < 1024) {
+            return size + " bytes";
+        }
+        String units = " KMGTPE";
+        int idx = 0;
+        float value = size;
+        while (value > 1024) {
+            value /= 1024;
+            idx++;
+        }
+        return String.format("%.1f %siB", value, units.substring(idx, idx + 1));
+    }
+
+    /**
+     * @return string representing Java properties of interest
+     */
+    public static String getJavaProperties() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("ncpu: ").append(Runtime.getRuntime().availableProcessors());
+        stringBuilder.append(", maxMemory: ").append(bytesToHumanReadable(Runtime.getRuntime().maxMemory()));
+        return stringBuilder.toString();
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -1126,7 +1126,6 @@ class IndexDatabaseTest {
         final String barName = "bar.txt";
         final String repoName = "gitNoChange";
         Path repositoryRootPath = Path.of(env.getSourceRootPath(), repoName);
-        List<String> projectList = List.of(File.separator + repoName);
         try (Git gitParent = Git.init().setDirectory(parentRepositoryRoot).call()) {
             // Create initial commits for the files in the parent repository.
             final String fooName = "foo.txt";
@@ -1164,7 +1163,7 @@ class IndexDatabaseTest {
                 List<RepositoryInfo> repositoryInfos = env.getProjectRepositoriesMap().get(project);
                 assertEquals(1, repositoryInfos.size());
                 assertEquals("git", repositoryInfos.get(0).getType());
-                indexer.doIndexerExecution(projectList, null);
+                indexer.doIndexerExecution(Set.of(project), null);
 
                 // Change the parent repository so that it contains nullified change to the foo.txt file.
                 final String data = "change foo";

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerMainTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerMainTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class IndexerMainTest {
     private TestRepository repository;
@@ -77,7 +78,7 @@ class IndexerMainTest {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         String[] argv = {"-S", "-H", "-s", repository.getSourceRoot(),
                 "-d", repository.getDataRoot(), "-v", "-c", env.getCtags()};
-        Indexer.main(argv);
+        Indexer.runMain(argv);
         checkNumberOfThreads();
     }
 
@@ -90,7 +91,16 @@ class IndexerMainTest {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         String[] argv = {"-S", "-P", "-s", repository.getSourceRoot(),
                 "-d", repository.getDataRoot(), "-v", "-c", env.getCtags()};
-        Indexer.main(argv);
+        Indexer.runMain(argv);
         checkNumberOfThreads();
+    }
+
+    @Test
+    void testSubFilesWithProjectsDisabled() {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setProjectsEnabled(false);
+        String[] argv = {"-s", repository.getSourceRoot(),
+                "-d", repository.getDataRoot(), "-v", "-c", env.getCtags(), "foo"};
+        assertNotEquals(0, Indexer.runMain(argv));
     }
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/WebappListener.java
@@ -40,6 +40,7 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.index.IndexCheck;
 import org.opengrok.indexer.index.IndexCheckException;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.util.RuntimeUtil;
 import org.opengrok.indexer.web.SearchHelper;
 import org.opengrok.web.api.ApiTaskManager;
 import org.opengrok.web.api.v1.controller.ConfigurationController;
@@ -79,8 +80,9 @@ public final class WebappListener implements ServletContextListener, ServletRequ
         ServletContext context = servletContextEvent.getServletContext();
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
-        LOGGER.log(Level.INFO, "Starting webapp with version {0} ({1}) on Java {2}",
-                    new Object[]{Info.getVersion(), Info.getRevision(), Runtime.version()});
+        LOGGER.log(Level.INFO, "Starting webapp with version {0} ({1}) on Java {2} with properties {3}",
+                    new Object[]{Info.getVersion(), Info.getRevision(), RuntimeUtil.getJavaVersion(),
+                    RuntimeUtil.getJavaProperties()});
 
         checkJavaVersion();
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/DirectoryListingControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/DirectoryListingControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.controller;
 
@@ -52,9 +52,9 @@ import org.opengrok.web.api.v1.RestApp;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -101,7 +101,9 @@ class DirectoryListingControllerTest extends OGKJerseyTest {
                 null); // repositories - needed when refreshing history partially
 
         // Run the indexer so that LOC fields are populated.
-        Indexer.getInstance().doIndexerExecution(Collections.singletonList("/git"), null);
+        Project project = Project.getProject("/git");
+        assertNotNull(project);
+        Indexer.getInstance().doIndexerExecution(Set.of(project), null);
     }
 
     @AfterEach

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -39,6 +39,7 @@ import org.opengrok.indexer.authorization.AuthControlFlag;
 import org.opengrok.indexer.authorization.AuthorizationFramework;
 import org.opengrok.indexer.authorization.AuthorizationPlugin;
 import org.opengrok.indexer.authorization.AuthorizationStack;
+import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.history.RepositoryFactory;
@@ -54,9 +55,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -105,7 +106,9 @@ class FileControllerTest extends OGKJerseyTest {
                 // don't create dictionary
                 null, // subFiles - needed when refreshing history partially
                 null); // repositories - needed when refreshing history partially
-        Indexer.getInstance().doIndexerExecution(Collections.singletonList("/git"), null);
+        Project project = Project.getProject("/git");
+        assertNotNull(project);
+        Indexer.getInstance().doIndexerExecution(Set.of(project), null);
     }
 
     @AfterEach


### PR DESCRIPTION
This change contains couple of notable changes:
  - more verbose Java/system/environment information reporting for both indexer and webapp
  - the `InterruptedException`/`ExecutionExecption` from `indexParallel()` now bubble up to the indexer, altering the exit value of the indexer process so that automation can e.g. wipe out the index and reindex from scratch.
  - removal of the capability to index individual directories (which is probably very rarely used if at all and potential source of index inconsistencies), simplifying `IndexDatabase`. Any extra indexer arguments are now treated as project paths.

In case of OOM error in one of the `indexParallel` tasks, the indexer logs look like this:
```
SEVERE: 6897 successes (100.0%) after aborting parallel-indexing
Jan 07, 2025 11:02:52 AM org.opengrok.indexer.index.IndexDatabase lambda$updateAll$5
SEVERE: Problem updating index database in directory '/var/opengrok/data.lucene/index/lucene': 
org.opengrok.indexer.index.IndexerException: java.util.concurrent.ExecutionException: java.lang.OutOfMemoryError: fake OOM error
	at org.opengrok.indexer.index.IndexDatabase.indexParallel(IndexDatabase.java:1931)
	at org.opengrok.indexer.index.IndexDatabase.update(IndexDatabase.java:689)
	at org.opengrok.indexer.index.IndexDatabase.lambda$updateAll$5(IndexDatabase.java:352)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.util.concurrent.ExecutionException: java.lang.OutOfMemoryError: fake OOM error
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at org.opengrok.indexer.index.IndexDatabase.indexParallel(IndexDatabase.java:1923)
	... 7 more
Caused by: java.lang.OutOfMemoryError: fake OOM error
	at org.opengrok.indexer.index.IndexDatabase.lambda$indexParallel$8(IndexDatabase.java:1913)
	... 4 more

Jan 07, 2025 11:02:52 AM org.opengrok.indexer.index.Indexer runMain
SEVERE: Indexer failed with IndexerException
Jan 07, 2025 11:02:52 AM org.opengrok.indexer.index.Indexer runMain
INFO: Suppressed exceptions (1 in total):
Jan 07, 2025 11:02:52 AM org.opengrok.indexer.index.Indexer runMain
INFO: 1: java.util.concurrent.ExecutionException: java.lang.OutOfMemoryError: fake OOM error
Jan 07, 2025 11:02:52 AM org.opengrok.indexer.util.Statistics logIt
INFO: Indexer finished (took 30.67 seconds)

Process finished with exit code 1
```