### PR TITLE
Add user-select CSS for line numbers in file viewer

### DIFF
--- a/opengrok-web/src/main/webapp/default/style-1.0.4.css
+++ b/opengrok-web/src/main/webapp/default/style-1.0.4.css
@@ -740,6 +740,10 @@ div[id^='src'] pre {
     background-color: #dddddd;
     color: #666;
     margin-right: .5ex;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .blame .search {


### PR DESCRIPTION
# Add CSS to disable text selection for line numbers
Fixes #4856
### Description
This pull request improves the user experience when copying code from the file viewer and diff views. Currently, selecting text often includes the line numbers, which interferes with copying code snippets.
I have added `user-select: none` (and its vendor-prefixed variants) to the CSS classes responsible for rendering line numbers (`.l`, `.hl`, `del.d`, etc.). This ensures that line numbers are skipped during text selection while ensuring links and other interactions remain functional.
### Changes
- Modified [opengrok-web/src/main/webapp/default/style-1.0.4.css] to apply selection disabling styles to line number classes.
### Verification
- Validated that the modified CSS classes (`.l`, `.hl`, `del.d`) are correctly used for line numbers in [diff.jsp] and other views.
- Verified that `user-select` is the standard approach for this behavior and does not affect the ability to click on line number links (if applicable).

<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be suing Oracle over code you donate to {OpenGrok project (and similarly, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
An alternative is to provide a written acceptance of the OCA line into the comment of specific pull request (and ideally sign, scan, and mail back the OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
