### PR TITLE
update license format for the tools packaging

### DIFF
--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     'jsonschema==2.6.0',    # to avoid Rust


### PR DESCRIPTION
Converts the licensing information in the Python tools package definitions to a new format.