### PR TITLE
update some of the Maven plugins used for reporting/javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.2.3</version>
+                <version>4.9.3.0</version>
                 <configuration>
                     <xmlOutput>true</xmlOutput>
                     <includeFilterFile>dev/findbugs_filter.xml</includeFilterFile>
@@ -448,7 +448,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.21.2</version>
+                <version>3.26.0</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -467,7 +467,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-docck-plugin</artifactId>
-                <version>1.1</version>
+                <version>1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Post Java 21 cleanup the javadoc build job started failing with:
```
[java] Exception in thread "main" java.lang.IllegalArgumentException: Unsupported class file major version 65
     [java] 	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:196)
     [java] 	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:177)
     [java] 	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:163)
     [java] 	at edu.umd.cs.findbugs.asm.FBClassReader.<init>(FBClassReader.java:35)
     [java] 	at edu.umd.cs.findbugs.classfile.engine.asm.ClassReaderAnalysisEngine.analyze(ClassReaderAnalysisEngine.java:48)
     [java] 	at edu.umd.cs.findbugs.classfile.engine.asm.ClassReaderAnalysisEngine.analyze(ClassReaderAnalysisEngine.java:34)
     [java] 	at edu.umd.cs.findbugs.classfile.impl.AnalysisCache.getClassAnalysis(AnalysisCache.java:261)
     [java] 	at edu.umd.cs.findbugs.classfile.engine.ClassInfoAnalysisEngine.analyze(ClassInfoAnalysisEngine.java:75)
     [java] 	at edu.umd.cs.findbugs.classfile.engine.ClassInfoAnalysisEngine.analyze(ClassInfoAnalysisEngine.java:38)
     [java] 	at edu.umd.cs.findbugs.classfile.impl.AnalysisCache.getClassAnalysis(AnalysisCache.java:261)
     [java] 	at edu.umd.cs.findbugs.ba.XFactory.getXClass(XFactory.java:693)
     [java] 	at edu.umd.cs.findbugs.ba.AnalysisContext.setAppClassList(AnalysisContext.java:975)
     [java] 	at edu.umd.cs.findbugs.FindBugs2.setAppClassList(FindBugs2.java:909)
     [java] 	at edu.umd.cs.findbugs.FindBugs2.execute(FindBugs2.java:252)
     [java] 	at edu.umd.cs.findbugs.FindBugs.runMain(FindBugs.java:395)
     [java] 	at edu.umd.cs.findbugs.FindBugs2.main(FindBugs2.java:1231)
```
This change fixes that by updating some of the Maven reporting plugins.