### PR TITLE
History cache control per project

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -84,9 +84,14 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     private Boolean handleRenamedFiles = null;
 
     /**
-     * This flag enables/disables per-project history cache.
+     * This flag enables/disables per-project history queries.
      */
     private Boolean historyEnabled = null;
+
+    /**
+     * This flag enables/disables per-project history cache.
+     */
+    private Boolean historyCacheEnabled = null;
 
     /**
      * This flag enables/disables per-project annotation cache.
@@ -302,6 +307,20 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     }
 
     /**
+     * @return true if this project should have history cache.
+     */
+    public boolean isHistoryCacheEnabled() {
+        return historyCacheEnabled != null && historyCacheEnabled;
+    }
+
+    /**
+     * @param flag true if project should have history cache, false otherwise.
+     */
+    public void setHistoryCacheEnabled(boolean flag) {
+        this.historyCacheEnabled = flag;
+    }
+
+    /**
      * @return true if this project should have annotation cache.
      */
     public boolean isAnnotationCacheEnabled() {
@@ -494,9 +513,14 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
             setHandleRenamedFiles(env.isHandleHistoryOfRenamedFiles());
         }
 
-        // Allow project to override global setting of history cache generation.
+        // Allow project to override global setting of history queries.
         if (historyEnabled == null) {
             setHistoryEnabled(env.isHistoryEnabled());
+        }
+
+        // Allow project to override global setting of history cache generation.
+        if (historyCacheEnabled == null) {
+            setHistoryCacheEnabled(env.useHistoryCache());
         }
 
         // Allow project to override global setting of annotation cache generation.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -1048,9 +1048,18 @@ public final class HistoryGuru {
     }
 
     private void createHistoryCache(Repository repository, String sinceRevision) throws CacheException, HistoryException {
+        // TODO: add test for this
+        if (!repository.isHistoryCacheEnabled()) {
+            LOGGER.log(Level.INFO,
+                    "Skipping history cache creation for {0} and its subdirectories: history cache disabled",
+                    repository);
+            return;
+        }
+
         if (!repository.isHistoryEnabled()) {
             LOGGER.log(Level.INFO,
-                    "Skipping history cache creation for {0} and its subdirectories", repository);
+                    "Skipping history cache creation for {0} and its subdirectories: history disabled",
+                    repository);
             return;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -135,6 +135,11 @@ public final class HistoryGuru {
         repositoryLookup = RepositoryLookup.cached();
     }
 
+    @VisibleForTesting
+    HistoryCache getHistoryCache() {
+        return historyCache;
+    }
+
     /**
      * Set annotation cache to its default implementation.
      * @return {@link AnnotationCache} instance or {@code null} on error
@@ -1048,7 +1053,6 @@ public final class HistoryGuru {
     }
 
     private void createHistoryCache(Repository repository, String sinceRevision) throws CacheException, HistoryException {
-        // TODO: add test for this
         if (!repository.isHistoryCacheEnabled()) {
             LOGGER.log(Level.INFO,
                     "Skipping history cache creation for {0} and its subdirectories: history cache disabled",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -191,8 +191,6 @@ public final class HistoryGuru {
             return false;
         }
 
-        // file = new File(env.getSourceRootPath(), file.getPath());
-
         return useHistoryCache(getRepository(file));
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -449,9 +449,20 @@ public class RepositoryInfo implements Serializable {
         stringBuilder.append(",");
 
         if (!isHistoryEnabled()) {
+            stringBuilder.append("history=off");
+        } else {
+            stringBuilder.append("history=on");
+        }
+
+        stringBuilder.append(",");
+        if (!isHistoryCacheEnabled()) {
             stringBuilder.append("historyCache=off");
         } else {
             stringBuilder.append("historyCache=on,");
+        }
+
+        if (isHandleRenamedFiles()) {
+            stringBuilder.append(",");
             stringBuilder.append("renamed=");
             stringBuilder.append(this.isHandleRenamedFiles());
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -78,6 +78,8 @@ public class RepositoryInfo implements Serializable {
     @DTOElement
     private boolean historyEnabled;
     @DTOElement
+    private boolean historyCacheEnabled;
+    @DTOElement
     private boolean annotationCacheEnabled;
     @DTOElement
     private boolean mergeCommitsEnabled;
@@ -105,6 +107,7 @@ public class RepositoryInfo implements Serializable {
         this.branch = orig.branch;
         this.currentVersion = orig.currentVersion;
         this.historyEnabled = orig.historyEnabled;
+        this.historyCacheEnabled = orig.historyCacheEnabled;
         this.annotationCacheEnabled = orig.annotationCacheEnabled;
         this.handleRenamedFiles = orig.handleRenamedFiles;
         this.mergeCommitsEnabled = orig.mergeCommitsEnabled;
@@ -164,7 +167,7 @@ public class RepositoryInfo implements Serializable {
     }
 
     /**
-     * @return true if the repository should have history cache.
+     * @return true if the repository should support history queries.
      */
     public boolean isHistoryEnabled() {
         return this.historyEnabled;
@@ -172,6 +175,17 @@ public class RepositoryInfo implements Serializable {
 
     public void setHistoryEnabled(boolean flag) {
         this.historyEnabled = flag;
+    }
+
+    /**
+     * @return true if the history for this repository should be stored in history cache.
+     */
+    public boolean isHistoryCacheEnabled() {
+        return this.historyCacheEnabled;
+    }
+
+    public void setHistoryCacheEnabled(boolean flag) {
+        this.historyCacheEnabled = flag;
     }
 
     public boolean isAnnotationCacheEnabled() {
@@ -381,6 +395,7 @@ public class RepositoryInfo implements Serializable {
         Project proj = Project.getProject(getDirectoryNameRelative());
         if (proj != null) {
             setHistoryEnabled(proj.isHistoryEnabled());
+            setHistoryCacheEnabled(proj.isHistoryCacheEnabled());
             setAnnotationCacheEnabled(proj.isAnnotationCacheEnabled());
             setHandleRenamedFiles(proj.isHandleRenamedFiles());
             setMergeCommitsEnabled(proj.isMergeCommitsEnabled());
@@ -391,6 +406,7 @@ public class RepositoryInfo implements Serializable {
             RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
             setHistoryEnabled(env.isHistoryEnabled());
+            setHistoryCacheEnabled(env.useHistoryCache());
             setAnnotationCacheEnabled(env.isAnnotationCacheEnabled());
             setHandleRenamedFiles(env.isHandleHistoryOfRenamedFiles());
             setMergeCommitsEnabled(env.isMergeCommitsEnabled());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/Indexer.java
@@ -1123,13 +1123,12 @@ public final class Indexer {
      * @param repositories       list of repository paths relative to source root
      * @return map of repository to exception
      * @throws IndexerException indexer exception
-     * @throws IOException      I/O exception
      */
     public Map<Repository, Optional<Exception>> prepareIndexer(RuntimeEnvironment env,
                                                                Set<String> searchPaths,
                                                                boolean addProjects,
                                                                boolean createHistoryCache,
-                                                               List<String> repositories) throws IndexerException, IOException {
+                                                               List<String> repositories) throws IndexerException {
 
         if (!env.validateUniversalCtags()) {
             throw new IndexerException("Could not find working Universal ctags. " +

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -505,6 +505,23 @@ class HistoryGuruTest {
         Files.move(tmpHistPath, histPath);
     }
 
+    @Test
+    void testGetHistoryVsHistoryCacheEnabled() throws Exception {
+        File file = Path.of(repository.getSourceRoot(), "git", "main.c").toFile();
+        assertTrue(file.exists());
+        HistoryGuru instance = HistoryGuru.getInstance();
+        Repository repository = instance.getRepository(file);
+        assertNotNull(repository);
+
+        assertTrue(repository.isHistoryCacheEnabled());
+        assertNotNull(instance.getHistory(file, false, false, false));
+        repository.setHistoryCacheEnabled(false);
+        assertNull(instance.getHistory(file, false, false, false));
+
+        // cleanup
+        repository.setHistoryCacheEnabled(true);
+    }
+
     /**
      * Test that it is not possible to get last history entries for repository
      * that does not have the merge changesets enabled.

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -38,6 +38,7 @@ import static org.opengrok.indexer.condition.RepositoryInstalled.Type.SUBVERSION
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -95,7 +96,9 @@ class HistoryGuruTest {
         savedNestingMaximum = env.getNestingMaximum();
 
         repository = new TestRepository();
-        repository.create(HistoryGuru.class.getResource("/repositories"));
+        URL resourceURL = HistoryGuru.class.getResource("/repositories");
+        assertNotNull(resourceURL);
+        repository.create(resourceURL);
         RepositoryFactory.initializeIgnoredNames(env);
         FileUtilities.getAllFiles(new File(repository.getSourceRoot()), FILES, true);
         assertNotEquals(0, FILES.size());

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -497,7 +497,6 @@ class HistoryGuruTest {
         Files.move(histPath, tmpHistPath);
         assertFalse(histPath.toFile().exists());
 
-        assertNotNull(repository);
         repository.setHistoryEnabled(false);
         assertNull(instance.getLastHistoryEntry(file, false, true));
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -486,9 +486,10 @@ class HistoryGuruTest {
         assertTrue(file.exists());
         HistoryGuru instance = HistoryGuru.getInstance();
         Repository repository = instance.getRepository(file);
+        assertNotNull(repository);
 
         // HistoryGuru is final class so cannot be reasonably mocked with Mockito.
-        // In order to avoid getting the history from the cache, move the cache away for a bit.
+        // In order to avoid getting the history from the cache, move the history cache directory aside for a bit.
         String dirName = CacheUtil.getRepositoryCacheDataDirname(repository, new FileHistoryCache());
         assertNotNull(dirName);
         Path histPath = Path.of(dirName);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruVsRepositoryCacheTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruVsRepositoryCacheTest.java
@@ -1,0 +1,101 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.history;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opengrok.indexer.configuration.CommandTimeoutType;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.util.IOUtils;
+import org.opengrok.indexer.util.TestRepository;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HistoryGuruVsRepositoryCacheTest {
+    private RuntimeEnvironment env;
+
+    private static TestRepository testRepository;
+
+    @BeforeEach
+    void setUpClass() throws Exception {
+        env = RuntimeEnvironment.getInstance();
+
+        testRepository = new TestRepository();
+        URL resourceURL = HistoryGuru.class.getResource("/repositories");
+        assertNotNull(resourceURL);
+        testRepository.create(resourceURL);
+
+        env.setSourceRoot(testRepository.getSourceRoot());
+        env.setDataRoot(testRepository.getDataRoot());
+        env.setHistoryEnabled(true);
+        env.setProjectsEnabled(true);
+        RepositoryFactory.initializeIgnoredNames(env);
+
+        // Restore the project and repository information.
+        env.setProjects(new HashMap<>());
+        env.setRepositories(testRepository.getSourceRoot());
+        HistoryGuru.getInstance().invalidateRepositories(env.getRepositories(), CommandTimeoutType.INDEXER);
+        env.generateProjectRepositoriesMap();
+    }
+
+    @AfterEach
+    void tearDownClass() throws Exception {
+        testRepository.destroy();
+    }
+
+    /**
+     * Test that {@link HistoryGuru#createHistoryCache(Collection)} honors
+     * the {@link Repository#isHistoryCacheEnabled()} setting.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testCreateCacheVsRepository(boolean historyCacheEnabled) throws Exception {
+        Path filePath = Path.of(env.getSourceRootPath(), "git", "main.c");
+        File file = filePath.toFile();
+        assertTrue(file.exists());
+        HistoryGuru histGuru = HistoryGuru.getInstance();
+        Repository repository = histGuru.getRepository(file);
+        assertNotNull(repository);
+
+        repository.setHistoryCacheEnabled(historyCacheEnabled);
+        histGuru.createHistoryCache(List.of(repository.getDirectoryNameRelative()));
+
+        HistoryCache historyCache = histGuru.getHistoryCache();
+        assertNotNull(historyCache);
+        assertEquals(historyCacheEnabled, historyCache.hasCacheForFile(file));
+
+        // cleanup
+        IOUtils.removeRecursive(Path.of(env.getDataRootPath()));
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -215,7 +215,7 @@ class IndexDatabaseTest {
      *     <li>the directory names used</li>
      *     <li>the way file paths are constructed ({@link TandemPath})</li>
      * </ul>
-     * @param fileName file name to check
+     * @param fileName path relative to source root
      * @param shouldExist whether the data file should exist
      */
     private void checkDataExistence(String fileName, boolean shouldExist) {
@@ -224,20 +224,12 @@ class IndexDatabaseTest {
 
         for (String dirName : new String[] {"historycache", "annotationcache", IndexDatabase.XREF_DIR}) {
             File dataDir = new File(env.getDataRootFile(), dirName);
-            File file = new File(env.getServerName(), fileName);
+            File file = new File(env.getSourceRootFile(), fileName);
             String cacheFile;
             if (dirName.equals("annotationcache")) {
-                if (shouldExist) {
-                    assertTrue(historyGuru.hasAnnotationCacheForFile(file));
-                } else {
-                    assertFalse(historyGuru.hasAnnotationCacheForFile(file));
-                }
+                assertEquals(shouldExist, historyGuru.hasAnnotationCacheForFile(file));
             } else if (dirName.equals("historycache")) {
-                if (shouldExist) {
-                    assertTrue(historyGuru.hasHistoryCacheForFile(file));
-                } else {
-                    assertFalse(historyGuru.hasHistoryCacheForFile(file));
-                }
+                assertEquals(shouldExist, historyGuru.hasHistoryCacheForFile(file));
             } else {
                 cacheFile = TandemPath.join(fileName, ".gz");
                 File dataFile = new File(dataDir, cacheFile);


### PR DESCRIPTION
This change allows for per project history cache control, fixing hopefully most of the confusion between history/historyCache enabled semantics. Paves the way for #4265.

Will need a change in https://github.com/oracle/opengrok/wiki/Per-project-configuration