### PR TITLE
increase coverage of PageConfig#getEtag()

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -136,7 +136,7 @@ public final class Configuration {
     private boolean authorizationWatchdogEnabled;
     private AuthorizationStack pluginStack;
     private Map<String, Project> projects; // project name -> Project
-    private Map<String, Group> groups; // project name -> Group
+    private Map<String, Group> groups; // group name -> Group
     private String sourceRoot;
     private String dataRoot;
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -2062,7 +2062,7 @@ public final class RuntimeEnvironment {
 
     /**
      * Add a message to the application.
-     * Also schedules a expiration timer to remove this message after its expiration.
+     * Also schedules an expiration timer to remove this message after its expiration.
      *
      * @param message the message
      */

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -90,7 +90,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
 import static org.opengrok.indexer.history.LatestRevisionUtil.getLatestRevision;
-import static org.opengrok.indexer.web.messages.MessagesContainer.MESSAGES_MAIN_PAGE_TAG;
 
 /**
  * Unit tests for the {@code PageConfig} class.

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -765,6 +765,7 @@ class PageConfigTest {
                 Collections.singleton(projectName),
                 Message.MessageLevel.INFO,
                 Duration.ofMinutes(100)));
+        assertEquals(1, env.getMessages(projectName).size());
 
         DummyHttpServletRequest req = mock(DummyHttpServletRequest.class);
         when(req.getPathInfo()).thenReturn("/mercurial/main.c");

--- a/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/PageConfigTest.java
@@ -30,11 +30,14 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -56,6 +59,7 @@ import org.opengrok.indexer.authorization.AuthorizationFramework;
 import org.opengrok.indexer.authorization.AuthorizationPlugin;
 import org.opengrok.indexer.authorization.TestPlugin;
 import org.opengrok.indexer.condition.EnabledForRepository;
+import org.opengrok.indexer.configuration.Group;
 import org.opengrok.indexer.configuration.IndexTimestamp;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -69,6 +73,7 @@ import org.opengrok.indexer.util.TestRepository;
 import org.opengrok.indexer.web.DummyHttpServletRequest;
 import org.opengrok.indexer.web.QueryParameters;
 import org.opengrok.indexer.web.SortOrder;
+import org.opengrok.indexer.web.messages.Message;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -85,6 +90,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.MERCURIAL;
 import static org.opengrok.indexer.history.LatestRevisionUtil.getLatestRevision;
+import static org.opengrok.indexer.web.messages.MessagesContainer.MESSAGES_MAIN_PAGE_TAG;
 
 /**
  * Unit tests for the {@code PageConfig} class.
@@ -744,8 +750,25 @@ class PageConfigTest {
 
     @Test
     void testIsNotModifiedNotModified() {
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        env.setProjectsEnabled(true);
+        Map<String, Group> groups = new TreeMap<>();
+        Map<String, Project> projects = new TreeMap<>();
+        final String groupName = "test-group";
+        final String projectName = "test-project";
+
+        // Add message for a project in a group to increase coverage of getEtag().
+        groups.put(groupName, new Group(groupName, projectName));
+        projects.put(projectName, new Project(projectName, "/mercurial"));
+        env.setGroups(groups);
+        env.setProjects(projects);
+        env.addMessage(new Message("test",
+                Collections.singleton(projectName),
+                Message.MessageLevel.INFO,
+                Duration.ofMinutes(100)));
+
         DummyHttpServletRequest req = mock(DummyHttpServletRequest.class);
-        when(req.getPathInfo()).thenReturn("/");
+        when(req.getPathInfo()).thenReturn("/mercurial/main.c");
         PageConfig cfg = PageConfig.get(req);
         final String etag = cfg.getEtag();
         when(req.getHeader(HttpHeaders.IF_NONE_MATCH)).thenReturn(etag);


### PR DESCRIPTION
The coverage of `PageConfig#getEtag()` can be increased further by adding a message to the system.