### PR TITLE
improve test coverate of Ctags.doCtags() a bit

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/Ctags.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
@@ -454,7 +454,7 @@ public class Ctags implements Resettable {
     }
 
     /**
-     * Run ctags on a file.
+     * Run {@code ctags} program on a file.
      * @param file file path to process
      * @return valid instance of {@link Definitions} or {@code null} on error
      * @throws IOException I/O exception
@@ -463,7 +463,7 @@ public class Ctags implements Resettable {
     @Nullable
     public Definitions doCtags(String file) throws IOException, InterruptedException {
 
-        if (file.length() < 1 || "\n".equals(file)) {
+        if (file.isEmpty() || "\n".equals(file)) {
             return null;
         }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
@@ -24,10 +24,7 @@
 package org.opengrok.indexer.analysis;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;


### PR DESCRIPTION
Improves test coverage of `Ctags.doCtags()` for invalid inputs. While there I performed some low hanging fruit maintenance on the neighboring areas.