### PR TITLE
add test for PageConfig#findDataFiles()

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/util/IOUtils.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/util/IOUtils.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, Trond Norbye.
  * Portions Copyright (c) 2017, 2021, Chris Fraire <cfraire@me.com>.
  */
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.jetbrains.annotations.NotNull;
 import org.opengrok.indexer.logger.LoggerFactory;
 
 /**
@@ -83,21 +85,21 @@ public final class IOUtils {
     public static void removeRecursive(Path path) throws IOException {
         Files.walkFileTree(path, new SimpleFileVisitor<>() {
             @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+            public @NotNull FileVisitResult visitFile(Path file, @NotNull BasicFileAttributes attrs)
                     throws IOException {
                 Files.delete(file);
                 return FileVisitResult.CONTINUE;
             }
 
             @Override
-            public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+            public @NotNull FileVisitResult visitFileFailed(Path file, @NotNull IOException exc) throws IOException {
                 // Try to delete the file anyway.
                 Files.delete(file);
                 return FileVisitResult.CONTINUE;
             }
 
             @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+            public @NotNull FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
                 if (exc == null) {
                     Files.delete(dir);
                     return FileVisitResult.CONTINUE;

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1290,7 +1290,7 @@ public class PageConfig {
      * {@code ".gz"} to the filename. If that fails or an uncompressed version of the
      * file is younger than its compressed version, the uncompressed file gets used.
      *
-     * @param filenames filenames to lookup.
+     * @param filenames filenames to lookup, relative to source root.
      * @return an empty array if the related directory does not exist or the
      * given list is {@code null} or empty, otherwise an array, which may
      * contain {@code null} entries (when the related file could not be found)

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -371,11 +371,8 @@ class PageConfigTest {
         assertEquals(HASH_AA35C258, rev);
 
         // cleanup
-        try {
-            IOUtils.removeRecursive(env.getDataRootFile().toPath());
-        } catch (IOException e) {
-            // pass
-        }
+        env.releaseIndexSearchers();
+        IOUtils.removeRecursive(env.getDataRootFile().toPath());
     }
 
     @Test
@@ -741,11 +738,8 @@ class PageConfigTest {
         verify(resp).setHeader(eq(HttpHeaders.ETAG), startsWith("W/"));
 
         // cleanup
-        try {
-            IOUtils.removeRecursive(env.getDataRootFile().toPath());
-        } catch (IOException e) {
-            // pass
-        }
+        env.releaseIndexSearchers();
+        IOUtils.removeRecursive(env.getDataRootFile().toPath());
     }
 
     @Test

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -1035,10 +1035,7 @@ class PageConfigTest {
         assertTrue(files[2].exists());
 
         // cleanup
-        try {
-            IOUtils.removeRecursive(env.getDataRootFile().toPath());
-        } catch (IOException e) {
-            // pass
-        }
+        env.releaseIndexSearchers();
+        IOUtils.removeRecursive(env.getDataRootFile().toPath());
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -371,7 +371,11 @@ class PageConfigTest {
         assertEquals(HASH_AA35C258, rev);
 
         // cleanup
-        IOUtils.removeRecursive(env.getDataRootFile().toPath());
+        try {
+            IOUtils.removeRecursive(env.getDataRootFile().toPath());
+        } catch (IOException e) {
+            // pass
+        }
     }
 
     @Test
@@ -737,7 +741,11 @@ class PageConfigTest {
         verify(resp).setHeader(eq(HttpHeaders.ETAG), startsWith("W/"));
 
         // cleanup
-        IOUtils.removeRecursive(env.getDataRootFile().toPath());
+        try {
+            IOUtils.removeRecursive(env.getDataRootFile().toPath());
+        } catch (IOException e) {
+            // pass
+        }
     }
 
     @Test
@@ -1027,6 +1035,10 @@ class PageConfigTest {
         assertTrue(files[2].exists());
 
         // cleanup
-        IOUtils.removeRecursive(env.getDataRootFile().toPath());
+        try {
+            IOUtils.removeRecursive(env.getDataRootFile().toPath());
+        } catch (IOException e) {
+            // pass
+        }
     }
 }


### PR DESCRIPTION
Yet another `PageConfig` test coverage change. This time for the `findDataFiles()` method used solely in the JSPs.