### PR TITLE
🐛 fix(search): align API result count with web UI

### DIFF
--- a/dev/checkstyle/suppressions.xml
+++ b/dev/checkstyle/suppressions.xml
@@ -36,7 +36,7 @@ Portions Copyright (c) 2018-2020, Chris Fraire <cfraire@me.com>.
         |LazilyInstantiate\.java|PortChecker\.java|CloseableReentrantReadWriteLock\.java|
         |ResourceLock\.java|ZeroReader\.java|ColorUtil\.java|RainbowColorGenerator\.java|WildCardMatcher.java|
         |BitKeeperAnnotationParser\.java|BitKeeperTagEntry\.java|BitKeeperTagParser\.java|BooleanUtilTest\.java|
-        |CorsEnable\.java|CorsFilter\.java" />
+        |CorsEnable\.java|CorsFilter\.java|SearchHelperStableCountTest\.java" />
 
     <suppress checks="ParameterNumber" files="CtagsReader\.java|Definitions\.java|
         |JFlexXrefUtils\.java|FileAnalyzerFactory\.java|SearchController\.java|

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -232,9 +232,9 @@ public class SearchEngine {
         int numHits = hitsPerPage * cachePages;
         TopDocs topDocs;
         if (luceneSort == null) {
-            topDocs = searcher.search(query, new TopScoreDocCollectorManager(numHits, Short.MAX_VALUE));
+            topDocs = searcher.search(query, new TopScoreDocCollectorManager(numHits, Integer.MAX_VALUE));
         } else {
-            topDocs = searcher.search(query, new TopFieldCollectorManager(luceneSort, numHits, Short.MAX_VALUE));
+            topDocs = searcher.search(query, new TopFieldCollectorManager(luceneSort, numHits, Integer.MAX_VALUE));
         }
         hits = topDocs.scoreDocs;
         totalHits = (int) topDocs.totalHits.value;
@@ -246,9 +246,9 @@ public class SearchEngine {
 
         if (!paging && totalHits > numHits) {
             if (luceneSort == null) {
-                topDocs = searcher.search(query, new TopScoreDocCollectorManager(totalHits, Short.MAX_VALUE));
+                topDocs = searcher.search(query, new TopScoreDocCollectorManager(totalHits, Integer.MAX_VALUE));
             } else {
-                topDocs = searcher.search(query, new TopFieldCollectorManager(luceneSort, totalHits, Short.MAX_VALUE));
+                topDocs = searcher.search(query, new TopFieldCollectorManager(luceneSort, totalHits, Integer.MAX_VALUE));
             }
             hits = topDocs.scoreDocs;
         }
@@ -397,7 +397,7 @@ public class SearchEngine {
                 LOGGER.log(Level.WARNING, "An error occurred while getting history context", e);
             }
         }
-        int count = hits == null ? 0 : hits.length;
+        int count = hits == null ? 0 : totalHits;
         queryBuilder = newBuilder;
         return count;
     }
