### PR TITLE
Add support for OCaml.

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
- * Portions Copyright (c) 2017, 2021, Chris Fraire <cfraire@me.com>.
+ * Portions Copyright (c) 2025, Yelisey Romanov <progoramur@gmail.com>.
  */
 package org.opengrok.indexer.analysis;
 
@@ -89,6 +89,7 @@ import org.opengrok.indexer.analysis.json.JsonAnalyzerFactory;
 import org.opengrok.indexer.analysis.kotlin.KotlinAnalyzerFactory;
 import org.opengrok.indexer.analysis.lisp.LispAnalyzerFactory;
 import org.opengrok.indexer.analysis.lua.LuaAnalyzerFactory;
+import org.opengrok.indexer.analysis.ocaml.OCamlAnalyzerFactory;
 import org.opengrok.indexer.analysis.pascal.PascalAnalyzerFactory;
 import org.opengrok.indexer.analysis.perl.PerlAnalyzerFactory;
 import org.opengrok.indexer.analysis.php.PhpAnalyzerFactory;
@@ -298,6 +299,7 @@ public class AnalyzerGuru {
                 new HaskellAnalyzerFactory(),
                 new GolangAnalyzerFactory(),
                 new LuaAnalyzerFactory(),
+                new OCamlAnalyzerFactory(),
                 new PascalAnalyzerFactory(),
                 new AdaAnalyzerFactory(),
                 new RubyAnalyzerFactory(),

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ocaml/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ocaml/Consts.java
@@ -1,0 +1,120 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2025, Yelisey Romanov <progoramur@gmail.com>.
+ */
+package org.opengrok.indexer.analysis.ocaml;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents a container for a set of OCaml keywords.
+ */
+public class Consts {
+
+    static final Set<String> kwd = new HashSet<>();
+
+    static {
+        /* OCaml 5.3.0 keywords */
+        kwd.add("and");
+        kwd.add("as");
+        kwd.add("assert");
+        kwd.add("begin");
+        kwd.add("class");
+        kwd.add("constraint");
+        kwd.add("do");
+        kwd.add("done");
+        kwd.add("downto");
+        kwd.add("effect");
+        kwd.add("else");
+        kwd.add("end");
+        kwd.add("exception");
+        kwd.add("external");
+        kwd.add("false");
+        kwd.add("for");
+        kwd.add("fun");
+        kwd.add("function");
+        kwd.add("functor");
+        kwd.add("if");
+        kwd.add("in");
+        kwd.add("include");
+        kwd.add("inherit");
+        kwd.add("initializer");
+        kwd.add("lazy");
+        kwd.add("let");
+        kwd.add("match");
+        kwd.add("method");
+        kwd.add("module");
+        kwd.add("mutable");
+        kwd.add("new");
+        kwd.add("nonrec");
+        kwd.add("object");
+        kwd.add("of");
+        kwd.add("open");
+        kwd.add("or");
+        kwd.add("parser");
+        kwd.add("private");
+        kwd.add("ref");
+        kwd.add("rec");
+        kwd.add("sig");
+        kwd.add("struct");
+        kwd.add("then");
+        kwd.add("to");
+        kwd.add("true");
+        kwd.add("try");
+        kwd.add("type");
+        kwd.add("val");
+        kwd.add("virtual");
+        kwd.add("when");
+        kwd.add("while");
+        kwd.add("with");
+        kwd.add("lor");
+        kwd.add("lxor");
+        kwd.add("mod");
+        kwd.add("land");
+        kwd.add("lsl");
+        kwd.add("lsr");
+        kwd.add("asr");
+
+        /* OCaml 5.3.0 predefined types */
+        /* it is possible to make a variable of such a name,
+           though people mostly do not use this opportunity */
+        kwd.add("bool");
+        kwd.add("char");
+        kwd.add("float");
+        kwd.add("int");
+
+        kwd.add("bytes");
+        kwd.add("string");
+
+        kwd.add("array");
+        kwd.add("list");
+        kwd.add("option");
+        /* "result" is often a variable, so not adding */
+
+        kwd.add("unit");
+    }
+
+    /** Private to enforce static. */
+    private Consts() {
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ocaml/OCamlAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ocaml/OCamlAnalyzer.java
@@ -1,0 +1,76 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2025, Yelisey Romanov <progoramur@gmail.com>.
+ */
+package org.opengrok.indexer.analysis.ocaml;
+
+import org.opengrok.indexer.analysis.AbstractAnalyzer;
+import org.opengrok.indexer.analysis.FileAnalyzerFactory;
+import org.opengrok.indexer.analysis.JFlexTokenizer;
+import org.opengrok.indexer.analysis.JFlexXref;
+import org.opengrok.indexer.analysis.plain.AbstractSourceCodeAnalyzer;
+
+import java.io.Reader;
+
+/**
+ * Represents an analyzer for the OCaml language.
+ */
+@SuppressWarnings("java:S110")
+public class OCamlAnalyzer extends AbstractSourceCodeAnalyzer {
+
+    /**
+     * Creates a new instance of {@link OCamlAnalyzer}.
+     * @param factory instance
+     */
+    protected OCamlAnalyzer(FileAnalyzerFactory factory) {
+        super(factory, () -> new JFlexTokenizer(new OCamlSymbolTokenizer(
+                AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code "ocaml"}
+     */
+    @Override
+    public String getCtagsLang() {
+        return "ocaml";
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20250403_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20250403_00; // Edit comment above too!
+    }
+
+    /**
+     * Creates a wrapped {@link OCamlXref} instance.
+     * @return a defined instance
+     */
+    @Override
+    protected JFlexXref newXref(Reader reader) {
+        return new JFlexXref(new OCamlXref(reader));
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ocaml/OCamlAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ocaml/OCamlAnalyzerFactory.java
@@ -1,0 +1,56 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2025, Yelisey Romanov <progoramur@gmail.com>.
+ */
+package org.opengrok.indexer.analysis.ocaml;
+
+import org.opengrok.indexer.analysis.AbstractAnalyzer.Genre;
+import org.opengrok.indexer.analysis.FileAnalyzer;
+import org.opengrok.indexer.analysis.FileAnalyzerFactory;
+
+/**
+ * Represents a factory to create {@link OCamlAnalyzer} instances.
+ */
+public class OCamlAnalyzerFactory extends FileAnalyzerFactory {
+
+    private static final String NAME = "OCaml";
+
+    private static final String[] SUFFIXES = {"ML", "MLI"};
+
+    /**
+     * Initializes a factory instance to associate a file extensions ".ml",
+     * ".mli" with {@link OCamlAnalyzer}.
+     */
+    public OCamlAnalyzerFactory() {
+        super(null, null, SUFFIXES, null, null, "text/plain", Genre.PLAIN,
+                NAME, true);
+    }
+
+    /**
+     * Creates a new {@link OCamlAnalyzer} instance.
+     * @return a defined instance
+     */
+    @Override
+    protected FileAnalyzer newAnalyzer() {
+        return new OCamlAnalyzer(this);
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ocaml/OCamlLexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/ocaml/OCamlLexer.java
@@ -1,0 +1,59 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2025, Yelisey Romanov <progoramur@gmail.com>.
+ */
+package org.opengrok.indexer.analysis.ocaml;
+
+import org.opengrok.indexer.analysis.JFlexJointLexer;
+import org.opengrok.indexer.analysis.JFlexSymbolMatcher;
+import org.opengrok.indexer.analysis.Resettable;
+
+/**
+ * Represents an abstract base class for OCaml lexers.
+ */
+@SuppressWarnings("Duplicates")
+abstract class OCamlLexer extends JFlexSymbolMatcher
+        implements JFlexJointLexer, Resettable {
+
+    /**
+     * Calls {@link #phLOC()} if the yystate is not COMMENT or SCOMMENT.
+     */
+    public void chkLOC() {
+        if (yystate() != COMMENT() && yystate() != SCOMMENT()) {
+            phLOC();
+        }
+    }
+
+    /**
+     * Subclasses must override to get the constant value created by JFlex to
+     * represent COMMENT.
+     */
+    @SuppressWarnings("java:S100")
+    abstract int COMMENT();
+
+    /**
+     * Subclasses must override to get the constant value created by JFlex to
+     * represent SCOMMENT.
+     */
+    @SuppressWarnings("java:S100")
+    abstract int SCOMMENT();
+}

--- a/opengrok-indexer/src/main/jflex/analysis/ocaml/OCaml.lexh
+++ b/opengrok-indexer/src/main/jflex/analysis/ocaml/OCaml.lexh
@@ -1,0 +1,132 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2025, Yelisey Romanov <progoramur@gmail.com>.
+ */
+
+Identifier = ({varid} | {conid} | {pvconid} | {typevarid})
+/*
+ * varid	→	(small {small | large | digit | ' })⟨reservedid⟩
+ * ; N.b. "except {reservedid} is excluded from OpenGrok's varid definition
+ */
+varid = {small} ({small} | {large} | {digit} | [\'])*
+/*
+ * conid	→	large {small | large | digit | ' }
+ */
+conid = {large} ({small} | {large} | {digit} | [\'])*
+/*
+ * polymorphic variant
+ * pvconid	→	`large {small | large | digit | ' }
+ */
+pvconid = [\`] {large} ({small} | {large} | {digit} | [\'])*
+/*
+ * type variable
+ * typevarid	→	'small {small | large | digit }
+ */
+typevarid = [\'] {small} ({small} | {large} | {digit})*
+/*
+ * small	→	ascSmall | uniSmall | _
+ * ascSmall	→	a | b | … | z
+ */
+small = [a-z_]
+/*
+ * large	→	ascLarge | uniLarge
+ * ascLarge	→	A | B | … | Z
+ */
+large = [A-Z]
+/*
+ * digit	→	ascDigit | uniDigit
+ * ascDigit	→	0 | 1 | … | 9
+ * uniDigit	→	any Unicode decimal digit
+ * octit	→	0 | 1 | … | 7
+ * hexit	→	digit | A | … | F | a | … | f
+ */
+digit = [0-9]
+octit = [0-7]
+hexit = [0-9A-Fa-f]
+binit = [0-1]
+
+Number = ({integer} | {float})
+/*
+ * decimal      → digit{digit}
+ * octal        → octit{octit}
+ * hexadecimal	→ hexit{hexit}
+ */
+decimal         = {digit}({digit} | _)*
+octal           = {octit}({octit} | _)*
+hexadecimal     = {hexit}({hexit} | _)*
+binary          = {binit}({binit} | _)*
+
+/*
+ * integer	→	decimal
+ *		|	0o octal | 0O octal
+ *		|	0x hexadecimal | 0X hexadecimal
+ *		|	0b binary | 0B binary
+ */
+integer = ({decimal} | [0][oO]{octal} | [0][xX]{hexadecimal} | [0][bB]{binary} ) ( l | L | n)?
+
+/*
+ * float	→	decimal . decimal [exponent]
+ *		|	decimal exponent
+ */
+float = ({decimal} [\.] {decimal} {exponent}? |
+    {decimal} {exponent})
+
+/*
+ * exponent	→	(e | E) [+ | -] decimal
+ */
+exponent = [eE] [\+\-]? {decimal}
+
+/*
+ * Special treatment of chars is due to type variables with quote
+ *
+ * char literal	→ '\n' | '[^ '\\' '\'' '\010' '\013']'
+           | escaped_char | dec_code | oct_code | hex_code
+ */
+Character = ( {newline_char} | {regular_char} | {escaped_char} |
+              {deccode_char} | {octcode_char} | {hexcode_char})
+
+newline_char = \' \n \'
+regular_char = \' [^ \\ \' '\010' '\013'] \'
+escaped_char = \' \\ [\\ \' \" n t b r ' '] \'
+deccode_char = \' \\ {digit}{digit}{digit} \'
+octcode_char = \' \\ o {octit}{octit}{octit} \'
+hexcode_char = \' \\ x {hexit}{hexit}{hexit} \'
+
+/*
+ * Extension	→	%attrid | %%attrid | @attrid
+ */
+lowercase = {varid}
+uppercase = {conid}
+
+attrid = ({lowercase} | {uppercase}) ( [\.] | {lowercase} | {uppercase})*
+
+Extension = \[ [ ]* @{attrid} | \[ [ ]* @@ {attrid} | \[ [ ]* @@@ {attrid} |
+            \% {attrid} | \%\% {attrid}
+
+QuotedStringBegin = \{ {lowercase}* \|
+QuotedStringEnd   = \| {lowercase}* \}
+
+/*
+ * Syntax sugar for extension nodes with quoted strings.
+ */
+QuotedExtensionBegin = \{ (\% {attrid} | \%\% {attrid}) [ ]*
+QuotedExtensionKey = {lowercase}* \|

--- a/opengrok-indexer/src/main/jflex/analysis/ocaml/OCamlSymbolTokenizer.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/ocaml/OCamlSymbolTokenizer.lex
@@ -1,0 +1,126 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2025, Yelisey Romanov <progoramur@gmail.com>.
+ */
+
+/*
+ * Get OCaml symbols
+ */
+
+package org.opengrok.indexer.analysis.ocaml;
+
+import java.io.IOException;
+import org.opengrok.indexer.analysis.JFlexSymbolMatcher;
+
+/**
+ * @author Harry Pan
+ */
+%%
+%public
+%class OCamlSymbolTokenizer
+%extends JFlexSymbolMatcher
+%unicode
+%int
+%include ../CommonLexer.lexh
+%char
+%{
+    private int nestedComment;
+    private String quotedStringKey;
+
+    public void reset() {
+        super.reset();
+        nestedComment = 0;
+        quotedStringKey = "";
+    }
+%}
+
+%state STRING QSTRING QEXTENSIONBEGIN BCOMMENT
+
+%include ../Common.lexh
+%include OCaml.lexh
+%%
+
+<YYINITIAL> {
+    {Character} {}
+    {Identifier} {
+        String id = yytext();
+        if (!Consts.kwd.contains(id)) {
+            onSymbolMatched(id, yychar);
+            return yystate();
+        }
+    }
+    {Extension} {}
+    {Number}    {}
+    \"   { yybegin(STRING);   }
+    {QuotedStringBegin} {
+        String key = yytext();
+        quotedStringKey = key.substring(1, key.length() - 1);
+        yybegin(QSTRING);
+    }
+    {QuotedExtensionBegin}     {
+        yypush(QEXTENSIONBEGIN);
+    }
+}
+
+<STRING> {
+    \\[\"\\]    {}
+    \"   { yybegin(YYINITIAL); }
+}
+
+<QSTRING> {
+    {QuotedStringEnd} {
+        String key = yytext();
+        if (quotedStringKey.equals(
+              key.substring(1, key.length() - 1))) {
+            quotedStringKey = "";
+            yybegin(YYINITIAL);
+        }
+    }
+}
+
+<QEXTENSIONBEGIN> {
+    {QuotedExtensionKey}         {
+        String key = yytext();
+        quotedStringKey = key.substring(0, key.length() - 1);
+        yybegin(QSTRING);
+    }
+}
+
+<YYINITIAL, BCOMMENT> {
+    "(*"    {
+        if (nestedComment++ == 0) {
+            yybegin(BCOMMENT);
+        }
+    }
+}
+
+<BCOMMENT> {
+    "*)"    {
+        if (--nestedComment == 0) {
+            yybegin(YYINITIAL);
+        }
+    }
+}
+
+// fallback
+{WhspChar}+ |
+[^] {}

--- a/opengrok-indexer/src/main/jflex/analysis/ocaml/OCamlXref.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/ocaml/OCamlXref.lex
@@ -1,0 +1,244 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2025, Yelisey Romanov <progoramur@gmail.com>.
+ */
+
+/*
+ * Cross reference a OCaml file
+ */
+
+package org.opengrok.indexer.analysis.ocaml;
+
+import java.io.IOException;
+import org.opengrok.indexer.analysis.JFlexSymbolMatcher;
+import org.opengrok.indexer.web.HtmlConsts;
+
+/**
+ * @author 
+ */
+%%
+%public
+%class OCamlXref
+%extends JFlexSymbolMatcher
+%unicode
+%int
+%char
+%include ../CommonLexer.lexh
+%include ../CommonXref.lexh
+%{
+    private int nestedComment;
+    private String quotedStringKey;
+
+    @Override
+    public void reset() {
+        super.reset();
+        nestedComment = 0;
+        quotedStringKey = "";
+    }
+
+    @Override
+    public void yypop() throws IOException {
+        onDisjointSpanChanged(null, yychar);
+        super.yypop();
+    }
+
+    protected void chkLOC() {
+        switch (yystate()) {
+            case BCOMMENT:
+                break;
+            default:
+                phLOC();
+                break;
+        }
+    }
+%}
+
+%state STRING QSTRING QEXTENSIONBEGIN BCOMMENT
+
+%include ../Common.lexh
+%include ../CommonURI.lexh
+%include ../CommonPath.lexh
+%include OCaml.lexh
+%%
+<YYINITIAL> {
+    {Character}  {
+        chkLOC();
+        onDisjointSpanChanged(HtmlConsts.STRING_CLASS, yychar);
+        onNonSymbolMatched(yytext(), yychar);
+        onDisjointSpanChanged(null, yychar);
+    }
+    {Identifier} {
+        chkLOC();
+        String id = yytext();
+        onFilteredSymbolMatched(id, yychar, Consts.kwd);
+    }
+    {Extension}     {
+        chkLOC();
+        onDisjointSpanChanged(HtmlConsts.MACRO_CLASS, yychar);
+        onNonSymbolMatched(yytext(), yychar);
+        onDisjointSpanChanged(null, yychar);
+    }
+    {Number}     {
+        chkLOC();
+        onDisjointSpanChanged(HtmlConsts.NUMBER_CLASS, yychar);
+        onNonSymbolMatched(yytext(), yychar);
+        onDisjointSpanChanged(null, yychar);
+    }
+}
+
+<STRING> {
+    \\[\"\\]    { chkLOC(); onNonSymbolMatched(yytext(), yychar); }
+    \"          {
+        chkLOC();
+        onNonSymbolMatched(yytext(), yychar);
+        yypop();
+        if (nestedComment > 0) {
+            onDisjointSpanChanged(HtmlConsts.COMMENT_CLASS, yychar);
+        }
+    }
+    /*
+     * "A string may include a 'gap'-—two backslants enclosing white
+     * characters—-which is ignored. This allows one to write long strings on
+     * more than one line by writing a backslant at the end of one line and at
+     * the start of the next." N.b. OpenGrok does not explicltly recognize the
+     * "gap" but since a STRING must end in a non-escaped quotation mark, just
+     * allow STRINGs to be multi-line regardless of syntax.
+     */
+}
+
+<QEXTENSIONBEGIN> {
+    {QuotedExtensionKey}         {
+        chkLOC();
+        yypop();
+        yypush(QSTRING);
+        if (nestedComment > 0) {
+            onDisjointSpanChanged(HtmlConsts.COMMENT_CLASS, yychar);
+        } else {
+            onDisjointSpanChanged(HtmlConsts.STRING_CLASS, yychar);
+        }
+        onNonSymbolMatched(yytext(), yychar);
+
+        String key = yytext();
+        quotedStringKey = key.substring(0, key.length() - 1);
+    }
+}
+
+<QSTRING> {
+    {QuotedStringEnd}        {
+        String key = yytext();
+        if (quotedStringKey.equals(
+              key.substring(1, key.length() - 1))) {
+            quotedStringKey = "";
+            chkLOC();
+            onNonSymbolMatched(yytext(), yychar);
+            yypop();
+            if (nestedComment > 0) {
+                onDisjointSpanChanged(HtmlConsts.COMMENT_CLASS, yychar);
+            }
+        } else {
+            chkLOC();
+            onNonSymbolMatched(yytext(), yychar);
+        }
+    }
+    /*
+     * "A string may include a 'gap'-—two backslants enclosing white
+     * characters—-which is ignored. This allows one to write long strings on
+     * more than one line by writing a backslant at the end of one line and at
+     * the start of the next." N.b. OpenGrok does not explicitly recognize the
+     * "gap" but since a STRING must end in a non-escaped quotation mark, just
+     * allow STRINGs to be multi-line regardless of syntax.
+     */
+}
+
+<YYINITIAL, BCOMMENT> {
+    "(*"    {
+        if (nestedComment++ == 0) {
+            yypush(BCOMMENT);
+            onDisjointSpanChanged(HtmlConsts.COMMENT_CLASS, yychar);
+        }
+        onNonSymbolMatched(yytext(), yychar);
+    }
+    \"           {
+        chkLOC();
+        yypush(STRING);
+        if (nestedComment == 0) {
+            onDisjointSpanChanged(HtmlConsts.STRING_CLASS, yychar);
+        }
+        onNonSymbolMatched(yytext(), yychar);
+    }
+    {QuotedStringBegin}         {
+        chkLOC();
+        yypush(QSTRING);
+        if (nestedComment == 0) {
+            onDisjointSpanChanged(HtmlConsts.STRING_CLASS, yychar);
+        }
+        onNonSymbolMatched(yytext(), yychar);
+
+        String key = yytext();
+        quotedStringKey = key.substring(1, key.length() - 1);
+    }
+    {QuotedExtensionBegin}     {
+        chkLOC();
+        if (nestedComment == 0) {
+            onDisjointSpanChanged(HtmlConsts.MACRO_CLASS, yychar);
+        }
+        onNonSymbolMatched(yytext(), yychar);
+        yypush(QEXTENSIONBEGIN);
+    }
+}
+
+<BCOMMENT> {
+    "*)"    {
+        onNonSymbolMatched(yytext(), yychar);
+        if (--nestedComment == 0) {
+            yypop();
+        }
+    }
+}
+
+{WhspChar}*{EOL}    { onEndOfLineMatched(yytext(), yychar); }
+[[\s]--[\n]]        { onNonSymbolMatched(yytext(), yychar); }
+[^\n]               { chkLOC(); onNonSymbolMatched(yytext(), yychar); }
+
+<STRING, BCOMMENT> {
+    {FPath}    {
+        chkLOC();
+        onPathlikeMatched(yytext(), '/', false, yychar);
+    }
+    {FNameChar}+ "@" {FNameChar}+ "." {FNameChar}+    {
+        chkLOC();
+        onEmailAddressMatched(yytext(), yychar);
+    }
+}
+
+<STRING> {
+    {BrowseableURI}    {
+        chkLOC();
+        onUriMatched(yytext(), yychar);
+    }
+}
+
+<BCOMMENT> {
+    {BrowseableURI} \}?    {
+        onUriMatched(yytext(), yychar);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
I am signing Oracle Contributor Agreement. 

This pull request adds support for OCaml. 

Almost full support for OCaml syntax is provided including quoted string literals and extension nodes. The support for docstrings is not implemented. Also, primitive types are added to the list of keywords because most programmers do not use them as variable names (`result` is an exception). 