### PR TITLE
rename to avoid confusion with Object.equals()

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/LineMatcher.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/LineMatcher.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.search.context;
@@ -56,7 +56,7 @@ public abstract class LineMatcher {
      * the check will return true if the only difference between the strings
      * is difference in case.
      */
-    boolean equal(String s1, String s2) {
+    boolean equalStrings(String s1, String s2) {
         return compareStrings(s1, s2) == 0;
     }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/PhraseMatcher.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/context/PhraseMatcher.java
@@ -37,7 +37,7 @@ class PhraseMatcher extends LineMatcher {
 
     @Override
     public int match(String token) {
-        if (equal(token, phraseTerms[cur])) {
+        if (equalStrings(token, phraseTerms[cur])) {
             if (cur < phraseTerms.length - 1) {
                 cur++;
                 return WAIT; //matching.
@@ -46,7 +46,7 @@ class PhraseMatcher extends LineMatcher {
             return MATCHED; //matched!
         } else if (cur > 0) {
             cur = 0;
-            if (equal(token, phraseTerms[cur])) {
+            if (equalStrings(token, phraseTerms[cur])) {
                 cur++;
                 return WAIT; //matching.
             }


### PR DESCRIPTION
This change attempts to silence SonarQube warning about confusing method naming.