@@ -450,7 +450,7 @@ public class SearchEngine {
         // TODO check if below fits for if end=old hits.length, or it should include it
         if (end > hits.length && !allCollected) {
             //do the requery, we want more than 5 pages
-            var collectorManager = new TopScoreDocCollectorManager(totalHits, Short.MAX_VALUE);
+            var collectorManager = new TopScoreDocCollectorManager(totalHits, Integer.MAX_VALUE);
             try {
                 hits = searcher.search(query, collectorManager).scoreDocs;
             } catch (Exception e) { // this exception should never be hit, since search() will hit this before

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/QueryParameters.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/QueryParameters.java
@@ -117,6 +117,27 @@ public class QueryParameters {
     public static final String MATCH_OFFSET_PARAM_EQ = MATCH_OFFSET_PARAM + "=";
 
     /**
+     * Parameter name to specify the maximum number of results returned by the search API.
+     */
+    public static final String MAXRESULTS_PARAM = "maxresults";
+
+    /**
+     * {@link #MAXRESULTS_PARAM} concatenated with {@code "=" }.
+     */
+    public static final String MAXRESULTS_PARAM_EQ = MAXRESULTS_PARAM + "=";
+
+    /**
+     * Parameter name to cap the number of matching lines returned per file by the search API
+     * (0 means unlimited, matching the HTML page).
+     */
+    public static final String MAXHITSPERFILE_PARAM = "maxhitsperfile";
+
+    /**
+     * {@link #MAXHITSPERFILE_PARAM} concatenated with {@code "=" }.
+     */
+    public static final String MAXHITSPERFILE_PARAM_EQ = MAXHITSPERFILE_PARAM + "=";
+
+    /**
      * Parameter name to specify a value indicating if redirection should be
      * short-circuited when state or query result would have an indicated
      * otherwise.

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java
@@ -61,7 +61,9 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopFieldCollectorManager;
 import org.apache.lucene.search.TopFieldDocs;
+import org.apache.lucene.search.TopScoreDocCollectorManager;
 import org.apache.lucene.search.spell.DirectSpellChecker;
 import org.apache.lucene.search.spell.SuggestMode;
 import org.apache.lucene.search.spell.SuggestWord;
@@ -475,7 +477,16 @@ public class SearchHelper {
             return this;
         }
         try {
-            TopFieldDocs fdocs = searcher.search(query, start + maxItems, sort);
+            // Use collector managers with Integer.MAX_VALUE totalHitsThreshold so totalHits
+            // is exact (rather than a lower-bound estimate). This keeps the hit count stable
+            // across repeated searches and aligns it with the SearchEngine used by the REST API.
+            int numHits = start + maxItems;
+            TopDocs fdocs;
+            if (Sort.RELEVANCE.equals(sort)) {
+                fdocs = searcher.search(query, new TopScoreDocCollectorManager(numHits, Integer.MAX_VALUE));
+            } else {
+                fdocs = searcher.search(query, new TopFieldCollectorManager(sort, numHits, Integer.MAX_VALUE));
+            }
             totalHits = fdocs.totalHits.value;
             hits = fdocs.scoreDocs;
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -305,6 +305,32 @@ class SearchEngineTest {
         instance.destroy();
     }
 
+    /**
+     * Verify that totalHits is exact (not an approximate lower bound) so that results()
+     * can fetch every matching document. With an inaccurate totalHitsThreshold, the
+     * re-query in results() would request too few documents, silently dropping results.
+     */
+    @Test
+    void testTotalHitsIsExactForFullRetrieval() {
+        SearchEngine instance = new SearchEngine();
+        instance.setFile("main.c");
+        instance.setFreetext("arguments");
+        instance.hitsPerPage = 1;
+        instance.cachePages = 1;
+
+        int count = instance.search();
+        assertTrue(count > 1);
+
+        List<Hit> allHits = new ArrayList<>();
+        instance.results(0, count, allHits);
+
+        long uniquePaths = allHits.stream().map(Hit::getPath).distinct().count();
+        assertEquals(count, uniquePaths,
+                "totalHits must be exact so results() retrieves every matching document");
+
+        instance.destroy();
+    }
+
     /* see https://github.com/oracle/opengrok/issues/2030
     @Test
     void testSearch() {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -282,6 +282,29 @@ class SearchEngineTest {
         hitsPerFile.values().forEach(count -> assertTrue(count <= maxPerFile));
     }
 
+    /**
+     * Verify that search() returns the total number of matching documents (totalHits),
+     * not the number of collected/cached hits (which is capped at hitsPerPage * cachePages).
+     */
+    @Test
+    void testSearchReturnsTotalHitsNotCachedCount() {
+        SearchEngine instance = new SearchEngine();
+        instance.setFile("main.c");
+        instance.setFreetext("arguments");
+
+        // Restrict the cache to 1 document so that totalHits > hitsPerPage * cachePages.
+        instance.hitsPerPage = 1;
+        instance.cachePages = 1;
+
+        int resultCount = instance.search();
+        assertTrue(resultCount > 1,
+                "Query should match multiple documents across test repositories");
+        assertEquals(instance.totalHits, resultCount,
+                "search() must return totalHits, not the number of cached hits");
+
+        instance.destroy();
+    }
+
     /* see https://github.com/oracle/opengrok/issues/2030
     @Test
     void testSearch() {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperStableCountTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperStableCountTest.java
@@ -1,0 +1,144 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.indexer.web;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.index.Indexer;
+import org.opengrok.indexer.search.QueryBuilder;
+import org.opengrok.indexer.util.TestRepository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link SearchHelper} produces an exact and stable {@code totalHits}
+ * regardless of the {@code maxItems} window, so the UI search total matches the REST
+ * API and does not vary across repeated searches. With the previous implementation
+ * {@code searcher.search(query, n, sort)} uses a {@code totalHitsThreshold} of 1000,
+ * so for queries matching more than 1000 documents {@code totalHits} becomes an
+ * approximate lower bound and can drift between calls.
+ *
+ * <p>To reliably exercise that threshold the test creates a synthetic corpus of
+ * {@value #SYNTHETIC_DOC_COUNT} files, each containing a unique marker token.</p>
+ */
+class SearchHelperStableCountTest {
+
+    private static final String MARKER = "searchhelperbug3239marker";
+    private static final int SYNTHETIC_DOC_COUNT = 1500;
+    private static final String SYNTHETIC_PROJECT = "synthetic_bulk";
+
+    private static TestRepository repository;
+    private static RuntimeEnvironment env;
+
+    @BeforeAll
+    static void setUpClass() throws Exception {
+        repository = new TestRepository();
+        repository.create(SearchHelperStableCountTest.class.getClassLoader().getResource("sources"));
+
+        Path syntheticDir = Path.of(repository.getSourceRoot(), SYNTHETIC_PROJECT);
+        Files.createDirectories(syntheticDir);
+        // Produce strong score variance so Lucene's block-max WAND can skip low-scoring
+        // docs once the heap is full. With the pre-fix implementation that lets the
+        // totalHitsThreshold of 1000 turn the totalHits into a lower-bound estimate.
+        for (int i = 0; i < SYNTHETIC_DOC_COUNT; i++) {
+            int repeat = (i == 0) ? 10_000 : 1;
+            Files.writeString(syntheticDir.resolve("doc_" + i + ".txt"),
+                    (MARKER + " ").repeat(repeat) + "\n");
+        }
+
+        env = RuntimeEnvironment.getInstance();
+        env.setSourceRoot(repository.getSourceRoot());
+        env.setDataRoot(repository.getDataRoot());
+        env.setHistoryEnabled(false);
+        env.setProjectsEnabled(true);
+
+        Indexer.getInstance().prepareIndexer(env, true, true, null, null);
+        env.setDefaultProjectsFromNames(
+                new TreeSet<>(Collections.singletonList("/" + SYNTHETIC_PROJECT)));
+        Indexer.getInstance().doIndexerExecution(null, null);
+    }
+
+    @AfterAll
+    static void tearDownClass() {
+        repository.destroy();
+    }
+
+    @Test
+    void testTotalHitsIsExactAndStable() {
+        SortedSet<String> projectNames = new TreeSet<>();
+        projectNames.add(SYNTHETIC_PROJECT);
+
+        // Run with a large maxItems first to capture the true matching document count;
+        // the pre-fix implementation returned an exact count only when the heap was
+        // large enough to disable block-max WAND early termination.
+        long reference = runSearchForTotalHits(projectNames, SYNTHETIC_DOC_COUNT);
+        assertTrue(reference > 1000,
+                "need more than the Lucene default threshold of 1000 matches to trigger the bug, got "
+                        + reference);
+
+        for (int maxItems : new int[]{1, 2, 10, 100}) {
+            assertEquals(reference, runSearchForTotalHits(projectNames, maxItems),
+                    "totalHits must be exact and stable regardless of maxItems");
+        }
+    }
+
+    @Test
+    void testTotalHitsIsStableAcrossRepeatedCalls() {
+        SortedSet<String> projectNames = new TreeSet<>();
+        projectNames.add(SYNTHETIC_PROJECT);
+
+        long first = runSearchForTotalHits(projectNames, 1);
+        assertTrue(first > 1000,
+                "need more than 1000 matches to trigger the bug, got " + first);
+        for (int i = 0; i < 5; i++) {
+            assertEquals(first, runSearchForTotalHits(projectNames, 1),
+                    "totalHits must not drift across repeated queries");
+        }
+    }
+
+    private long runSearchForTotalHits(SortedSet<String> projectNames, int maxItems) {
+        SearchHelper searchHelper = new SearchHelper.Builder(env.getDataRootFile(),
+                env.getSourceRootFile(), null,
+                new QueryBuilder().setFreetext(MARKER), env.getUrlPrefix())
+                .maxItems(maxItems)
+                .build()
+                .prepareExec(projectNames)
+                .executeQuery();
+        try {
+            assertNull(searchHelper.getErrorMsg());
+            return searchHelper.getTotalHits();
+        } finally {
+            searchHelper.destroy();
+        }
+    }
+}

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperStableCountTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperStableCountTest.java
@@ -1,25 +1,3 @@
-/*
- * CDDL HEADER START
- *
- * The contents of this file are subject to the terms of the
- * Common Development and Distribution License (the "License").
- * You may not use this file except in compliance with the License.
- *
- * See LICENSE.txt included in this distribution for the specific
- * language governing permissions and limitations under the License.
- *
- * When distributing Covered Code, include this CDDL HEADER in each
- * file and include the License file at LICENSE.txt.
- * If applicable, add the following below this CDDL HEADER, with the
- * fields enclosed by brackets "[]" replaced with your own identifying
- * information: Portions Copyright [yyyy] [name of copyright owner]
- *
- * CDDL HEADER END
- */
-
-/*
- * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
- */
 package org.opengrok.indexer.web;
 
 import java.nio.file.Files;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperStableCountTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/SearchHelperStableCountTest.java
@@ -21,13 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Verifies that {@link SearchHelper} produces an exact and stable {@code totalHits}
  * regardless of the {@code maxItems} window, so the UI search total matches the REST
- * API and does not vary across repeated searches. With the previous implementation
- * {@code searcher.search(query, n, sort)} uses a {@code totalHitsThreshold} of 1000,
- * so for queries matching more than 1000 documents {@code totalHits} becomes an
- * approximate lower bound and can drift between calls.
+ * API and does not vary across repeated searches. The previous implementation could
+ * return an approximate lower-bound count for queries matching more than about a
+ * thousand documents.
  *
- * <p>To reliably exercise that threshold the test creates a synthetic corpus of
- * {@value #SYNTHETIC_DOC_COUNT} files, each containing a unique marker token.</p>
+ * <p>The test creates a synthetic corpus of {@value #SYNTHETIC_DOC_COUNT} files,
+ * each containing a unique marker token, large enough to exercise that boundary.</p>
  */
 class SearchHelperStableCountTest {
 
@@ -45,9 +44,8 @@ class SearchHelperStableCountTest {
 
         Path syntheticDir = Path.of(repository.getSourceRoot(), SYNTHETIC_PROJECT);
         Files.createDirectories(syntheticDir);
-        // Produce strong score variance so Lucene's block-max WAND can skip low-scoring
-        // docs once the heap is full. With the pre-fix implementation that lets the
-        // totalHitsThreshold of 1000 turn the totalHits into a lower-bound estimate.
+        // Make one document score much higher than the rest. Without this variance
+        // the bug does not reproduce reliably on a small corpus.
         for (int i = 0; i < SYNTHETIC_DOC_COUNT; i++) {
             int repeat = (i == 0) ? 10_000 : 1;
             Files.writeString(syntheticDir.resolve("doc_" + i + ".txt"),
@@ -77,12 +75,11 @@ class SearchHelperStableCountTest {
         projectNames.add(SYNTHETIC_PROJECT);
 
         // Run with a large maxItems first to capture the true matching document count;
-        // the pre-fix implementation returned an exact count only when the heap was
-        // large enough to disable block-max WAND early termination.
+        // the pre-fix implementation returned the exact count only with a sufficiently
+        // large result window.
         long reference = runSearchForTotalHits(projectNames, SYNTHETIC_DOC_COUNT);
         assertTrue(reference > 1000,
-                "need more than the Lucene default threshold of 1000 matches to trigger the bug, got "
-                        + reference);
+                "need more than a thousand matches to reliably trigger the bug, got " + reference);
 
         for (int maxItems : new int[]{1, 2, 10, 100}) {
             assertEquals(reference, runSearchForTotalHits(projectNames, maxItems),
@@ -97,7 +94,7 @@ class SearchHelperStableCountTest {
 
         long first = runSearchForTotalHits(projectNames, 1);
         assertTrue(first > 1000,
-                "need more than 1000 matches to trigger the bug, got " + first);
+                "need more than a thousand matches to reliably trigger the bug, got " + first);
         for (int i = 0; i < 5; i++) {
             assertEquals(first, runSearchForTotalHits(projectNames, 1),
                     "totalHits must not drift across repeated queries");

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
@@ -107,7 +107,8 @@ public class SearchController {
 
             long duration = Duration.between(startTime, Instant.now()).toMillis();
 
-            int endDocument = startDocIndex + hits.size() - 1;
+            int pageSize = Math.min(maxResults, Math.max(0, engine.numResults - startDocIndex));
+            int endDocument = pageSize > 0 ? startDocIndex + pageSize - 1 : startDocIndex;
 
             return new SearchResult(duration, engine.numResults, hits, startDocIndex, endDocument);
         }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
@@ -82,11 +82,11 @@ public class SearchController {
             @QueryParam(QueryParameters.HIST_SEARCH_PARAM) final String hist,
             @QueryParam(QueryParameters.TYPE_SEARCH_PARAM) final String type,
             @QueryParam("projects") final List<String> projects,
-            @QueryParam("maxresults") // Akin to QueryParameters.COUNT_PARAM
+            @QueryParam(QueryParameters.MAXRESULTS_PARAM)
             @DefaultValue(MAX_RESULTS + "") final int maxResults,
             @QueryParam(QueryParameters.START_PARAM) @DefaultValue(0 + "") final int startDocIndex,
             @QueryParam(QueryParameters.SORT_PARAM) @DefaultValue(DEFAULT_SORT_ORDER) final String sort,
-            @QueryParam("maxhitsperfile") @DefaultValue("0") final int maxHitsPerFile
+            @QueryParam(QueryParameters.MAXHITSPERFILE_PARAM) @DefaultValue("0") final int maxHitsPerFile
     ) {
         try (SearchEngineWrapper engine = new SearchEngineWrapper(full, def, symbol, path, hist, type, SortOrder.get(sort), maxHitsPerFile)) {
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
 
@@ -169,5 +170,37 @@ class SearchControllerTest extends OGKJerseyTest {
                     assertFalse(hit.get("lineNumber").toString().isEmpty());
                 })
         );
+    }
+
+    /**
+     * Verify that resultCount reflects the true total number of matching documents and
+     * endDocument is derived from the document page size, not from the number of unique
+     * file paths in the grouped results map.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testResultCountAndEndDocument() {
+        int maxResults = 100;
+        GenericType<Map<String, Object>> type = new GenericType<>() { };
+        Response response = target(SearchController.PATH)
+                .queryParam(QueryParameters.FULL_SEARCH_PARAM, "main")
+                .queryParam("maxresults", maxResults)
+                .request()
+                .get();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+        Map<String, Object> json = response.readEntity(type);
+        int resultCount = (int) json.get("resultCount");
+        int startDocument = (int) json.get("startDocument");
+        int endDocument = (int) json.get("endDocument");
+
+        assertTrue(resultCount > 0, "Search for 'main' should return results");
+
+        int expectedPageSize = Math.min(maxResults, resultCount - startDocument);
+        int expectedEndDocument = expectedPageSize > 0
+                ? startDocument + expectedPageSize - 1
+                : startDocument;
+        assertEquals(expectedEndDocument, endDocument,
+                "endDocument must reflect the document page size, not the number of unique file paths");
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
@@ -184,7 +184,7 @@ class SearchControllerTest extends OGKJerseyTest {
         GenericType<Map<String, Object>> type = new GenericType<>() { };
         Response response = target(SearchController.PATH)
                 .queryParam(QueryParameters.FULL_SEARCH_PARAM, "main")
-                .queryParam("maxresults", maxResults)
+                .queryParam(QueryParameters.MAXRESULTS_PARAM, maxResults)
                 .request()
                 .get();
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());


### PR DESCRIPTION
The REST API search endpoint (`/api/v1/search`) reports different result counts than the web UI for identical queries. In project-less mode the API always caps `resultCount` at `hitsPerPage * cachePages` (defaulting to 125) because `SearchEngine.search()` returns the collected `hits.length` rather than Lucene's `totalHits`. 🔍 This is the root cause of both #3239 and #3170.

A second source of inaccuracy comes from using `Short.MAX_VALUE` (32,767) as the Lucene `totalHitsThreshold` in all collector constructions. For queries exceeding that threshold, `totalHits.value` becomes an approximate lower bound. The web UI already uses `Integer.MAX_VALUE` implicitly through the 3-arg `searcher.search(query, n, sort)` overload, so switching the API collectors to match eliminates the discrepancy with zero performance impact for the common case and marginal cost for very large result sets.

The `endDocument` field in the JSON response was also wrong, computed from the grouped result map's key count (unique file paths) instead of the actual document page size. A page of 10 documents spanning 5 files would report `endDocument` as `startDocIndex + 4` instead of `startDocIndex + 9`. ✅ Now derived from the same page-size arithmetic used internally by `SearchEngineWrapper.search()`.

Fixes #3239. Fixes #3170.