### PR TITLE
Docker: fix chown missing operand

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -26,8 +26,8 @@ function fix_ownership() {
   # Perform the check per subdirectory to avoid unnecessary churn.
   # Assumes the ownership of the directories matches its subdirectories/files.
   #
-  find "$dir" -maxdepth 1 -mindepth 1 \! -user $OWNER_USER -o \! -group $OWNER_GROUP | \
-      xargs chown -R $OWNER_USER:$OWNER_GROUP
+  find "$dir" -maxdepth 1 -mindepth 1 \( ! -user "$OWNER_USER" -o ! -group "$OWNER_GROUP" \) \
+    -exec chown -R "$OWNER_USER:$OWNER_GROUP" {} +
 }
 
 command -v gosu >/dev/null 2>&1 || { echo "gosu missing"; exit 1; }
@@ -35,13 +35,13 @@ command -v gosu >/dev/null 2>&1 || { echo "gosu missing"; exit 1; }
 DATA_ROOT="/opengrok/data"
 if [[ ! -d $DATA_ROOT ]]; then
   echo "Expected mounted directory at '$DATA_ROOT' but found none; create volume or directory"
-	exit 1
+  exit 1
 fi
 
 SRC_ROOT="/opengrok/src"
 if [[ ! -d $SRC_ROOT ]]; then
   echo "Expected mounted directory at '$SRC_ROOT' but found none; create volume or directory"
-	exit 1
+  exit 1
 fi
 
 # The user/group the start program will run as.


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
I get this error with the latest (1.14.9) docker image:
chown: missing operand after ‘appuser:appgroup’
My change seems to fix the problem.