### PR TITLE
avoid global isHistoryEnabled() checks in favor of per repository check

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2021, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
@@ -596,7 +596,7 @@ public class AnalyzerGuru {
         doc.add(new SortedDocValuesField(QueryBuilder.FULLPATH,
                 new BytesRef(file.getAbsolutePath())));
 
-        if (RuntimeEnvironment.getInstance().isHistoryEnabled()) {
+        if (HistoryGuru.getInstance().repositorySupportsHistory(file)) {
             populateDocumentHistory(doc, file);
         }
         doc.add(new Field(QueryBuilder.DATE, date, string_ft_stored_nanalyzed_norms));

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, Aleksandr Kirillov <alexkirillovsamara@gmail.com>.
  */
@@ -580,7 +580,7 @@ public final class Configuration {
         setHandleHistoryOfRenamedFiles(false);
         setHistoryBasedReindex(true);
         setHistoryCache(true);
-        setHistoryEnabled(true);
+        setHistoryEnabled(false);
         setHitsPerPage(25);
         setIgnoredNames(new IgnoredNames());
         setIncludedNames(new Filter());
@@ -1608,39 +1608,6 @@ public final class Configuration {
 
         public ConfigurationException(String message) {
             super(message);
-        }
-    }
-
-    /**
-     * Check if configuration is populated and self-consistent.
-     * @throws ConfigurationException on error
-     */
-    public void checkConfiguration() throws ConfigurationException {
-
-        if (getSourceRoot() == null) {
-            throw new ConfigurationException("Source root is not specified.");
-        }
-
-        if (getDataRoot() == null) {
-            throw new ConfigurationException("Data root is not specified.");
-        }
-
-        if (!new File(getSourceRoot()).canRead()) {
-            throw new ConfigurationException("Source root directory '" + getSourceRoot() + "' must be readable.");
-        }
-
-        if (!new File(getDataRoot()).canWrite()) {
-            throw new ConfigurationException("Data root directory '" + getDataRoot() + "' must be writable.");
-        }
-
-        if (!isHistoryEnabled() && isHistoryBasedReindex()) {
-            LOGGER.log(Level.INFO, "History based reindex is on, however history is off. " +
-                    "History has to be enabled for history based reindex.");
-        }
-
-        if (!isHistoryCache() && isHistoryBasedReindex()) {
-            LOGGER.log(Level.INFO, "History based reindex is on, however history cache is off. " +
-                    "History cache has to be enabled for history based reindex.");
         }
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -1610,4 +1610,37 @@ public final class Configuration {
             super(message);
         }
     }
+
+    /**
+     * Check if configuration is populated and self-consistent.
+     * @throws ConfigurationException on error
+     */
+    public void checkConfiguration() throws ConfigurationException {
+
+        if (getSourceRoot() == null) {
+            throw new ConfigurationException("Source root is not specified.");
+        }
+
+        if (getDataRoot() == null) {
+            throw new ConfigurationException("Data root is not specified.");
+        }
+
+        if (!new File(getSourceRoot()).canRead()) {
+            throw new ConfigurationException("Source root directory '" + getSourceRoot() + "' must be readable.");
+        }
+
+        if (!new File(getDataRoot()).canWrite()) {
+            throw new ConfigurationException("Data root directory '" + getDataRoot() + "' must be writable.");
+        }
+
+        if (!isHistoryEnabled() && isHistoryBasedReindex()) {
+            LOGGER.log(Level.INFO, "History based reindex is on, however history is off. " +
+                    "History has to be enabled for history based reindex.");
+        }
+
+        if (!isHistoryCache() && isHistoryBasedReindex()) {
+            LOGGER.log(Level.INFO, "History based reindex is on, however history cache is off. " +
+                    "History cache has to be enabled for history based reindex.");
+        }
+    }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -633,7 +633,7 @@ public final class HistoryGuru {
     }
 
     /**
-     * @param file file object
+     * @param file {@link File} object for a file under source root
      * @return whether related {@link Repository} and settings allow for history retrieval
      */
     public boolean repositorySupportsHistory(File file) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -54,7 +54,6 @@ import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.analysis.AnalyzerFactory;
 import org.opengrok.indexer.analysis.AnalyzerGuru;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
-import org.opengrok.indexer.configuration.Configuration;
 import org.opengrok.indexer.configuration.Configuration.RemoteSCM;
 import org.opengrok.indexer.configuration.OpenGrokThreadFactory;
 import org.opengrok.indexer.configuration.PathAccepter;
@@ -630,6 +629,14 @@ public final class HistoryGuru {
             }
         }
 
+        return repositorySupportsHistory(file);
+    }
+
+    /**
+     * @param file file object
+     * @return whether related {@link Repository} and settings allow for history retrieval
+     */
+    public boolean repositorySupportsHistory(File file) {
         Repository repo = getRepository(file);
         if (repo == null) {
             LOGGER.finest(() -> String.format("cannot find repository for '%s' to check history presence",
@@ -642,7 +649,7 @@ public final class HistoryGuru {
         }
 
         // This should return true for Annotate view.
-        Configuration.RemoteSCM globalRemoteSupport = env.getRemoteScmSupported();
+        RemoteSCM globalRemoteSupport = env.getRemoteScmSupported();
         boolean remoteSupported = ((globalRemoteSupport == RemoteSCM.ON)
                 || (globalRemoteSupport == RemoteSCM.UIONLY)
                 || (globalRemoteSupport == RemoteSCM.DIRBASED)

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/LatestRevisionUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/LatestRevisionUtil.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -26,7 +26,6 @@ import org.apache.lucene.document.DateTools;
 import org.apache.lucene.document.Document;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
-import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.index.IndexDatabase;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.search.QueryBuilder;
@@ -52,11 +51,11 @@ public class LatestRevisionUtil {
 
     /**
      * @param file file object corresponding to a file under source root
-     * @return last revision string for {@code file} or null
+     * @return last revision string for {@code file} or {@code null}
      */
     @Nullable
     public static String getLatestRevision(File file) {
-        if (!RuntimeEnvironment.getInstance().isHistoryEnabled()) {
+        if (!HistoryGuru.getInstance().repositorySupportsHistory(file)) {
             return null;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDatabase.java
@@ -1283,10 +1283,9 @@ public class IndexDatabase {
         }
     }
 
-    private AbstractAnalyzer getAnalyzerFor(File file, String path)
-            throws IOException {
-        try (InputStream in = new BufferedInputStream(
-                new FileInputStream(file))) {
+    @VisibleForTesting
+    static AbstractAnalyzer getAnalyzerFor(File file, String path) throws IOException {
+        try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
             return AnalyzerGuru.getAnalyzer(in, path);
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -209,8 +209,6 @@ public final class Indexer {
                 exitWithHelp();
             }
 
-            checkConfiguration();
-
             if (awaitProfiler) {
                 pauseToAwaitProfiler();
             }
@@ -277,6 +275,8 @@ public final class Indexer {
                     entry.getValue().setName(entry.getKey());
                 }
             }
+
+            checkConfiguration(cfg);
 
             // Set updated configuration in RuntimeEnvironment. This is called so that the tunables set
             // via command line options are available.
@@ -495,10 +495,43 @@ public final class Indexer {
     }
 
     /**
+     * Check if configuration is populated and self-consistent.
+     * @throws Configuration.ConfigurationException on error
+     */
+    public static void checkConfigurationValues(Configuration cfg) throws Configuration.ConfigurationException {
+
+        if (cfg.getSourceRoot() == null) {
+            throw new Configuration.ConfigurationException("Source root is not specified.");
+        }
+
+        if (cfg.getDataRoot() == null) {
+            throw new Configuration.ConfigurationException("Data root is not specified.");
+        }
+
+        if (!new File(cfg.getSourceRoot()).canRead()) {
+            throw new Configuration.ConfigurationException("Source root directory '" + cfg.getSourceRoot() + "' must be readable.");
+        }
+
+        if (!new File(cfg.getDataRoot()).canWrite()) {
+            throw new Configuration.ConfigurationException("Data root directory '" + cfg.getDataRoot() + "' must be writable.");
+        }
+
+        if (!cfg.isHistoryEnabled() && cfg.isHistoryBasedReindex()) {
+            LOGGER.log(Level.INFO, "History based reindex is on, however history is off. " +
+                    "History has to be enabled for history based reindex.");
+        }
+
+        if (!cfg.isHistoryCache() && cfg.isHistoryBasedReindex()) {
+            LOGGER.log(Level.INFO, "History based reindex is on, however history cache is off. " +
+                    "History cache has to be enabled for history based reindex.");
+        }
+    }
+
+    /**
      * This is supposed to be run after {@link #parseOptions(String[])}.
      * It will exit the program if there is some serious configuration (meaning {@link #cfg}) discrepancy.
      */
-    private static void checkConfiguration() {
+    private static void checkConfiguration(Configuration cfg) {
         if (bareConfig && (env.getConfigURI() == null || env.getConfigURI().isEmpty())) {
             die("Missing webappURI setting");
         }
@@ -513,7 +546,7 @@ public final class Indexer {
         }
 
         try {
-            cfg.checkConfiguration();
+            checkConfigurationValues(cfg);
         } catch (Configuration.ConfigurationException e) {
             die(e.getMessage());
         }
@@ -1025,8 +1058,6 @@ public final class Indexer {
         if (cfg == null) {
             cfg = new Configuration();
         }
-
-        cfg.setHistoryEnabled(false);  // force user to turn on history capture
 
         argv = optParser.parse(argv);
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -209,6 +209,8 @@ public final class Indexer {
                 exitWithHelp();
             }
 
+            checkConfiguration();
+
             if (awaitProfiler) {
                 pauseToAwaitProfiler();
             }
@@ -275,8 +277,6 @@ public final class Indexer {
                     entry.getValue().setName(entry.getKey());
                 }
             }
-
-            checkConfiguration(cfg);
 
             // Set updated configuration in RuntimeEnvironment. This is called so that the tunables set
             // via command line options are available.
@@ -495,43 +495,10 @@ public final class Indexer {
     }
 
     /**
-     * Check if configuration is populated and self-consistent.
-     * @throws Configuration.ConfigurationException on error
-     */
-    public static void checkConfigurationValues(Configuration cfg) throws Configuration.ConfigurationException {
-
-        if (cfg.getSourceRoot() == null) {
-            throw new Configuration.ConfigurationException("Source root is not specified.");
-        }
-
-        if (cfg.getDataRoot() == null) {
-            throw new Configuration.ConfigurationException("Data root is not specified.");
-        }
-
-        if (!new File(cfg.getSourceRoot()).canRead()) {
-            throw new Configuration.ConfigurationException("Source root directory '" + cfg.getSourceRoot() + "' must be readable.");
-        }
-
-        if (!new File(cfg.getDataRoot()).canWrite()) {
-            throw new Configuration.ConfigurationException("Data root directory '" + cfg.getDataRoot() + "' must be writable.");
-        }
-
-        if (!cfg.isHistoryEnabled() && cfg.isHistoryBasedReindex()) {
-            LOGGER.log(Level.INFO, "History based reindex is on, however history is off. " +
-                    "History has to be enabled for history based reindex.");
-        }
-
-        if (!cfg.isHistoryCache() && cfg.isHistoryBasedReindex()) {
-            LOGGER.log(Level.INFO, "History based reindex is on, however history cache is off. " +
-                    "History cache has to be enabled for history based reindex.");
-        }
-    }
-
-    /**
      * This is supposed to be run after {@link #parseOptions(String[])}.
      * It will exit the program if there is some serious configuration (meaning {@link #cfg}) discrepancy.
      */
-    private static void checkConfiguration(Configuration cfg) {
+    private static void checkConfiguration() {
         if (bareConfig && (env.getConfigURI() == null || env.getConfigURI().isEmpty())) {
             die("Missing webappURI setting");
         }
@@ -546,7 +513,7 @@ public final class Indexer {
         }
 
         try {
-            checkConfigurationValues(cfg);
+            cfg.checkConfiguration();
         } catch (Configuration.ConfigurationException e) {
             die(e.getMessage());
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileAnnotationCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileAnnotationCacheTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -60,6 +60,8 @@ class FileAnnotationCacheTest {
     void setUp() throws Exception {
         repositories = new TestRepository();
         repositories.create(getClass().getResource("/repositories"));
+
+        env.setHistoryEnabled(true);
 
         // This needs to be set before the call to env.setRepositories() below as it instantiates HistoryGuru.
         env.setAnnotationCacheEnabled(true);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/FileHistoryCacheTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, 2023, Ric Harris <harrisric@users.noreply.github.com>.
  */
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.time.DateUtils;
 import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -89,6 +90,12 @@ class FileHistoryCacheTest {
     private boolean savedFetchHistoryWhenNotInCache;
     private boolean savedIsHandleHistoryOfRenamedFiles;
     private boolean savedIsTagsEnabled;
+
+    @BeforeAll
+    static void setUpClass() throws Exception {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setHistoryEnabled(true);
+    }
 
     /**
      * Set up the test environment with repositories and a cache instance.

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -90,6 +90,7 @@ class HistoryGuruTest {
     @BeforeAll
     static void setUpClass() throws Exception {
         env = RuntimeEnvironment.getInstance();
+        env.setHistoryEnabled(true);
         env.setAnnotationCacheEnabled(true);
         savedNestingMaximum = env.getNestingMaximum();
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -25,6 +25,7 @@ package org.opengrok.indexer.history;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -106,6 +107,12 @@ public class MercurialRepositoryTest {
         repository = new TestRepository();
         repository.create(Objects.requireNonNull(getClass().getResource("/repositories")));
         repositoryRoot = new File(repository.getSourceRoot(), "mercurial");
+    }
+
+    @BeforeAll
+    static void setUpClass() throws Exception {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setHistoryEnabled(true);
     }
 
     @BeforeEach

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/AnalyzerGuruDocumentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/AnalyzerGuruDocumentTest.java
@@ -46,7 +46,6 @@ import java.io.Writer;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -57,33 +56,33 @@ import static org.mockito.Mockito.verify;
 class AnalyzerGuruDocumentTest {
     private RuntimeEnvironment env;
 
-    private static TestRepository repository;
+    private static TestRepository testRepository;
 
     @BeforeEach
     void setUpClass() throws Exception {
         env = RuntimeEnvironment.getInstance();
 
-        repository = new TestRepository();
+        testRepository = new TestRepository();
         URL resourceURL = HistoryGuru.class.getResource("/repositories");
         assertNotNull(resourceURL);
-        repository.create(resourceURL);
+        testRepository.create(resourceURL);
 
-        env.setSourceRoot(repository.getSourceRoot());
-        env.setDataRoot(repository.getDataRoot());
+        env.setSourceRoot(testRepository.getSourceRoot());
+        env.setDataRoot(testRepository.getDataRoot());
         env.setHistoryEnabled(true);
         env.setProjectsEnabled(true);
         RepositoryFactory.initializeIgnoredNames(env);
 
         // Restore the project and repository information.
         env.setProjects(new HashMap<>());
-        env.setRepositories(repository.getSourceRoot());
+        env.setRepositories(testRepository.getSourceRoot());
         HistoryGuru.getInstance().invalidateRepositories(env.getRepositories(), CommandTimeoutType.INDEXER);
         env.generateProjectRepositoriesMap();
     }
 
     @AfterEach
     void tearDownClass() throws Exception {
-        repository.destroy();
+        testRepository.destroy();
     }
 
     /**
@@ -99,9 +98,9 @@ class AnalyzerGuruDocumentTest {
         File file = filePath.toFile();
         assertTrue(file.exists());
         HistoryGuru histGuru = HistoryGuru.getInstance();
-        Repository fileRepository = histGuru.getRepository(file);
-        assertNotNull(fileRepository);
-        fileRepository.setHistoryEnabled(historyEnabled);
+        Repository repository = histGuru.getRepository(file);
+        assertNotNull(repository);
+        repository.setHistoryEnabled(historyEnabled);
         String relativePath = env.getPathRelativeToSourceRoot(file);
         analyzerGuru.populateDocument(doc, file, relativePath,
                 IndexDatabase.getAnalyzerFor(file, relativePath), new NullWriter());

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/AnalyzerGuruDocumentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/AnalyzerGuruDocumentTest.java
@@ -76,7 +76,6 @@ class AnalyzerGuruDocumentTest {
 
         // Restore the project and repository information.
         env.setProjects(new HashMap<>());
-        HistoryGuru.getInstance().removeRepositories(List.of("/git"));
         env.setRepositories(repository.getSourceRoot());
         HistoryGuru.getInstance().invalidateRepositories(env.getRepositories(), CommandTimeoutType.INDEXER);
         env.generateProjectRepositoriesMap();
@@ -84,7 +83,6 @@ class AnalyzerGuruDocumentTest {
 
     @AfterEach
     void tearDownClass() throws Exception {
-        env.releaseIndexSearchers();
         repository.destroy();
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/AnalyzerGuruDocumentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/AnalyzerGuruDocumentTest.java
@@ -1,0 +1,115 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.index;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.TextField;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.opengrok.indexer.analysis.AbstractAnalyzer;
+import org.opengrok.indexer.analysis.AnalyzerGuru;
+import org.opengrok.indexer.configuration.CommandTimeoutType;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.history.HistoryGuru;
+import org.opengrok.indexer.history.Repository;
+import org.opengrok.indexer.history.RepositoryFactory;
+import org.opengrok.indexer.search.QueryBuilder;
+import org.opengrok.indexer.util.NullWriter;
+import org.opengrok.indexer.util.TestRepository;
+
+import java.io.File;
+import java.io.Writer;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+
+class AnalyzerGuruDocumentTest {
+    private RuntimeEnvironment env;
+
+    private static TestRepository repository;
+
+    @BeforeEach
+    void setUpClass() throws Exception {
+        env = RuntimeEnvironment.getInstance();
+
+        repository = new TestRepository();
+        URL resourceURL = HistoryGuru.class.getResource("/repositories");
+        assertNotNull(resourceURL);
+        repository.create(resourceURL);
+
+        env.setSourceRoot(repository.getSourceRoot());
+        env.setDataRoot(repository.getDataRoot());
+        env.setHistoryEnabled(true);
+        env.setProjectsEnabled(true);
+        RepositoryFactory.initializeIgnoredNames(env);
+
+        // Restore the project and repository information.
+        env.setProjects(new HashMap<>());
+        HistoryGuru.getInstance().removeRepositories(List.of("/git"));
+        env.setRepositories(repository.getSourceRoot());
+        HistoryGuru.getInstance().invalidateRepositories(env.getRepositories(), CommandTimeoutType.INDEXER);
+        env.generateProjectRepositoriesMap();
+    }
+
+    @AfterEach
+    void tearDownClass() throws Exception {
+        env.releaseIndexSearchers();
+        repository.destroy();
+    }
+
+    /**
+     * {@link AnalyzerGuru#populateDocument(Document, File, String, AbstractAnalyzer, Writer)} should populate
+     * the history of the document only if the repository related to the file allows for it.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testPopulateDocumentHistory(boolean historyEnabled) throws Exception {
+        AnalyzerGuru analyzerGuru = new AnalyzerGuru();
+        Document doc = Mockito.mock(Document.class);
+        Path filePath = Path.of(env.getSourceRootPath(), "git", "main.c");
+        File file = filePath.toFile();
+        assertTrue(file.exists());
+        HistoryGuru histGuru = HistoryGuru.getInstance();
+        Repository fileRepository = histGuru.getRepository(file);
+        assertNotNull(fileRepository);
+        fileRepository.setHistoryEnabled(historyEnabled);
+        String relativePath = env.getPathRelativeToSourceRoot(file);
+        analyzerGuru.populateDocument(doc, file, relativePath,
+                IndexDatabase.getAnalyzerFor(file, relativePath), new NullWriter());
+        ArgumentCaptor<TextField> argument = ArgumentCaptor.forClass(TextField.class);
+        verify(doc, atLeast(1)).add(argument.capture());
+        assertEquals(historyEnabled,
+                argument.getAllValues().stream().anyMatch(e -> e.name().equals(QueryBuilder.HIST)));
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexerVsDeletedDocumentsTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.index;
 
@@ -36,6 +36,7 @@ import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -80,6 +81,12 @@ import static org.opengrok.indexer.index.IndexCheck.getLiveDocumentPaths;
  */
 class IndexerVsDeletedDocumentsTest {
     RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
+    @BeforeAll
+    static void setUpClass() {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setHistoryEnabled(true);
+    }
 
     private static String getRandomString(int numChars) {
         Random random = new Random();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/HistoryContextTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;
@@ -64,9 +64,12 @@ class HistoryContextTest {
 
     @BeforeAll
     static void setUpClass() throws Exception {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setHistoryEnabled(true);
+
         repositories = new TestRepository();
         repositories.create(HistoryContextTest.class.getResource("/repositories"));
-        RuntimeEnvironment.getInstance().setRepositories(repositories.getSourceRoot());
+        env.setRepositories(repositories.getSourceRoot());
     }
 
     @AfterAll

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/ProjectsController.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -113,7 +113,7 @@ public class ProjectsController {
         if (!env.getProjects().containsKey(projectName)) {
             Project project = new Project(projectName, "/" + projectName);
 
-            if (env.isHistoryEnabled()) {
+            if (project.isHistoryEnabled()) {
                 // Add repositories in this project.
                 List<RepositoryInfo> repos = getRepositoriesInDir(projDir);
 
@@ -130,7 +130,7 @@ public class ProjectsController {
             Project project = env.getProjects().get(projectName);
             Map<Project, List<RepositoryInfo>> map = env.getProjectRepositoriesMap();
 
-            if (env.isHistoryEnabled()) {
+            if (project.isHistoryEnabled()) {
                 // Refresh the list of repositories of this project.
                 // This is the goal of this action: if an existing project
                 // is re-added, this means its list of repositories has changed.
@@ -202,7 +202,7 @@ public class ProjectsController {
             group.getProjects().remove(project);
         }
 
-        if (env.isHistoryEnabled()) {
+        if (project.isHistoryEnabled()) {
             // Now remove the repositories associated with this project.
             List<RepositoryInfo> repos = env.getProjectRepositoriesMap().get(project);
             if (repos != null) {
@@ -302,11 +302,11 @@ public class ProjectsController {
     public Response deleteHistoryCache(@Context HttpServletRequest request,
                                        @PathParam("project") String projectNameParam) {
 
-        if (!env.isHistoryEnabled()) {
+        Project project = getProjectFromName(projectNameParam);
+        if (!project.isHistoryEnabled()) {
             return Response.status(Response.Status.NO_CONTENT).build();
         }
 
-        Project project = getProjectFromName(projectNameParam);
         List<RepositoryInfo> repos = env.getProjectRepositoriesMap().get(project);
         if (repos == null || repos.isEmpty()) {
             LOGGER.log(Level.INFO, NO_REPO_LOG_MSG, project.getName());

--- a/opengrok-web/src/main/webapp/help.jsp
+++ b/opengrok-web/src/main/webapp/help.jsp
@@ -16,7 +16,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 Portions Copyright (c) 2022, Krystof Tulinger <k.tulinger@seznam.cz>.
@@ -184,14 +184,8 @@ A <dfn>Query</dfn> is a series of clauses. A clause may be prefixed by:
     <dt>path</dt>
     <dd>path of the source file (no need to use dividers, or if, then use "/" - Windows users, "\" is an escape key in Lucene query syntax! <br/>Please don't use "\", or replace it with "/").<br/>Also note that if you want just exact path, enclose it in "", e.g. "src/mypath", otherwise dividers will be removed and you get more hits.</dd>
 
-    <%
-        if (PageConfig.get(request).getEnv().isHistoryEnabled()) {
-    %>
     <dt>hist</dt>
     <dd>History log comments.</dd>
-    <%
-        }
-    %>
 
     <dt>type</dt>
     <dd>Type of analyzer used to scope down to certain file types (e.g. just C sources).<br/>Current mappings: <%=SearchHelper.getFileTypeDescriptions().toString()%></dd>

--- a/opengrok-web/src/main/webapp/list.jsp
+++ b/opengrok-web/src/main/webapp/list.jsp
@@ -16,7 +16,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2017-2020, Chris Fraire <cfraire@me.com>.
 
@@ -62,7 +62,7 @@ org.opengrok.web.DirectoryListing"
     cfg.checkSourceRootExistence();
 
     String rev = cfg.getRequestedRevision();
-    if (!cfg.isDir() && rev.length() == 0) {
+    if (!cfg.isDir() && rev.isEmpty()) {
         /*
          * Get the latest revision and redirect so that the revision number
          * appears in the URL.

--- a/opengrok-web/src/main/webapp/menu.jspf
+++ b/opengrok-web/src/main/webapp/menu.jspf
@@ -16,7 +16,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
 
@@ -177,9 +177,6 @@ document.domReady.push(function() { domReadyMenu(); });
             id="<%= QueryParameters.PATH_SEARCH_PARAM %>" type="text" value="<%=
             Util.formQuoteEscape(queryParams.getPath()) %>"/></td>
     </tr>
-    <%
-        if (cfg.getEnv().isHistoryEnabled()) {
-    %>
     <tr>
         <td><label for="<%= QueryParameters.HIST_SEARCH_PARAM %>"
               title="Search in project(s) repository log messages">History</label></td>
@@ -188,9 +185,6 @@ document.domReady.push(function() { domReadyMenu(); });
             id="<%= QueryParameters.HIST_SEARCH_PARAM %>" type="text" value="<%=
             Util.formQuoteEscape(queryParams.getHist()) %>"/></td>
     </tr>
-    <%
-        }
-    %>
     <tr>
         <td id="typeLabelTd"><label for="<%= QueryParameters.TYPE_SEARCH_PARAM %>">Type</label></td>
         <td><select class="q" tabindex="6" name="<%= QueryParameters.TYPE_SEARCH_PARAM %>"

--- a/opengrok-web/src/main/webapp/menu.jspf
+++ b/opengrok-web/src/main/webapp/menu.jspf
@@ -45,7 +45,7 @@ org.opengrok.indexer.web.messages.MessagesUtils"
     String messages;
     Set<Project> projects = ph.getAllProjects();
     int projectsSize = ph.getAllUngrouped().size();
-    if (ph.getGroups().size() > 0 && ph.getAllUngrouped().size() > 0)
+    if (!ph.getGroups().isEmpty() && !ph.getAllUngrouped().isEmpty())
         projectsSize++;
     for (Group group : ph.getGroups()) {
         projectsSize++;
@@ -61,7 +61,7 @@ document.domReady.push(function() { domReadyMenu(); });
 <div id="qtbl">
     <table aria-label="query table">
     <%
-    if (projects.size() != 0) {
+    if (!projects.isEmpty()) {
     %>
     <tbody id="ptbl">
     <tr>
@@ -75,7 +75,7 @@ document.domReady.push(function() { domReadyMenu(); });
         SortedSet<String> pRequested = new TreeSet<>(cfg.getRequestedProjects());
         for (Group group : ph.getGroups()) {
             Set<Project> groupProjects = ph.getAllGrouped(group);
-            if (groupProjects.size() > 0) {
+            if (!groupProjects.isEmpty()) {
                 %><optgroup label="<%= group.getName() %>"><%
                 for (Project p : groupProjects) {
                     if (!p.isIndexed()) {
@@ -100,7 +100,7 @@ document.domReady.push(function() { domReadyMenu(); });
         }
 
         // Handle projects not listed in any group.
-        if (ph.getGroups().size() > 0 && ph.getAllUngrouped().size() > 0) {
+        if (!ph.getGroups().isEmpty() && !ph.getAllUngrouped().isEmpty()) {
             %><optgroup label="Other"><%
         }
         for (Project p : ph.getAllUngrouped()) {
@@ -118,7 +118,7 @@ document.domReady.push(function() { domReadyMenu(); });
             }
             %>><%= Util.formQuoteEscape(p.getName()) %></option><%
         }
-        if (ph.getGroups().size() > 0 && ph.getAllUngrouped().size() > 0) {
+        if (!ph.getGroups().isEmpty() && !ph.getAllUngrouped().isEmpty()) {
             %></optgroup><%
         }
     %></select>

--- a/opengrok-web/src/main/webapp/minisearch.jspf
+++ b/opengrok-web/src/main/webapp/minisearch.jspf
@@ -16,7 +16,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
 --%>
 <%@ page session="false" errorPage="error.jsp" import="
@@ -35,13 +35,11 @@ org.opengrok.indexer.web.Util"%><%
 <div id="bar">
     <ul>
         <li><a href="<%= context %>/"><span id="home"></span>Home</a></li><%
-    if (cfg.getEnv().isHistoryEnabled()) {
-        if (!cfg.hasHistory()) {
-            %><li><span id="history"></span><span class="c">History</span></li><%
-        } else {
-            %><li><a href="<%= context + Prefix.HIST_L + cfg.getUriEncodedPath()
-                %>"><span id="history"></span>History</a></li><%
-        }
+    if (!cfg.hasHistory()) {
+        %><li><span id="history"></span><span class="c">History</span></li><%
+    } else {
+        %><li><a href="<%= context + Prefix.HIST_L + cfg.getUriEncodedPath()
+            %>"><span id="history"></span>History</a></li><%
     }
     if (!cfg.hasAnnotations() /* || cfg.getPrefix() == Prefix.HIST_S */ ) {
         %><li><span class="c"><span class="annotate"></span>Annotate</span></li><%
@@ -87,11 +85,11 @@ org.opengrok.indexer.web.Util"%><%
         }
         %>
 	<li><a href="<%= context + Prefix.RAW_P + cfg.getUriEncodedPath() +
-            (cfg.getRequestedRevision().length() == 0 ? "" : "?" +
+            (cfg.getRequestedRevision().isEmpty() ? "" : "?" +
             QueryParameters.REVISION_PARAM_EQ + Util.uriEncode(cfg.getRequestedRevision()))
             %>"><span id="raw"></span>Raw</a></li>
 	<li><a href="<%= context + Prefix.DOWNLOAD_P + cfg.getUriEncodedPath() +
-            (cfg.getRequestedRevision().length() == 0 ? "" : "?" +
+            (cfg.getRequestedRevision().isEmpty() ? "" : "?" +
             QueryParameters.REVISION_PARAM_EQ + Util.uriEncode(cfg.getRequestedRevision()))
             %>"><span id="download"></span>Download</a></li>
 	<%

--- a/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/DirectoryListingTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web;
@@ -43,6 +43,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -203,6 +204,12 @@ class DirectoryListingTest {
 
             return ret;
         }
+    }
+
+    @BeforeAll
+    static void setUpClass() {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setHistoryEnabled(true);
     }
 
     /**

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web;
@@ -75,9 +75,12 @@ class PageConfigTest {
 
     @BeforeAll
     public static void setUpClass() throws Exception {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setHistoryEnabled(true);
+
         repository = new TestRepository();
         repository.create(PageConfigTest.class.getResource("/repositories"));
-        RuntimeEnvironment.getInstance().setRepositories(repository.getSourceRoot());
+        env.setRepositories(repository.getSourceRoot());
     }
 
     @AfterAll


### PR DESCRIPTION
This change allows for real per project history override.

Tested with indexer running with:
```
-P
-S
-R
/var/opengrok/etc/readonly_configuration-per_project_history.xml
-s
/var/opengrok/src.perproj
-d
/var/opengrok/data.perproj
-W
/var/opengrok/etc/configuration.xml
```
where the contents of `/var/opengrok/etc/readonly_configuration-per_project_history.xml` looked like this:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<java version="11.0.4" class="java.beans.XMLDecoder">
 <object class="org.opengrok.indexer.configuration.Configuration" id="Configuration0">

  <void property="historyEnabled">
    <boolean>true</boolean>
  </void>

  <void property="projectsEnabled">
   <boolean>true</boolean>
  </void>

   <void property="projects">
     <void method="put">
      <string>foo</string>
      <object class="org.opengrok.indexer.configuration.Project">
       <void property="handleRenamedFiles">
        <boolean>false</boolean>
       </void>
       <void property="historyEnabled">
        <boolean>false</boolean>
       </void>
       <void property="name">
        <string>foo</string>
       </void>
       <void property="path">
        <string>/foo</string>
       </void>
       <void property="mergeCommitsEnabled">
        <boolean>false</boolean>
       </void>
      </object>
     </void>
   </void>

 </object>
</java>
```
The source root had two projects, each with single Git repository, named `foo` and `bar`. I ran two tests, one with global history on and per project/repository off and vice versa. Checked the `list`/`minisearch` JSPs in debugger for each test.

Also ran indexer with and without -H to make sure the history is disabled by default as before the change and also that the history cache is created if history is on (to test the `AnalyzerGuru` changes).

Also tested in project-less mode.