### PR TITLE
Add support for Java record definitions in JavaXref

### DIFF
--- a/opengrok-indexer/src/main/jflex/analysis/java/JavaXref.lex
+++ b/opengrok-indexer/src/main/jflex/analysis/java/JavaXref.lex
@@ -90,6 +90,18 @@ ParamName = {Identifier} | "<" {Identifier} ">"
  \}     { chkLOC(); onScopeChanged(ScopeAction.DEC, yytext(), yychar); }
  \;     { chkLOC(); onScopeChanged(ScopeAction.END, yytext(), yychar); }
 
+"record" {WhspChar}+ {Identifier} {
+    chkLOC();
+
+    String text = yytext();
+    int idx = text.lastIndexOf(' ');
+    String keyword = text.substring(0, idx);
+    String recordName = text.substring(idx + 1);
+
+    onNonSymbolMatched(keyword + " ", yychar);
+    onFilteredSymbolMatched(recordName, yychar + idx + 1, Consts.kwd);
+}
+
 {Identifier} {
     chkLOC();
     String id = yytext();


### PR DESCRIPTION
What changes were proposed in this pull request?

This change adds handling for Java record declarations in JavaXref.lex.

Previously, record declarations were treated as normal identifiers, so the record name was not highlighted or indexed similarly to classes, interfaces, and enums.

This update adds a dedicated lexer rule for:

record User(String name, int age) {}

so that User is recognized as a symbol and can participate in navigation and definition lookup.

Why are these changes needed?

Java records are now commonly used in modern Java codebases, but OpenGrok did not recognize record declarations in the same way as other type definitions.

Without this change, record names were not indexed correctly, making navigation less useful for projects using Java records.

How was this patch tested?
Built the opengrok-indexer module successfully with Java 21
Verified that the updated lexer compiles correctly
Added a sample Java record declaration locally to confirm the lexer rule matches record definitions

Example used during testing:

record User(String name, int age) {}
Related Issue

Fixes #4930 