### PR TITLE
add Linux ARM64 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
     - name: Checkout master branch
       uses: actions/checkout@v4


### PR DESCRIPTION
Paves the way for ARM64 Docker images. The Linux ARM64 Github runners are currently in public preview.