### PR TITLE
Add support for YANG file extension and analyzer support (#4415)

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -111,6 +111,7 @@ import org.opengrok.indexer.analysis.typescript.TypeScriptAnalyzerFactory;
 import org.opengrok.indexer.analysis.uue.UuencodeAnalyzerFactory;
 import org.opengrok.indexer.analysis.vb.VBAnalyzerFactory;
 import org.opengrok.indexer.analysis.verilog.VerilogAnalyzerFactory;
+import org.opengrok.indexer.analysis.yang.YangAnalyzerFactory;
 import org.opengrok.indexer.analysis.yaml.YamlAnalyzerFactory;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -263,6 +264,7 @@ public class AnalyzerGuru {
                 new BZip2AnalyzerFactory(),
                 new XMLAnalyzerFactory(),
                 new YamlAnalyzerFactory(),
+                new YangAnalyzerFactory(),
                 MandocAnalyzerFactory.DEFAULT_INSTANCE,
                 TroffAnalyzerFactory.DEFAULT_INSTANCE,
                 new ELFAnalyzerFactory(),
@@ -353,7 +355,7 @@ public class AnalyzerGuru {
      * has been called.
      */
     public static long getVersionNo() {
-        final int ver32 = 20230921_00; // Edit comment above too!
+        final int ver32 = 20260217_00; // Edit comment above too!
         long ver = ver32;
         if (customizationHashCode != 0) {
             ver |= (long) customizationHashCode << 32;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/AnalyzerGuru.java
@@ -112,6 +112,7 @@ import org.opengrok.indexer.analysis.typescript.TypeScriptAnalyzerFactory;
 import org.opengrok.indexer.analysis.uue.UuencodeAnalyzerFactory;
 import org.opengrok.indexer.analysis.vb.VBAnalyzerFactory;
 import org.opengrok.indexer.analysis.verilog.VerilogAnalyzerFactory;
+import org.opengrok.indexer.analysis.yang.YangAnalyzerFactory;
 import org.opengrok.indexer.analysis.yaml.YamlAnalyzerFactory;
 import org.opengrok.indexer.configuration.Project;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -264,6 +265,7 @@ public class AnalyzerGuru {
                 new BZip2AnalyzerFactory(),
                 new XMLAnalyzerFactory(),
                 new YamlAnalyzerFactory(),
+                new YangAnalyzerFactory(),
                 MandocAnalyzerFactory.DEFAULT_INSTANCE,
                 TroffAnalyzerFactory.DEFAULT_INSTANCE,
                 new ELFAnalyzerFactory(),
@@ -347,7 +349,7 @@ public class AnalyzerGuru {
      * {@link FileAnalyzerFactory} subclasses are revised to target more or
      * different files.
      * @return a value whose lower 32-bits are a static value
-     * 20260504_00
+     * 20260511_00
      * for the current implementation and whose higher-32 bits are non-zero if
      * {@link #addExtension(java.lang.String, AnalyzerFactory)}
      * or
@@ -355,7 +357,7 @@ public class AnalyzerGuru {
      * has been called.
      */
     public static long getVersionNo() {
-        final int ver32 = 20260504_00; // Edit comment above too!
+        final int ver32 = 20260511_00; // Edit comment above too!
         long ver = ver32;
         if (customizationHashCode != 0) {
             ver |= (long) customizationHashCode << 32;

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/Consts.java
@@ -1,0 +1,111 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, nishank.soni <soninishank8@gmail.com>.
+ */
+package org.opengrok.indexer.analysis.yang;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * YANG statement keywords.
+ */
+public class Consts {
+
+    private static final Set<String> kwd = new HashSet<>();
+
+    public static final Set<String> KEYWORDS = Collections.unmodifiableSet(kwd);
+
+    static {
+        kwd.add("action");
+        kwd.add("anydata");
+        kwd.add("anyxml");
+        kwd.add("argument");
+        kwd.add("augment");
+        kwd.add("base");
+        kwd.add("belongs-to");
+        kwd.add("bit");
+        kwd.add("case");
+        kwd.add("choice");
+        kwd.add("config");
+        kwd.add("contact");
+        kwd.add("container");
+        kwd.add("default");
+        kwd.add("description");
+        kwd.add("deviation");
+        kwd.add("deviate");
+        kwd.add("enum");
+        kwd.add("error-app-tag");
+        kwd.add("error-message");
+        kwd.add("extension");
+        kwd.add("feature");
+        kwd.add("fraction-digits");
+        kwd.add("grouping");
+        kwd.add("identity");
+        kwd.add("if-feature");
+        kwd.add("import");
+        kwd.add("include");
+        kwd.add("input");
+        kwd.add("key");
+        kwd.add("leaf");
+        kwd.add("leaf-list");
+        kwd.add("length");
+        kwd.add("list");
+        kwd.add("mandatory");
+        kwd.add("max-elements");
+        kwd.add("min-elements");
+        kwd.add("modifier");
+        kwd.add("module");
+        kwd.add("must");
+        kwd.add("namespace");
+        kwd.add("notification");
+        kwd.add("ordered-by");
+        kwd.add("organization");
+        kwd.add("output");
+        kwd.add("path");
+        kwd.add("pattern");
+        kwd.add("position");
+        kwd.add("prefix");
+        kwd.add("presence");
+        kwd.add("range");
+        kwd.add("reference");
+        kwd.add("refine");
+        kwd.add("require-instance");
+        kwd.add("revision");
+        kwd.add("revision-date");
+        kwd.add("rpc");
+        kwd.add("status");
+        kwd.add("submodule");
+        kwd.add("type");
+        kwd.add("typedef");
+        kwd.add("unique");
+        kwd.add("units");
+        kwd.add("uses");
+        kwd.add("value");
+        kwd.add("when");
+        kwd.add("yang-version");
+        kwd.add("yin-element");
+    }
+
+    private Consts() {
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangAnalyzer.java
@@ -1,0 +1,40 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates.
+ */
+package org.opengrok.indexer.analysis.yang;
+
+import org.opengrok.indexer.analysis.AnalyzerFactory;
+import org.opengrok.indexer.analysis.plain.PlainAnalyzer;
+
+/**
+ * Analyzer for YANG files with plain-text indexing and xref behavior.
+ */
+public class YangAnalyzer extends PlainAnalyzer {
+
+    /**
+     * Creates a new instance of YangAnalyzer.
+     * @param factory defined instance for the analyzer
+     */
+    protected YangAnalyzer(AnalyzerFactory factory) {
+        super(factory);
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangAnalyzer.java
@@ -1,0 +1,40 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, nishank.soni <soninishank8@gmail.com>.
+ */
+package org.opengrok.indexer.analysis.yang;
+
+import org.opengrok.indexer.analysis.AnalyzerFactory;
+import org.opengrok.indexer.analysis.plain.PlainAnalyzer;
+
+/**
+ * Analyzer for YANG files with plain-text indexing and xref behavior.
+ */
+public class YangAnalyzer extends PlainAnalyzer {
+
+    /**
+     * Creates a new instance of YangAnalyzer.
+     * @param factory defined instance for the analyzer
+     */
+    protected YangAnalyzer(AnalyzerFactory factory) {
+        super(factory);
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangAnalyzer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangAnalyzer.java
@@ -22,19 +22,54 @@
  */
 package org.opengrok.indexer.analysis.yang;
 
+import java.io.Reader;
+import org.opengrok.indexer.analysis.AbstractAnalyzer;
 import org.opengrok.indexer.analysis.AnalyzerFactory;
-import org.opengrok.indexer.analysis.plain.PlainAnalyzer;
+import org.opengrok.indexer.analysis.JFlexTokenizer;
+import org.opengrok.indexer.analysis.JFlexXref;
+import org.opengrok.indexer.analysis.plain.AbstractSourceCodeAnalyzer;
 
 /**
- * Analyzer for YANG files with plain-text indexing and xref behavior.
+ * Analyzer for YANG files.
  */
-public class YangAnalyzer extends PlainAnalyzer {
+@SuppressWarnings("java:S110")
+public class YangAnalyzer extends AbstractSourceCodeAnalyzer {
 
     /**
      * Creates a new instance of YangAnalyzer.
      * @param factory defined instance for the analyzer
      */
     protected YangAnalyzer(AnalyzerFactory factory) {
-        super(factory);
+        super(factory, () -> new JFlexTokenizer(new YangSymbolTokenizer(
+                AbstractAnalyzer.DUMMY_READER)));
+    }
+
+    /**
+     * @return {@code null} as there is no aligned ctags language.
+     */
+    @Override
+    public String getCtagsLang() {
+        return null;
+    }
+
+    /**
+     * Gets a version number to be used to tag processed documents so that
+     * re-analysis can be re-done later if a stored version number is different
+     * from the current implementation.
+     * @return 20260511_00
+     */
+    @Override
+    protected int getSpecializedVersionNo() {
+        return 20260511_00; // Edit comment above too!
+    }
+
+    /**
+     * Creates a wrapped instance of {@link YangXref}.
+     * @param reader an instance passed to the new {@link YangXref}
+     * @return a defined instance
+     */
+    @Override
+    protected JFlexXref newXref(Reader reader) {
+        return new JFlexXref(new YangXref(reader));
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangAnalyzerFactory.java
@@ -1,0 +1,48 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates.
+ */
+package org.opengrok.indexer.analysis.yang;
+
+import org.opengrok.indexer.analysis.AbstractAnalyzer;
+import org.opengrok.indexer.analysis.FileAnalyzerFactory;
+
+/**
+ * Factory for YANG files.
+ */
+public class YangAnalyzerFactory extends FileAnalyzerFactory {
+
+    private static final String NAME = "Yang";
+
+    private static final String[] SUFFIXES = {
+        "YANG"
+    };
+
+    public YangAnalyzerFactory() {
+        super(null, null, SUFFIXES, null, null, "text/plain",
+                AbstractAnalyzer.Genre.PLAIN, NAME, true);
+    }
+
+    @Override
+    protected AbstractAnalyzer newAnalyzer() {
+        return new YangAnalyzer(this);
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangAnalyzerFactory.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangAnalyzerFactory.java
@@ -1,0 +1,48 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, nishank.soni <soninishank8@gmail.com>.
+ */
+package org.opengrok.indexer.analysis.yang;
+
+import org.opengrok.indexer.analysis.AbstractAnalyzer;
+import org.opengrok.indexer.analysis.FileAnalyzerFactory;
+
+/**
+ * Factory for YANG files.
+ */
+public class YangAnalyzerFactory extends FileAnalyzerFactory {
+
+    private static final String NAME = "Yang";
+
+    private static final String[] SUFFIXES = {
+        "YANG"
+    };
+
+    public YangAnalyzerFactory() {
+        super(null, null, SUFFIXES, null, null, "text/plain",
+                AbstractAnalyzer.Genre.PLAIN, NAME, true);
+    }
+
+    @Override
+    protected AbstractAnalyzer newAnalyzer() {
+        return new YangAnalyzer(this);
+    }
+}

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangLexer.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/yang/YangLexer.java
@@ -1,0 +1,68 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, nishank.soni <soninishank8@gmail.com>.
+ */
+package org.opengrok.indexer.analysis.yang;
+
+import java.io.IOException;
+import org.opengrok.indexer.analysis.JFlexJointLexer;
+import org.opengrok.indexer.analysis.JFlexSymbolMatcher;
+import org.opengrok.indexer.analysis.Resettable;
+
+/**
+ * Base class for YANG lexers.
+ */
+public abstract class YangLexer extends JFlexSymbolMatcher
+        implements JFlexJointLexer, Resettable {
+
+    /**
+     * Calls {@link #phLOC()} if the scanner is not in a comment state.
+     */
+    public void chkLOC() {
+        int state = yystate();
+        if (state != COMMENT() && state != SCOMMENT()) {
+            phLOC();
+        }
+    }
+
+    public abstract void offer(String value) throws IOException;
+
+    public abstract boolean offerSymbol(String value, int captureOffset, boolean ignoreKwd)
+            throws IOException;
+
+    public abstract void skipSymbol();
+
+    public abstract void offerKeyword(String value) throws IOException;
+
+    public abstract void startNewLine() throws IOException;
+
+    public abstract void disjointSpan(String className) throws IOException;
+
+    public abstract void phLOC();
+
+    protected abstract boolean takeAllContent();
+
+    protected abstract boolean returnOnSymbol();
+
+    public abstract int COMMENT();
+
+    public abstract int SCOMMENT();
+}

--- a/opengrok-indexer/src/main/jflex/analysis/yang/Yang.lexh
+++ b/opengrok-indexer/src/main/jflex/analysis/yang/Yang.lexh
@@ -1,0 +1,31 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, nishank.soni <soninishank8@gmail.com>.
+ */
+
+MaybeWhsp = {WhspChar}*
+Identifier = [A-Za-z_] [A-Za-z0-9_.-]*
+Date = [0-9]{4} "-" [0-9]{2} "-" [0-9]{2}
+Number = [+-]? [0-9]+ ("." [0-9]+)?
+FileExt = [Yy][Aa][Nn][Gg]
+File = [a-zA-Z]{FNameChar}* "." {FileExt}
+
+%state COMMENT SCOMMENT DSTRING SSTRING

--- a/opengrok-indexer/src/main/jflex/analysis/yang/YangProductions.lexh
+++ b/opengrok-indexer/src/main/jflex/analysis/yang/YangProductions.lexh
@@ -1,0 +1,171 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, nishank.soni <soninishank8@gmail.com>.
+ */
+
+<YYINITIAL> {
+    {Identifier}    {
+        chkLOC();
+        if (offerSymbol(yytext(), 0, false) && returnOnSymbol()) {
+            return yystate();
+        }
+    }
+
+    {Date}    {
+        chkLOC();
+        offer(yytext());
+    }
+
+    {Number}    {
+        chkLOC();
+        onDisjointSpanChanged(HtmlConsts.NUMBER_CLASS, yychar);
+        offer(yytext());
+        onDisjointSpanChanged(null, yychar + yylength());
+    }
+
+    \"    {
+        chkLOC();
+        yypush(DSTRING);
+        onDisjointSpanChanged(HtmlConsts.STRING_CLASS, yychar);
+        offer(yytext());
+    }
+
+    \'    {
+        chkLOC();
+        yypush(SSTRING);
+        onDisjointSpanChanged(HtmlConsts.STRING_CLASS, yychar);
+        offer(yytext());
+    }
+
+    "//"    {
+        yypush(SCOMMENT);
+        onDisjointSpanChanged(HtmlConsts.COMMENT_CLASS, yychar);
+        offer(yytext());
+    }
+
+    "/*"    {
+        yypush(COMMENT);
+        onDisjointSpanChanged(HtmlConsts.COMMENT_CLASS, yychar);
+        offer(yytext());
+    }
+}
+
+<DSTRING> {
+    \\ [^]    {
+        chkLOC();
+        offer(yytext());
+    }
+
+    \"    {
+        chkLOC();
+        offer(yytext());
+        yypop();
+        onDisjointSpanChanged(null, yychar + yylength());
+    }
+}
+
+<SSTRING> {
+    \'    {
+        chkLOC();
+        offer(yytext());
+        yypop();
+        onDisjointSpanChanged(null, yychar + yylength());
+    }
+}
+
+<COMMENT> {
+    {MaybeWhsp}{EOL}    {
+        onDisjointSpanChanged(null, yychar);
+        onEndOfLineMatched(yytext(), yychar);
+        onDisjointSpanChanged(HtmlConsts.COMMENT_CLASS, yychar);
+    }
+
+    "*/"    {
+        offer(yytext());
+        onDisjointSpanChanged(null, yychar + yylength());
+        yypop();
+    }
+}
+
+<DSTRING, SSTRING> {
+    {MaybeWhsp}{EOL}    {
+        onDisjointSpanChanged(null, yychar);
+        onEndOfLineMatched(yytext(), yychar);
+        onDisjointSpanChanged(HtmlConsts.STRING_CLASS, yychar);
+    }
+}
+
+<SCOMMENT> {
+    {MaybeWhsp}{EOL}    {
+        yypushback(yylength());
+        yypop();
+        onDisjointSpanChanged(null, yychar);
+    }
+}
+
+<YYINITIAL, SCOMMENT> {
+    {MaybeWhsp}{EOL}    {
+        onEndOfLineMatched(yytext(), yychar);
+    }
+}
+
+<YYINITIAL, COMMENT, SCOMMENT, DSTRING, SSTRING> {
+    {WhspChar} | [[\s]--[\n\r]]    {
+        offer(yytext());
+    }
+}
+
+<YYINITIAL, COMMENT, SCOMMENT, DSTRING, SSTRING> {
+    [^\n\r]    {
+        chkLOC();
+        offer(yytext());
+    }
+}
+
+<COMMENT, SCOMMENT, DSTRING, SSTRING> {
+    {FPath}    {
+        chkLOC();
+        if (takeAllContent()) {
+            onPathlikeMatched(yytext(), '/', false, yychar);
+        }
+    }
+
+    {File}    {
+        chkLOC();
+        if (takeAllContent()) {
+            onFilelikeMatched(yytext(), yychar);
+        }
+    }
+
+    {FNameChar}+ "@" {FNameChar}+ "." {FNameChar}+    {
+        chkLOC();
+        if (takeAllContent()) {
+            onEmailAddressMatched(yytext(), yychar);
+        }
+    }
+
+    {BrowseableURI}    {
+        chkLOC();
+        if (takeAllContent()) {
+            onUriMatched(yytext(), yychar, null);
+        }
+    }
+}

--- a/opengrok-indexer/src/main/jflex/analysis/yang/YangSymbolTokenizer.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/yang/YangSymbolTokenizer.lex
@@ -1,0 +1,114 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, nishank.soni <soninishank8@gmail.com>.
+ */
+
+/*
+ * Gets YANG symbols -- ignores comments, strings, and keywords.
+ */
+
+package org.opengrok.indexer.analysis.yang;
+
+import java.io.IOException;
+import org.opengrok.indexer.web.HtmlConsts;
+%%
+%public
+%class YangSymbolTokenizer
+%extends YangLexer
+%unicode
+%int
+%char
+%include ../CommonLexer.lexh
+%{
+    private String lastSymbol;
+
+    @Override
+    public void reset() {
+        super.reset();
+        lastSymbol = null;
+    }
+
+    @Override
+    public void offer(String value) throws IOException {
+    }
+
+    @Override
+    public boolean offerSymbol(String value, int captureOffset, boolean ignoreKwd)
+            throws IOException {
+        if (ignoreKwd || !Consts.KEYWORDS.contains(value)) {
+            lastSymbol = value;
+            onSymbolMatched(value, yychar + captureOffset);
+            return true;
+        }
+        lastSymbol = null;
+        return false;
+    }
+
+    @Override
+    public void skipSymbol() {
+        lastSymbol = null;
+    }
+
+    @Override
+    public void offerKeyword(String value) throws IOException {
+        lastSymbol = null;
+    }
+
+    @Override
+    public void startNewLine() throws IOException {
+    }
+
+    @Override
+    public void disjointSpan(String className) throws IOException {
+    }
+
+    @Override
+    public void phLOC() {
+    }
+
+    @Override
+    protected boolean takeAllContent() {
+        return false;
+    }
+
+    @Override
+    protected boolean returnOnSymbol() {
+        return lastSymbol != null;
+    }
+
+    @Override
+    public int COMMENT() {
+        return COMMENT;
+    }
+
+    @Override
+    public int SCOMMENT() {
+        return SCOMMENT;
+    }
+%}
+
+%include ../Common.lexh
+%include ../CommonURI.lexh
+%include ../CommonPath.lexh
+%include Yang.lexh
+
+%%
+%include YangProductions.lexh

--- a/opengrok-indexer/src/main/jflex/analysis/yang/YangXref.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/yang/YangXref.lex
@@ -1,0 +1,101 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, nishank.soni <soninishank8@gmail.com>.
+ */
+
+/*
+ * Cross references a YANG file.
+ */
+
+package org.opengrok.indexer.analysis.yang;
+
+import java.io.IOException;
+import java.util.Set;
+import org.opengrok.indexer.web.HtmlConsts;
+%%
+%public
+%class YangXref
+%extends YangLexer
+%unicode
+%int
+%char
+%include ../CommonLexer.lexh
+%include ../CommonXref.lexh
+%{
+    @Override
+    public void offer(String value) throws IOException {
+        onNonSymbolMatched(value, yychar);
+    }
+
+    @Override
+    public boolean offerSymbol(String value, int captureOffset, boolean ignoreKwd)
+            throws IOException {
+        Set<String> keywords = ignoreKwd ? null : Consts.KEYWORDS;
+        return onFilteredSymbolMatched(value, yychar + captureOffset, keywords);
+    }
+
+    @Override
+    public void skipSymbol() {
+    }
+
+    @Override
+    public void offerKeyword(String value) throws IOException {
+        onKeywordMatched(value, yychar);
+    }
+
+    @Override
+    public void startNewLine() throws IOException {
+        onEndOfLineMatched("\n", yychar);
+    }
+
+    @Override
+    public void disjointSpan(String className) throws IOException {
+        onDisjointSpanChanged(className, yychar);
+    }
+
+    @Override
+    protected boolean takeAllContent() {
+        return true;
+    }
+
+    @Override
+    protected boolean returnOnSymbol() {
+        return false;
+    }
+
+    @Override
+    public int COMMENT() {
+        return COMMENT;
+    }
+
+    @Override
+    public int SCOMMENT() {
+        return SCOMMENT;
+    }
+%}
+
+%include ../Common.lexh
+%include ../CommonURI.lexh
+%include ../CommonPath.lexh
+%include Yang.lexh
+
+%%
+%include YangProductions.lexh

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/AnalyzerGuruTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/AnalyzerGuruTest.java
@@ -48,6 +48,7 @@ import org.opengrok.indexer.analysis.plain.PlainAnalyzer;
 import org.opengrok.indexer.analysis.plain.XMLAnalyzer;
 import org.opengrok.indexer.analysis.sh.ShAnalyzer;
 import org.opengrok.indexer.analysis.sh.ShAnalyzerFactory;
+import org.opengrok.indexer.analysis.yang.YangAnalyzer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -66,6 +67,15 @@ class AnalyzerGuruTest {
     void testGetFileTypeDescriptions() {
         Map<String, String> map = AnalyzerGuru.getfileTypeDescriptions();
         assertFalse(map.isEmpty());
+        assertEquals("Yang", map.get("yang"));
+    }
+
+    @Test
+    void testYangAnalyzerBySuffix() throws Exception {
+        ByteArrayInputStream in = new ByteArrayInputStream(
+                "module example-yang {}".getBytes(StandardCharsets.UTF_8));
+        AbstractAnalyzer fa = AnalyzerGuru.getAnalyzer(in, "/dummy/file.yang");
+        assertSame(YangAnalyzer.class, fa.getClass());
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yang/YangSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yang/YangSymbolTokenizerTest.java
@@ -1,0 +1,50 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, nishank.soni <soninishank8@gmail.com>.
+ */
+package org.opengrok.indexer.analysis.yang;
+
+import java.io.InputStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.opengrok.indexer.util.CustomAssertions.assertSymbolStream;
+import static org.opengrok.indexer.util.StreamUtils.readSampleSymbols;
+
+/**
+ * Tests for {@link YangSymbolTokenizer}.
+ */
+class YangSymbolTokenizerTest {
+
+    @Test
+    void testYangSymbolStream() throws Exception {
+        String source = "analysis/yang/sample.yang";
+        String symbols = "analysis/yang/samplesymbols.txt";
+        InputStream sourceStream = getClass().getClassLoader().getResourceAsStream(source);
+        assertNotNull(sourceStream, "Should get resource " + source);
+        InputStream symbolStream = getClass().getClassLoader().getResourceAsStream(symbols);
+        assertNotNull(symbolStream, "Should get resource " + symbols);
+
+        List<String> expectedSymbols = readSampleSymbols(symbolStream);
+        assertSymbolStream(YangSymbolTokenizer.class, sourceStream, expectedSymbols);
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yang/YangXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/yang/YangXrefTest.java
@@ -1,0 +1,49 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, nishank.soni <soninishank8@gmail.com>.
+ */
+package org.opengrok.indexer.analysis.yang;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.analysis.XrefTestBase;
+
+/**
+ * Tests for {@link YangXref}.
+ */
+class YangXrefTest extends XrefTestBase {
+
+    @Test
+    @SuppressWarnings("squid:S2699")
+    void sampleTest() throws IOException {
+        writeAndCompare(new YangAnalyzerFactory(),
+                "analysis/yang/sample.yang",
+                "analysis/yang/sample_xref.html", null, 10);
+    }
+
+    @Test
+    @SuppressWarnings("squid:S2699")
+    void shouldCloseTruncatedStringSpan() throws IOException {
+        writeAndCompare(new YangAnalyzerFactory(),
+                "analysis/yang/truncated.yang",
+                "analysis/yang/truncated_xref.html", null, 1);
+    }
+}

--- a/opengrok-indexer/src/test/resources/analysis/yang/sample.yang
+++ b/opengrok-indexer/src/test/resources/analysis/yang/sample.yang
@@ -1,0 +1,13 @@
+module sample-module {
+  yang-version 1.1;
+  namespace "urn:example:sample";
+  prefix smp;
+
+  import ietf-inet-types {
+    prefix inet;
+    revision-date 2013-07-15;
+  }
+
+  // See http://example.com/yang/sample.yang and /opt/yang/sample.yang
+  leaf host { type inet:ip-address; default '127.0.0.1'; }
+}

--- a/opengrok-indexer/src/test/resources/analysis/yang/sample_xref.html
+++ b/opengrok-indexer/src/test/resources/analysis/yang/sample_xref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>sampleFile - OpenGrok cross reference for /sampleFile</title></head><body>
+<a class="l" name="1" href="#1">1</a><b>module</b> <a href="/source/s?defs=sample%5C-module" class="intelliWindow-symbol" data-definition-place="undefined-in-file">sample-module</a> {
+<a class="l" name="2" href="#2">2</a>  <b>yang-version</b> <span class="n">1.1</span>;
+<a class="l" name="3" href="#3">3</a>  <b>namespace</b> <span class="s">&quot;urn:example:sample&quot;</span>;
+<a class="l" name="4" href="#4">4</a>  <b>prefix</b> <a href="/source/s?defs=smp" class="intelliWindow-symbol" data-definition-place="undefined-in-file">smp</a>;
+<a class="l" name="5" href="#5">5</a>
+<a class="l" name="6" href="#6">6</a>  <b>import</b> <a href="/source/s?defs=ietf%5C-inet%5C-types" class="intelliWindow-symbol" data-definition-place="undefined-in-file">ietf-inet-types</a> {
+<a class="l" name="7" href="#7">7</a>    <b>prefix</b> <a href="/source/s?defs=inet" class="intelliWindow-symbol" data-definition-place="undefined-in-file">inet</a>;
+<a class="l" name="8" href="#8">8</a>    <b>revision-date</b> 2013-07-15;
+<a class="l" name="9" href="#9">9</a>  }
+<a class="hl" name="10" href="#10">10</a>
+<a class="l" name="11" href="#11">11</a>  <span class="c">// See <a href="http://example.com/yang/sample.yang">http://example.com/yang/sample.yang</a> and /<a href="/source/s?path=/opt/">opt</a>/<a href="/source/s?path=/opt/yang/">yang</a>/<a href="/source/s?path=/opt/yang/sample.yang">sample.yang</a></span>
+<a class="l" name="12" href="#12">12</a>  <b>leaf</b> <a href="/source/s?defs=host" class="intelliWindow-symbol" data-definition-place="undefined-in-file">host</a> { <b>type</b> <a href="/source/s?defs=inet" class="intelliWindow-symbol" data-definition-place="undefined-in-file">inet</a>:<a href="/source/s?defs=ip%5C-address" class="intelliWindow-symbol" data-definition-place="undefined-in-file">ip-address</a>; <b>default</b> <span class="s">&apos;127.0.0.1&apos;</span>; }
+<a class="l" name="13" href="#13">13</a>}
+<a class="l" name="14" href="#14">14</a></body>
+</html>

--- a/opengrok-indexer/src/test/resources/analysis/yang/samplesymbols.txt
+++ b/opengrok-indexer/src/test/resources/analysis/yang/samplesymbols.txt
@@ -1,0 +1,7 @@
+sample-module
+smp
+ietf-inet-types
+inet
+host
+inet
+ip-address

--- a/opengrok-indexer/src/test/resources/analysis/yang/truncated.yang
+++ b/opengrok-indexer/src/test/resources/analysis/yang/truncated.yang
@@ -1,0 +1,1 @@
+module unfinished { description "unterminated

--- a/opengrok-indexer/src/test/resources/analysis/yang/truncated_xref.html
+++ b/opengrok-indexer/src/test/resources/analysis/yang/truncated_xref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>sampleFile - OpenGrok cross reference for /sampleFile</title></head><body>
+<a class="l" name="1" href="#1">1</a><b>module</b> <a href="/source/s?defs=unfinished" class="intelliWindow-symbol" data-definition-place="undefined-in-file">unfinished</a> { <b>description</b> <span class="s">&quot;unterminated</span>
+<a class="l" name="2" href="#2">2</a><span class="s"></span></body>
+</html>


### PR DESCRIPTION
## Summary
This pull request adds support for the YANG file extension in OpenGrok:
- Recognizes `.yang` files for indexing
- Integrates analyzer support
- Adds YANG to the UI file type selector
- Includes basic indexing tests

Fixes: #4415

---

## Oracle Contributor Agreement
I hereby certify that I have signed the Oracle Contributor Agreement (OCA)
or this PR includes my acceptance of the agreement as required.

Signed-off-by: Nishank Soni <soninishank8@gmail.com>