### PR TITLE
add test for PageConfig#evaluateMatchOffset()

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -1890,4 +1890,9 @@ public class PageConfig {
         }
         return false;
     }
+
+    @VisibleForTesting
+    String getFragmentIdentifier() {
+        return fragmentIdentifier;
+    }
 }


### PR DESCRIPTION
Another test addition to cover the `PageConfig#evaluateMatchOffset()` method called only from JSPs.