### PR TITLE
switch to Java 21 for build/Docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os }} with Java 17
+    name: ${{ matrix.os }} with Java 21
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -22,11 +22,11 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up JDK 17
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
         distribution: 'oracle'
-        java-version: '17'
+        java-version: '21'
     - name: Cache Maven packages
       uses: actions/cache@v4
       with:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
     - name: Checkout master branch
       uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
         distribution: 'oracle'
-        java-version: '17'
+        java-version: '21'
     - name: Cache Maven packages
       uses: actions/cache@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
     - name: Checkout master branch
       uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
         distribution: 'oracle'
-        java-version: '17'
+        java-version: '21'
     - name: Cache Maven packages
       uses: actions/cache@v4
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2025 Oracle and/or its affiliates. All rights reserved.
 # Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
 
 FROM ubuntu:jammy AS build
@@ -41,7 +41,7 @@ RUN cp `ls -t distribution/target/*.tar.gz | head -1` /opengrok.tar.gz
 # Store the version in a file so that the tools can report it.
 RUN /mvn/mvnw help:evaluate -Dexpression=project.version -q -DforceStdout > /mvn/VERSION
 
-FROM tomcat:10.1.40-jdk17
+FROM tomcat:10.1.40-jdk21
 LABEL maintainer="https://github.com/oracle/opengrok"
 LABEL org.opencontainers.image.source="https://github.com/oracle/opengrok"
 LABEL org.opencontainers.image.description="OpenGrok code search"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:jammy AS build
 
 # hadolint ignore=DL3008
-RUN apt-get update && apt-get install --no-install-recommends -y openjdk-17-jdk python3 python3-venv && \
+RUN apt-get update && apt-get install --no-install-recommends -y openjdk-21-jdk python3 python3-venv && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,7 @@ image based on the official one.
 ## Additional info about the image
 
 * Tomcat 10
