### PR TITLE
replace URL() constructors

### DIFF
--- a/docker/start.py
+++ b/docker/start.py
@@ -115,7 +115,7 @@ def index():
     API endpoint for triggering reindex.
     :return: message describing the outcome
     """
-    global periodic_timer   # noqa: F824
+    global periodic_timer  # noqa: F824
 
     if periodic_timer:
         logger = logging.getLogger(__name__)
@@ -360,7 +360,7 @@ def indexer_no_projects(logger, uri, config_path, extra_indexer_options):
         indexer.execute()
 
         logger.info("Waiting for reindex to be triggered")
-        global periodic_timer   # noqa: F824
+        global periodic_timer  # noqa: F824
         periodic_timer.wait_for_event()
 
 
@@ -420,7 +420,7 @@ def project_syncer(logger, loglevel, uri, config_path, numworkers, env, api_time
             save_config(logger, uri, config_path, api_timeout)
 
         logger.info("Waiting for reindex to be triggered")
-        global periodic_timer   # noqa: F824
+        global periodic_timer  # noqa: F824
         periodic_timer.wait_for_event()
 
 

--- a/docker/start.py
+++ b/docker/start.py
@@ -115,7 +115,7 @@ def index():
     API endpoint for triggering reindex.
     :return: message describing the outcome
     """
-    global periodic_timer
+    global periodic_timer   # noqa: F824
 
     if periodic_timer:
         logger = logging.getLogger(__name__)
@@ -360,7 +360,7 @@ def indexer_no_projects(logger, uri, config_path, extra_indexer_options):
         indexer.execute()
 
         logger.info("Waiting for reindex to be triggered")
-        global periodic_timer
+        global periodic_timer   # noqa: F824
         periodic_timer.wait_for_event()
 
 
