### PR TITLE
fix MercurialRepositoryTest.testBuildTagListOneMore failure with Mercurial 7.1.1 on macOS

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -92,7 +92,7 @@ public class Executor {
      * @param cmdList A list containing the command to execute
      * @param workingDirectory The directory the process should have as the working directory
      */
-    public Executor(List<String> cmdList, File workingDirectory) {
+    public Executor(List<String> cmdList, @Nullable File workingDirectory) {
         this(cmdList, workingDirectory, new HashMap<>());
     }
 
@@ -104,7 +104,7 @@ public class Executor {
      *                it will be terminated. If the value is 0, no timer
      *                will be set up.
      */
-    public Executor(List<String> cmdList, File workingDirectory, int timeout) {
+    public Executor(List<String> cmdList, @Nullable File workingDirectory, int timeout) {
         this(cmdList, workingDirectory, new HashMap<>());
 
         this.timeout = timeout * 1000;
@@ -116,7 +116,7 @@ public class Executor {
      * @param cmdList A list containing the command to execute
      * @param workingDirectory The directory the process should have as the working directory
      */
-    public Executor(List<String> cmdList, File workingDirectory, Map<String, String> environ) {
+    public Executor(List<String> cmdList, @Nullable File workingDirectory, Map<String, String> environ) {
         this.cmdList = cmdList;
         this.workingDirectory = workingDirectory;
         this.environ = environ;
@@ -142,6 +142,10 @@ public class Executor {
         int timeoutSec = env.isIndexer() ? env.getIndexerCommandTimeout() : env.getInteractiveCommandTimeout();
 
         this.timeout = timeoutSec * 1000;
+    }
+
+    int getTimeout() {
+        return timeout / 1000;
     }
 
     /**
@@ -239,7 +243,7 @@ public class Executor {
                     @Override public void run() {
                         LOGGER.log(Level.WARNING,
                             String.format("Terminating process of command [%s] in directory '%s' " +
-                            "due to timeout %d seconds", cmd_str, dir_str, timeout / 1000));
+                            "due to timeout %d seconds", cmd_str, dir_str, getTimeout()));
                         proc.destroy();
                     }
                 }, timeout);

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -131,7 +131,7 @@ public class Executor {
      * @param workingDirectory The directory the process should have as the working directory
      * @param useTimeout terminate the process after default timeout or not
      */
-    public Executor(List<String> cmdList, File workingDirectory, boolean useTimeout) {
+    public Executor(List<String> cmdList, @Nullable File workingDirectory, boolean useTimeout) {
         this(cmdList, workingDirectory);
         if (!useTimeout) {
             this.timeout = 0;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/Executor.java
@@ -111,10 +111,11 @@ public class Executor {
     }
 
     /**
-     * Create a new instance of the Executor with default command timeout value.
+     * Create a new instance of the Executor with default command timeout value and environment.
      * The timeout value will be based on the running context (indexer or web application).
      * @param cmdList A list containing the command to execute
      * @param workingDirectory The directory the process should have as the working directory
+     * @param environ map of environment variables to be added/overridden
      */
     public Executor(List<String> cmdList, @Nullable File workingDirectory, Map<String, String> environ) {
         this.cmdList = cmdList;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -196,6 +196,7 @@ public class MercurialRepositoryTest {
         commandWithArgs.addAll(Arrays.asList(args));
 
         final Map<String, String> env = new HashMap<>();
+        // Set the user to record commits in order to prevent hg commands entering interactive mode.
         env.put("HGUSER", "Snufkin <snufkin@example.com>");
         Executor exec = new Executor(commandWithArgs, reposRoot, env);
         int exitCode = exec.exec();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -189,17 +189,17 @@ public class MercurialRepositoryTest {
      * @param args {@code hg} command arguments
      */
     public static void runHgCommand(File reposRoot, String... args) {
-        List<String> cmdargs = new ArrayList<>();
+        List<String> commandWithArgs = new ArrayList<>();
         MercurialRepository repo = new MercurialRepository();
 
-        cmdargs.add(repo.getRepoCommand());
-        cmdargs.addAll(Arrays.asList(args));
+        commandWithArgs.add(repo.getRepoCommand());
+        commandWithArgs.addAll(Arrays.asList(args));
 
-        Map<String, String> env = new HashMap<>();
-        env.put("HGUSER", "foo <foo@example.com>");
-        Executor exec = new Executor(cmdargs, reposRoot, env);
+        final Map<String, String> env = new HashMap<>();
+        env.put("HGUSER", "Snufkin <snufkin@example.com>");
+        Executor exec = new Executor(commandWithArgs, reposRoot, env);
         int exitCode = exec.exec();
-        assertEquals(0, exitCode, "hg command '" + cmdargs + "' failed."
+        assertEquals(0, exitCode, "command '" + commandWithArgs + "' failed."
                 + "\nexit code: " + exitCode
                 + "\nstdout:\n" + exec.getOutputString()
                 + "\nstderr:\n" + exec.getErrorString());
@@ -303,10 +303,7 @@ public class MercurialRepositoryTest {
         String exp_str = "This is totally plaintext file.\n";
         byte[] buffer = new byte[1024];
 
-        /*
-         * In our test repository the file was renamed twice since
-         * revision 3.
-         */
+        // In our test repository the file was renamed twice since revision 3.
         InputStream input = mr.getHistoryGet(repositoryRoot.getCanonicalPath(),
                 "novel.txt", "3");
         assertNotNull(input);
@@ -354,8 +351,7 @@ public class MercurialRepositoryTest {
         assertNotNull(history);
         assertNotNull(history.getHistoryEntries());
         assertEquals(6, history.getHistoryEntries().size());
-        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).
-                collect(Collectors.toList());
+        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).toList();
         assertEquals(List.of(Arrays.copyOfRange(REVISIONS, 4, REVISIONS.length)), revisions);
     }
 
@@ -366,8 +362,7 @@ public class MercurialRepositoryTest {
         assertNotNull(history);
         assertNotNull(history.getHistoryEntries());
         assertEquals(3, history.getHistoryEntries().size());
-        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).
-                collect(Collectors.toList());
+        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).toList();
         assertEquals(List.of(Arrays.copyOfRange(REVISIONS, 0, 3)), revisions);
     }
 
@@ -378,8 +373,7 @@ public class MercurialRepositoryTest {
         assertNotNull(history);
         assertNotNull(history.getHistoryEntries());
         assertEquals(5, history.getHistoryEntries().size());
-        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).
-                collect(Collectors.toList());
+        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).toList();
         assertEquals(List.of(Arrays.copyOfRange(REVISIONS, 2, 7)), revisions);
     }
 
@@ -393,8 +387,7 @@ public class MercurialRepositoryTest {
         assertNotNull(history);
         assertNotNull(history.getHistoryEntries());
         assertEquals(5, history.getHistoryEntries().size());
-        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).
-                collect(Collectors.toList());
+        List<String> revisions = history.getHistoryEntries().stream().map(HistoryEntry::getRevision).toList();
         assertEquals(List.of(Arrays.copyOfRange(REVISIONS, 2, 7)), revisions);
     }
 
@@ -447,8 +440,10 @@ public class MercurialRepositoryTest {
     }
 
     private static Stream<Triple<String, List<String>, List<String>>> provideParametersForPositiveAnnotationTest() {
-        return Stream.of(Triple.of("8:6a8c423f5624", List.of("7", "8"), List.of("8:6a8c423f5624", "7:db1394c05268")),
-                Triple.of("7:db1394c05268", List.of("7"), List.of("7:db1394c05268")));
+        return Stream.of(
+                Triple.of("8:6a8c423f5624", List.of("7", "8"), List.of("8:6a8c423f5624", "7:db1394c05268")),
+                Triple.of("7:db1394c05268", List.of("7"), List.of("7:db1394c05268"))
+        );
     }
 
     @ParameterizedTest
@@ -583,7 +578,7 @@ public class MercurialRepositoryTest {
         assertNotNull(tags);
         assertEquals(3, tags.size());
         expectedTags = List.of("start_of_novel", newTagName, branchTagName);
-        assertEquals(expectedTags, tags.stream().map(TagEntry::getTags).collect(Collectors.toList()));
+        assertEquals(expectedTags, tags.stream().map(TagEntry::getTags).toList());
 
         // cleanup
         IOUtils.removeRecursive(repositoryRootPath);

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/MercurialRepositoryTest.java
@@ -50,7 +50,9 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -193,7 +195,9 @@ public class MercurialRepositoryTest {
         cmdargs.add(repo.getRepoCommand());
         cmdargs.addAll(Arrays.asList(args));
 
-        Executor exec = new Executor(cmdargs, reposRoot);
+        Map<String, String> env = new HashMap<>();
+        env.put("HGUSER", "foo <foo@example.com>");
+        Executor exec = new Executor(cmdargs, reposRoot, env);
         int exitCode = exec.exec();
         assertEquals(0, exitCode, "hg command '" + cmdargs + "' failed."
                 + "\nexit code: " + exitCode

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ExecutorTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ExecutorTest.java
@@ -109,7 +109,7 @@ class ExecutorTest {
 
     /**
      * Test setting environment variable. Assumes the {@code env} program exists
-     * and reports list of environment variables.
+     * and reports list of environment variables along with their values.
      */
     @Test
     void testEnv() throws IOException {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ExecutorTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ExecutorTest.java
@@ -49,6 +49,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ExecutorTest {
 
     @Test
+    void testConstructorWithTimeout() {
+        int timeout = 42;
+        Executor executor = new Executor(List.of("foo"), null, timeout);
+        assertEquals(timeout, executor.getTimeout());
+    }
+
+    @Test
     void testString() {
         List<String> cmdList = new ArrayList<>();
         cmdList.add("echo");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ExecutorTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/util/ExecutorTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.util;
@@ -30,9 +30,12 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -64,10 +67,14 @@ class ExecutorTest {
         cmdList.add("testing org.opengrok.indexer.util.Executor");
         Executor instance = new Executor(cmdList);
         assertEquals(0, instance.exec());
-        BufferedReader in = new BufferedReader(instance.getOutputReader());
+        Reader outputReader = instance.getOutputReader();
+        assertNotNull(outputReader);
+        BufferedReader in = new BufferedReader(outputReader);
         assertEquals("testing org.opengrok.indexer.util.Executor", in.readLine());
         in.close();
-        in = new BufferedReader(instance.getErrorReader());
+        Reader errorReader = instance.getErrorReader();
+        assertNotNull(errorReader);
+        in = new BufferedReader(errorReader);
         assertNull(in.readLine());
         in.close();
     }
@@ -81,11 +88,41 @@ class ExecutorTest {
         assertEquals(0, instance.exec());
         assertNotNull(instance.getOutputStream());
         assertNotNull(instance.getErrorStream());
-        BufferedReader in = new BufferedReader(instance.getOutputReader());
+        Reader outputReader = instance.getOutputReader();
+        assertNotNull(outputReader);
+        BufferedReader in = new BufferedReader(outputReader);
         assertEquals("testing org.opengrok.indexer.util.Executor", in.readLine());
         in.close();
-        in = new BufferedReader(instance.getErrorReader());
+        Reader errorReader = instance.getErrorReader();
+        assertNotNull(errorReader);
+        in = new BufferedReader(errorReader);
         assertNull(in.readLine());
+        in.close();
+    }
+
+    /**
+     * Test setting environment variable. Assumes the {@code env} program exists
+     * and reports list of environment variables.
+     */
+    @Test
+    void testEnv() throws IOException {
+        List<String> cmdList = List.of("env");
+        final Map<String, String> env = new HashMap<>();
+        env.put("foo", "bar");
+        Executor instance = new Executor(cmdList, null, env);
+        assertEquals(0, instance.exec());
+        Reader outputReader = instance.getOutputReader();
+        assertNotNull(outputReader);
+        BufferedReader in = new BufferedReader(outputReader);
+        String line;
+        boolean found = false;
+        while ((line = in.readLine()) != null) {
+            if (line.equals("foo=bar")) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found);
         in.close();
     }
 


### PR DESCRIPTION
This fixes the `MercurialRepositoryTest.testBuildTagListOneMore` failure on macOS with Mercurial 7.1.1 by setting the `HGUSER` environment variable which evidently prevents `hg tag` from going into interactive mode.