### PR TITLE
Server name laundering

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Laundromat.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Laundromat.java
@@ -53,6 +53,15 @@ public class Laundromat {
 
     /**
      * Sanitize {@code value} where it will be used in subsequent OpenGrok
+     * (non-logging) processing. Also allows for IPv6 address URIs with port number.
+     * @return {@code null} if null or else {@code value} with invalid characters removed and leading dashes stripped
+     */
+    public static String launderServerName(String value) {
+        return replaceAll(value, "(^\\-*)|[^A-Za-z0-9\\-\\.: \\[\\]]", "");
+    }
+
+    /**
+     * Sanitize {@code value} where it will be used in subsequent OpenGrok
      * (non-logging) processing.
      * @return {@code null} if null or else {@code value} with anything besides
      * alphanumeric or {@code :} characters removed.

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/LaundromatTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/LaundromatTest.java
@@ -19,14 +19,19 @@
 
 /*
  * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.web;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -52,6 +57,17 @@ class LaundromatTest {
     void launderLog() {
         String laundry = Laundromat.launderLog(TEST_CONTENT);
         assertEquals(TEST_CONTENT_LOG_LAUNDRY, laundry);
+    }
+
+    private static Stream<Pair<String, String>> getParamsForTestLaunderServerName() {
+        return Stream.of(Pair.of("foo.example.com", Laundromat.launderServerName("--foo.example\n.com?=")),
+                Pair.of("[2001:db8::1]:8080", Laundromat.launderServerName("[2001:db8::1]:8080")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getParamsForTestLaunderServerName")
+    void testLaunderServerName(Pair<String, String> param) {
+        assertEquals(param.getLeft(), param.getRight());
     }
 
     @Test

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1483,7 +1483,7 @@ public class PageConfig {
         if (env.getServerName() != null) {
             return env.getServerName();
         } else {
-            return req.getServerName();
+            return Laundromat.launderServerName(req.getServerName());
         }
     }
 

--- a/opengrok-web/src/main/webapp/opensearch.jsp
+++ b/opengrok-web/src/main/webapp/opensearch.jsp
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
 
@@ -45,20 +45,15 @@ include file="/projects.jspf"
 
     // Optimize for URLs up to 128 characters. 
     StringBuilder url = new StringBuilder(128);
-    String scheme = request.getScheme();
-    int port = request.getServerPort();
-
+    final String scheme = request.getScheme();
     url.append(scheme).append("://");
-
-    String serverName = cfg.getServerName();
-    url.append(serverName);
+    url.append(cfg.getServerName());
 
     // Append port if needed.
+    int port = request.getServerPort();
     if ((port != 80 && scheme.equals("http")) || (port != 443 && scheme.equals("https"))) {
         url.append(':').append(port);
     }
-
-    String imgUrl = url + cfg.getCssDir() + "/img/icon.png";
 
     /* TODO  Bug 11749 ??? */
     StringBuilder text = new StringBuilder();
@@ -68,15 +63,15 @@ include file="/projects.jspf"
         text.append(name).append(',');
         Util.appendQuery(url, QueryParameters.PROJECT_SEARCH_PARAM, name);
     }
-    if (text.length() != 0) {
-        text.setLength(text.length()-1);
+    if (!text.isEmpty()) {
+        text.setLength(text.length() - 1);
     }
 %><?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
     <ShortName>OpenGrok <%= text.toString() %></ShortName>
     <Description>Search in OpenGrok <%= text.toString() %></Description>
     <InputEncoding>UTF-8</InputEncoding>
-    <Image height="16" width="16" type="image/png"><%= imgUrl %></Image>
+    <Image height="16" width="16" type="image/png"><%= url + cfg.getCssDir() + "/img/icon.png" %></Image>
 <%-- <Url type="application/x-suggestions+json" template="suggestionURL"/>--%>
     <Url template="<%= url.toString() %>&amp;<%= QueryParameters.FULL_SEARCH_PARAM_EQ %>{searchTerms}"
         type="text/html"/>


### PR DESCRIPTION
This change should address SonarQube warning about unsanitized input in the rss and opensearch JSPs. Basic level of sanitization is performed, not enforcing double dots, length restrictions, consecutive dashes in the middle, etc.