### PR TITLE
encode separately to avoid full URL

### DIFF
--- a/opengrok-web/src/main/webapp/history.jsp
+++ b/opengrok-web/src/main/webapp/history.jsp
@@ -289,17 +289,16 @@ document.domReady.push(function() {domReadyHistory();});
             <td><%= htmlEncodedDisplayRevision %></td><%
                 } else {
                     if (entry.isActive()) {
-                        StringBuffer urlBuffer = request.getRequestURL();
+                        StringBuffer urlBuffer = new StringBuffer(context + Prefix.HIST_L + uriEncodedName);
                         if (request.getQueryString() != null) {
                             urlBuffer.append('?').append(request.getQueryString());
                         }
-                        urlBuffer.append('#').append(rev);
+                        urlBuffer.append('#').append(Util.uriEncode(rev));
             %>
-            <td><a href="<%= urlBuffer %>"
-                title="link to revision line">#</a>
+            <td><a href="<%= urlBuffer %>" title="link to revision line">#</a>
                 <a href="<%= context + Prefix.XREF_P + uriEncodedName + "?" +
-                        QueryParameters.REVISION_PARAM_EQ + Util.uriEncode(rev) %>"><%= htmlEncodedDisplayRevision %>
-                </a></td>
+                        QueryParameters.REVISION_PARAM_EQ + Util.uriEncode(rev) %>"><%= htmlEncodedDisplayRevision %></a>
+            </td>
             <td><%
                 %><input type="radio"
                         aria-label="From"


### PR DESCRIPTION
This is an attempt to resolve SonarQube warning about lack of sanitization of the `request.getRequestURL()` in `history.jsp`. This should be resolved by constructing the link from scratch. In the page the link will now start with absolute path rather than the scheme+server prefix. This should not matter given that browsers will produce the whole link.