### PR TITLE
use \uFFFF as upper range for PHP identifiers

### DIFF
--- a/opengrok-indexer/src/main/jflex/analysis/php/PhpSymbolTokenizer.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/php/PhpSymbolTokenizer.lex
@@ -72,7 +72,7 @@ import org.opengrok.indexer.analysis.JFlexSymbolMatcher;
   }
 %}
 
-Identifier = [a-zA-Z_\u007F-\u10FFFF] [a-zA-Z0-9_\u007F-\u10FFFF]*
+Identifier = [a-zA-Z_\u007F-\uFFFF] [a-zA-Z0-9_\u007F-\uFFFF]*
 
 File = [a-zA-Z]{FNameChar}* "." ("php"|"php3"|"php4"|"phps"|"phtml"|"inc"|"diff"|"patch")
 

--- a/opengrok-indexer/src/main/jflex/analysis/php/PhpXref.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/php/PhpXref.lex
@@ -136,7 +136,7 @@ import org.opengrok.indexer.web.HtmlConsts;
   }
 %}
 
-Identifier = [a-zA-Z_\u007F-\u10FFFF] [a-zA-Z0-9_\u007F-\u10FFFF]*
+Identifier = [a-zA-Z_\u007F-\uFFFF] [a-zA-Z0-9_\u007F-\uFFFF]*
 
 File = [a-zA-Z]{FNameChar}* "." ("php"|"php3"|"php4"|"phps"|"phtml"|"inc"|"diff"|"patch")
 
@@ -172,7 +172,7 @@ DocParamWithName = "uses"
 DocInlineTags = "internal" | "inheritDoc" | "link" | "example"
 //method needs special treatment
 
-HtmlNameStart = [a-zA-Z_\u00C0-\u10FFFFFF]
+HtmlNameStart = [a-zA-Z_\u00C0-\uFFFF]
 HtmlName      = {HtmlNameStart} ({HtmlNameStart} | [\-.0-9\u00B7])*
 
 %state TAG_NAME AFTER_TAG_NAME ATTRIBUTE_NOQUOTE ATTRIBUTE_SINGLE ATTRIBUTE_DOUBLE HTMLCOMMENT


### PR DESCRIPTION
This change gets rid of the JFlex produced warnings for the PHP lex files.