### PR TITLE
change max Java version to v22 in wiki

### DIFF
--- a/22_to_21.diff
+++ b/22_to_21.diff
@@ -1,0 +1,13 @@
+diff --git a/How-to-setup-OpenGrok.md b/How-to-setup-OpenGrok.md
+index 442a258..3e14e3c 100644
+--- a/How-to-setup-OpenGrok.md
++++ b/How-to-setup-OpenGrok.md
+@@ -5,7 +5,7 @@ Note, that you need to create the index no matter what is your use case. Without
+ 
+ You need the following:
+ 
+-- Java from 11 to 22
++- Java from 11 to 21
+ - OpenGrok '''binaries''' from https://github.com/OpenGrok/OpenGrok/releases (.tar.gz file with binaries, not the source code tarball !)
+ - https://github.com/universal-ctags for analysis
+   - avoid Exuberant ctags, they are not maintained anymore and OpenGrok does not run with it


### PR DESCRIPTION
The wiki says Java v11 to v22, but actually v22 is blocked by the installer and won't work.  See this commit, which blocks v22: https://github.com/oracle/opengrok/commit/785896c3c8709731cca53bc6791419743dfcdefe

Therefore, the wiki should be updated to match.

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
