### PR TITLE
control history tagging per project

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Project.java
@@ -104,6 +104,11 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     private Boolean mergeCommitsEnabled = null;
 
     /**
+     * This flag enables/disables per project tagging of history entries.
+     */
+    private Boolean tagsEnabled = null;
+
+    /**
      * Username to used for repository authentication. This is propagated to all repositories of this project.
      */
     private String username = null;
@@ -286,6 +291,13 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
     }
 
     /**
+     * @return whether tagging of history entries is on
+     */
+    public boolean isTagsEnabled() {
+        return tagsEnabled != null && tagsEnabled;
+    }
+
+    /**
      * @param flag true if project should handle renamed files, false otherwise.
      */
     public final void setHandleRenamedFiles(boolean flag) {
@@ -339,6 +351,13 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
      */
     public final void setMergeCommitsEnabled(boolean flag) {
         this.mergeCommitsEnabled = flag;
+    }
+
+    /**
+     * @param flag whether to tag history entries
+     */
+    public final void setTagsEnabled(boolean flag) {
+        this.tagsEnabled = flag;
     }
 
     /**
@@ -554,6 +573,10 @@ public class Project implements Comparable<Project>, Nameable, Serializable {
 
         if (historyBasedReindex == null) {
             setHistoryBasedReindex(env.isHistoryBasedReindex());
+        }
+
+        if (tagsEnabled == null) {
+            setTagsEnabled(env.isTagsEnabled());
         }
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BazaarRepository.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2018, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -206,7 +206,7 @@ public class BazaarRepository extends Repository {
         History result = new BazaarHistoryParser(this).parse(file, sinceRevision);
         // Assign tags to changesets they represent
         // We don't need to check if this repository supports tags, because we know it:-)
-        if (env.isTagsEnabled()) {
+        if (this.isTagsEnabled()) {
             assignTagsInHistory(result);
         }
         return result;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BitKeeperRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/BitKeeperRepository.java
@@ -293,7 +293,7 @@ public class BitKeeperRepository extends Repository {
         // Assign tags to changesets they represent
         // We don't need to check if this repository supports tags,
         // because we know it :-)
-        if (env.isTagsEnabled()) {
+        if (this.isTagsEnabled()) {
             assignTagsInHistory(history);
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/FileHistoryCache.java
@@ -129,7 +129,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
         }
 
         // Assign tags to changesets they represent.
-        if (env.isTagsEnabled() && repository.hasFileBasedTags()) {
+        if (repository.isTagsEnabled() && repository.hasFileBasedTags()) {
             repository.assignTagsInHistory(history);
         }
 
@@ -183,7 +183,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
         History history = new History(historyEntryList);
 
         // Read tags from separate file.
-        if (env.isTagsEnabled() && repository.hasFileBasedTags()) {
+        if (repository.isTagsEnabled() && repository.hasFileBasedTags()) {
             File tagFile = getTagsFile(cacheFile);
             try (SmileParser parser = factory.createParser(tagFile)) {
                 parser.setCodec(mapper);
@@ -290,11 +290,11 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
      *
      * @param histNew history object to store
      * @param file file to store the history object into
-     * @param repo repository for the file
+     * @param repository repository for the file
      * @param mergeHistory whether to merge the history with existing or store the histNew as is
      * @throws HistoryException if there was any problem with history cache generation
      */
-    private void storeFile(History histNew, File file, Repository repo, boolean mergeHistory) throws HistoryException {
+    private void storeFile(History histNew, File file, Repository repository, boolean mergeHistory) throws HistoryException {
         File cacheFile;
         try {
             cacheFile = getCachedFile(file);
@@ -321,7 +321,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
             throw new HistoryException("Failed to write history", ioe);
         }
 
-        boolean assignTags = env.isTagsEnabled() && repo.hasFileBasedTags();
+        boolean assignTags = repository.isTagsEnabled() && repository.hasFileBasedTags();
 
         // Append the contents of the pre-existing cache file to the temporary file.
         if (mergeHistory && cacheFile.exists()) {
@@ -353,7 +353,7 @@ class FileHistoryCache extends AbstractCache implements HistoryCache {
             // to this somewhat crude solution of re-tagging from scratch.
             if (assignTags) {
                 histNew.strip();
-                repo.assignTagsInHistory(histNew);
+                repository.assignTagsInHistory(histNew);
             }
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/Repository.java
@@ -415,7 +415,7 @@ public abstract class Repository extends RepositoryInfo {
     void finishCreateCache(HistoryCache cache, History history, String tillRevision) throws CacheException {
         // We need to refresh list of tags for incremental reindex.
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        if (env.isTagsEnabled() && this.hasFileBasedTags()) {
+        if (this.isTagsEnabled() && this.hasFileBasedTags()) {
             this.buildTagList(new File(this.getDirectoryName()), CommandTimeoutType.INDEXER);
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryFactory.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -215,11 +215,11 @@ public final class RepositoryFactory {
                             });
                 }
 
-                if (repo.getType() == null || repo.getType().length() == 0) {
+                if (repo.getType() == null || repo.getType().isEmpty()) {
                     repo.setType(repo.getClass().getSimpleName());
                 }
 
-                if (repo.getParent() == null || repo.getParent().length() == 0) {
+                if (repo.getParent() == null || repo.getParent().isEmpty()) {
                     try {
                         repo.setParent(repo.determineParent(cmdType));
                     } catch (IOException ex) {
@@ -229,7 +229,7 @@ public final class RepositoryFactory {
                     }
                 }
 
-                if (repo.getBranch() == null || repo.getBranch().length() == 0) {
+                if (repo.getBranch() == null || repo.getBranch().isEmpty()) {
                     try {
                         repo.setBranch(repo.determineBranch(cmdType));
                     } catch (IOException ex) {
@@ -239,7 +239,7 @@ public final class RepositoryFactory {
                     }
                 }
 
-                if (repo.getCurrentVersion() == null || repo.getCurrentVersion().length() == 0) {
+                if (repo.getCurrentVersion() == null || repo.getCurrentVersion().isEmpty()) {
                     try {
                         repo.setCurrentVersion(repo.determineCurrentVersion(cmdType));
                     } catch (IOException ex) {
@@ -249,13 +249,15 @@ public final class RepositoryFactory {
                     }
                 }
 
+                // This has to be called before building tag list below as it depends on the repository properties
+                // inherited from the project/configuration.
+                repo.fillFromProject();
+
                 // If this repository displays tags only for files changed by tagged
                 // revision, we need to prepare list of all tags in advance.
-                if (cmdType.equals(CommandTimeoutType.INDEXER) && env.isTagsEnabled() && repo.hasFileBasedTags()) {
+                if (cmdType.equals(CommandTimeoutType.INDEXER) && repo.isTagsEnabled() && repo.hasFileBasedTags()) {
                     repo.buildTagList(file, cmdType);
                 }
-
-                repo.fillFromProject();
 
                 break;
             }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -84,6 +84,8 @@ public class RepositoryInfo implements Serializable {
     @DTOElement
     private boolean mergeCommitsEnabled;
     @DTOElement
+    private boolean tagsEnabled;
+    @DTOElement
     private boolean historyBasedReindex;
     @DTOElement
     private String username;
@@ -112,6 +114,7 @@ public class RepositoryInfo implements Serializable {
         this.handleRenamedFiles = orig.handleRenamedFiles;
         this.mergeCommitsEnabled = orig.mergeCommitsEnabled;
         this.historyBasedReindex = orig.historyBasedReindex;
+        this.tagsEnabled = orig.tagsEnabled;
         this.username = orig.username;
         this.password = orig.password;
     }
@@ -146,10 +149,24 @@ public class RepositoryInfo implements Serializable {
     }
 
     /**
+     * @return whether history entries should be tagged
+     */
+    public boolean isTagsEnabled() {
+        return this.tagsEnabled;
+    }
+
+    /**
      * @param flag true if the repository should handle merge commits, false otherwise.
      */
     public void setMergeCommitsEnabled(boolean flag) {
         this.mergeCommitsEnabled = flag;
+    }
+
+    /**
+     * @param flag whether to tag history entries
+     */
+    public void setTagsEnabled(boolean flag) {
+        this.tagsEnabled = flag;
     }
 
     /**
@@ -399,6 +416,7 @@ public class RepositoryInfo implements Serializable {
             setAnnotationCacheEnabled(proj.isAnnotationCacheEnabled());
             setHandleRenamedFiles(proj.isHandleRenamedFiles());
             setMergeCommitsEnabled(proj.isMergeCommitsEnabled());
+            setTagsEnabled(proj.isTagsEnabled());
             setHistoryBasedReindex(proj.isHistoryBasedReindex());
             setUsername(proj.getUsername());
             setPassword(proj.getPassword());
@@ -410,6 +428,7 @@ public class RepositoryInfo implements Serializable {
             setAnnotationCacheEnabled(env.isAnnotationCacheEnabled());
             setHandleRenamedFiles(env.isHandleHistoryOfRenamedFiles());
             setMergeCommitsEnabled(env.isMergeCommitsEnabled());
+            setTagsEnabled(env.isTagsEnabled());
             setHistoryBasedReindex(env.isHistoryBasedReindex());
         }
     }
@@ -478,6 +497,13 @@ public class RepositoryInfo implements Serializable {
             stringBuilder.append("annotationCache=on");
         } else {
             stringBuilder.append("annotationCache=off");
+        }
+
+        stringBuilder.append(",");
+        if (isTagsEnabled()) {
+            stringBuilder.append("tagsEnabled=on");
+        } else {
+            stringBuilder.append("tagsEnabled=off");
         }
 
         if (getUsername() != null) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryInfo.java
@@ -477,7 +477,7 @@ public class RepositoryInfo implements Serializable {
         if (!isHistoryCacheEnabled()) {
             stringBuilder.append("historyCache=off");
         } else {
-            stringBuilder.append("historyCache=on,");
+            stringBuilder.append("historyCache=on");
         }
 
         if (isHandleRenamedFiles()) {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryWithHistoryTraversal.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/RepositoryWithHistoryTraversal.java
@@ -116,7 +116,7 @@ public abstract class RepositoryWithHistoryTraversal extends RepositoryWithPerPa
                 historyCollector.latestRev);
 
         // Assign tags to changesets they represent.
-        if (RuntimeEnvironment.getInstance().isTagsEnabled() && hasFileBasedTags()) {
+        if (this.isTagsEnabled() && hasFileBasedTags()) {
             assignTagsInHistory(history);
         }
 
@@ -155,7 +155,7 @@ public abstract class RepositoryWithHistoryTraversal extends RepositoryWithPerPa
                     historyCollector.latestRev);
 
             // Assign tags to changesets they represent.
-            if (env.isTagsEnabled() && hasFileBasedTags()) {
+            if (this.isTagsEnabled() && hasFileBasedTags()) {
                 assignTagsInHistory(history);
             }
 
@@ -197,7 +197,7 @@ public abstract class RepositoryWithHistoryTraversal extends RepositoryWithPerPa
                     historyCollector.latestRev);
 
             // Assign tags to changesets they represent.
-            if (env.isTagsEnabled() && hasFileBasedTags()) {
+            if (this.isTagsEnabled() && hasFileBasedTags()) {
                 assignTagsInHistory(history);
             }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ProjectTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/ProjectTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.configuration;
 
@@ -149,6 +149,7 @@ class ProjectTest {
         env.setBugPattern("([1-9][0-9]{6,7})");
         env.setReviewPage("http://example.com/reviewPage");
         env.setReviewPattern("([A-Z]{2}ARC[ \\\\/]\\\\d{4}/\\\\d{3})");
+        env.setTagsEnabled(!new Configuration().isTagsEnabled());
 
         Project p1 = new Project();
         assertNotNull(p1);
@@ -161,7 +162,8 @@ class ProjectTest {
                 () -> assertEquals(env.getBugPage(), p1.getBugPage()),
                 () -> assertEquals(env.getBugPattern(), p1.getBugPattern()),
                 () -> assertEquals(env.getReviewPage(), p1.getReviewPage()),
-                () -> assertEquals(env.getReviewPattern(), p1.getReviewPattern())
+                () -> assertEquals(env.getReviewPattern(), p1.getReviewPattern()),
+                () -> assertEquals(env.isTagsEnabled(), p1.isTagsEnabled())
         );
     }
 
@@ -205,6 +207,7 @@ class ProjectTest {
         p1.setTabSize(new Project().getTabSize() + 9737);
         p1.setNavigateWindowEnabled(true);
         p1.setHandleRenamedFiles(true);
+        p1.setTagsEnabled(true);
         final String customBugPage = "http://example.com/bugPage";
         p1.setBugPage(customBugPage);
         final String customBugPattern = "([1-9][0-1]{6,7})";
@@ -220,11 +223,12 @@ class ProjectTest {
                 () -> assertNotNull(p1),
                 () -> assertTrue(p1.isNavigateWindowEnabled(), "Navigate window should be turned on"),
                 () -> assertTrue(p1.isHandleRenamedFiles(), "Renamed file handling should be true"),
+                () -> assertTrue(p1.isTagsEnabled(), "Tags should be turned on"),
                 () -> assertEquals(new Project().getTabSize() + 9737, p1.getTabSize()),
-                () -> assertEquals(p1.getBugPage(), customBugPage),
-                () -> assertEquals(p1.getBugPattern(), customBugPattern),
-                () -> assertEquals(p1.getReviewPage(), customReviewPage),
-                () -> assertEquals(p1.getReviewPattern(), customReviewPattern)
+                () -> assertEquals(customBugPage, p1.getBugPage()),
+                () -> assertEquals(customBugPattern, p1.getBugPattern()),
+                () -> assertEquals(customReviewPage, p1.getReviewPage()),
+                () -> assertEquals(customReviewPattern, p1.getReviewPattern())
         );
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/HistoryGuruTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.history;
@@ -466,18 +466,18 @@ class HistoryGuruTest {
     void testGetLastHistoryEntryVsIndexer(boolean isIndexerParam) throws HistoryException {
         boolean isIndexer = env.isIndexer();
         env.setIndexer(isIndexerParam);
-        boolean isTagsEnabled = env.isTagsEnabled();
-        env.setTagsEnabled(true);
         HistoryGuru instance = HistoryGuru.getInstance();
         File file = new File(repository.getSourceRoot(), "git");
         assertTrue(file.exists());
+        Repository gitRepo = HistoryGuru.getInstance().getRepository(file);
+        assertNotNull(gitRepo);
+        gitRepo.setTagsEnabled(true);
         if (isIndexerParam) {
             assertThrows(IllegalStateException.class, () -> instance.getLastHistoryEntry(file, true, true));
         } else {
             assertNotNull(instance.getLastHistoryEntry(file, true, true));
         }
         env.setIndexer(isIndexer);
-        env.setTagsEnabled(isTagsEnabled);
     }
 
     @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryInfoTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/RepositoryInfoTest.java
@@ -109,14 +109,22 @@ class RepositoryInfoTest {
 
     private static Stream<Arguments> provideArgumentsForTestHistoryAndAnnotationFields() {
         return Stream.of(
-                Arguments.of(true, true, true),
-                Arguments.of(true, true, false),
-                Arguments.of(true, false, true),
-                Arguments.of(false, true, true),
-                Arguments.of(true, false, false),
-                Arguments.of(false, false, true),
-                Arguments.of(false, true, false),
-                Arguments.of(false, false, false)
+                Arguments.of(true, true, true, true),
+                Arguments.of(true, true, true, false),
+                Arguments.of(true, true, false, true),
+                Arguments.of(true, true, false, false),
+                Arguments.of(true, false, true, true),
+                Arguments.of(true, false, true, false),
+                Arguments.of(false, true, true, true),
+                Arguments.of(false, true, true, false),
+                Arguments.of(true, false, false, true),
+                Arguments.of(true, false, false, false),
+                Arguments.of(false, false, true, true),
+                Arguments.of(false, false, true, false),
+                Arguments.of(false, true, false, true),
+                Arguments.of(false, true, false, false),
+                Arguments.of(false, false, false, true),
+                Arguments.of(false, false, false, false)
         );
     }
 
@@ -128,7 +136,8 @@ class RepositoryInfoTest {
      */
     @ParameterizedTest
     @MethodSource("provideArgumentsForTestHistoryAndAnnotationFields")
-    void testHistoryAndAnnotationFields(boolean isProjectPresent, boolean historyEnabled, boolean useAnnotationCache) {
+    void testHistoryAndAnnotationFields(boolean isProjectPresent, boolean historyEnabled, boolean useAnnotationCache,
+                                        boolean tagsEnabled) {
         RuntimeEnvironment env = RuntimeEnvironment.getInstance();
         env.setProjectsEnabled(true);
 
@@ -139,10 +148,12 @@ class RepositoryInfoTest {
             project.setPath(dirName);
             project.setAnnotationCacheEnabled(useAnnotationCache);
             project.setHistoryEnabled(historyEnabled);
+            project.setTagsEnabled(tagsEnabled);
             env.setProjects(Map.of(projectName, project));
         } else {
             env.setProjects(Collections.emptyMap());
             env.setHistoryEnabled(historyEnabled);
+            env.setTagsEnabled(tagsEnabled);
             env.setAnnotationCacheEnabled(useAnnotationCache);
         }
 
@@ -151,5 +162,6 @@ class RepositoryInfoTest {
         repositoryInfo.fillFromProject();
         assertEquals(historyEnabled, repositoryInfo.isHistoryEnabled());
         assertEquals(useAnnotationCache, repositoryInfo.isAnnotationCacheEnabled());
+        assertEquals(tagsEnabled, repositoryInfo.isTagsEnabled());
     }
 }


### PR DESCRIPTION
This change introduces the `tagsEnabled` per project/repository tunable that allows to control whether tags should be applied to history entries (so that they are visible in history view).

This will require a change to https://github.com/oracle/opengrok/wiki/Per-project-configuration

Tested with the indexer running with:
```
-s
/var/opengrok/src
-d
/var/opengrok/data
-P
-H
-S
-c
/opt/homebrew/bin/ctags
-R
/var/opengrok/etc/ro-config-project.xml
-W
/var/opengrok/etc/configuration.xml
```
and the `/var/opengrok/etc/ro-config-project.xml` overriding the `tagsEnabled`:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<java version="1.8.0_121" class="java.beans.XMLDecoder">
 <object class="org.opengrok.indexer.configuration.Configuration">

  <void property="projects">
   <void method="put">
    <string>Lucene</string>
    <object class="org.opengrok.indexer.configuration.Project">
     <void property="handleRenamedFiles">
      <boolean>true</boolean>
     </void>
     <void property="historyEnabled">
      <boolean>true</boolean>
     </void>
     <void property="tagsEnabled">
      <boolean>true</boolean>
     </void>
     <void property="mergeCommitsEnabled">
      <boolean>true</boolean>
     </void>
     <void property="name">
      <string>Lucene</string>
     </void>
     <void property="path">
      <string>/Lucene</string>
     </void>
    </object>
   </void>
  </void>

 </object>
</java>
```
Then after the indexing is done, check that the history view contains list of tags.

The indexer log entry relevant to the repository:
```
INFO: Creating history cache for {dir='/private/var/opengrok/src/Lucene',type=git,history=on,historyCache=on,renamed=true,merge=true,annotationCache=off,tagsEnabled=on}
Jun 04, 2025 3:00:10 PM org.opengrok.indexer.history.HistoryGuru createHistoryCache
```