### PR TITLE
improve logging for isStrictlyNewerThanDocument()

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -2111,7 +2111,8 @@ public class IndexDatabase {
         try {
             Statistics stat = new Statistics();
             TopDocs top = searcher.search(q, 1);
-            stat.report(LOGGER, Level.FINEST, String.format("search via getDocument(%s) done", file),
+            stat.report(LOGGER, Level.FINEST,
+                    String.format("search via getDocument(%s) done (%d hits)", file, top.totalHits.value),
                     "search.latency", new String[]{"category", "getdocument",
                             "outcome", top.totalHits.value == 0 ? "empty" : "success"});
             if (top.totalHits.value == 0) {
@@ -2123,6 +2124,7 @@ public class IndexDatabase {
 
             // Only use the document if we found an exact match.
             if (!path.equals(foundPath)) {
+                LOGGER.log(Level.FINEST, "not matching path: ''{0}''", foundPath);
                 return null;
             }
         } finally {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -893,6 +893,7 @@ public class IndexDatabase {
         try {
             Document doc = IndexDatabase.getDocument(file);
             if (Objects.isNull(doc)) {
+                LOGGER.log(Level.WARNING, "cannot get document for ''{0}''", file);
                 return true;
             }
             IndexableField field = doc.getField(QueryBuilder.DATE);
@@ -900,14 +901,19 @@ public class IndexDatabase {
                 Date docDate = DateTools.stringToDate(field.stringValue());
                 // Assumes millisecond precision.
                 long lastModified = file.lastModified();
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINEST, String.format("checking date for '%s': %d %d",
+                            file, lastModified, docDate.getTime()));
+                }
                 if (lastModified <= docDate.getTime()) {
                     return false;
                 }
             } catch (java.text.ParseException e) {
+                LOGGER.log(Level.WARNING, String.format("cannot convert date for '%s'", file), e);
                 return true;
             }
         } catch (ParseException | IOException e) {
-            LOGGER.log(Level.FINEST, "cannot get document for ''{0}''", file);
+            LOGGER.log(Level.WARNING, String.format("cannot get document for '%s'", file), e);
         }
 
         return true;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -2124,7 +2124,8 @@ public class IndexDatabase {
 
             // Only use the document if we found an exact match.
             if (!path.equals(foundPath)) {
-                LOGGER.log(Level.FINEST, "not matching path: ''{0}''", foundPath);
+                LOGGER.log(Level.FINEST, "not matching path: ''{0}'' for ''{1}''",
+                        new Object[]{foundPath, path});
                 return null;
             }
         } finally {


### PR DESCRIPTION
Lately I have been debugging a case of failed indexing due to the failed check https://github.com/oracle/opengrok/blob/4ba3aefc4eb07b735a3deeb607bb177f63d19677/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java#L1734-L1741 and realized the `isStrictlyNewerThanDocument()` should really due better in terms of logging.

For the record, in my case (indexing the linux Git repository) it failed due to `getDocument()` returning null.