-* JRE 17
+* JRE 21
 * Configurable mirroring/reindexing (default every 10 min)
 
 The mirroring step works by going through all projects and attempting to

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Definitions.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Definitions.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
@@ -66,7 +66,7 @@ public class Definitions implements Serializable {
 
         private static final long serialVersionUID = 1191703801007779481L;
         @SuppressWarnings("java:S116")
-        private final Map<String, Set<Tag>> sym_tags; //NOPMD
+        private final HashMap<String, Set<Tag>> sym_tags; //NOPMD
 
         protected LineTagMap() {
             this.sym_tags = new HashMap<>();
@@ -74,16 +74,16 @@ public class Definitions implements Serializable {
     }
     // line number -> tag map
     @SuppressWarnings("java:S116")
-    private final Map<Integer, LineTagMap> line_maps;
+    private final HashMap<Integer, LineTagMap> line_maps;
 
     /**
      * Map from symbol to the line numbers on which the symbol is defined.
      */
-    private final Map<String, Set<Integer>> symbols;
+    private final HashMap<String, Set<Integer>> symbols;
     /**
      * List of all the tags.
      */
-    private final List<Tag> tags;
+    private final ArrayList<Tag> tags;
 
     public Definitions() {
         symbols = new HashMap<>();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/JFlexTokenizer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/JFlexTokenizer.java
@@ -18,7 +18,7 @@
  */
 
  /*
- * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
@@ -49,6 +49,7 @@ public class JFlexTokenizer extends Tokenizer
      * will be owned by the {@link JFlexTokenizer}.
      * @param matcher a defined instance
      */
+    @SuppressWarnings("this-escape")
     public JFlexTokenizer(ScanningSymbolMatcher matcher) {
         if (matcher == null) {
             throw new IllegalArgumentException("`matcher' is null");
@@ -83,12 +84,9 @@ public class JFlexTokenizer extends Tokenizer
         matcher.yyclose();
     }
 
-    private final CharTermAttribute termAtt = addAttribute(
-        CharTermAttribute.class);
-    private final OffsetAttribute offsetAtt = addAttribute(
-        OffsetAttribute.class);
-    private final PositionIncrementAttribute posIncrAtt = addAttribute(
-        PositionIncrementAttribute.class);
+    private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+    private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
+    private final PositionIncrementAttribute posIncrAtt = addAttribute(PositionIncrementAttribute.class);
 
     /**
      * Attempts to advance the stream to the next acceptable token, and updates

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/JFlexXref.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/JFlexXref.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2011, Jens Elkner.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
@@ -37,8 +37,7 @@ import org.opengrok.indexer.web.Util;
 /**
  * @author Lubos Kosco
  */
-public class JFlexXref implements Xrefer, SymbolMatchedListener,
-        NonSymbolMatchedListener {
+public class JFlexXref implements Xrefer, SymbolMatchedListener, NonSymbolMatchedListener {
 
     /**
      * Used to indicate pre-formatted output with
@@ -99,6 +98,7 @@ public class JFlexXref implements Xrefer, SymbolMatchedListener,
      * will be owned by the {@link JFlexXref}.
      * @param matcher a defined instance
      */
+    @SuppressWarnings("this-escape")
     public JFlexXref(ScanningSymbolMatcher matcher) {
         if (matcher == null) {
             throw new IllegalArgumentException("`matcher' is null");
@@ -109,11 +109,11 @@ public class JFlexXref implements Xrefer, SymbolMatchedListener,
         // The xrefer will own the matcher, so we won't have to unsubscribe.
 
         userPageLink = RuntimeEnvironment.getInstance().getUserPage();
-        if (userPageLink != null && userPageLink.length() == 0) {
+        if (userPageLink != null && userPageLink.isEmpty()) {
             userPageLink = null;
         }
         userPageSuffix = RuntimeEnvironment.getInstance().getUserPageSuffix();
-        if (userPageSuffix != null && userPageSuffix.length() == 0) {
+        if (userPageSuffix != null && userPageSuffix.isEmpty()) {
             userPageSuffix = null;
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/PathTokenizer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/PathTokenizer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
@@ -52,7 +52,9 @@ public class PathTokenizer extends Tokenizer {
     // below should be '/' since we try to convert even windows file separators
     // to unix ones
     public static final char DEFAULT_DELIMITER = '/';
+    @SuppressWarnings("this-escape")
     private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+    @SuppressWarnings("this-escape")
     private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
     private int startPosition = 0;
     private final char delimiter;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/DefinitionsTokenStream.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/plain/DefinitionsTokenStream.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.plain;
@@ -48,12 +48,12 @@ public class DefinitionsTokenStream extends TokenStream {
      */
     private final List<PendingToken> events = new ArrayList<>();
 
-    private final CharTermAttribute termAtt = addAttribute(
-        CharTermAttribute.class);
-    private final OffsetAttribute offsetAtt = addAttribute(
-        OffsetAttribute.class);
-    private final PositionIncrementAttribute posIncrAtt = addAttribute(
-        PositionIncrementAttribute.class);
+    @SuppressWarnings("this-escape")
+    private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+    @SuppressWarnings("this-escape")
+    private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
+    @SuppressWarnings("this-escape")
+    private final PositionIncrementAttribute posIncrAtt = addAttribute(PositionIncrementAttribute.class);
 
     private int offset;
 
@@ -65,8 +65,7 @@ public class DefinitionsTokenStream extends TokenStream {
      * @param wrapper an optional instance
      * @throws IOException if I/O error occurs
      */
-    public void initialize(Definitions defs, StreamSource src,
-            ReaderWrapper wrapper) throws IOException {
+    public void initialize(Definitions defs, StreamSource src, ReaderWrapper wrapper) throws IOException {
         if (defs == null) {
             throw new IllegalArgumentException("`defs' is null");
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationEntity.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationEntity.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.authorization;
@@ -119,14 +119,14 @@ public abstract class AuthorizationEntity implements Nameable, Serializable, Clo
      */
     protected AuthControlFlag flag;
     protected String name;
-    protected Map<String, Object> setup = new TreeMap<>();
+    protected transient Map<String, Object> setup = new TreeMap<>();
     /**
      * Hold current setup - merged with all ancestor's stacks.
      */
     protected transient Map<String, Object> currentSetup = new TreeMap<>();
 
-    private Set<String> forProjects = new TreeSet<>();
-    private Set<String> forGroups = new TreeSet<>();
+    private transient Set<String> forProjects = new TreeSet<>();
+    private transient Set<String> forGroups = new TreeSet<>();
 
     protected transient boolean working = true;
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationStack.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/authorization/AuthorizationStack.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.authorization;
@@ -51,7 +51,7 @@ public class AuthorizationStack extends AuthorizationEntity {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationStack.class);
 
-    private List<AuthorizationEntity> stack = new ArrayList<>();
+    private transient List<AuthorizationEntity> stack = new ArrayList<>();
 
     public AuthorizationStack() {
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Filter.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Filter.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;
@@ -37,11 +37,11 @@ public class Filter implements Serializable {
     private static final long serialVersionUID = 3L;
 
     /** The list of exact filenames. */
-    private final Set<String> filenames;
+    private final transient Set<String> filenames;
     /** The list of filenames with wildcards. */
-    private final List<Pattern> patterns;
+    private final transient List<Pattern> patterns;
     /** The list of paths. */
-    private final List<String> paths;
+    private final transient List<String> paths;
     /**
      * The full list of all patterns. This list will be saved in the
      * configuration file (if used).

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuggesterConfig.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/SuggesterConfig.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;
@@ -170,7 +170,7 @@ public class SuggesterConfig {
         return enabled;
     }
 
-    public void setEnabled(final boolean enabled) {
+    public final void setEnabled(final boolean enabled) {
         this.enabled = enabled;
     }
 
@@ -178,7 +178,7 @@ public class SuggesterConfig {
         return maxResults;
     }
 
-    public void setMaxResults(final int maxResults) {
+    public final void setMaxResults(final int maxResults) {
         if (maxResults <= 0) {
             throw new IllegalArgumentException("Max results cannot be negative or zero");
         }
@@ -189,7 +189,7 @@ public class SuggesterConfig {
         return minChars;
     }
 
-    public void setMinChars(final int minChars) {
+    public final void setMinChars(final int minChars) {
         if (minChars < 0) {
             throw new IllegalArgumentException(
                     "Minimum number of characters needed for suggester to provide suggestions cannot be negative");
@@ -201,7 +201,7 @@ public class SuggesterConfig {
         return allowedProjects;
     }
 
-    public void setAllowedProjects(final Set<String> allowedProjects) {
+    public final void setAllowedProjects(final Set<String> allowedProjects) {
         this.allowedProjects = allowedProjects;
     }
 
@@ -209,7 +209,7 @@ public class SuggesterConfig {
         return maxProjects;
     }
 
-    public void setMaxProjects(final int maxProjects) {
+    public final void setMaxProjects(final int maxProjects) {
         if (maxProjects < 1) {
             throw new IllegalArgumentException("Maximum projects for suggestions cannot be less than 1");
         }
@@ -220,7 +220,7 @@ public class SuggesterConfig {
         return allowedFields;
     }
 
-    public void setAllowedFields(final Set<String> allowedFields) {
+    public final void setAllowedFields(final Set<String> allowedFields) {
         this.allowedFields = new HashSet<>(allowedFields);
     }
 
@@ -228,7 +228,7 @@ public class SuggesterConfig {
         return allowComplexQueries;
     }
 
-    public void setAllowComplexQueries(final boolean allowComplexQueries) {
+    public final void setAllowComplexQueries(final boolean allowComplexQueries) {
         this.allowComplexQueries = allowComplexQueries;
     }
 
@@ -236,7 +236,7 @@ public class SuggesterConfig {
         return allowMostPopular;
     }
 
-    public void setAllowMostPopular(final boolean allowMostPopular) {
+    public final void setAllowMostPopular(final boolean allowMostPopular) {
         this.allowMostPopular = allowMostPopular;
     }
 
@@ -244,7 +244,7 @@ public class SuggesterConfig {
         return showScores;
     }
 
-    public void setShowScores(final boolean showScores) {
+    public final void setShowScores(final boolean showScores) {
         this.showScores = showScores;
     }
 
@@ -252,7 +252,7 @@ public class SuggesterConfig {
         return showProjects;
     }
 
-    public void setShowProjects(final boolean showProjects) {
+    public final void setShowProjects(final boolean showProjects) {
         this.showProjects = showProjects;
     }
 
@@ -260,7 +260,7 @@ public class SuggesterConfig {
         return showTime;
     }
 
-    public void setShowTime(final boolean showTime) {
+    public final void setShowTime(final boolean showTime) {
         this.showTime = showTime;
     }
 
@@ -268,7 +268,7 @@ public class SuggesterConfig {
         return rebuildCronConfig;
     }
 
-    public void setRebuildCronConfig(final String rebuildCronConfig) {
+    public final void setRebuildCronConfig(final String rebuildCronConfig) {
         if (rebuildCronConfig != null) { // check cron format
             CronParser parser = new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX));
             parser.parse(rebuildCronConfig); // throws IllegalArgumentException if invalid
@@ -280,7 +280,7 @@ public class SuggesterConfig {
         return buildTerminationTime;
     }
 
-    public void setBuildTerminationTime(final int buildTerminationTime) {
+    public final void setBuildTerminationTime(final int buildTerminationTime) {
         if (buildTerminationTime < 0) {
             throw new IllegalArgumentException("Suggester build termination time cannot be negative");
         }
@@ -291,14 +291,14 @@ public class SuggesterConfig {
         return timeThreshold;
     }
 
-    public void setTimeThreshold(final int timeThreshold) {
+    public final void setTimeThreshold(final int timeThreshold) {
         if (timeThreshold < 0) {
             throw new IllegalArgumentException("Time threshold for suggestions cannot be negative");
         }
         this.timeThreshold = timeThreshold;
     }
 
-    public void setRebuildThreadPoolSizeInNcpuPercent(final int percent) {
+    public final void setRebuildThreadPoolSizeInNcpuPercent(final int percent) {
         if (percent < 0 || percent > 100) {
             throw new IllegalArgumentException("Need percentage value");
         }
@@ -309,7 +309,7 @@ public class SuggesterConfig {
         return rebuildThreadPoolSizeInNcpuPercent;
     }
 
-    public void setSearchThreadPoolSizeInNcpuPercent(final int percent) {
+    public final void setSearchThreadPoolSizeInNcpuPercent(final int percent) {
         if (percent < 0 || percent > 100) {
             throw new IllegalArgumentException("Need percentage value");
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/framework/PluginFramework.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.framework;
 
@@ -97,7 +97,7 @@ public abstract class PluginFramework<P> {
      *
      * @param pluginDirectory the directory
      */
-    public synchronized void setPluginDirectory(File pluginDirectory) {
+    public final synchronized void setPluginDirectory(File pluginDirectory) {
         this.pluginDirectory = pluginDirectory;
     }
 
@@ -106,7 +106,7 @@ public abstract class PluginFramework<P> {
      *
      * @param directory the directory path
      */
-    public synchronized void setPluginDirectory(String directory) {
+    public final synchronized void setPluginDirectory(String directory) {
         setPluginDirectory(directory != null ? new File(directory) : null);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AccuRevRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AccuRevRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -96,6 +96,7 @@ public class AccuRevRepository extends Repository {
      */
     private static final String DEPOT_ROOT = String.format("%s.%s", File.separator, File.separator);
 
+    @SuppressWarnings("this-escape")
     public AccuRevRepository() {
         type = "AccuRev";
         datePatterns = new String[]{

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Krystof Tulinger <k.tulinger@seznam.cz>.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2023, Ric Harris <harrisric@users.noreply.github.com>.
@@ -123,9 +123,9 @@ public class Annotation {
     /**
      * Gets all revisions that are in use, first is the lowest one (sorted using natural order).
      *
-     * @return list of all revisions the file has
+     * @return set of all revisions the file has
      */
-    public Set<String> getRevisions() {
+    public final Set<String> getRevisions() {
         return annotationData.getRevisions();
     }
 
@@ -180,7 +180,7 @@ public class Annotation {
      * @param revision revision number
      * @return file version number. 0 if unknown. 1 first version of file, etc.
      */
-    public int getFileVersion(String revision) {
+    public final int getFileVersion(String revision) {
         return fileVersions.getOrDefault(revision, 0);
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AnnotationData.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AnnotationData.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2023, Ric Harris <harrisric@users.noreply.github.com>.
  */
 package org.opengrok.indexer.history;
@@ -52,7 +52,7 @@ public class AnnotationData implements Serializable {
         this.filename = filename;
     }
 
-    private List<AnnotationLine> annotationLines = new ArrayList<>();
+    private transient List<AnnotationLine> annotationLines = new ArrayList<>();
     private int widestRevision;
     private int widestAuthor;
     private String filename;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BitKeeperRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BitKeeperRepository.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2017, James Service <jas2701@googlemail.com>
- * Portions Copyright (c) 2017, 2021, Oracle and/or its affiliates.
+ * Portions Copyright (c) 2017, 2025, Oracle and/or its affiliates.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -88,7 +88,7 @@ public class BitKeeperRepository extends Repository {
     /**
      * The version of the BitKeeper executable. This affects the correct dspec to use for tags.
      */
-    private Version version = null;
+    private transient Version version = null;
 
     /**
      * Constructor to construct the thing to be constructed.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/CVSRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -58,6 +58,7 @@ public class CVSRepository extends RCSRepository {
      */
     public static final String CMD_FALLBACK = "cvs";
 
+    @SuppressWarnings("this-escape")
     public CVSRepository() {
         /*
          * This variable is set in the ancestor to TRUE which has a side effect

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/History.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -46,12 +46,12 @@ public class History implements Serializable {
     static final String TAGS_SEPARATOR = ", ";
 
     /** Entries in the log. The first entry is the most recent one. */
-    private List<HistoryEntry> entries;
+    private transient List<HistoryEntry> entries;
     /**
      * Track renamed files, so they can be treated in special way (for some SCMs) during cache creation.
      * These are relative to repository root.
      */
-    private final Set<String> renamedFiles;
+    private final transient Set<String> renamedFiles;
 
     /**
      * Revision of the newest change. Used in history cache.
@@ -59,7 +59,7 @@ public class History implements Serializable {
     private String latestRev;
 
     // revision to tag list. Individual tags are joined via TAGS_SEPARATOR.
-    private Map<String, String> tags = new HashMap<>();
+    private transient Map<String, String> tags = new HashMap<>();
 
     public History() {
         this(new ArrayList<>());

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryEntry.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -57,7 +57,7 @@ public class HistoryEntry implements Serializable {
 
     private boolean active;
     @JsonIgnore
-    private SortedSet<String> files;
+    private transient SortedSet<String> files;
 
     /** Creates a new instance of HistoryEntry. */
     public HistoryEntry() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepoRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepoRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2010, Trond Norbye <trond.norbye@gmail.com>. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
@@ -48,6 +48,7 @@ public class RepoRepository extends Repository {
      */
     public static final String CMD_FALLBACK = "repo";
 
+    @SuppressWarnings("this-escape")
     public RepoRepository() {
         type = "repo";
         setWorking(Boolean.TRUE);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -78,15 +78,15 @@ public abstract class Repository extends RepositoryInfo {
      */
     protected String RepoCommand;
 
-    protected final List<String> ignoredFiles;
+    protected final transient List<String> ignoredFiles;
 
-    protected final List<String> ignoredDirs;
+    protected final transient List<String> ignoredDirs;
 
     /**
      * List of &lt;revision, tags&gt; pairs for repositories which display tags
      * only for files changed by the tagged commit.
      */
-    protected NavigableSet<TagEntry> tagList = null;
+    protected transient NavigableSet<TagEntry> tagList = null;
 
     abstract boolean fileHasHistory(File file);
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SSCMRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/SSCMRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -70,6 +70,7 @@ public class SSCMRepository extends Repository {
     private static final String BRANCH_PROPERTY = "SCMBranch";
     private static final String REPOSITORY_PROPERTY = "SCMRepository";
 
+    @SuppressWarnings("this-escape")
     public SSCMRepository() {
         setType("SSCM");
         setRemote(true);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexAnalysisSettings.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexAnalysisSettings.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Portions Copyright (c) 2025, Oracle and/or its affiliates.
  * Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -69,7 +70,7 @@ public final class IndexAnalysisSettings implements Serializable {
      * de-serialization circumvents normal construction.
      * @serial
      */
-    private Map<String, Long> analyzersVersions = new HashMap<>();
+    private transient Map<String, Long> analyzersVersions = new HashMap<>();
 
     /**
      * Gets the project name to be used to distinguish different instances of

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexAnalysisSettings3.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexAnalysisSettings3.java
@@ -18,6 +18,7 @@
  */
 
 /*
+ * Portions Copyright (c) 2025, Oracle and/or its affiliates.
  * Copyright (c) 2018, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.index;
@@ -69,7 +70,7 @@ public final class IndexAnalysisSettings3 implements Serializable {
      * de-serialization circumvents normal construction.
      * @serial
      */
-    private Map<String, Long> analyzersVersions = new HashMap<>();
+    private transient Map<String, Long> analyzersVersions = new HashMap<>();
 
     /**
      * Nullable because otherwise custom de-serialization does not work, as a
@@ -78,7 +79,7 @@ public final class IndexAnalysisSettings3 implements Serializable {
      * anything but a simple {@link HashMap} here.
      * @serial
      */
-    private Map<String, IndexedSymlink> indexedSymlinks = new HashMap<>();
+    private transient Map<String, IndexedSymlink> indexedSymlinks = new HashMap<>();
 
     /**
      * Gets the project name to be used to distinguish different instances of

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheckException.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexCheckException.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.index;
 
@@ -33,7 +33,7 @@ import java.util.Set;
 public class IndexCheckException extends Exception {
     private static final long serialVersionUID = 5693446916108385595L;
 
-    private final Set<Path> failedPaths = new HashSet<>();
+    private final transient Set<Path> failedPaths = new HashSet<>();
 
     public IndexCheckException(String message, Path path) {
         super(message);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDocumentException.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexDocumentException.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.index;
 
@@ -32,8 +32,8 @@ import java.util.Set;
 public class IndexDocumentException extends IndexCheckException {
     private static final long serialVersionUID = -277429315137557112L;
 
-    private final Map<Path, Integer> duplicatePathMap;
-    private final Set<Path> missingPaths;
+    private final transient Map<Path, Integer> duplicatePathMap;
+    private final transient Set<Path> missingPaths;
 
     public IndexDocumentException(String s, Path path) {
         super(s, path);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/CustomQueryParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/CustomQueryParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search;
@@ -40,6 +40,7 @@ public class CustomQueryParser extends QueryParser {
      *
      * @param field default field for unqualified query terms
      */
+    @SuppressWarnings("this-escape")
     public CustomQueryParser(String field) {
         super(field, new CompatibleAnalyser());
         setDefaultOperator(AND_OPERATOR);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/PrefixMatcher.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/PrefixMatcher.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.search.context;
 
@@ -28,6 +28,7 @@ package org.opengrok.indexer.search.context;
 public class PrefixMatcher extends LineMatcher {
     private final String prefix;
 
+    @SuppressWarnings("this-escape")
     public PrefixMatcher(String prefix, boolean caseInsensitive) {
         super(caseInsensitive);
         this.prefix = normalizeString(prefix);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/TokenSetMatcher.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/TokenSetMatcher.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.search.context;
 
@@ -28,6 +28,7 @@ import java.util.TreeSet;
 public class TokenSetMatcher extends LineMatcher {
     private final Set<String> tokenSet;
 
+    @SuppressWarnings("this-escape")
     public TokenSetMatcher(Set<String> tokenSet, boolean caseInsensitive) {
         super(caseInsensitive);
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/WildCardMatcher.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/WildCardMatcher.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * Portions Apache software license, see below
  *
@@ -29,6 +29,7 @@ public class WildCardMatcher extends LineMatcher {
 
     final String pattern;
 
+    @SuppressWarnings("this-escape")
     public WildCardMatcher(String pattern, boolean caseInsensitive) {
         super(caseInsensitive);
         this.pattern = normalizeString(pattern);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Progress.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.util;
@@ -189,7 +189,7 @@ public class Progress implements AutoCloseable {
     }
 
     @VisibleForTesting
-    Level getLevel(Map<Level, Long> lastLoggedChunk, long currentCount, Level currentLevel) {
+    final Level getLevel(Map<Level, Long> lastLoggedChunk, long currentCount, Level currentLevel) {
         // The intention is to log the initial and final count at the base log level.
         if (currentCount <= 1 || (totalCount != null && currentCount == totalCount)) {
             currentLevel = baseLogLevel;

--- a/opengrok-indexer/src/main/jflex/search/context/PlainLineTokenizer.lex
+++ b/opengrok-indexer/src/main/jflex/search/context/PlainLineTokenizer.lex
@@ -18,12 +18,9 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 
-/**
- * for plain text tokenizers
- */
 package org.opengrok.indexer.search.context;
 
 import java.io.CharArrayReader;
@@ -37,6 +34,9 @@ import org.opengrok.indexer.web.Util;
 import org.opengrok.indexer.analysis.Scopes;
 import org.opengrok.indexer.analysis.Scopes.Scope;
 
+/**
+ * for plain text tokenizers
+ */
 %%
 
 %public

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/DefinitionsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/DefinitionsTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
@@ -140,9 +140,9 @@ class DefinitionsTest {
         Definitions instance = new Definitions();
         instance.addTag(1, "one", "", "", 0, 0);
         byte[] serial = instance.serialize();
-        Definitions instance2 = Definitions.deserialize(serial);
-        assertEquals(instance.getTags().size(), instance2.getTags().size());
-        assertEquals(instance.getSymbols().size(), instance2.getSymbols().size());
+        Definitions deserializedInstance = Definitions.deserialize(serial);
+        assertEquals(instance.getTags().size(), deserializedInstance.getTags().size());
+        assertEquals(instance.getSymbols().size(), deserializedInstance.getSymbols().size());
     }
 
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/RestApp.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/RestApp.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1;
 
@@ -31,10 +31,10 @@ public class RestApp extends ResourceConfig {
 
     public static final String API_PATH = "api/v1";
 
+    @SuppressWarnings("this-escape")
     public RestApp() {
         register(new SuggesterAppBinder());
         packages("org.opengrok.web.api.constraints", "org.opengrok.web.api.error");
         packages(true, "org.opengrok.web.api.v1");
     }
-
 }

--- a/plugins/src/main/java/opengrok/auth/entity/LdapUser.java
+++ b/plugins/src/main/java/opengrok/auth/entity/LdapUser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.entity;
 
@@ -36,7 +36,7 @@ import java.util.Set;
 public class LdapUser implements Serializable {
 
     private String dn; // Distinguished Name
-    private final Map<String, Set<String>> attributes;
+    private final transient Map<String, Set<String>> attributes;
 
     private static final long serialVersionUID = 1L;
 

--- a/plugins/src/main/java/opengrok/auth/plugin/configuration/Configuration.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/configuration/Configuration.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin.configuration;
 
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -55,7 +56,7 @@ public class Configuration implements Serializable {
     private static final long serialVersionUID = -1;
 
     @JsonProperty
-    private List<LdapServer> servers = new ArrayList<>();
+    private ArrayList<LdapServer> servers = new ArrayList<>();
     @JsonProperty
     private int interval;
     @JsonProperty
@@ -71,8 +72,8 @@ public class Configuration implements Serializable {
     @JsonProperty
     private int countLimit;
 
-    public void setServers(List<LdapServer> servers) {
-        this.servers = servers;
+    public void setServers(Collection<LdapServer> servers) {
+        this.servers = new ArrayList<>(servers);
     }
 
     public List<LdapServer> getServers() {

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapFacade.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin.ldap;
 
@@ -182,7 +182,7 @@ public class LdapFacade extends AbstractLdapProvider {
         setSearchBase(cfg.getSearchBase());
         setWebHooks(cfg.getWebHooks());
 
-        // Anti-pattern: do some non trivial stuff in the constructor.
+        // Anti-pattern: do some non-trivial stuff in the constructor.
         prepareSearchControls(cfg.getSearchTimeout(), cfg.getCountLimit());
         prepareServers();
     }
@@ -194,8 +194,8 @@ public class LdapFacade extends AbstractLdapProvider {
     /**
      * Go through all servers in the pool and record the first working.
      */
-    void prepareServers() {
-        LOGGER.log(Level.FINER, "checking servers for {0}", this);
+    final void prepareServers() {
+        LOGGER.log(Level.FINER, "checking servers {0}", servers);
         for (int i = 0; i < servers.size(); i++) {
             LdapServer server = servers.get(i);
             if (server.isWorking() && actualServer == -1) {
@@ -231,7 +231,7 @@ public class LdapFacade extends AbstractLdapProvider {
         return servers;
     }
 
-    public LdapFacade setServers(List<LdapServer> servers, int connectTimeout, int readTimeout) {
+    public final LdapFacade setServers(List<LdapServer> servers, int connectTimeout, int readTimeout) {
         this.servers = servers;
         // Inherit timeout values from server pool configuration.
         for (LdapServer server : servers) {
@@ -249,7 +249,7 @@ public class LdapFacade extends AbstractLdapProvider {
         return interval;
     }
 
-    public void setInterval(int interval) {
+    public final void setInterval(int interval) {
         this.interval = interval;
         for (LdapServer server : servers) {
             server.setInterval(interval);
@@ -260,7 +260,7 @@ public class LdapFacade extends AbstractLdapProvider {
         return searchBase;
     }
 
-    public void setSearchBase(String base) {
+    public final void setSearchBase(String base) {
         this.searchBase = base;
     }
 

--- a/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/ldap/LdapServer.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin.ldap;
 
@@ -83,7 +83,7 @@ public class LdapServer implements Serializable {
     private int readTimeout;
 
     private int interval = 10 * 1000;
-    private final Map<String, String> env;
+    private final transient Map<String, String> env;
     private transient LdapContext ctx;
     private long errorTimestamp = 0;
 
@@ -111,7 +111,7 @@ public class LdapServer implements Serializable {
         return url;
     }
 
-    public LdapServer setName(String name) {
+    public final LdapServer setName(String name) {
         this.url = name;
         return this;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 
 -->
@@ -74,7 +74,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <maven-surefire.version>3.0.0-M5</maven-surefire.version>
         <apache-commons-lang3.version>3.13.0</apache-commons-lang3.version>
         <micrometer.version>1.14.1</micrometer.version>
-        <mockito.version>5.2.0</mockito.version>
+        <mockito.version>5.17.0</mockito.version>
         <commons-io.version>2.14.0</commons-io.version>
     </properties>
 

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
 
 -->
@@ -101,7 +101,7 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
         <dependency>
             <groupId>net.openhft</groupId>
             <artifactId>chronicle-map</artifactId>
-            <version>3.22.9</version>
+            <version>3.27ea0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.java</groupId>

--- a/suggester/src/main/java/org/opengrok/suggest/popular/impl/chronicle/ChronicleMapAdapter.java
+++ b/suggester/src/main/java/org/opengrok/suggest/popular/impl/chronicle/ChronicleMapAdapter.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest.popular.impl.chronicle;
 
@@ -52,7 +52,7 @@ public class ChronicleMapAdapter implements PopularityMap {
                 .averageKeySize(averageKeySize)
                 .keyReaderAndDataAccess(BytesRefSizedReader.INSTANCE, new BytesRefDataAccess())
                 .entries(entries)
-                .createOrRecoverPersistedTo(file);
+                .createPersistedTo(file);
         this.chronicleMapFile = file;
     }
 
@@ -135,7 +135,7 @@ public class ChronicleMapAdapter implements PopularityMap {
                     .averageKeySize(newMapAvgKey)
                     .entries(newMapSize)
                     .keyReaderAndDataAccess(BytesRefSizedReader.INSTANCE, new BytesRefDataAccess())
-                    .createOrRecoverPersistedTo(chronicleMapFile);
+                    .createPersistedTo(chronicleMapFile);
             m.putAll(tempFile.toFile());
             map = m;
         } finally {

--- a/suggester/src/main/java/org/opengrok/suggest/util/Progress.java
+++ b/suggester/src/main/java/org/opengrok/suggest/util/Progress.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.suggest.util;
@@ -152,7 +152,7 @@ public class Progress implements AutoCloseable {
     }
 
     @VisibleForTesting
-    Level getLevel(Map<Level, Long> lastLoggedChunk, long currentCount, Level currentLevel) {
+    final Level getLevel(Map<Level, Long> lastLoggedChunk, long currentCount, Level currentLevel) {
         // The intention is to log the initial and final count at the base log level.
         if (currentCount <= 1 || (totalCount != null && currentCount == totalCount)) {
             currentLevel = baseLogLevel;


### PR DESCRIPTION
The bytecode target is still Java 11 to support older deployments.

I had to solve multiple issues:
  - bump Mockito so that it uses newer Byte buddy library which supports Java 21
  - address non-serializable members by either switching them to `transient` or using `Serializable` type
  - avoid `this` leaks from constructors or suppress the warning
  - udpate Chronicle Map so that it does not attempt to get method not present in Java 21

Tested the newly built Docker image with pre-existing data root. Also tested with JRE 11 on Solaris x86 with pre-existing data-root and semi-complex setup (authorization, suggester, annotation cache).