### PR TITLE
Fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Copyright (c) 2006, 2025 Oracle and/or its affiliates. All rights reserved.
 
 
 # OpenGrok - a wicked fast source browser
-[![Github actions build](https://github.com/oracle/opengrok/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/oracle/opengrok/actions)
+[![GitHub actions build](https://github.com/oracle/opengrok/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/oracle/opengrok/actions)
 [![Coverage status](https://sonarcloud.io/api/project_badges/measure?project=org.opengrok%3Aopengrok-top&metric=coverage)](https://sonarcloud.io/summary/new_code?id=org.opengrok%3Aopengrok-top)
 [![SonarQube status](https://sonarcloud.io/api/project_badges/measure?project=org.opengrok%3Aopengrok-top&metric=alert_status)](https://sonarcloud.io/dashboard?id=org.opengrok%3Aopengrok-top)
 [![License](https://img.shields.io/badge/License-CDDL%201.0-blue.svg)](https://opensource.org/licenses/CDDL-1.0)
@@ -52,7 +52,7 @@ For full list of contributors see https://github.com/oracle/opengrok/graphs/cont
 
 ## 5. Contact us
 
-Use the [Github Discussions](https://github.com/oracle/opengrok/discussions).
+Use the [GitHub Discussions](https://github.com/oracle/opengrok/discussions).
 
 ## 6. Run as container
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -123,7 +123,7 @@ The container has OpenGrok as default web app installed (accessible directly fro
 
 http://localhost:8080/
 
-The first reindex will take some time to finish. Subsequent reindex will be incremental so will take signigicantly less time.
+The first reindex will take some time to finish. Subsequent reindex will be incremental so will take significantly less time.
 
 ## Using Docker compose
 


### PR DESCRIPTION
Fixed a few typos I noticed while reading through the docs:

  - "signigicantly" → "significantly" in docker/README.md
  - "Github" → "GitHub" in README.md (2 places)

  All changes are in markdown files only.