### PR TITLE
rename Docker password to PAT (personal access token)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Build and optionally push Docker image
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        DOCKER_PAT: ${{ secrets.DOCKER_PAT }}
         OPENGROK_REPO_SLUG: ${{ github.repository }}
         OPENGROK_REF: ${{ github.ref }}
       run: ./dev/docker.sh
@@ -46,5 +46,5 @@ jobs:
       env:
         OPENGROK_REPO_SLUG: ${{ github.repository }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        DOCKER_PAT: ${{ secrets.DOCKER_PAT }}
       run: ./dev/dockerhub_readme.py

--- a/dev/dockerhub_readme.py
+++ b/dev/dockerhub_readme.py
@@ -5,7 +5,7 @@
 
  This script uses the following secure variables:
   - DOCKER_USERNAME
-  - DOCKER_PASSWORD
+  - DOCKER_PAT
 
  These are set via https://github.com/oracle/opengrok/settings/secrets
 """
@@ -21,36 +21,36 @@ IMAGE = "opengrok/docker"
 MAIN_REPO_SLUG = "oracle/opengrok"
 
 
-def get_token(username, password):
+def get_token(username, pat):
     """
     :param username: Docker hub username
-    :param password: Docker hub password
+    :param pat: Docker hub PAT (personal access token)
     :return JWT token string from Docker hub API response
     """
 
     logger = logging.getLogger(__name__)
 
-    logger.debug("Getting Docker hub token using username/password")
+    logger.debug("Getting Docker hub token using username/pat")
     headers = {"Content-Type": "application/json"}
-    data = {"username": f"{username}", "password": f"{password}"}
+    data = {"username": f"{username}", "password": f"{pat}"}
     response = requests.post(f"{API_URL}/users/login/", headers=headers, json=data)
     response.raise_for_status()
 
     return response.json()["token"]
 
 
-def update_readme(image, readme_file_path, username, password):
+def update_readme(image, readme_file_path, username, pat):
     """
     Update README file for given image on Docker hub.
     :param image: image path (in the form of "namespace_name/repository_name")
     :param readme_file_path path to the README file
     :param username: Docker hub username
-    :param password: Docker hub password
+    :param pat: Docker hub PAT (personal access token)
     """
 
     logger = logging.getLogger(__name__)
 
-    token = get_token(username, password)
+    token = get_token(username, pat)
     headers = {"Content-Type": "application/json", "Authorization": f"JWT {token}"}
     with open(readme_file_path, "r") as readme_fp:
         readme_data = readme_fp.read()
@@ -70,8 +70,8 @@ def check_push_env():
     Will exit the program if the environment is not setup for pushing images to Docker hub.
     Specifically, number of environment variables is required:
       - DOCKER_USERNAME
-      - DOCKER_PASSWORD
-    :return Docker hub username and password
+      - DOCKER_pat
+    :return Docker hub username and pat
     """
 
     logger = logging.getLogger(__name__)
@@ -95,12 +95,12 @@ def check_push_env():
         logger.info("DOCKER_USERNAME is empty, exiting")
         sys.exit(1)
 
-    docker_password = os.environ.get("DOCKER_PASSWORD")
-    if docker_password is None or len(docker_password) == 0:
-        logger.info("DOCKER_PASSWORD is empty, exiting")
+    docker_pat = os.environ.get("DOCKER_PAT")
+    if docker_pat is None or len(docker_pat) == 0:
+        logger.info("DOCKER_PAT is empty, exiting")
         sys.exit(1)
 
-    return docker_username, docker_password
+    return docker_username, docker_pat
 
 
 def main():
@@ -110,9 +110,9 @@ def main():
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
 
-    docker_username, docker_password = check_push_env()
+    docker_username, docker_pat = check_push_env()
     try:
-        update_readme(IMAGE, "docker/README.md", docker_username, docker_password)
+        update_readme(IMAGE, "docker/README.md", docker_username, docker_pat)
     except requests.exceptions.HTTPError as exc:
         logger.error(exc)
         sys.exit(1)


### PR DESCRIPTION
This change renames `DOCKER_PASSWORD` environment variable used by the docker scripts to `DOCKER_PAT` to signify this is a PAT (personal access token) rather than user's password.

New PAT was created on Docker hub and the `DOCKER_PAT` secret set in Github repo's settings.

Also, some shell nits are being fixed in `docker.sh`.