### PR TITLE
add tests for PageConfig#addScript()

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -526,7 +526,7 @@ public class PageConfig {
 
     @VisibleForTesting
     public static List<String> getSortedFiles(File[] files) {
-        return Arrays.stream(files).sorted(getFileComparator()).map(File::getName).collect(Collectors.toList());
+        return Arrays.stream(files).sorted(getFileComparator()).map(File::getName).toList();
     }
 
     /**

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -135,7 +135,8 @@ public class PageConfig {
     // query parameters
     static final String PROJECT_PARAM_NAME = "project";
     static final String GROUP_PARAM_NAME = "group";
-    private static final String DEBUG_PARAM_NAME = "debug";
+    @VisibleForTesting
+    static final String DEBUG_PARAM_NAME = "debug";
 
     private final AuthorizationFramework authFramework;
     private RuntimeEnvironment env;

--- a/opengrok-web/src/main/java/org/opengrok/web/Scripts.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/Scripts.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2022, Krystof Tulinger <k.tulinger@seznam.cz>.
  */
@@ -34,6 +34,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.webjars.WebJarAssetLocator;
 
 /**
@@ -43,10 +44,14 @@ import org.webjars.WebJarAssetLocator;
  */
 public class Scripts implements Iterable<Scripts.Script> {
 
-    private static final String DEBUG_SUFFIX = "-debug";
+    @VisibleForTesting
+    static final String DEBUG_SUFFIX = "-debug";
     private static final String WEBJAR_PATH_PREFIX = "META-INF/resources/";
 
-    enum Type {
+    /**
+     * Holds type of the script.
+     */
+    public enum Type {
         MINIFIED, DEBUG
     }
 
@@ -64,10 +69,16 @@ public class Scripts implements Iterable<Scripts.Script> {
          */
         protected String scriptData;
         protected int priority;
+        private final String scriptName;
 
-        protected Script(String scriptData, int priority) {
+        protected Script(String scriptName, String scriptData, int priority) {
+            this.scriptName = scriptName;
             this.scriptData = scriptData;
             this.priority = priority;
+        }
+
+        public String getScriptName() {
+            return scriptName;
         }
 
         public abstract String toHtml();
@@ -87,7 +98,11 @@ public class Scripts implements Iterable<Scripts.Script> {
     public static class FileScript extends Script {
 
         public FileScript(String script, int priority) {
-            super(script, priority);
+            super(null, script, priority);
+        }
+
+        public FileScript(String scriptName, String script, int priority) {
+            super(scriptName, script, priority);
         }
 
         @Override
@@ -98,7 +113,6 @@ public class Scripts implements Iterable<Scripts.Script> {
                     this.getPriority() +
                     "\"></script>\n";
         }
-
     }
 
     protected static final Map<String, Script> SCRIPTS = new TreeMap<>();
@@ -209,6 +223,11 @@ public class Scripts implements Iterable<Scripts.Script> {
         return outputScripts.iterator();
     }
 
+    @VisibleForTesting
+    List<String> getScriptNames() {
+        return outputScripts.stream().map(Script::getScriptName).toList();
+    }
+
     /**
      * Add a script which is identified by the name.
      *
@@ -231,7 +250,7 @@ public class Scripts implements Iterable<Scripts.Script> {
     }
 
     private void addScript(String contextPath, String scriptName) {
-        this.addScript(new FileScript(contextPath + SCRIPTS.get(scriptName).getScriptData(),
+        this.addScript(new FileScript(scriptName, contextPath + SCRIPTS.get(scriptName).getScriptData(),
                 SCRIPTS.get(scriptName).getPriority()));
     }
 

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -874,4 +874,54 @@ class PageConfigTest {
         PageConfig cfg = PageConfig.get(req);
         assertEquals(List.of(SortOrder.LASTMODIFIED), cfg.getSortOrder());
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testAddScript(boolean isDebug) {
+        HttpServletRequest req = new DummyHttpServletRequest() {
+            @Override
+            public String getPathInfo() {
+                return "path";
+            }
+
+            @Override
+            public String getContextPath() {
+                return "/";
+            }
+
+            @Override
+            public String getParameter(String name) {
+                if (name.equals(PageConfig.DEBUG_PARAM_NAME)) {
+                    return isDebug ? "true" : "false";
+                }
+                return null;
+            }
+        };
+
+        PageConfig cfg = PageConfig.get(req);
+        final String scriptName = "utils";
+        cfg.addScript(scriptName);
+        assertTrue(cfg.getScripts().getScriptNames().
+                contains(isDebug ? scriptName + Scripts.DEBUG_SUFFIX : scriptName));
+    }
+
+    @Test
+    void testAddScriptInvalid() {
+        HttpServletRequest req = new DummyHttpServletRequest() {
+            @Override
+            public String getPathInfo() {
+                return "path";
+            }
+
+            @Override
+            public String getContextPath() {
+                return "/";
+            }
+        };
+
+        PageConfig cfg = PageConfig.get(req);
+        final String scriptName = "invalidScriptName";
+        cfg.addScript(scriptName);
+        assertFalse(cfg.getScripts().getScriptNames().contains(scriptName));
+    }
 }


### PR DESCRIPTION
Continuing the quest to increase coverage of the `PageConfig` class, this change adds tests for the `addScript()` method. Note there is a pre-existing set of tests which exercise the `Scripts` class, this merely adds tests for the missing chain link from the JSPs.

While there, I fixed some pre-existing nits such as the exposed visibility of the `Scripts#Type` enum via the `addScript(String contextPath, String scriptName, Type type)` method (by promoting it to `public`).