### PR TITLE
Add option to disable immediate redirect on singular results

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -291,6 +291,12 @@ public final class Configuration {
      */
     private boolean navigateWindowEnabled;
 
+    /**
+     * If true, redirect to a single result when a single search result is found.
+     */
+    private boolean redirectOnSingleSearchResult;
+
+
     private SuggesterConfig suggesterConfig = new SuggesterConfig();
 
     private StatsdConfig statsdConfig = new StatsdConfig();
@@ -604,6 +610,7 @@ public final class Configuration {
         setQuickContextScan(true);
         //below can cause an outofmemory error, since it is defaulting to NO LIMIT
         setRamBufferSize(DEFAULT_RAM_BUFFER_SIZE); //MB
+        setRedirectOnSingleSearchResult(true);
         setRemoteScmSupported(RemoteSCM.OFF);
         setRepositories(new ArrayList<>());
         setReviewPattern("\\b(\\d{4}/\\d{3})\\b"); // in form e.g. PSARC 2008/305
@@ -1232,6 +1239,14 @@ public final class Configuration {
 
     public void setDisplayRepositories(boolean flag) {
         this.displayRepositories = flag;
+    }
+
+    public boolean isRedirectOnSingleSearchResult() {
+        return redirectOnSingleSearchResult;
+    }
+
+    public void setRedirectOnSingleSearchResult(boolean flag) {
+        this.redirectOnSingleSearchResult = flag;
     }
 
     public boolean getListDirsFirst() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1437,6 +1437,14 @@ public final class RuntimeEnvironment {
         syncWriteConfiguration(displayRepositories, Configuration::setDisplayRepositories);
     }
 
+    public boolean isRedirectOnSingleSearchResult() {
+        return syncReadConfiguration(Configuration::isRedirectOnSingleSearchResult);
+    }
+
+    public void setRedirectOnSingleSearchResult(boolean redirectOnSingleSearchResult) {
+        syncWriteConfiguration(redirectOnSingleSearchResult, Configuration::setRedirectOnSingleSearchResult);
+    }
+
     public boolean getListDirsFirst() {
         return syncReadConfiguration(Configuration::getListDirsFirst);
     }

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1520,7 +1520,12 @@ public class PageConfig {
      * @return a search helper.
      */
     public SearchHelper prepareInternalSearch(SortOrder sortOrder) {
+        boolean isRedirectOnSingleSearchResult = getEnv().isRedirectOnSingleSearchResult();
         String xrValue = req.getParameter(QueryParameters.NO_REDIRECT_PARAM);
+        if (xrValue != null && !xrValue.isEmpty()) {
+            isRedirectOnSingleSearchResult = false;
+        }
+
         return new SearchHelper.Builder(getDataRoot(), new File(getSourceRootPath()), getEftarReader(),
                 getQueryBuilder(), req.getContextPath())
                 .start(getStartIndex())
@@ -1528,7 +1533,7 @@ public class PageConfig {
                 .maxItems(getMaxItems())
                 .crossRefSearch(getPrefix() == Prefix.SEARCH_R)
                 .guiSearch(getPrefix() == Prefix.SEARCH_R || getPrefix() == Prefix.SEARCH_P)
-                .noRedirect(xrValue != null && !xrValue.isEmpty())
+                .noRedirect(!isRedirectOnSingleSearchResult)
                 .build();
     }
 


### PR DESCRIPTION
Per #3582 add an option to disable the redirection behaviour when there is only a single file result.