@@ -420,7 +420,7 @@ def project_syncer(logger, loglevel, uri, config_path, numworkers, env, api_time
             save_config(logger, uri, config_path, api_timeout)
 
         logger.info("Waiting for reindex to be triggered")
-        global periodic_timer
+        global periodic_timer   # noqa: F824
         periodic_timer.wait_for_event()
 
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -59,6 +59,7 @@ import org.opengrok.indexer.authorization.AuthControlFlag;
 import org.opengrok.indexer.authorization.AuthorizationStack;
 import org.opengrok.indexer.history.RepositoryInfo;
 import org.opengrok.indexer.logger.LoggerFactory;
+import org.opengrok.indexer.web.Util;
 
 import static org.opengrok.indexer.configuration.PatternUtil.compilePattern;
 
@@ -1641,6 +1642,13 @@ public final class Configuration {
         if (!isHistoryCache() && isHistoryBasedReindex()) {
             LOGGER.log(Level.INFO, "History based reindex is on, however history cache is off. " +
                     "History cache has to be enabled for history based reindex.");
+        }
+
+        if (!Objects.isNull(getBugPage()) && !Util.isHttpUri(getBugPage())) {
+            throw new ConfigurationException("Bug page must be valid HTTP(S) URI");
+        }
+        if (!Objects.isNull(getReviewPage()) && !Util.isHttpUri(getReviewPage())) {
+            throw new ConfigurationException("Review page must be valid HTTP(S) URI");
         }
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -46,8 +46,17 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
 import java.util.function.IntConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -1595,7 +1604,7 @@ public final class Util {
             stringBuilder.append(buildLink(group1, appendedUrl, true));
             stringBuilder.append(text.substring(result.end(1), result.end(0)));
             return stringBuilder.toString();
-        } catch (URISyntaxException|MalformedURLException e) {
+        } catch (URISyntaxException | MalformedURLException e) {
             LOGGER.log(Level.WARNING, "The given URL ''{0}'' is not valid", appendedUrl);
             return result.group(0);
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1479,7 +1479,7 @@ public final class Util {
     }
 
     /**
-     * Build an HTML link to the given HTTP URL. If the URL is not a HTTP URL
+     * Build an HTML link to the given HTTP URL. If the URL is not an HTTP URL
      * then it is returned as it was received. This has the same effect as
      * invoking <code>linkify(url, true)</code>.
      *
@@ -1493,7 +1493,7 @@ public final class Util {
     }
 
     /**
-     * Build an HTML link to the given http URL. If the URL is not a HTTP URL
+     * Build an HTML link to the given http URL. If the URL is not an HTTP URL
      * then it is returned as it was received.
      *
      * @param url the HTTP URL
@@ -1631,8 +1631,7 @@ public final class Util {
     }
 
     /**
-     * Try to complete the given URL part into full URL with server name, port,
-     * scheme, ...
+     * Try to complete the given URL part into full URL with server name, port, scheme, ...
      * <dl>
      * <dt>for request http://localhost:8080/source/xref/xxx and part
      * /cgi-bin/user=</dt>
@@ -1654,7 +1653,8 @@ public final class Util {
         try {
             if (!isHttpUri(url)) {
                 if (url.startsWith("/")) {
-                    return new URI(req.getScheme(), null, req.getServerName(), req.getServerPort(), url, null, null).toString();
+                    return new URI(req.getScheme(), null, req.getServerName(), req.getServerPort(), url,
+                            null, null).toString();
                 }
                 var prepUrl = req.getRequestURL();
                 if (!url.isEmpty()) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1607,9 +1607,13 @@ public final class Util {
         final String appendedUrl = url + uriEncode(group1);
         try {
             StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.append(text.substring(result.start(0), result.start(1)));
+            if (result.start(0) < result.start(1)) {
+                stringBuilder.append(text.substring(result.start(0), result.start(1)));
+            }
             stringBuilder.append(buildLink(group1, appendedUrl, true));
-            stringBuilder.append(text.substring(result.end(1), result.end(0)));
+            if (result.end(1) < result.end(0)) {
+                stringBuilder.append(text.substring(result.end(1), result.end(0)));
+            }
             return stringBuilder.toString();
         } catch (URISyntaxException | MalformedURLException e) {
             LOGGER.log(Level.WARNING, "The given URL ''{0}'' is not valid", appendedUrl);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1603,6 +1603,9 @@ public final class Util {
      * @return replacement for the first group in the pattern
      */
     private static String buildLinkReplacer(MatchResult result, String text, String url) {
+        if (result.groupCount() < 1) {
+            return result.group(0);
+        }
         final String group1 = result.group(1);
         final String appendedUrl = url + uriEncode(group1);
         try {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1493,7 +1493,7 @@ public final class Util {
     }
 
     /**
-     * Build an HTML link to the given http URL. If the URL is not an HTTP URL
+     * Build an HTML link to the given HTTP URL. If the URL is not an HTTP URL
      * then it is returned as it was received.
      *
      * @param url the HTTP URL

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1438,10 +1438,10 @@ public final class Util {
 
 
     /**
-     * Check if the string is an HTTP URL.
+     * Check if the string is an HTTP URI (i.e. allows for relative identifiers).
      *
      * @param string the string to check
-     * @return true if it is HTTP URL, false otherwise
+     * @return true if it is HTTP URI, false otherwise
      */
     public static boolean isHttpUri(String string) {
         URI uri;
@@ -1460,12 +1460,12 @@ public final class Util {
     static final String REDACTED_USER_INFO = "redacted_by_OpenGrok";
 
     /**
-     * If given path is a URL, return the string representation with the user-info part filtered out.
+     * If given path is a URI, return the string representation with the user-info part filtered out.
      * @param path path to object
-     * @return either the original string (if the URL is not valid)
+     * @return either the original string (if the URI is not valid)
      * or string representation of the URL with the user-info part removed
      */
-    public static String redactUrl(String path) {
+    public static String redactUri(String path) {
         URI uri;
         try {
             uri = new URI(path);
@@ -1520,9 +1520,9 @@ public final class Util {
     }
 
     /**
-     * Build an anchor with given name and a pack of attributes. Automatically
-     * escapes href attributes and automatically escapes the name into HTML
-     * entities.
+     * Build an anchor with given name and a pack of attributes.
+     * Assumes the <code>href</code> attribute value is URI encoded.
+     * Automatically escapes the name into HTML entities.
      *
      * @param name displayed name of the anchor
      * @param attrs map of attributes for the html element
@@ -1553,9 +1553,9 @@ public final class Util {
     }
 
     /**
-     * Build an anchor with given name and a pack of attributes. Automatically
-     * escapes href attributes and automatically escapes the name into HTML
-     * entities.
+     * Build an anchor with given name and a pack of attributes.
+     * Assumes the <code>href</code> attribute value is URI encoded.
+     * Automatically escapes the name into HTML entities.
      *
      * @param name displayed name of the anchor
      * @param url anchor's URL
@@ -1564,17 +1564,16 @@ public final class Util {
      * @throws URISyntaxException URI syntax
      * @throws MalformedURLException bad URL
      */
-    public static String buildLink(String name, String url)
-            throws URISyntaxException, MalformedURLException {
+    public static String buildLink(String name, String url) throws URISyntaxException, MalformedURLException {
         Map<String, String> attrs = new TreeMap<>();
         attrs.put("href", url);
         return buildLink(name, attrs);
     }
 
     /**
-     * Build an anchor with given name and a pack of attributes. Automatically
-     * escapes href attributes and automatically escapes the name into HTML
-     * entities.
+     * Build an anchor with given name and a pack of attributes.
+     * Assumes the <code>href</code> attribute value is URI encoded.
+     * Automatically escapes the name into HTML entities.
      *
      * @param name displayed name of the anchor
      * @param url anchor's URL
@@ -1595,6 +1594,15 @@ public final class Util {
         return buildLink(name, attrs);
     }
 
+    /**
+     * Callback function to provide replacement value for pattern match.
+     * It replaces the first group of the pattern and retains the rest of the pattern.
+     *
+     * @param result {@link MatchResult} object representing pattern match
+     * @param text original text containing the match
+     * @param url URL to be used for the replacement
+     * @return replacement for the first group in the pattern
+     */
     private static String buildLinkReplacer(MatchResult result, String text, String url) {
         final String group1 = result.group(1);
         final String appendedUrl = url + uriEncode(group1);
@@ -1612,8 +1620,7 @@ public final class Util {
 
     /**
      * Replace all occurrences of pattern in the incoming text with the link
-     * named name pointing to a URL. It is possible to use the regexp pattern
-     * groups in name and URL when they are specified in the pattern.
+     * named name pointing to a URL.
      *
      * @param text    text to replace all patterns
      * @param pattern the pattern to match

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1437,10 +1437,10 @@ public final class Util {
     }
 
     /**
-     * Check if the string is an HTTP URI (i.e. allows for relative identifiers).
+     * Check if the string is an HTTP(S) URI (i.e. allows for relative identifiers).
      *
      * @param string the string to check
-     * @return true if it is HTTP URI, false otherwise
+     * @return true if it is HTTP(S) URI, false otherwise
      */
     public static boolean isHttpUri(String string) {
         URI uri;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1457,7 +1457,7 @@ public final class Util {
         return uri.getScheme().equals("http") || uri.getScheme().equals("https");
     }
 
-    protected static final String REDACTED_USER_INFO = "redacted_by_OpenGrok";
+    static final String REDACTED_USER_INFO = "redacted_by_OpenGrok";
 
     /**
      * If given path is a URL, return the string representation with the user-info part filtered out.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1462,7 +1462,7 @@ public final class Util {
      * If given path is a URI, return the string representation with the user-info part filtered out.
      * @param path path to object
      * @return either the original string (if the URI is not valid)
-     * or string representation of the URL with the user-info part removed
+     * or string representation of the URI with the user-info part removed
      */
     public static String redactUri(String path) {
         URI uri;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -1436,7 +1436,6 @@ public final class Util {
 
     }
 
-
     /**
      * Check if the string is an HTTP URI (i.e. allows for relative identifiers).
      *

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -46,16 +46,8 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.TreeMap;
 import java.util.function.IntConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -1443,13 +1435,17 @@ public final class Util {
      * @return true if it is HTTP URL, false otherwise
      */
     public static boolean isHttpUri(String string) {
-        URL url;
+        URI uri;
         try {
-            url = new URI(string).toURL();
-        } catch (MalformedURLException | URISyntaxException ex) {
+            uri = new URI(string);
+        } catch (URISyntaxException ex) {
             return false;
         }
-        return url.getProtocol().equals("http") || url.getProtocol().equals("https");
+        String scheme = uri.getScheme();
+        if (Objects.isNull(scheme)) {
+            return false;
+        }
+        return uri.getScheme().equals("http") || uri.getScheme().equals("https");
     }
 
     protected static final String REDACTED_USER_INFO = "redacted_by_OpenGrok";
@@ -1461,14 +1457,14 @@ public final class Util {
      * or string representation of the URL with the user-info part removed
      */
     public static String redactUrl(String path) {
-        URL url;
+        URI uri;
         try {
-            url = new URI(path).toURL();
-        } catch (MalformedURLException | URISyntaxException e) {
+            uri = new URI(path);
+        } catch (URISyntaxException e) {
             return path;
         }
-        if (url.getUserInfo() != null) {
-            return url.toString().replace(url.getUserInfo(), REDACTED_USER_INFO);
+        if (uri.getUserInfo() != null) {
+            return uri.toString().replace(uri.getUserInfo(), REDACTED_USER_INFO);
         } else {
             return path;
         }
@@ -1536,7 +1532,7 @@ public final class Util {
             buffer.append("=\"");
             String value = attr.getValue();
             if (attr.getKey().equals("href")) {
-                value = new URI(value).toString();
+                value = new URI(value).toURL().toString();
             }
             buffer.append(value);
             buffer.append("\"");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -495,6 +495,14 @@ class UtilTest {
     }
 
     @Test
+    void testLinkifyPatternNoGroup() {
+        final String text = "foo bug <123456> bar bug 777";
+
+        assertEquals(text,
+                Util.linkifyPattern(text, Pattern.compile("[0-9]{3,}"), "http://www.example.com?bug="));
+    }
+
+    @Test
     void testCompleteUrl() {
         HttpServletRequest req = new DummyHttpServletRequest() {
             @Override

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -409,13 +409,6 @@ class UtilTest {
         assertEquals("smtp://example.com/OpenGrok/OpenGrok", Util.linkify("smtp://example.com/OpenGrok/OpenGrok"));
         assertEquals("just some crazy text", Util.linkify("just some crazy text"));
 
-        // escaping url
-        assertTrue(Util.linkify("http://www.example.com/\"quotation\"/else")
-                .contains("href=\"" + Util.encodeURL("http://www.example.com/\"quotation\"/else") + "\""));
-        assertTrue(Util.linkify("https://example.com/><\"")
-                .contains("href=\"" + Util.encodeURL("https://example.com/><\"") + "\""));
-        assertTrue(Util.linkify("http://www.example.com?param=1&param2=2&param3=\"quoted>\"")
-                .contains("href=\"" + Util.encodeURL("http://www.example.com?param=1&param2=2&param3=\"quoted>\"") + "\""));
         // escaping titles
         assertTrue(Util.linkify("http://www.example.com/\"quotation\"/else")
                 .contains("title=\"Link to " + Util.encode("http://www.example.com/\"quotation\"/else") + "\""));

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -53,7 +53,12 @@ import org.opengrok.indexer.util.TestRepository;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
 
 /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -408,14 +408,6 @@ class UtilTest {
         assertEquals("ldap://example.com/OpenGrok/OpenGrok", Util.linkify("ldap://example.com/OpenGrok/OpenGrok"));
         assertEquals("smtp://example.com/OpenGrok/OpenGrok", Util.linkify("smtp://example.com/OpenGrok/OpenGrok"));
         assertEquals("just some crazy text", Util.linkify("just some crazy text"));
-
-        // escaping titles
-        assertTrue(Util.linkify("http://www.example.com/\"quotation\"/else")
-                .contains("title=\"Link to " + Util.encode("http://www.example.com/\"quotation\"/else") + "\""));
-        assertTrue(Util.linkify("https://example.com/><\"")
-                .contains("title=\"Link to " + Util.encode("https://example.com/><\"") + "\""));
-        assertTrue(Util.linkify("http://www.example.com?param=1&param2=2&param3=\"quoted>\"")
-                .contains("title=\"Link to " + Util.encode("http://www.example.com?param=1&param2=2&param3=\"quoted>\"") + "\""));
     }
 
     @Test
@@ -445,7 +437,7 @@ class UtilTest {
 
     @Test
     void testBuildLinkInvalidUrl1() {
-        assertThrows(MalformedURLException.class, () -> Util.buildLink("link", "www.example.com")); // invalid protocol
+        assertThrows(IllegalArgumentException.class, () -> Util.buildLink("link", "www.example.com")); // invalid protocol
     }
 
     @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -53,11 +53,7 @@ import org.opengrok.indexer.util.TestRepository;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
 
 /**
@@ -490,23 +486,21 @@ class UtilTest {
                 + " fugiat nulla pariatur. Excepteur sint "
                 + "occaecat bug6478abc cupidatat non proident, sunt in culpa qui officia "
                 + "deserunt mollit anim id est laborum.";
-        String expected2
-                = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
-                + "sed do eiusmod tempor incididunt as per 12345698 ut labore et dolore magna "
-                + "aliqua. "
-                + "<a href=\"http://www.other-example.com?bug=3333\" rel=\"noreferrer\" target=\"_blank\">bug3333fff</a>"
-                + " Ut enim ad minim veniam, quis nostrud exercitation "
-                + "ullamco laboris nisi ut aliquip ex ea introduced in 9791216541 commodo consequat. "
-                + "Duis aute irure dolor in reprehenderit in voluptate velit "
-                + "esse cillum dolore eu fixes 132469187 fugiat nulla pariatur. Excepteur sint "
-                + "occaecat "
-                + "<a href=\"http://www.other-example.com?bug=6478\" rel=\"noreferrer\" target=\"_blank\">bug6478abc</a>"
-                + " cupidatat non proident, sunt in culpa qui officia "
-                + "deserunt mollit anim id est laborum.";
 
-        assertEquals(expected, Util.linkifyPattern(text, Pattern.compile("\\b([0-9]{8,})\\b"), "$1", "http://www.example.com?bug=$1"));
-        assertEquals(expected2, Util.linkifyPattern(text, Pattern.compile("\\b(bug([0-9]{4})\\w{3})\\b"), "$1",
-                "http://www.other-example.com?bug=$2"));
+        assertEquals(expected, Util.linkifyPattern(text, Pattern.compile("\\b([0-9]{8,})\\b"), "http://www.example.com?bug="));
+    }
+
+    /**
+     * Matched pattern should be properly encoded in the resulting HTML.
+     */
+    @Test
+    void testLinkifyPatternEscape() {
+        final String text = "foo bug <123456> bar";
+        final String expected = "foo bug <a href=\"http://www.example.com?bug=%3C123456%3E\" " +
+                "rel=\"noreferrer\" target=\"_blank\">&lt;123456&gt;</a> bar";
+
+        assertEquals(expected,
+                Util.linkifyPattern(text, Pattern.compile("[ \\t]+([0-9<>]{3,})[ \\t]+"), "http://www.example.com?bug="));
     }
 
     @Test
@@ -652,7 +646,9 @@ class UtilTest {
     @Test
     void testWriteHAD() throws Exception {
         TestRepository repository = new TestRepository();
-        repository.create(UtilTest.class.getResource("/repositories"));
+        URL repositoryURL = UtilTest.class.getResource("/repositories");
+        assertNotNull(repositoryURL);
+        repository.create(repositoryURL);
 
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -376,13 +376,13 @@ class UtilTest {
     }
 
     @Test
-    void testRedactUrl() {
-        assertEquals("/foo/bar", Util.redactUrl("/foo/bar"));
-        assertEquals("http://foo/bar?r=xxx", Util.redactUrl("http://foo/bar?r=xxx"));
+    void testRedactUri() {
+        assertEquals("/foo/bar", Util.redactUri("/foo/bar"));
+        assertEquals("http://foo/bar?r=xxx", Util.redactUri("http://foo/bar?r=xxx"));
         assertEquals("http://" + Util.REDACTED_USER_INFO + "@foo/bar?r=xxx",
-                Util.redactUrl("http://user@foo/bar?r=xxx"));
+                Util.redactUri("http://user@foo/bar?r=xxx"));
         assertEquals("http://" + Util.REDACTED_USER_INFO + "@foo/bar?r=xxx",
-                Util.redactUrl("http://user:pass@foo/bar?r=xxx"));
+                Util.redactUri("http://user:pass@foo/bar?r=xxx"));
     }
 
     @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/UtilTest.java
@@ -485,12 +485,13 @@ class UtilTest {
      */
     @Test
     void testLinkifyPatternEscape() {
-        final String text = "foo bug <123456> bar";
+        final String text = "foo bug <123456> bar bug 777";
         final String expected = "foo bug <a href=\"http://www.example.com?bug=%3C123456%3E\" " +
-                "rel=\"noreferrer\" target=\"_blank\">&lt;123456&gt;</a> bar";
+                "rel=\"noreferrer\" target=\"_blank\">&lt;123456&gt;</a> bar " +
+                "bug <a href=\"http://www.example.com?bug=777\" rel=\"noreferrer\" target=\"_blank\">777</a>";
 
         assertEquals(expected,
-                Util.linkifyPattern(text, Pattern.compile("[ \\t]+([0-9<>]{3,})[ \\t]+"), "http://www.example.com?bug="));
+                Util.linkifyPattern(text, Pattern.compile("[ \\t]+([0-9<>]{3,})[ \\t]*"), "http://www.example.com?bug="));
     }
 
     @Test

--- a/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
+++ b/opengrok-web/src/main/webapp/WEB-INF/tags/repository.tag
@@ -69,7 +69,7 @@ Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
         </c:if>
     </td>
     <td>${Util.htmlize(ObjectUtils.defaultIfNull(repositoryInfo.type, "N/A"))}:
-        ${Util.linkify(ObjectUtils.defaultIfNull(Util.redactUrl(repositoryInfo.parent), "N/A"))}
+        ${Util.linkify(ObjectUtils.defaultIfNull(Util.redactUri(repositoryInfo.parent), "N/A"))}
         (${Util.htmlize(ObjectUtils.defaultIfNull(repositoryInfo.branch, "N/A"))})
     </td>
     <td>

--- a/opengrok-web/src/main/webapp/history.jsp
+++ b/opengrok-web/src/main/webapp/history.jsp
@@ -369,10 +369,10 @@ document.domReady.push(function() {domReadyHistory();});
                 String cout = Util.htmlize(entry.getMessage());
 
                 if (bugPage != null && !bugPage.isEmpty() && bugPattern != null) {
-                    cout = Util.linkifyPattern(cout, bugPattern, "$1", Util.completeUrl(bugPage + "$1", request));
+                    cout = Util.linkifyPattern(cout, bugPattern, Util.completeUrl(bugPage, request));
                 }
                 if (reviewPage != null && !reviewPage.isEmpty() && reviewPattern != null) {
-                    cout = Util.linkifyPattern(cout, reviewPattern, "$1", Util.completeUrl(reviewPage + "$1", request));
+                    cout = Util.linkifyPattern(cout, reviewPattern, Util.completeUrl(reviewPage, request));
                 }
                 
                 boolean showSummary = false;
@@ -382,10 +382,10 @@ document.domReady.push(function() {domReadyHistory();});
                     coutSummary = coutSummary.substring(0, summaryLength - 1);
                     coutSummary = Util.htmlize(coutSummary);
                     if (bugPage != null && !bugPage.isEmpty() && bugPattern != null) {
-                        coutSummary = Util.linkifyPattern(coutSummary, bugPattern, "$1", Util.completeUrl(bugPage + "$1", request));
+                        coutSummary = Util.linkifyPattern(coutSummary, bugPattern, Util.completeUrl(bugPage, request));
                     }
                     if (reviewPage != null && !reviewPage.isEmpty() && reviewPattern != null) {
-                        coutSummary = Util.linkifyPattern(coutSummary, reviewPattern, "$1", Util.completeUrl(reviewPage + "$1", request));
+                        coutSummary = Util.linkifyPattern(coutSummary, reviewPattern, Util.completeUrl(reviewPage, request));
                     }
                 }
 


### PR DESCRIPTION
This change gets rid of the `URL()` constructors deprecated in Java 20 and addresses a case of unescaped patterns.

Background: https://gist.github.com/vladak/beb43b9056b546869196d09a16542466

Approaches #4459 and takes over the `URL()` changes from @tarzanek's PR #4570 

I had to add a flake8 suppression to the Docker entry point to make the build pass.

Tested with this read-only configuration:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<java version="1.8.0_121" class="java.beans.XMLDecoder">
 <object class="org.opengrok.indexer.configuration.Configuration">

  <void property="bugPage">
   <string>https://github.com/apache/lucene/issues/</string>
  </void>

  <void property="bugPattern">
   <string>LUCENE-(\d+)</string>
  </void>

 </object>
</java>
```
and The Lucene Git repository.