### PR TITLE
yet more coverage for PageConfig#isNotModified()

### DIFF
--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -657,6 +657,26 @@ class PageConfigTest {
         };
     }
 
+    @Test
+    void testIsNotModifiedNullHeaderEtag() throws IOException {
+        HttpServletRequest req = new DummyHttpServletRequest() {
+            @Override
+            public String getHeader(String name) {
+                return null;
+            }
+
+            @Override
+            public String getPathInfo() {
+                return "path";
+            }
+        };
+
+        PageConfig cfg = PageConfig.get(req);
+        HttpServletResponse resp = mock(HttpServletResponse.class);
+        assertFalse(cfg.isNotModified(req, resp));
+        verify(resp).setHeader(eq(HttpHeaders.ETAG), startsWith("W/"));
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void testIsNotModifiedEtag(boolean createTimestamp) throws IOException {


### PR DESCRIPTION
Builds upon #4852 and #4853 to provide yet more coverage for `PageConfig#isNotModified()`.