### PR TITLE
add security-events: read permission

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  security-events: read
 
 jobs:
   analyze:


### PR DESCRIPTION
The recent #4936 change reduced CodeQL workflow permissions to just `contents: read`. Looks like this is not enough.