### PR TITLE
use reflection to get thread ID

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/OpenGrokThreadFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/OpenGrokThreadFactory.java
@@ -18,11 +18,12 @@
  */
 
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.configuration;
 
 import org.jetbrains.annotations.NotNull;
+import org.opengrok.indexer.util.ThreadUtil;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -47,7 +48,7 @@ public class OpenGrokThreadFactory implements ThreadFactory {
     @Override
     public Thread newThread(@NotNull Runnable runnable) {
         Thread thread = Executors.defaultThreadFactory().newThread(Objects.requireNonNull(runnable, "runnable"));
-        thread.setName(PREFIX + threadPrefix + thread.getId());
+        thread.setName(PREFIX + threadPrefix + ThreadUtil.getThreadId(thread));
         return thread;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.util;
@@ -412,7 +412,7 @@ public class Executor {
             LOGGER.log(Level.FINE, "Installing default uncaught exception handler");
             Thread.setDefaultUncaughtExceptionHandler((t, e) ->
                     LOGGER.log(Level.SEVERE, String.format("Uncaught exception in thread %s with ID %d: %s",
-                            t.getName(), t.getId(), e.getMessage()), e));
+                            t.getName(), ThreadUtil.getThreadId(t), e.getMessage()), e));
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/ThreadUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/ThreadUtil.java
@@ -31,6 +31,8 @@ public class ThreadUtil {
     }
 
     /**
+     * Retrieve thread ID, preferring the non-deprecated <code>threadId</code> method.
+     * This can be replaced with direct call after target Java version is switched to Java 21 or higher.
      * @param thread thread object
      * @return thread id
      */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/ThreadUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/ThreadUtil.java
@@ -1,0 +1,55 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ThreadUtil {
+    private ThreadUtil() {
+        // private to enforce static
+    }
+
+    /**
+     * @param thread thread object
+     * @return thread id
+     */
+    public static long getThreadId(Thread thread) {
+        Class<? extends Thread> clazz = thread.getClass();
+        Method method;
+        try {
+            method = clazz.getMethod("threadId");
+        } catch (NoSuchMethodException e) {
+            try {
+                method = clazz.getMethod("getId");
+            } catch (NoSuchMethodException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+        try {
+            return (long) method.invoke(thread);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/suggester/src/main/java/org/opengrok/suggest/Suggester.java
+++ b/suggester/src/main/java/org/opengrok/suggest/Suggester.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.suggest;
 
@@ -34,6 +34,7 @@ import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.BytesRef;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
+import org.opengrok.suggest.util.ThreadUtil;
 import org.opengrok.suggest.query.SuggesterPrefixQuery;
 import org.opengrok.suggest.query.SuggesterQuery;
 import org.opengrok.suggest.util.Progress;
@@ -161,7 +162,7 @@ public final class Suggester implements Closeable {
                 runnable -> {
                     Thread thread = Executors.defaultThreadFactory().newThread(runnable);
                     // This should match the naming in OpenGrokThreadFactory class.
-                    thread.setName("OpenGrok-suggester-lookup-" + thread.getId());
+                    thread.setName("OpenGrok-suggester-lookup-" + ThreadUtil.getThreadId(thread));
                     return thread;
                 });
 
@@ -169,7 +170,7 @@ public final class Suggester implements Closeable {
                 runnable -> {
                     Thread thread = Executors.defaultThreadFactory().newThread(runnable);
                     // This should match the naming in OpenGrokThreadFactory class.
-                    thread.setName("OpenGrok-suggester-rebuild-" + thread.getId());
+                    thread.setName("OpenGrok-suggester-rebuild-" + ThreadUtil.getThreadId(thread));
                     return thread;
                 });
 

--- a/suggester/src/main/java/org/opengrok/suggest/util/ThreadUtil.java
+++ b/suggester/src/main/java/org/opengrok/suggest/util/ThreadUtil.java
@@ -1,0 +1,55 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.suggest.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ThreadUtil {
+    private ThreadUtil() {
+        // private to enforce static
+    }
+
+    /**
+     * @param thread thread object
+     * @return thread id
+     */
+    public static long getThreadId(Thread thread) {
+        Class<? extends Thread> clazz = thread.getClass();
+        Method method;
+        try {
+            method = clazz.getMethod("threadId");
+        } catch (NoSuchMethodException e) {
+            try {
+                method = clazz.getMethod("getId");
+            } catch (NoSuchMethodException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+        try {
+            return (long) method.invoke(thread);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/suggester/src/main/java/org/opengrok/suggest/util/ThreadUtil.java
+++ b/suggester/src/main/java/org/opengrok/suggest/util/ThreadUtil.java
@@ -31,6 +31,8 @@ public class ThreadUtil {
     }
 
     /**
+     * Retrieve thread ID, preferring the non-deprecated <code>threadId</code> method.
+     * This can be replaced with direct call after target Java version is switched to Java 21 or higher.
      * @param thread thread object
      * @return thread id
      */


### PR DESCRIPTION
This change gets rid of the remaining deprecation warnings when building with target version of 21. It's a bit of a hack, however removes potential developer barrier.