### PR TITLE
use longer revision for Mercurial repository annotation search links

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Annotation.java
@@ -129,6 +129,10 @@ public class Annotation {
         return annotationData.getRevisions();
     }
 
+    final Set<String> getDisplayRevisions() {
+        return annotationData.getDisplayRevisions();
+    }
+
     @TestOnly
     Set<String> getAuthors() {
         return annotationData.getAuthors();
@@ -138,8 +142,7 @@ public class Annotation {
      * Gets the author who last modified the specified line.
      *
      * @param line line number (counting from 1)
-     * @return author, or an empty string if there is no information about the
-     * specified line
+     * @return author, or an empty string if there is no information about the specified line
      */
     public String getAuthor(int line) {
         return annotationData.getAuthor(line);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AnnotationData.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/AnnotationData.java
@@ -52,6 +52,10 @@ public class AnnotationData implements Serializable {
         this.filename = filename;
     }
 
+    /**
+     * The <code>transient</code> does not matter here since the object is serialized explicitly
+     * in {@link FileAnnotationCache#store(File, Annotation)}.
+     */
     private transient List<AnnotationLine> annotationLines = new ArrayList<>();
     private int widestRevision;
     private int widestAuthor;
@@ -220,6 +224,14 @@ public class AnnotationData implements Serializable {
         Set<String> ret = new HashSet<>();
         for (AnnotationLine ln : annotationLines) {
             ret.add(ln.getRevision());
+        }
+        return ret;
+    }
+
+    Set<String> getDisplayRevisions() {
+        Set<String> ret = new HashSet<>();
+        for (AnnotationLine ln : annotationLines) {
+            ret.add(ln.getDisplayRevision());
         }
         return ret;
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -355,7 +355,9 @@ public final class HistoryGuru {
     private void completeAnnotationWithHistory(File file, Annotation annotation, Repository repo) {
         try {
             History history = getHistory(file);
-            completeAnnotationWithHistory(annotation, history, repo);
+            if (history != null) {
+                completeAnnotationWithHistory(annotation, history, repo);
+            }
         } catch (HistoryException ex) {
             LOGGER.log(Level.WARNING, "Cannot get messages for tooltip: ", ex);
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -361,7 +361,6 @@ public final class HistoryGuru {
         }
     }
 
-    // TODO: add test Mercurial
     @VisibleForTesting
     static void completeAnnotationWithHistory(Annotation annotation, @NotNull History history, Repository repo) {
         Set<String> revs = annotation.getRevisions();

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/HistoryGuru.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.queryparser.classic.ParseException;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.opengrok.indexer.analysis.AnalyzerFactory;
@@ -352,32 +353,34 @@ public final class HistoryGuru {
     }
 
     private void completeAnnotationWithHistory(File file, Annotation annotation, Repository repo) {
-        History history = null;
         try {
-            history = getHistory(file);
+            History history = getHistory(file);
+            completeAnnotationWithHistory(annotation, history, repo);
         } catch (HistoryException ex) {
             LOGGER.log(Level.WARNING, "Cannot get messages for tooltip: ", ex);
         }
+    }
 
-        if (history != null) {
-            Set<String> revs = annotation.getRevisions();
-            int revsMatched = 0;
-            // !!! cannot do this because of not matching rev ids (keys)
-            // first is the most recent one, so we need the position of "rev"
-            // until the end of the list
-            //if (hent.indexOf(rev)>0) {
-            //     hent = hent.subList(hent.indexOf(rev), hent.size());
-            //}
-            for (HistoryEntry he : history.getHistoryEntries()) {
-                String hist_rev = he.getRevision();
-                String short_rev = repo.getRevisionForAnnotate(hist_rev);
-                if (revs.contains(short_rev)) {
-                    annotation.addDesc(short_rev, he.getDescription());
-                    // History entries are coming from recent to older,
-                    // file version should be from oldest to newer.
-                    annotation.addFileVersion(short_rev, revs.size() - revsMatched);
-                    revsMatched++;
-                }
+    // TODO: add test Mercurial
+    @VisibleForTesting
+    static void completeAnnotationWithHistory(Annotation annotation, @NotNull History history, Repository repo) {
+        Set<String> revs = annotation.getRevisions();
+        int revsMatched = 0;
+        // !!! cannot do this because of not matching rev ids (keys)
+        // first is the most recent one, so we need the position of "rev"
+        // until the end of the list
+        //if (hent.indexOf(rev)>0) {
+        //     hent = hent.subList(hent.indexOf(rev), hent.size());
+        //}
+        for (HistoryEntry historyEntry : history.getHistoryEntries()) {
+            String historyEntryRevision = historyEntry.getRevision();
+            String revisionForAnnotate = repo.getRevisionForAnnotate(historyEntryRevision);
+            if (revs.contains(revisionForAnnotate)) {
+                annotation.addDesc(revisionForAnnotate, historyEntry.getDescription());
+                // History entries are coming from recent to older,
+                // file version should be from oldest to newer.
+                annotation.addFileVersion(revisionForAnnotate, revs.size() - revsMatched);
+                revsMatched++;
             }
         }
     }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialAnnotationParser.java
@@ -79,7 +79,6 @@ class MercurialAnnotationParser implements Executor.StreamHandler {
                     // Use the history index hash map to get the author.
                     String author = Optional.ofNullable(revs.get(fullRev)).map(HistoryEntry::getAuthor).
                             orElse("N/A");
-                    // TODO: add check that history stored in the index uses the same format of the revision
                     annotation.addLine(fullRev, Util.getEmail(author.trim()), true, displayRev);
                 } else {
                     LOGGER.log(Level.WARNING,

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialAnnotationParser.java
@@ -52,8 +52,10 @@ class MercurialAnnotationParser implements Executor.StreamHandler {
 
     /**
      * Pattern used to extract author/revision from the {@code hg annotate} command.
+     * Obviously, this has to be in concordance with the output template used by
+     * {@link MercurialRepository#annotate(File, String)}.
      */
-    private static final Pattern ANNOTATION_PATTERN = Pattern.compile("^(\\d+)\\s+([0-9a-f]+):");
+    private static final Pattern ANNOTATION_PATTERN = Pattern.compile("^(\\d+)\\t([0-9a-f]+):");
 
     MercurialAnnotationParser(File file, @NotNull HashMap<String, HistoryEntry> revs) {
         this.file = file;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialAnnotationParser.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialAnnotationParser.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.history;
 
@@ -28,10 +28,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.NotNull;
 import org.opengrok.indexer.logger.LoggerFactory;
 import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.web.Util;
@@ -50,9 +53,9 @@ class MercurialAnnotationParser implements Executor.StreamHandler {
     /**
      * Pattern used to extract author/revision from the {@code hg annotate} command.
      */
-    private static final Pattern ANNOTATION_PATTERN = Pattern.compile("^\\s*(\\d+):");
+    private static final Pattern ANNOTATION_PATTERN = Pattern.compile("^(\\d+)\\s+([0-9a-f]+):");
 
-    MercurialAnnotationParser(File file, HashMap<String, HistoryEntry> revs) {
+    MercurialAnnotationParser(File file, @NotNull HashMap<String, HistoryEntry> revs) {
         this.file = file;
         this.revs = revs;
     }
@@ -69,13 +72,13 @@ class MercurialAnnotationParser implements Executor.StreamHandler {
                 ++lineno;
                 matcher.reset(line);
                 if (matcher.find()) {
-                    String rev = matcher.group(1);
-                    String author = "N/A";
+                    String displayRev = matcher.group(1);
+                    String fullRev = displayRev + ":" + matcher.group(2);
                     // Use the history index hash map to get the author.
-                    if (revs.get(rev) != null) {
-                        author = revs.get(rev).getAuthor();
-                    }
-                    annotation.addLine(rev, Util.getEmail(author.trim()), true);
+                    String author = Optional.ofNullable(revs.get(fullRev)).map(HistoryEntry::getAuthor).
+                            orElse("N/A");
+                    // TODO: add check that history stored in the index uses the same format of the revision
+                    annotation.addLine(fullRev, Util.getEmail(author.trim()), true, displayRev);
                 } else {
                     LOGGER.log(Level.WARNING,
                             "Error: did not find annotation in line {0} for ''{1}'': [{2}]",

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/MercurialRepository.java
@@ -322,8 +322,7 @@ public class MercurialRepository extends RepositoryWithHistoryTraversal {
      * of a file in historical revision.
      *
      * @param fullpath file path
-     * @param fullRevToFind revision number (in the form of
-     * {rev}:{node|short})
+     * @param fullRevToFind revision number (in the form of <code>{rev}:{node|short}</code>)
      * @return original filename
      */
     private String findOriginalName(String fullpath, String fullRevToFind) throws IOException {
@@ -464,8 +463,11 @@ public class MercurialRepository extends RepositoryWithHistoryTraversal {
         ensureCommand(CMD_PROPERTY_KEY, CMD_FALLBACK);
         argv.add(RepoCommand);
         argv.add("annotate");
-        argv.add("-n");
-        argv.add("-c"); // TODO: use --template ?
+        argv.add("--template");
+        /*
+         * This has to be in concordance with TEMPLATE_REVS, in particular the format of the 'node'.
+         */
+        argv.add("{lines % '{rev}\t{node|short}:{line}'}");
         if (!this.isHandleRenamedFiles()) {
             argv.add("--no-follow");
         }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Util.java
@@ -717,41 +717,41 @@ public final class Util {
 
     private static void writeAnnotation(int num, Writer out, Annotation annotation, String userPageLink,
                                         String userPageSuffix, String project) throws IOException {
-        String r = annotation.getRevision(num);
+        String revision = annotation.getRevision(num);
         boolean enabled = annotation.isEnabled(num);
         out.write("<span class=\"blame\">");
         if (enabled) {
             out.write(ANCHOR_CLASS_START);
             out.write("r title-tooltip");
             out.write("\" style=\"background-color: ");
-            out.write(annotation.getColors().getOrDefault(r, "inherit"));
+            out.write(annotation.getColors().getOrDefault(revision, "inherit"));
             out.write("\" href=\"");
             out.write(uriEncode(annotation.getFilename()));
             out.write("?");
             out.write(QueryParameters.ANNOTATION_PARAM_EQ_TRUE);
             out.write(AMP);
             out.write(QueryParameters.REVISION_PARAM_EQ);
-            out.write(uriEncode(r));
-            String msg = annotation.getDesc(r);
+            out.write(uriEncode(revision));
+            String msg = annotation.getDesc(revision);
             out.write("\" title=\"");
             if (msg != null) {
                 out.write(Util.encode(msg));
             }
-            if (annotation.getFileVersion(r) != 0) {
-                out.write("&lt;br/&gt;version: " + annotation.getFileVersion(r) + "/"
+            if (annotation.getFileVersion(revision) != 0) {
+                out.write("&lt;br/&gt;version: " + annotation.getFileVersion(revision) + "/"
                         + annotation.getRevisions().size());
             }
             out.write(CLOSE_QUOTED_TAG);
         }
         StringBuilder buf = new StringBuilder();
-        final boolean most_recent_revision = annotation.getFileVersion(r) == annotation.getRevisions().size();
+        final boolean isMostRecentRevision = annotation.getFileVersion(revision) == annotation.getRevisions().size();
         // print an asterisk for the most recent revision
-        if (most_recent_revision) {
+        if (isMostRecentRevision) {
             buf.append("<span class=\"most_recent_revision\">");
             buf.append('*');
         }
         htmlize(annotation.getRevisionForDisplay(num), buf);
-        if (most_recent_revision) {
+        if (isMostRecentRevision) {
             buf.append(SPAN_END); // recent revision span
         }
         out.write(buf.toString());
@@ -773,7 +773,7 @@ public final class Util {
             out.write(AMP);
             out.write(QueryParameters.HIST_SEARCH_PARAM_EQ);
             out.write(QUOTE);
-            out.write(uriEncode(r));
+            out.write(uriEncode(revision));
             out.write("&quot;&amp;");
             out.write(QueryParameters.TYPE_SEARCH_PARAM_EQ);
             out.write("\" title=\"Search history for this revision");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -23,7 +23,6 @@
  */
 package org.opengrok.indexer.history;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -438,7 +438,7 @@ public class MercurialRepositoryTest {
     }
 
     private static Stream<Triple<String, List<String>, List<String>>> provideParametersForPositiveAnnotationTest() {
-        return Stream.of(Triple.of("8:6a8c423f5624", List.of("7", "8"), List.of("7:db1394c05268", "8:6a8c423f5624")),
+        return Stream.of(Triple.of("8:6a8c423f5624", List.of("7", "8"), List.of("8:6a8c423f5624", "7:db1394c05268")),
                 Triple.of("7:db1394c05268", List.of("7"), List.of("7:db1394c05268")));
     }
 
@@ -467,6 +467,7 @@ public class MercurialRepositoryTest {
                 collect(Collectors.toList());
         assertFalse(relevantEntries.isEmpty());
         for (HistoryEntry entry : relevantEntries) {
+            assertTrue(annotation.getRevisions().contains(entry.getRevision()));
             assertEquals(entry.getDescription(), annotation.getDesc(entry.getRevision()));
             assertTrue(annotation.getAuthors().contains(Util.getEmail(entry.getAuthor())));
         }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -38,6 +38,7 @@ import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.IOUtils;
 import org.opengrok.indexer.util.TestRepository;
+import org.opengrok.indexer.web.Util;
 
 import java.io.File;
 import java.io.IOException;
@@ -467,6 +468,7 @@ public class MercurialRepositoryTest {
         assertFalse(relevantEntries.isEmpty());
         for (HistoryEntry entry : relevantEntries) {
             assertEquals(entry.getDescription(), annotation.getDesc(entry.getRevision()));
+            assertTrue(annotation.getAuthors().contains(Util.getEmail(entry.getAuthor())));
         }
     }
 


### PR DESCRIPTION
This change addresses a problem with imprecise history search from annotate view for projects with multiple Mercurial repositories by storing annotation data for Mercurial repositories with both short/display (`rev`) and longer (`node|short`) version of the revision ID and using the latter to construct the history search links.

Will require reindex from scratch if using annotation cache (for given project).