### PR TITLE
Upload build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,3 +56,8 @@ jobs:
         OPENGROK_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ./dev/main
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        path: distribution/target/opengrok-*.tar.gz
+        compression-level: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,6 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: opengrok-${{ matrix.os }}.tar.gz
+        name: opengrok-${{ github.sha }}-${{ matrix.os }}.tar.gz
         path: distribution/target/opengrok-*.tar.gz
         compression-level: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,5 +59,6 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
+        name: opengrok-${{ matrix.os }}.tar.gz
         path: distribution/target/opengrok-*.tar.gz
         compression-level: 0


### PR DESCRIPTION
Sometimes having build artifact is handy for testing, verifying. This change uploads build artifact for each OS in the matrix.