### PR TITLE
remove localhost bypass for API checks

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4,9 +4,16 @@ HIFORMAT: 1A
 
 OpenGrok RESTful API documentation. The following endpoints are accessible under `/api/v1` with the exception of `/metrics`.
 
-Besides `/suggester`, `/search`, `/system/ping`, `/system/indextime` and `/metrics` endpoints, everything is accessible from `localhost` only
-unless authentication bearer tokens are configured in the web application and used via the 'Authorization' HTTP header
-(within HTTPS connection).
+Protected endpoints require an authentication bearer token configured in the web application and supplied via the
+`Authorization` HTTP header (`Authorization: Bearer <token>`). Bearer tokens are accepted over HTTPS connections;
+HTTP token use has to be explicitly enabled with the `allowInsecureTokens` configuration option and should be limited
+to trusted internal deployments. Example of a protected endpoint is `/configuration`.
+
+The access to the `/annotation`, `/file`, `/history`, `/search` and `/suggest` endpoints is controlled with
+authorization framework and requires user authentication if set up.
+
+The `/system/ping`, `/system/indextime`, `/suggest/config` and `/metrics` endpoints are public and do not require
+bearer token authentication.
 
 Some of the APIs are asynchronous. They return status code 202 (Accepted) and a Location header that contains the URL
 for the status endpoint to check for the result of the API call. Once the status API returns result other than 202,

--- a/docker/README.md
+++ b/docker/README.md
@@ -91,6 +91,14 @@ The image contains these directories:
 `/opengrok/src` | source root - input data
 `/scripts` | startup script and top level configuration. Do not override unless debugging.
 
+At startup, the container generates an internal bearer token for OpenGrok web
+application REST API calls using the operating system's cryptographic random
+source. The token is not user configurable and is stored only in private files
+under `/opengrok/etc` that are used by the startup, synchronization, and indexer
+tooling. This is separate from the `REST_TOKEN` variable below, which protects
+only the small `/reindex` trigger endpoint exposed by the container startup
+program.
+
 ## Environment Variables
 
 | Docker Environment Var. | Default value | Description |

--- a/docker/start.py
+++ b/docker/start.py
@@ -22,12 +22,13 @@ Entry point for the OpenGrok Docker container.
 # CDDL HEADER END
 
 #
-# Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
 #
 
 import logging
 import multiprocessing
 import os
+import secrets
 import shutil
 import signal
 import subprocess
@@ -81,6 +82,9 @@ OPENGROK_SRC_ROOT = os.path.join(OPENGROK_BASE_DIR, "src")
 BODY_INCLUDE_FILE = os.path.join(OPENGROK_DATA_ROOT, "body_include")
 OPENGROK_CONFIG_DIR = os.path.join(OPENGROK_BASE_DIR, "etc")
 OPENGROK_CONFIG_FILE = os.path.join(OPENGROK_CONFIG_DIR, "configuration.xml")
+WEBAPP_API_TOKEN_FILE = os.path.join(OPENGROK_CONFIG_DIR, "webapp_api_token")
+WEBAPP_API_HEADERS_FILE = os.path.join(OPENGROK_CONFIG_DIR, "webapp_api_headers")
+DOCKER_READONLY_CONFIG_FILE = os.path.join(OPENGROK_CONFIG_DIR, "token-auth-config.xml")
 OPENGROK_WEBAPPS_DIR = os.path.join(tomcat_root, "webapps")
 OPENGROK_JAR = os.path.join(OPENGROK_LIB_DIR, "opengrok.jar")
 
@@ -245,11 +249,103 @@ def wait_for_tomcat(logger, uri):
     logger.info("Tomcat is ready")
 
 
-def refresh_projects(logger, uri, api_timeout):
+def write_private_file(file_path, content):
+    """
+    Write a file that is readable/writable only by the current user.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(file_path, flags, 0o600)
+    with os.fdopen(fd, "w") as file:
+        file.write(content)
+    os.chmod(file_path, 0o600)
+
+
+def create_webapp_api_auth_files(logger):
+    """
+    Generate Docker-internal API authentication token and write it to
+    private files for tools that accept token/header file arguments.
+
+    Return tuple of raw token value and dictionary with the HTTP header carrying the token
+    that can be used for requests.
+    """
+    if os.path.exists(WEBAPP_API_TOKEN_FILE) and os.path.exists(
+        WEBAPP_API_HEADERS_FILE
+    ):
+        with open(WEBAPP_API_TOKEN_FILE, "r", encoding="utf-8") as token_file:
+            token = token_file.readline().rstrip()
+        return token, {"Authorization": "Bearer " + token}
+
+    token = secrets.token_hex(32)
+    write_private_file(WEBAPP_API_TOKEN_FILE, token + "\n")
+    write_private_file(WEBAPP_API_HEADERS_FILE, "Authorization: Bearer " + token + "\n")
+    logger.info("Created private OpenGrok web app API authentication files")
+    return token, {"Authorization": "Bearer " + token}
+
+
+def create_token_readonly_config(logger, token):
+    """
+    Create read-only configuration overlay that enables Docker-internal
+    authenticated HTTP REST calls.
+    """
+    content = f"""<?xml version="1.0" encoding="UTF-8"?>
+<java version="11.0.8" class="java.beans.XMLDecoder">
+    <object class="org.opengrok.indexer.configuration.Configuration">
+        <void property="allowInsecureTokens">
+            <boolean>true</boolean>
+        </void>
+        <void property="authenticationTokens">
+            <void method="add">
+                <string>{token}</string>
+            </void>
+        </void>
+        <void property="indexerAuthenticationToken">
+            <string>{token}</string>
+        </void>
+    </object>
+</java>
+"""
+    write_private_file(DOCKER_READONLY_CONFIG_FILE, content)
+    logger.info("Created Docker read-only configuration for web app API authentication")
+    return DOCKER_READONLY_CONFIG_FILE
+
+
+def merge_readonly_config(logger, log_level, read_only_config_file):
+    """
+    Merge read-only configuration file with current OpenGrok configuration.
+    """
+    logger.info(
+        "Merging read-only configuration from '{}' with current "
+        "configuration in '{}'".format(read_only_config_file, OPENGROK_CONFIG_FILE)
+    )
+    out_file_path = None
+    with tempfile.NamedTemporaryFile(
+        mode="w+", delete=False, prefix="merged_config"
+    ) as tmp_out_fobj:
+        out_file_path = tmp_out_fobj.name
+        merge_config_files(
+            read_only_config_file,
+            OPENGROK_CONFIG_FILE,
+            out_file_path,
+            jar=OPENGROK_JAR,
+            loglevel=log_level,
+        )
+
+    if out_file_path and os.path.getsize(out_file_path) > 0:
+        os.chmod(out_file_path, 0o600)
+        shutil.move(out_file_path, OPENGROK_CONFIG_FILE)
+    else:
+        logger.warning(
+            "Failed to merge read-only configuration, " "leaving the original in place"
+        )
+        if out_file_path:
+            os.remove(out_file_path)
+
+
+def refresh_projects(logger, uri, api_timeout, headers):
     """
     Ensure each immediate source root subdirectory is a project.
     """
-    webapp_projects = list_projects(logger, uri, timeout=api_timeout)
+    webapp_projects = list_projects(logger, uri, headers=headers, timeout=api_timeout)
     if webapp_projects is None:
         return
 
@@ -265,10 +361,12 @@ def refresh_projects(logger, uri, api_timeout):
             else:
                 action = "Adding"
             logger.info(f"{action} project {item}")
-            add_project(logger, item, uri, timeout=api_timeout)
+            add_project(logger, item, uri, headers=headers, timeout=api_timeout)
 
             if logger.level == logging.DEBUG:
-                repos = get_repos(logger, item, uri)
+                repos = get_repos(
+                    logger, item, uri, headers=headers, timeout=api_timeout
+                )
                 if repos:
                     logger.debug(
                         "Project {} has these repositories: {}".format(item, repos)
@@ -278,10 +376,10 @@ def refresh_projects(logger, uri, api_timeout):
     for item in webapp_projects:
         if not os.path.isdir(os.path.join(src_root, item)):
             logger.info("Deleting project {}".format(item))
-            delete_project(logger, item, uri, timeout=api_timeout)
+            delete_project(logger, item, uri, headers=headers, timeout=api_timeout)
 
 
-def save_config(logger, uri, config_path, api_timeout):
+def save_config(logger, uri, config_path, api_timeout, headers):
     """
     Retrieve configuration from the web app and write it to file.
     :param logger: logger instance
@@ -289,7 +387,7 @@ def save_config(logger, uri, config_path, api_timeout):
     :param config_path: file path
     """
 
-    config = get_configuration(logger, uri, timeout=api_timeout)
+    config = get_configuration(logger, uri, headers=headers, timeout=api_timeout)
     if config is None:
         return
 
@@ -344,6 +442,8 @@ def indexer_no_projects(logger, uri, config_path, extra_indexer_options):
             config_path,
             "-U",
             uri,
+            "--token",
+            "@" + WEBAPP_API_TOKEN_FILE,
         ]
         if extra_indexer_options:
             logger.debug(
@@ -364,7 +464,9 @@ def indexer_no_projects(logger, uri, config_path, extra_indexer_options):
         periodic_timer.wait_for_event()
 
 
-def project_syncer(logger, loglevel, uri, config_path, numworkers, env, api_timeout):
+def project_syncer(
+    logger, loglevel, uri, config_path, numworkers, env, api_timeout, headers
+):
     """
     Wrapper for running opengrok-sync.
     To be run in a thread/process in the background.
@@ -373,7 +475,7 @@ def project_syncer(logger, loglevel, uri, config_path, numworkers, env, api_time
     wait_for_tomcat(logger, uri)
 
     while True:
-        refresh_projects(logger, uri, api_timeout)
+        refresh_projects(logger, uri, api_timeout, headers)
 
         if os.environ.get("OPENGROK_SYNC_YML"):  # debug only
             config_file = os.environ.get("OPENGROK_SYNC_YML")
@@ -384,7 +486,7 @@ def project_syncer(logger, loglevel, uri, config_path, numworkers, env, api_time
             logger.error(f"Cannot read config file from {config_file}")
             raise Exception("no sync config")
 
-        projects = list_projects(logger, uri, timeout=api_timeout)
+        projects = list_projects(logger, uri, headers=headers, timeout=api_timeout)
         if projects:
             #
             # The driveon=True is needed for the initial indexing of newly
@@ -410,6 +512,7 @@ def project_syncer(logger, loglevel, uri, config_path, numworkers, env, api_time
                 driveon=True,
                 logger=logger,
                 print_output=True,
+                http_headers=headers,
                 timeout=api_timeout,
             )
             logger.info("Sync done")
@@ -417,7 +520,7 @@ def project_syncer(logger, loglevel, uri, config_path, numworkers, env, api_time
             # Workaround for https://github.com/oracle/opengrok/issues/1670
             Path(os.path.join(OPENGROK_DATA_ROOT, "timestamp")).touch()
 
-            save_config(logger, uri, config_path, api_timeout)
+            save_config(logger, uri, config_path, api_timeout, headers)
 
         logger.info("Waiting for reindex to be triggered")
         global periodic_timer  # noqa: F824
@@ -602,6 +705,9 @@ def main():
     ):
         create_bare_config(logger, use_projects, extra_indexer_options.split())
 
+    webapp_api_token, webapp_api_headers = create_webapp_api_auth_files(logger)
+    token_config_file = create_token_readonly_config(logger, webapp_api_token)
+
     #
     # Index check needs read-only configuration, so it is called
     # right after create_bare_config().
@@ -614,32 +720,10 @@ def main():
     #
     read_only_config_file = os.environ.get("READONLY_CONFIG_FILE")
     if read_only_config_file and os.path.exists(read_only_config_file):
-        logger.info(
-            "Merging read-only configuration from '{}' with current "
-            "configuration in '{}'".format(read_only_config_file, OPENGROK_CONFIG_FILE)
-        )
-        out_file_path = None
-        with tempfile.NamedTemporaryFile(
-            mode="w+", delete=False, prefix="merged_config"
-        ) as tmp_out_fobj:
-            out_file_path = tmp_out_fobj.name
-            merge_config_files(
-                read_only_config_file,
-                OPENGROK_CONFIG_FILE,
-                out_file_path,
-                jar=OPENGROK_JAR,
-                loglevel=log_level,
-            )
+        merge_readonly_config(logger, log_level, read_only_config_file)
 
-        if out_file_path and os.path.getsize(out_file_path) > 0:
-            shutil.move(out_file_path, OPENGROK_CONFIG_FILE)
-        else:
-            logger.warning(
-                "Failed to merge read-only configuration, "
-                "leaving the original in place"
-            )
-            if out_file_path:
-                os.remove(out_file_path)
+    merge_readonly_config(logger, log_level, token_config_file)
+    os.remove(token_config_file)
 
     sync_enabled = True
     if use_projects:
@@ -670,6 +754,7 @@ def main():
             num_workers,
             env,
             api_timeout,
+            webapp_api_headers,
         )
     else:
         worker_function = indexer_no_projects

--- a/docker/sync.yml
+++ b/docker/sync.yml
@@ -2,6 +2,7 @@ commands:
 - call:
     uri: '%URL%api/v1/messages'
     method: POST
+    headers_file: /opengrok/etc/webapp_api_headers
     data:
       messageLevel: warning
       duration: PT1H
@@ -10,21 +11,25 @@ commands:
     api_timeout: "$API_TIMEOUT"
 - command:
     args: [opengrok-mirror, -c, '/opengrok/etc/mirror.yml',
+           -H, '@/opengrok/etc/webapp_api_headers',
            --api_timeout, '%API_TIMEOUT%',
            -I, -U, '%URL%', '%PROJECT%']
     args_subst: {"%API_TIMEOUT%": "$API_TIMEOUT"}
 - command:
     args: [opengrok-reindex-project, --printoutput,
       --api_timeout, '%API_TIMEOUT%',
+      -H, '@/opengrok/etc/webapp_api_headers',
       --jar, /opengrok/lib/opengrok.jar, -U, '%URL%', -P, '%PROJECT%', --,
       --connectTimeout, '%API_TIMEOUT%',
       -r, dirbased, -G, -m, '256', --leadingWildCards, 'on',
-      -c, /usr/local/bin/ctags, -U, '%URL%', -H, '%PROJECT%']
+      -c, /usr/local/bin/ctags, -U, '%URL%', --token, '@/opengrok/etc/webapp_api_token',
+      -H, '%PROJECT%']
     args_subst: {"%API_TIMEOUT%": "$API_TIMEOUT"}
 - call:
     uri: '%URL%api/v1/messages?tag=%PROJECT%'
     method: DELETE
     data: 'resync + reindex in progress'
+    headers_file: /opengrok/etc/webapp_api_headers
     headers:
       'Content-type': 'text/plain'
     api_timeout: "$API_TIMEOUT"
@@ -33,6 +38,7 @@ cleanup:
     uri: '%URL%api/v1/messages?tag=%PROJECT%'
     method: DELETE
     data: 'resync + reindex in progress'
+    headers_file: /opengrok/etc/webapp_api_headers
     headers:
       'Content-type': 'text/plain'
     api_timeout: "$API_TIMEOUT"

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2020, Aleksandr Kirillov <alexkirillovsamara@gmail.com>.
  */
@@ -37,6 +37,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Serial;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -298,9 +299,9 @@ public final class Configuration {
 
     private Set<String> disabledRepositories;
 
-    private Set<String> authenticationTokens; // for non-localhost API access
-    private String indexerAuthenticationToken;
-    private boolean allowInsecureTokens;
+    private Set<String> authenticationTokens; // set of bearer tokens used by the webapp to validate access to certain API endpoints
+    private String indexerAuthenticationToken;  // bearer token used by the indexer to communicate with the webapp
+    private boolean allowInsecureTokens;    // whether to allow bearer tokens over plain HTTP (as opposed to HTTPS)
 
     private int historyChunkCount;
     private boolean historyCachePerPartesEnabled = true;
@@ -629,7 +630,7 @@ public final class Configuration {
         if (clazzName == null) {
             return null;
         }
-        if (cmd == null || cmd.length() == 0) {
+        if (cmd == null || cmd.isEmpty()) {
             return cmds.remove(clazzName);
         }
         return cmds.put(clazzName, cmd);
@@ -1557,7 +1558,7 @@ public final class Configuration {
 
         List<Group> nonRootGroups = conf.groups.values().stream()
                 .filter(g -> Objects.nonNull(g.getParent()))
-                .collect(Collectors.toList());
+                .toList();
         nonRootGroups.forEach(g ->
                     conf.groups.remove(g.getName())
         );
@@ -1605,7 +1606,8 @@ public final class Configuration {
     }
 
     public static class ConfigurationException extends Exception {
-        static final long serialVersionUID = -1;
+        @Serial
+        private static final long serialVersionUID = -1;
 
         public ConfigurationException(String message) {
             super(message);

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SuggesterController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SuggesterController.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -210,7 +210,7 @@ public final class SuggesterController {
                         if (fieldQueryText.size() > 2) {
                             logger.log(Level.WARNING, "Bad format, ignoring {0}", urlStr);
                         } else {
-                            getQuery(field, fieldQueryText.get(0))
+                            getQuery(field, fieldQueryText.getFirst())
                                     .ifPresent(q -> suggester.onSearch(projects, q));
 
                         }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
@@ -68,7 +68,8 @@ public class IncomingFilter implements ContainerRequestFilter, ConfigurationChan
      */
     private static final Set<String> allowedPaths = new HashSet<>(Arrays.asList(
             SearchController.PATH, SuggesterController.PATH, SuggesterController.PATH + "/config",
-            HistoryController.PATH, FileController.PATH, AnnotationController.PATH,
+            HistoryController.PATH, FileController.PATH + "/content", FileController.PATH + "/genre",
+            FileController.PATH + "/defs", AnnotationController.PATH,
             SystemController.PATH + "/ping", SystemController.PATH + "/" + SystemController.INDEX_TIME ));
 
     @Context

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.filter;
 
@@ -41,8 +41,6 @@ import org.opengrok.web.api.v1.controller.SearchController;
 import org.opengrok.web.api.v1.controller.SuggesterController;
 import org.opengrok.web.api.v1.controller.SystemController;
 
-import java.io.IOException;
-import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
@@ -52,10 +50,8 @@ import java.util.logging.Logger;
 
 /**
  * This filter allows the request in case it contains the correct authentication bearer token
- * (needs to come in via HTTPS) or it is coming from localhost or its path matches the list
- * of built in paths.
- * If the request does not contain valid token and appears to come from localhost however is proxied
- * (contains either X-Forwarded-For or Forwarded HTTP headers) it is denied.
+ * (needs to come in via HTTPS unless insecure tokens are explicitly allowed) or its path matches
+ * the list of built-in paths.
  */
 @Provider
 @PreMatching
@@ -78,10 +74,6 @@ public class IncomingFilter implements ContainerRequestFilter, ConfigurationChan
     @Context
     private HttpServletRequest request;
 
-    private final Set<String> localAddresses = new HashSet<>(Arrays.asList(
-            "127.0.0.1", "0:0:0:0:0:0:0:1", "localhost"
-    ));
-
     static final String BEARER = "Bearer ";  // Authorization header value prefix
 
     private Set<String> tokens;
@@ -96,15 +88,6 @@ public class IncomingFilter implements ContainerRequestFilter, ConfigurationChan
 
     @PostConstruct
     public void init() {
-        try {
-            localAddresses.add(InetAddress.getLocalHost().getHostAddress());
-            for (InetAddress inetAddress : InetAddress.getAllByName("localhost")) {
-                localAddresses.add(inetAddress.getHostAddress());
-            }
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "Could not get localhost addresses", e);
-        }
-
         // Cache the tokens to avoid locking.
         setTokens(RuntimeEnvironment.getInstance().getAuthenticationTokens());
 
@@ -141,20 +124,6 @@ public class IncomingFilter implements ContainerRequestFilter, ConfigurationChan
 
         if (allowedPaths.contains(path)) {
             LOGGER.log(Level.FINEST, "allowing request to {0} based on allow listed path", path);
-            return;
-        }
-
-        // In a reverse proxy environment the connection appears to be coming from localhost.
-        // These request should really be using tokens.
-        if (request.getHeader("X-Forwarded-For") != null || request.getHeader("Forwarded") != null) {
-            LOGGER.log(Level.FINEST, "denying request to {0} due to existence of forwarded header in the request",
-                    path);
-            context.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
-            return;
-        }
-
-        if (localAddresses.contains(request.getRemoteAddr())) {
-            LOGGER.log(Level.FINEST, "allowing request to {0} based on localhost IP address", path);
             return;
         }
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/DirectoryListingControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/DirectoryListingControllerTest.java
@@ -18,11 +18,12 @@
  */
 
 /*
- * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.controller;
 
 import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.test.DeploymentContext;
@@ -52,6 +53,7 @@ import org.opengrok.web.api.v1.RestApp;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -65,12 +67,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.web.api.v1.controller.DirectoryListingController.getDirectoryEntriesDTO;
 
 class DirectoryListingControllerTest extends OGKJerseyTest {
+    private static final String AUTH_TOKEN = "directory-listing-controller-test-token";
+    private static final String AUTH_HEADER = "Bearer " + AUTH_TOKEN;
+
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
     private TestRepository repository;
 
     @Override
     protected DeploymentContext configureDeployment() {
+        RuntimeEnvironment.getInstance().setAuthenticationTokens(Collections.singleton(AUTH_TOKEN));
+        RuntimeEnvironment.getInstance().setAllowInsecureTokens(true);
+
         return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
     }
 
@@ -115,6 +123,8 @@ class DirectoryListingControllerTest extends OGKJerseyTest {
         env.setProjects(new ConcurrentHashMap<>());
         env.setRepositories(new ArrayList<>());
         env.getProjectRepositoriesMap().clear();
+        env.setAuthenticationTokens(Collections.emptySet());
+        env.setAllowInsecureTokens(false);
 
         repository.destroy();
     }
@@ -177,6 +187,7 @@ class DirectoryListingControllerTest extends OGKJerseyTest {
         Response response = target("list")
                 .queryParam("path", "/" + path)
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .get();
         List<DirectoryListingController.DirectoryEntryDTO> entriesResp = response.readEntity(new GenericType<>() {
         });

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
@@ -18,12 +18,13 @@
  */
 
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
 
 import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.test.DeploymentContext;
@@ -55,6 +56,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -69,6 +71,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FileControllerTest extends OGKJerseyTest {
 
+    private static final String AUTH_TOKEN = "file-controller-test-token";
+    private static final String AUTH_HEADER = "Bearer " + AUTH_TOKEN;
+
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
     private static final String validPath = "git/main.c";
@@ -77,6 +82,9 @@ class FileControllerTest extends OGKJerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
+        RuntimeEnvironment.getInstance().setAuthenticationTokens(Collections.singleton(AUTH_TOKEN));
+        RuntimeEnvironment.getInstance().setAllowInsecureTokens(true);
+
         return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
     }
 
@@ -120,6 +128,8 @@ class FileControllerTest extends OGKJerseyTest {
         env.setProjects(new ConcurrentHashMap<>());
         env.setRepositories(new ArrayList<>());
         env.getProjectRepositoriesMap().clear();
+        env.setAuthenticationTokens(Collections.emptySet());
+        env.setAllowInsecureTokens(false);
 
         repository.destroy();
     }
@@ -133,6 +143,7 @@ class FileControllerTest extends OGKJerseyTest {
                 .path("content")
                 .queryParam("path", path)
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .get(String.class);
         assertEquals(contents, output);
     }
@@ -143,6 +154,7 @@ class FileControllerTest extends OGKJerseyTest {
                 .path("genre")
                 .queryParam("path", validPath)
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .get(String.class);
         assertEquals("PLAIN", genre);
     }
@@ -155,6 +167,7 @@ class FileControllerTest extends OGKJerseyTest {
                 .path("defs")
                 .queryParam("path", validPath)
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .get(type);
         assertFalse(defs.isEmpty());
         assertAll(() -> assertFalse(defs.stream().map(Definitions.Tag::getType).anyMatch(Objects::isNull)),
@@ -183,6 +196,7 @@ class FileControllerTest extends OGKJerseyTest {
                 .path("defs")
                 .queryParam("path", path)
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .get(type);
         assertTrue(defs.isEmpty());
     }
@@ -209,7 +223,9 @@ class FileControllerTest extends OGKJerseyTest {
         Response response = target("file")
                 .path("defs")
                 .queryParam("path", validPath)
-                .request().get();
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+                .get();
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
 
         // Cleanup.

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatusControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/StatusControllerTest.java
@@ -18,10 +18,12 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.controller;
 
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.test.DeploymentContext;
@@ -31,17 +33,25 @@ import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.web.api.ApiTask;
 import org.opengrok.web.api.ApiTaskManager;
 import org.opengrok.web.api.v1.RestApp;
 
+import java.util.Collections;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class StatusControllerTest extends OGKJerseyTest {
+    private static final String AUTH_TOKEN = "status-controller-test-token";
+    private static final String AUTH_HEADER = "Bearer " + AUTH_TOKEN;
+
     @Override
     protected DeploymentContext configureDeployment() {
+        RuntimeEnvironment.getInstance().setAuthenticationTokens(Collections.singleton(AUTH_TOKEN));
+        RuntimeEnvironment.getInstance().setAllowInsecureTokens(true);
+
         return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
     }
 
@@ -53,26 +63,31 @@ class StatusControllerTest extends OGKJerseyTest {
     @AfterAll
     static void cleanup() throws InterruptedException {
         ApiTaskManager.getInstance().shutdown();
+        RuntimeEnvironment.getInstance().setAuthenticationTokens(Collections.emptySet());
+        RuntimeEnvironment.getInstance().setAllowInsecureTokens(false);
     }
 
     private Object doNothing() {
         return null;
     }
 
+    private Invocation.Builder authorizedRequest(String uuidString) {
+        return target(StatusController.PATH)
+                .path(uuidString)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER);
+    }
+
     @Test
     void testGetNoUuid() {
-        Response response = target(StatusController.PATH)
-                .path(UUID.randomUUID().toString())
-                .request()
+        Response response = authorizedRequest(UUID.randomUUID().toString())
                 .get();
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     }
 
     @Test
     void testDeleteNoUuid() {
-        Response response = target(StatusController.PATH)
-                .path(UUID.randomUUID().toString())
-                .request()
+        Response response = authorizedRequest(UUID.randomUUID().toString())
                 .delete();
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     }
@@ -93,16 +108,12 @@ class StatusControllerTest extends OGKJerseyTest {
         String poolName = "foo";
         apiTaskManager.addPool(poolName, 1);
         apiTaskManager.submitApiTask(poolName, apiTask);
-        Response response = target(StatusController.PATH)
-                .path(uuidString)
-                .request()
+        Response response = authorizedRequest(uuidString)
                 .get();
         assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
 
         Thread.sleep(sleepTime);
-        response = target(StatusController.PATH)
-                .path(uuidString)
-                .request()
+        response = authorizedRequest(uuidString)
                 .get();
         assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
     }
@@ -123,9 +134,7 @@ class StatusControllerTest extends OGKJerseyTest {
         String poolName = "deleteNotCompleted";
         apiTaskManager.addPool(poolName, 1);
         apiTaskManager.submitApiTask(poolName, apiTask);
-        Response response = target(StatusController.PATH)
-                .path(uuidString)
-                .request()
+        Response response = authorizedRequest(uuidString)
                 .delete();
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
@@ -139,9 +148,7 @@ class StatusControllerTest extends OGKJerseyTest {
         apiTaskManager.addPool(poolName, 1);
         apiTaskManager.submitApiTask(poolName, apiTask);
         Thread.sleep(1000);
-        Response response = target(StatusController.PATH)
-                .path(uuidString)
-                .request()
+        Response response = authorizedRequest(uuidString)
                 .delete();
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -18,13 +18,14 @@
  */
 
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2019, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
 
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.apache.lucene.index.Term;
 import org.glassfish.jersey.servlet.ServletContainer;
@@ -68,6 +69,9 @@ import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 class SuggesterControllerTest extends OGKJerseyTest {
 
+    private static final String AUTH_TOKEN = "suggester-controller-test-token";
+    private static final String AUTH_HEADER = "Bearer " + AUTH_TOKEN;
+
     public static class Result {
         public long time;
         public List<ResultItem> suggestions;
@@ -99,6 +103,9 @@ class SuggesterControllerTest extends OGKJerseyTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
+        RuntimeEnvironment.getInstance().setAuthenticationTokens(Collections.singleton(AUTH_TOKEN));
+        RuntimeEnvironment.getInstance().setAllowInsecureTokens(true);
+
         return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
     }
 
@@ -127,6 +134,8 @@ class SuggesterControllerTest extends OGKJerseyTest {
     @AfterAll
     public static void tearDownClass() {
         repository.destroy();
+        env.setAuthenticationTokens(Collections.emptySet());
+        env.setAllowInsecureTokens(false);
     }
 
     @BeforeEach
@@ -437,6 +446,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .path("init")
                 .path("queries")
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .post(Entity.json(queries));
 
         Result res = target(SuggesterController.PATH)
@@ -474,6 +484,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .path("init")
                 .path("raw")
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .post(Entity.json(Arrays.asList(data1, data2)));
 
         Result res = target(SuggesterController.PATH)
@@ -503,6 +514,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .path("init")
                 .path("raw")
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .post(Entity.json(Collections.singleton(data)));
 
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), r.getStatus());
@@ -604,6 +616,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .path("popularity")
                 .path("rust")
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .get(popularityDataType);
 
         assertThat(res, contains(new SimpleEntry<>("main", 10)));
@@ -622,6 +635,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .queryParam("pageSize", 1)
                 .queryParam("all", true)
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .get(popularityDataType);
 
         assertThat(res, contains(new SimpleEntry<>("topclass", 15), new SimpleEntry<>("mynamespace", 10)));
@@ -639,6 +653,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .path("swift")
                 .queryParam("field", QueryBuilder.DEFS)
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .get(popularityDataType);
 
         assertThat(res, contains(new SimpleEntry<>("greet", 4)));
@@ -662,6 +677,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
         Response res = target(SuggesterController.PATH)
                 .path("rebuild")
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .put(Entity.text(""));
 
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), res.getStatus());
@@ -674,6 +690,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .path("rebuild")
                 .path("c")
                 .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .put(Entity.text(""));
 
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), res.getStatus());

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SystemControllerTest.java
@@ -18,12 +18,13 @@
  */
 
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
 
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.test.DeploymentContext;
@@ -31,6 +32,7 @@ import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.opengrok.indexer.Info;
 import org.opengrok.indexer.configuration.Configuration;
@@ -49,6 +51,7 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,16 +60,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SystemControllerTest extends OGKJerseyTest {
 
+    private static final String AUTH_TOKEN = "system-controller-test-token";
+    private static final String AUTH_HEADER = "Bearer " + AUTH_TOKEN;
+
     private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
     @Override
     protected DeploymentContext configureDeployment() {
+        RuntimeEnvironment.getInstance().setAuthenticationTokens(Collections.singleton(AUTH_TOKEN));
+        RuntimeEnvironment.getInstance().setAllowInsecureTokens(true);
+
         return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
     }
 
     @Override
     protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
         return new GrizzlyWebTestContainerFactory();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        RuntimeEnvironment.getInstance().setAuthenticationTokens(Collections.emptySet());
+        RuntimeEnvironment.getInstance().setAllowInsecureTokens(false);
     }
 
     /**
@@ -101,7 +116,9 @@ class SystemControllerTest extends OGKJerseyTest {
         // Reload the contents via API call.
         try (Response r = target("system")
                 .path("includes").path("reload")
-                .request().put(Entity.text(""))) {
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+                .put(Entity.text(""))) {
             assertEquals(Response.Status.NO_CONTENT.getStatusCode(), r.getStatus());
         }
 
@@ -130,7 +147,9 @@ class SystemControllerTest extends OGKJerseyTest {
         // Reload the contents via API call.
         try (Response r = target("system")
                 .path("pathdesc")
-                .request().post(Entity.json(descriptions))) {
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+                .post(Entity.json(descriptions))) {
             assertEquals(Response.Status.NO_CONTENT.getStatusCode(), r.getStatus());
         }
 
@@ -160,7 +179,9 @@ class SystemControllerTest extends OGKJerseyTest {
 
         Response r = target("system")
                 .path(SystemController.INDEX_TIME)
-                .request().get();
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+                .get();
         String result = r.readEntity(String.class);
 
         assertEquals("\"2021-02-16T11:18:01.000+00:00\"", result);
@@ -173,7 +194,9 @@ class SystemControllerTest extends OGKJerseyTest {
     void testVersion() {
         Response r = target("system")
                 .path("version")
-                .request().get();
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+                .get();
         String result = r.readEntity(String.class);
 
         assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
@@ -184,7 +207,9 @@ class SystemControllerTest extends OGKJerseyTest {
     void testPing() {
         Response r = target("system")
                 .path("ping")
-                .request().get();
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+                .get();
         String result = r.readEntity(String.class);
 
         assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/filter/IncomingFilterTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/filter/IncomingFilterTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.api.v1.filter;
 
@@ -29,6 +29,8 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
@@ -49,9 +51,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class IncomingFilterTest {
+
+    private final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+
     @BeforeEach
     void beforeTest() {
-        RuntimeEnvironment.getInstance().setAuthenticationTokens(new HashSet<>());
+        env.setAuthenticationTokens(new HashSet<>());
+        env.setAllowInsecureTokens(false);
     }
 
     @Test
@@ -60,9 +66,9 @@ class IncomingFilterTest {
 
         Set<String> tokens = new HashSet<>();
         tokens.add(allowedToken);
-        RuntimeEnvironment.getInstance().setAuthenticationTokens(tokens);
+        env.setAuthenticationTokens(tokens);
 
-        nonLocalhostTestWithToken(true, allowedToken);
+        nonLocalhostTestWithToken(true, allowedToken, true);
     }
 
     @Test
@@ -71,20 +77,35 @@ class IncomingFilterTest {
 
         Set<String> tokens = new HashSet<>();
         tokens.add(allowedToken);
-        RuntimeEnvironment.getInstance().setAuthenticationTokens(tokens);
+        env.setAuthenticationTokens(tokens);
 
-        nonLocalhostTestWithToken(false, allowedToken + "_");
+        nonLocalhostTestWithToken(false, allowedToken + "_", true);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void nonLocalhostTestWithValidTokenInsecure(boolean isSecure) throws Exception {
+        String allowedToken = "foo";
+
+        Set<String> tokens = new HashSet<>();
+        tokens.add(allowedToken);
+        env.setAuthenticationTokens(tokens);
+        boolean insecureOrigValue = env.isAllowInsecureTokens();
+        env.setAllowInsecureTokens(true);
+
+        nonLocalhostTestWithToken(true, allowedToken, isSecure);
+
+        // cleanup
+        env.setAllowInsecureTokens(insecureOrigValue);
     }
 
     @Test
     void nonLocalhostTestWithTokenChange() throws Exception {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
         String token = "foobar";
 
-        Map<String, String> headers = new TreeMap<>();
         final String authHeaderValue = IncomingFilter.BEARER + token;
-        headers.put(HttpHeaders.AUTHORIZATION, authHeaderValue);
+        Map<String, String> headers = new TreeMap<>(Map.of(HttpHeaders.AUTHORIZATION, authHeaderValue));
         assertTrue(env.getAuthenticationTokens().isEmpty());
         IncomingFilter filter = mockWithRemoteAddress("192.168.1.1", headers, true);
 
@@ -109,11 +130,10 @@ class IncomingFilterTest {
         verify(context, never()).abortWith(captor.capture());
     }
 
-    private void nonLocalhostTestWithToken(boolean allowed, String token) throws Exception {
-        Map<String, String> headers = new TreeMap<>();
+    private void nonLocalhostTestWithToken(boolean allowed, String token, boolean isSecure) throws Exception {
         final String authHeaderValue = IncomingFilter.BEARER + token;
-        headers.put(HttpHeaders.AUTHORIZATION, authHeaderValue);
-        IncomingFilter filter = mockWithRemoteAddress("192.168.1.1", headers, true);
+        Map<String, String> headers = new TreeMap<>(Map.of(HttpHeaders.AUTHORIZATION, authHeaderValue));
+        IncomingFilter filter = mockWithRemoteAddress("192.168.1.1", headers, isSecure);
 
         ContainerRequestContext context = mockContainerRequestContext("test");
 
@@ -125,13 +145,13 @@ class IncomingFilterTest {
             verify(context, never()).abortWith(captor.capture());
         } else {
             verify(context).abortWith(captor.capture());
+            assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), captor.getValue().getStatus());
         }
     }
 
     @Test
-    void localhostTestWithForwardedHeader() throws Exception {
-        Map<String, String> headers = new TreeMap<>();
-        headers.put("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17");
+    void forwardedHeaderTestWithoutToken() throws Exception {
+        Map<String, String> headers = new TreeMap<>(Map.of("X-Forwarded-For", "192.0.2.43, 2001:db8:cafe::17"));
         IncomingFilter filter = mockWithRemoteAddress("127.0.0.1", headers, true);
 
         ContainerRequestContext context = mockContainerRequestContext("test");
@@ -159,7 +179,7 @@ class IncomingFilterTest {
         assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), captor.getValue().getStatus());
     }
 
-    private IncomingFilter mockWithRemoteAddress(final String remoteAddr, Map<String, String> headers, boolean secure)
+    private IncomingFilter mockWithRemoteAddress(final String remoteAddr, Map<String, String> headers, boolean isSecure)
             throws Exception {
         IncomingFilter filter = new IncomingFilter();
         filter.init();
@@ -168,7 +188,7 @@ class IncomingFilterTest {
         for (String name : headers.keySet()) {
             when(request.getHeader(name)).thenReturn(headers.get(name));
         }
-        when(request.isSecure()).thenReturn(secure);
+        when(request.isSecure()).thenReturn(isSecure);
         when(request.getRemoteAddr()).thenReturn(remoteAddr);
 
         setHttpRequest(filter, request);
@@ -198,8 +218,8 @@ class IncomingFilterTest {
     }
 
     @Test
-    void localhostTest() throws Exception {
-        assertFilterDoesNotBlockAddress("127.0.0.1", "test");
+    void localhostTestWithoutToken() throws Exception {
+        assertFilterBlocksAddress("127.0.0.1", "test");
     }
 
     private void assertFilterDoesNotBlockAddress(final String remoteAddr, final String url) throws Exception {
@@ -214,9 +234,22 @@ class IncomingFilterTest {
         verify(context, never()).abortWith(captor.capture());
     }
 
+    private void assertFilterBlocksAddress(final String remoteAddr, final String url) throws Exception {
+        IncomingFilter filter = mockWithRemoteAddress(remoteAddr);
+
+        ContainerRequestContext context = mockContainerRequestContext(url);
+
+        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+
+        filter.filter(context);
+
+        verify(context).abortWith(captor.capture());
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), captor.getValue().getStatus());
+    }
+
     @Test
-    void localhostIPv6Test() throws Exception {
-        assertFilterDoesNotBlockAddress("0:0:0:0:0:0:0:1", "test");
+    void localhostIPv6TestWithoutToken() throws Exception {
+        assertFilterBlocksAddress("0:0:0:0:0:0:0:1", "test");
     }
 
     @Test

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/filter/IncomingFilterTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/filter/IncomingFilterTest.java
@@ -263,6 +263,17 @@ class IncomingFilterTest {
     }
 
     @Test
+    void suggestConfigRemoteWithoutTokenTest() throws Exception {
+        assertFilterDoesNotBlockAddress("10.0.0.1", "suggest/config");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"file/genre", "file/defs", "file/content"})
+    void fileRemoteWithoutTokenTest(final String path) throws Exception {
+        assertFilterDoesNotBlockAddress("10.0.0.1", path);
+    }
+
+    @Test
     void systemPathDescWithoutTokenTest() throws Exception {
 
         IncomingFilter filter = mockWithRemoteAddress("192.168.1.1");

--- a/tools/src/main/python/opengrok_tools/utils/commandsequence.py
+++ b/tools/src/main/python/opengrok_tools/utils/commandsequence.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
 #
 
 import logging
@@ -40,6 +40,7 @@ import re
 API_TIMEOUT_PROPERTY = "api_timeout"
 ASYNC_API_TIMEOUT_PROPERTY = "async_api_timeout"
 HEADERS_PROPERTY = "headers"
+HEADERS_FILE_PROPERTY = "headers_file"
 METHOD_PROPERTY = "method"
 URI_PROPERTY = "uri"
 ARGS_SUBST_PROPERTY = "args_subst"
@@ -63,7 +64,7 @@ def check_call_config(call):
 
     for key in call.keys():
         if key not in [URI_PROPERTY, METHOD_PROPERTY, API_TIMEOUT_PROPERTY, ASYNC_API_TIMEOUT_PROPERTY,
-                       DATA_PROPERTY, HEADERS_PROPERTY]:
+                       DATA_PROPERTY, HEADERS_PROPERTY, HEADERS_FILE_PROPERTY]:
             raise CommandConfigurationException(f"unknown property {key} in call {call}")
 
     uri = call.get(URI_PROPERTY)
@@ -77,6 +78,16 @@ def check_call_config(call):
     headers = call.get(HEADERS_PROPERTY)
     if headers and not isinstance(headers, dict):
         raise CommandConfigurationException("headers must be a dictionary")
+
+    headers_file = call.get(HEADERS_FILE_PROPERTY)
+    if headers_file:
+        if not isinstance(headers_file, str):
+            raise CommandConfigurationException("headers_file must be a string")
+        try:
+            with open(headers_file, encoding="utf-8"):
+                pass
+        except OSError as exc:
+            raise CommandConfigurationException(f"cannot open headers_file {headers_file}") from exc
 
     call_timeout = call.get(API_TIMEOUT_PROPERTY)
     if call_timeout:
@@ -188,6 +199,8 @@ class ApiCall:
         self.headers = call_dict.get(HEADERS_PROPERTY)
         if not self.headers:
             self.headers = {}
+
+        self.headers_file = call_dict.get(HEADERS_FILE_PROPERTY)
 
         self.api_timeout = None
         call_timeout = call_dict.get(API_TIMEOUT_PROPERTY)

--- a/tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/tools/src/main/python/opengrok_tools/utils/restful.py
@@ -18,7 +18,7 @@
 #
 
 #
-# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
 #
 
 import json
@@ -144,6 +144,24 @@ def subst(src, substitutions):
     return src
 
 
+def read_headers_file(path):
+    """
+    Read HTTP headers from a file. Each header has to be on a separate line
+    in the form of 'name: value'. Lines not matching this form are ignored.
+    :param path: path to the headers file
+    :return: dictionary indexed with header names
+    """
+    headers = {}
+    with open(path, encoding="utf-8") as headers_file:
+        for line in headers_file:
+            line = line.rstrip()
+            if ': ' in line:
+                name, value = line.split(': ', 1)
+                headers[name] = value
+
+    return headers
+
+
 def call_rest_api(call, substitutions=None, http_headers=None, timeout=None, api_timeout=None):
     """
     Make REST API call. Occurrence of the pattern in the URI
@@ -163,7 +181,12 @@ def call_rest_api(call, substitutions=None, http_headers=None, timeout=None, api
     logger = logging.getLogger(__name__)
 
     logger.debug(f"Headers from the ApiCall object: {call.headers}")
-    headers = call.headers
+    headers = dict(call.headers)
+    if call.headers_file:
+        headers_file = subst(call.headers_file, substitutions)
+        logger.debug(f"Updating HTTP headers from file: {headers_file}")
+        headers.update(read_headers_file(headers_file))
+
     if http_headers:
         logger.debug("Updating HTTP headers for API call {} with {}".
                      format(call, http_headers))

--- a/tools/src/main/python/opengrok_tools/utils/restful.py
+++ b/tools/src/main/python/opengrok_tools/utils/restful.py
@@ -183,9 +183,8 @@ def call_rest_api(call, substitutions=None, http_headers=None, timeout=None, api
     logger.debug(f"Headers from the ApiCall object: {call.headers}")
     headers = dict(call.headers)
     if call.headers_file:
-        headers_file = subst(call.headers_file, substitutions)
-        logger.debug(f"Updating HTTP headers from file: {headers_file}")
-        headers.update(read_headers_file(headers_file))
+        logger.debug(f"Updating HTTP headers from file: {call.headers_file}")
+        headers.update(read_headers_file(call.headers_file))
 
     if http_headers:
         logger.debug("Updating HTTP headers for API call {} with {}".

--- a/tools/src/test/python/test_command_sequence.py
+++ b/tools/src/test/python/test_command_sequence.py
@@ -20,7 +20,7 @@
 #
 
 #
-# Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
 #
 
 import os
@@ -31,15 +31,21 @@ import tempfile
 
 from requests.exceptions import HTTPError
 
-from opengrok_tools.utils.commandsequence import CommandSequence, \
-    CommandSequenceBase, CommandConfigurationException
+from opengrok_tools.utils.commandsequence import (
+    CommandSequence,
+    CommandSequenceBase,
+    CommandConfigurationException,
+)
 from opengrok_tools.utils.patterns import PROJECT_SUBST, CALL_PROPERTY, COMMAND_PROPERTY
 
 
 def test_str():
-    cmds = CommandSequence(CommandSequenceBase("opengrok-master",
-                                               [{"command": {"args": ['foo']}},
-                                                {"command": {"args": ["bar"]}}]))
+    cmds = CommandSequence(
+        CommandSequenceBase(
+            "opengrok-master",
+            [{"command": {"args": ["foo"]}}, {"command": {"args": ["bar"]}}],
+        )
+    )
     assert str(cmds) == "opengrok-master"
 
 
@@ -52,29 +58,34 @@ def test_invalid_configuration_commands_none():
 
 def test_invalid_configuration_commands_no_command():
     with pytest.raises(CommandConfigurationException) as exc_info:
-        CommandSequence(CommandSequenceBase("foo", [{"command": {"args": ['foo']}},
-                                                    {"foo": "bar"}]))
+        CommandSequence(
+            CommandSequenceBase("foo", [{"command": {"args": ["foo"]}}, {"foo": "bar"}])
+        )
 
     assert str(exc_info.value).startswith("command dictionary has unknown key")
 
 
 def test_invalid_configuration_commands_no_dict1():
     with pytest.raises(CommandConfigurationException) as exc_info:
-        CommandSequence(CommandSequenceBase("foo", [{"command": {"args": ['foo']}},
-                                                    {"command": ["bar"]}]))
+        CommandSequence(
+            CommandSequenceBase(
+                "foo", [{"command": {"args": ["foo"]}}, {"command": ["bar"]}]
+            )
+        )
 
     assert str(exc_info.value).startswith("command value not a dictionary")
 
 
 def test_invalid_configuration_commands_no_dict2():
     with pytest.raises(CommandConfigurationException) as exc_info:
-        CommandSequence(CommandSequenceBase("foo", [{"command": {"args": ['foo']}},
-                                                    "command"]))
+        CommandSequence(
+            CommandSequenceBase("foo", [{"command": {"args": ["foo"]}}, "command"])
+        )
 
     assert str(exc_info.value).find("is not a dictionary") != -1
 
 
-@pytest.mark.parametrize('type', [COMMAND_PROPERTY, CALL_PROPERTY])
+@pytest.mark.parametrize("type", [COMMAND_PROPERTY, CALL_PROPERTY])
 def test_invalid_configuration_commands_none_value(type):
     with pytest.raises(CommandConfigurationException) as exc_info:
         CommandSequence(CommandSequenceBase("foo", [{type: None}]))
@@ -88,116 +99,133 @@ def test_timeout_propagation():
     """
     expected_timeout = 11
     expected_api_timeout = 22
-    cmd_seq_base = CommandSequenceBase("foo", [{"command": {"args": ['foo']}}],
-                                       api_timeout=expected_timeout,
-                                       async_api_timeout=expected_api_timeout)
+    cmd_seq_base = CommandSequenceBase(
+        "foo",
+        [{"command": {"args": ["foo"]}}],
+        api_timeout=expected_timeout,
+        async_api_timeout=expected_api_timeout,
+    )
     cmd_seq = CommandSequence(cmd_seq_base)
     assert cmd_seq.api_timeout == expected_timeout
     assert cmd_seq.async_api_timeout == expected_api_timeout
 
 
-@pytest.mark.skipif(not os.path.exists('/bin/sh')
-                    or not os.path.exists('/bin/echo'),
-                    reason="requires Unix")
+@pytest.mark.skipif(
+    not os.path.exists("/bin/sh") or not os.path.exists("/bin/echo"),
+    reason="requires Unix",
+)
 def test_run_retcodes():
-    cmd_list = [{"command": {"args": ["/bin/echo"]}},
-                {"command": {"args": ["/bin/sh", "-c",
-                 "echo " + PROJECT_SUBST + "; exit 0"]}},
-                {"command": {"args": ["/bin/sh", "-c",
-                 "echo " + PROJECT_SUBST + "; exit 1"]}}]
+    cmd_list = [
+        {"command": {"args": ["/bin/echo"]}},
+        {"command": {"args": ["/bin/sh", "-c", "echo " + PROJECT_SUBST + "; exit 0"]}},
+        {"command": {"args": ["/bin/sh", "-c", "echo " + PROJECT_SUBST + "; exit 1"]}},
+    ]
     cmds = CommandSequence(CommandSequenceBase("opengrok-master", cmd_list))
     cmds.run()
     assert cmds.retcodes == {
-        '/bin/echo opengrok-master': 0,
-        '/bin/sh -c echo opengrok-master; exit 0': 0,
-        '/bin/sh -c echo opengrok-master; exit 1': 1
+        "/bin/echo opengrok-master": 0,
+        "/bin/sh -c echo opengrok-master; exit 0": 0,
+        "/bin/sh -c echo opengrok-master; exit 1": 1,
     }
 
 
-@pytest.mark.skipif(not os.path.exists('/bin/sh')
-                    or not os.path.exists('/bin/echo'),
-                    reason="requires Unix")
+@pytest.mark.skipif(
+    not os.path.exists("/bin/sh") or not os.path.exists("/bin/echo"),
+    reason="requires Unix",
+)
 def test_terminate_after_non_zero_code():
-    cmd_list = [{"command": {"args": ["/bin/sh", "-c",
-                 "echo " + PROJECT_SUBST + "; exit 255"]}},
-                {"command": {"args": ["/bin/echo"]}}]
+    cmd_list = [
+        {
+            "command": {
+                "args": ["/bin/sh", "-c", "echo " + PROJECT_SUBST + "; exit 255"]
+            }
+        },
+        {"command": {"args": ["/bin/echo"]}},
+    ]
     cmds = CommandSequence(CommandSequenceBase("opengrok-master", cmd_list))
     cmds.run()
-    assert cmds.retcodes == {
-        '/bin/sh -c echo opengrok-master; exit 255': 255
-    }
+    assert cmds.retcodes == {"/bin/sh -c echo opengrok-master; exit 255": 255}
 
 
-@pytest.mark.skipif(not os.path.exists('/bin/sh')
-                    or not os.path.exists('/bin/echo'),
-                    reason="requires Unix")
+@pytest.mark.skipif(
+    not os.path.exists("/bin/sh") or not os.path.exists("/bin/echo"),
+    reason="requires Unix",
+)
 def test_exit_2_handling():
-    cmd_list = [{"command": {"args": ["/bin/sh", "-c",
-                 "echo " + PROJECT_SUBST + "; exit 2"]}},
-                {"command": {"args": ["/bin/echo"]}}]
+    cmd_list = [
+        {"command": {"args": ["/bin/sh", "-c", "echo " + PROJECT_SUBST + "; exit 2"]}},
+        {"command": {"args": ["/bin/echo"]}},
+    ]
     cmds = CommandSequence(CommandSequenceBase("opengrok-master", cmd_list))
     cmds.run()
-    assert cmds.retcodes == {
-        '/bin/sh -c echo opengrok-master; exit 2': 2
-    }
+    assert cmds.retcodes == {"/bin/sh -c echo opengrok-master; exit 2": 2}
     assert not cmds.failed
 
 
-@pytest.mark.skipif(not os.path.exists('/bin/sh')
-                    or not os.path.exists('/bin/echo'),
-                    reason="requires Unix")
+@pytest.mark.skipif(
+    not os.path.exists("/bin/sh") or not os.path.exists("/bin/echo"),
+    reason="requires Unix",
+)
 def test_driveon_flag():
-    cmd_list = [{"command": {"args": ["/bin/sh", "-c",
-                 "echo " + PROJECT_SUBST + "; exit 2"]}},
-                {"command": {"args": ["/bin/echo"]}},
-                {"command": {"args": ["/bin/sh", "-c",
-                                      "echo " + PROJECT_SUBST +
-                                      "; exit 1"]}},
-                {"command": {"args": ["/bin/sh", "-c",
-                             "echo " + PROJECT_SUBST]}}]
-    cmds = CommandSequence(CommandSequenceBase("opengrok-master",
-                                               cmd_list, driveon=True))
+    cmd_list = [
+        {"command": {"args": ["/bin/sh", "-c", "echo " + PROJECT_SUBST + "; exit 2"]}},
+        {"command": {"args": ["/bin/echo"]}},
+        {"command": {"args": ["/bin/sh", "-c", "echo " + PROJECT_SUBST + "; exit 1"]}},
+        {"command": {"args": ["/bin/sh", "-c", "echo " + PROJECT_SUBST]}},
+    ]
+    cmds = CommandSequence(
+        CommandSequenceBase("opengrok-master", cmd_list, driveon=True)
+    )
     cmds.run()
     assert cmds.retcodes == {
-        '/bin/sh -c echo opengrok-master; exit 2': 2,
-        '/bin/echo opengrok-master': 0,
-        '/bin/sh -c echo opengrok-master; exit 1': 1
+        "/bin/sh -c echo opengrok-master; exit 2": 2,
+        "/bin/echo opengrok-master": 0,
+        "/bin/sh -c echo opengrok-master; exit 1": 1,
     }
     assert cmds.failed
 
 
-@pytest.mark.skipif(not os.path.exists('/bin/echo'),
-                    reason="requires Unix")
+@pytest.mark.skipif(not os.path.exists("/bin/echo"), reason="requires Unix")
 def test_project_subst():
     cmd_list = [{"command": {"args": ["/bin/echo", PROJECT_SUBST]}}]
     cmds = CommandSequence(CommandSequenceBase("test-subst", cmd_list))
     cmds.run()
 
-    assert cmds.outputs['/bin/echo test-subst'] == ['test-subst']
+    assert cmds.outputs["/bin/echo test-subst"] == ["test-subst"]
 
 
-@pytest.mark.skipif(not os.path.exists('/bin/echo'),
-                    reason="requires Unix")
+@pytest.mark.skipif(not os.path.exists("/bin/echo"), reason="requires Unix")
 def test_args_subst():
-    cmd_list = [{"command": {"args": ["/bin/echo", "%PATTERN%"],
-                             "args_subst": {"%PATTERN%": "foo"}}}]
+    cmd_list = [
+        {
+            "command": {
+                "args": ["/bin/echo", "%PATTERN%"],
+                "args_subst": {"%PATTERN%": "foo"},
+            }
+        }
+    ]
     cmds = CommandSequence(CommandSequenceBase("test-subst", cmd_list))
     cmds.run()
 
-    assert cmds.outputs['/bin/echo foo'] == ['foo']
+    assert cmds.outputs["/bin/echo foo"] == ["foo"]
 
 
-@pytest.mark.skipif(not os.path.exists('/bin/echo'),
-                    reason="requires Unix")
+@pytest.mark.skipif(not os.path.exists("/bin/echo"), reason="requires Unix")
 def test_args_subst_env():
-    cmd_list = [{"command": {"args": ["/bin/echo", "%PATTERN%"],
-                             "args_subst": {"%PATTERN%": "$FOO"}}}]
+    cmd_list = [
+        {
+            "command": {
+                "args": ["/bin/echo", "%PATTERN%"],
+                "args_subst": {"%PATTERN%": "$FOO"},
+            }
+        }
+    ]
     os.environ["FOO"] = "bar"
     cmds = CommandSequence(CommandSequenceBase("test-subst", cmd_list))
     cmds.run()
     os.environ.pop("FOO")
 
-    assert cmds.outputs['/bin/echo bar'] == ['bar']
+    assert cmds.outputs["/bin/echo bar"] == ["bar"]
 
 
 def test_cleanup_exception():
@@ -207,28 +235,31 @@ def test_cleanup_exception():
     """
     cleanup = {"cleanup": ["foo", PROJECT_SUBST]}
     with pytest.raises(CommandConfigurationException):
-        CommandSequence(CommandSequenceBase("test-cleanup-list", None,
-                                            cleanup=cleanup))
+        CommandSequence(CommandSequenceBase("test-cleanup-list", None, cleanup=cleanup))
 
 
 # /bin/cat returns 2 on Solaris
-@pytest.mark.skipif(not os.path.exists('/usr/bin/touch') or
-                    not os.path.exists('/bin/cat') or
-                    sys.platform == "sunos5",
-                    reason="requires Unix")
+@pytest.mark.skipif(
+    not os.path.exists("/usr/bin/touch")
+    or not os.path.exists("/bin/cat")
+    or sys.platform == "sunos5",
+    reason="requires Unix",
+)
 def test_cleanup():
     with tempfile.TemporaryDirectory() as tmpdir:
         file_foo = os.path.join(tmpdir, "foo")
         file_bar = os.path.join(tmpdir, "bar")
-        cleanup_list = [{"command": {"args": ["/usr/bin/touch", file_foo]}},
-                        {"command": {"args": ["/bin/cat", "/totallynonexistent"]}},
-                        {"command": {"args": ["/usr/bin/touch", file_bar]}}]
+        cleanup_list = [
+            {"command": {"args": ["/usr/bin/touch", file_foo]}},
+            {"command": {"args": ["/bin/cat", "/totallynonexistent"]}},
+            {"command": {"args": ["/usr/bin/touch", file_bar]}},
+        ]
         # Running 'cat' on non-existing entry causes it to return 1.
         cmd = ["/bin/cat", "/foobar"]
         cmd_list = [{"command": {"args": cmd}}]
-        commands = CommandSequence(CommandSequenceBase("test-cleanup-list",
-                                                       cmd_list,
-                                                       cleanup=cleanup_list))
+        commands = CommandSequence(
+            CommandSequenceBase("test-cleanup-list", cmd_list, cleanup=cleanup_list)
+        )
         assert commands is not None
         commands.run()
         assert list(commands.retcodes.values()) == [1]
@@ -249,8 +280,11 @@ def test_restful_fail(monkeypatch):
         return MockResponse()
 
     commands = CommandSequence(
-        CommandSequenceBase("test-cleanup-list",
-                            [{CALL_PROPERTY: {"uri": 'http://foo', "method": 'PUT', "data": 'data'}}]))
+        CommandSequenceBase(
+            "test-cleanup-list",
+            [{CALL_PROPERTY: {"uri": "http://foo", "method": "PUT", "data": "data"}}],
+        )
+    )
     assert commands is not None
     with monkeypatch.context() as m:
         m.setattr("requests.put", mock_response)
@@ -259,19 +293,77 @@ def test_restful_fail(monkeypatch):
 
 
 def test_headers_init():
-    headers = {'foo': 'bar'}
+    headers = {"foo": "bar"}
 
     # First verify that header parameter of a command does not impact class member.
-    commands = CommandSequence(CommandSequenceBase("opengrok-master",
-                                                   [{CALL_PROPERTY: {"uri": 'http://foo', "method": 'PUT',
-                                                                     "data": 'data', "headers": headers}}]))
+    commands = CommandSequence(
+        CommandSequenceBase(
+            "opengrok-master",
+            [
+                {
+                    CALL_PROPERTY: {
+                        "uri": "http://foo",
+                        "method": "PUT",
+                        "data": "data",
+                        "headers": headers,
+                    }
+                }
+            ],
+        )
+    )
 
     assert commands.http_headers is None
 
     # Second, verify that init function propagates the headers.
-    commands = CommandSequence(CommandSequenceBase("opengrok-master",
-                                                   [{CALL_PROPERTY: {"uri": 'http://foo',
-                                                                     "method": 'PUT', "data": 'data'}}],
-                                                   http_headers=headers))
+    commands = CommandSequence(
+        CommandSequenceBase(
+            "opengrok-master",
+            [{CALL_PROPERTY: {"uri": "http://foo", "method": "PUT", "data": "data"}}],
+            http_headers=headers,
+        )
+    )
 
     assert commands.http_headers == headers
+
+
+def test_headers_file_validation():
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as headers_file:
+        headers_file.write("Authorization: Bearer token\n")
+
+    commands = CommandSequence(
+        CommandSequenceBase(
+            "opengrok-master",
+            [
+                {
+                    CALL_PROPERTY: {
+                        "uri": "http://foo",
+                        "method": "GET",
+                        "headers_file": headers_file.name,
+                    }
+                }
+            ],
+        )
+    )
+
+    os.remove(headers_file.name)
+    assert commands.commands[0][CALL_PROPERTY]["headers_file"] == headers_file.name
+
+
+def test_headers_file_validation_failure():
+    with pytest.raises(CommandConfigurationException) as exc_info:
+        CommandSequence(
+            CommandSequenceBase(
+                "opengrok-master",
+                [
+                    {
+                        CALL_PROPERTY: {
+                            "uri": "http://foo",
+                            "method": "GET",
+                            "headers_file": "/does/not/exist",
+                        }
+                    }
+                ],
+            )
+        )
+
+    assert str(exc_info.value).startswith("cannot open headers_file")

--- a/tools/src/test/python/test_restful.py
+++ b/tools/src/test/python/test_restful.py
@@ -20,19 +20,23 @@
 #
 
 #
-# Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
 #
+
+import os
+import tempfile
 
 import pytest
 import requests
-
-from requests.exceptions import HTTPError
-
-from mockito import verify, patch, mock
-
-from opengrok_tools.utils.restful import call_rest_api, \
-    CONTENT_TYPE, APPLICATION_JSON, do_api_call
+from mockito import mock, patch, verify
 from opengrok_tools.utils.commandsequence import ApiCall
+from opengrok_tools.utils.restful import (
+    APPLICATION_JSON,
+    CONTENT_TYPE,
+    call_rest_api,
+    do_api_call,
+)
+from requests.exceptions import HTTPError
 
 
 def test_replacement(monkeypatch):
@@ -53,25 +57,32 @@ def test_replacement(monkeypatch):
         # Spying on mocked function is maybe too much so verify
         # the arguments here.
         assert uri == "http://localhost:8080/source/api/v1/BAR"
-        assert kwargs['data'] == '"fooBARbar"'
+        assert kwargs["data"] == '"fooBARbar"'
 
         return MockResponse()
 
     for verb in ["PUT", "POST", "DELETE"]:
-        call = {"uri": "http://localhost:8080/source/api/v1/%FOO%",
-                "method": verb, "data": "foo%FOO%bar"}
+        call = {
+            "uri": "http://localhost:8080/source/api/v1/%FOO%",
+            "method": verb,
+            "data": "foo%FOO%bar",
+        }
         pattern = "%FOO%"
         value = "BAR"
         with monkeypatch.context() as m:
-            m.setattr("opengrok_tools.utils.restful.do_api_call",
-                      mock_do_api_call)
-            assert call_rest_api(ApiCall(call), {pattern: value}). \
-                status_code == okay_status
+            m.setattr("opengrok_tools.utils.restful.do_api_call", mock_do_api_call)
+            assert (
+                call_rest_api(ApiCall(call), {pattern: value}).status_code
+                == okay_status
+            )
 
 
 def test_unknown_method():
-    call = {"uri": "http://localhost:8080/source/api/v1/foo",
-            "method": "FOOBAR", "data": "data"}
+    call = {
+        "uri": "http://localhost:8080/source/api/v1/foo",
+        "method": "FOOBAR",
+        "data": "data",
+    }
     pattern = "%FOO%"
     value = "BAR"
     with pytest.raises(Exception):
@@ -83,22 +94,24 @@ def test_content_type(monkeypatch):
     Test HTTP Content-type header handling.
     """
     for method in ["PUT", "POST", "DELETE"]:
-        text_plain_header = {CONTENT_TYPE: 'text/plain'}
+        text_plain_header = {CONTENT_TYPE: "text/plain"}
         for header_arg in [text_plain_header, None]:
-            call = {"uri": "http://localhost:8080/source/api/v1/foo",
-                    "method": method, "data": "data", "headers": header_arg}
+            call = {
+                "uri": "http://localhost:8080/source/api/v1/foo",
+                "method": method,
+                "data": "data",
+                "headers": header_arg,
+            }
 
             def mock_response(verb, uri, **kwargs):
-                headers = kwargs['headers']
+                headers = kwargs["headers"]
                 if header_arg:
                     assert text_plain_header.items() <= headers.items()
                 else:
-                    assert {CONTENT_TYPE: APPLICATION_JSON}.items() \
-                        <= headers.items()
+                    assert {CONTENT_TYPE: APPLICATION_JSON}.items() <= headers.items()
 
             with monkeypatch.context() as m:
-                m.setattr("opengrok_tools.utils.restful.do_api_call",
-                          mock_response)
+                m.setattr("opengrok_tools.utils.restful.do_api_call", mock_response)
                 call_rest_api(ApiCall(call))
 
 
@@ -108,27 +121,64 @@ def test_headers_timeout(monkeypatch):
     HTTP headers passed to call_res_api(). Also test timeout.
     :param monkeypatch: monkey fixture
     """
-    headers = {'Tatsuo': 'Yasuko'}
+    headers = {"Tatsuo": "Yasuko"}
     expected_timeout = 42
     expected_api_timeout = 24
-    call = {"uri": "http://localhost:8080/source/api/v1/bar",
-            "method": "GET", "data": "data", "headers": headers}
-    extra_headers = {'Mei': 'Totoro'}
+    call = {
+        "uri": "http://localhost:8080/source/api/v1/bar",
+        "method": "GET",
+        "data": "data",
+        "headers": headers,
+    }
+    extra_headers = {"Mei": "Totoro"}
 
     def mock_do_api_call(verb, uri, **kwargs):
         all_headers = headers
         all_headers.update(extra_headers)
         assert headers == all_headers
-        assert kwargs['timeout'] == expected_timeout
-        assert kwargs['api_timeout'] == expected_api_timeout
+        assert kwargs["timeout"] == expected_timeout
+        assert kwargs["api_timeout"] == expected_api_timeout
 
     with monkeypatch.context() as m:
-        m.setattr("opengrok_tools.utils.restful.do_api_call",
-                  mock_do_api_call)
-        call_rest_api(ApiCall(call),
-                      http_headers=extra_headers,
-                      timeout=expected_timeout,
-                      api_timeout=expected_api_timeout)
+        m.setattr("opengrok_tools.utils.restful.do_api_call", mock_do_api_call)
+        call_rest_api(
+            ApiCall(call),
+            http_headers=extra_headers,
+            timeout=expected_timeout,
+            api_timeout=expected_api_timeout,
+        )
+
+
+def test_headers_file(monkeypatch):
+    """
+    Test that HTTP headers from a file are united with headers from command
+    specification and HTTP headers passed to call_rest_api().
+    """
+    headers = {"Satsuki": "Tatsuo"}
+    file_headers = {"Authorization": "Bearer token"}
+    extra_headers = {"Mei": "Totoro"}
+
+    def mock_do_api_call(verb, uri, **kwargs):
+        assert headers.items() <= kwargs["headers"].items()
+        assert file_headers.items() <= kwargs["headers"].items()
+        assert extra_headers.items() <= kwargs["headers"].items()
+
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as headers_file:
+        for header, value in file_headers.items():
+            headers_file.write(f"{header}: {value}\n")
+
+    call = {
+        "uri": "http://localhost:8080/source/api/v1/bar",
+        "method": "GET",
+        "headers": headers,
+        "headers_file": headers_file.name,
+    }
+
+    with monkeypatch.context() as m:
+        m.setattr("opengrok_tools.utils.restful.do_api_call", mock_do_api_call)
+        call_rest_api(ApiCall(call), http_headers=extra_headers)
+
+    os.remove(headers_file.name)
 
 
 def test_api_call_timeout_override(monkeypatch):
@@ -138,21 +188,25 @@ def test_api_call_timeout_override(monkeypatch):
     expected_timeout = 42
     expected_api_timeout = 24
 
-    call = {"uri": "http://localhost:8080/source/api/v1/bar",
-            "method": "POST", "data": "data",
-            "api_timeout": expected_timeout,
-            "async_api_timeout": expected_api_timeout}
+    call = {
+        "uri": "http://localhost:8080/source/api/v1/bar",
+        "method": "POST",
+        "data": "data",
+        "api_timeout": expected_timeout,
+        "async_api_timeout": expected_api_timeout,
+    }
 
     def mock_do_api_call(verb, uri, **kwargs):
-        assert kwargs['timeout'] == expected_timeout
-        assert kwargs['api_timeout'] == expected_api_timeout
+        assert kwargs["timeout"] == expected_timeout
+        assert kwargs["api_timeout"] == expected_api_timeout
 
     with monkeypatch.context() as m:
-        m.setattr("opengrok_tools.utils.restful.do_api_call",
-                  mock_do_api_call)
-        call_rest_api(ApiCall(call),
-                      timeout=expected_timeout + 1,
-                      api_timeout=expected_api_timeout + 1)
+        m.setattr("opengrok_tools.utils.restful.do_api_call", mock_do_api_call)
+        call_rest_api(
+            ApiCall(call),
+            timeout=expected_timeout + 1,
+            api_timeout=expected_api_timeout + 1,
+        )
 
 
 def test_headers_timeout_requests():
@@ -172,9 +226,9 @@ def test_headers_timeout_requests():
     with patch(requests.get, mock_requests_get):
         do_api_call("GET", uri, headers=headers, timeout=timeout)
 
-        verify(requests).get(uri, data=None, params=None,
-                             headers=headers, proxies=None,
-                             timeout=timeout)
+        verify(requests).get(
+            uri, data=None, params=None, headers=headers, proxies=None, timeout=timeout
+        )
 
 
 def test_restful_fail(monkeypatch):
@@ -182,6 +236,7 @@ def test_restful_fail(monkeypatch):
     Test that failures in call_rest_api() result in HTTPError exception.
     This is done only for the PUT HTTP verb.
     """
+
     class MockResponse:
         def p(self):
             raise HTTPError("foo")
@@ -196,7 +251,9 @@ def test_restful_fail(monkeypatch):
     with monkeypatch.context() as m:
         m.setattr("requests.put", mock_response)
         with pytest.raises(HTTPError):
-            call_rest_api(ApiCall({"uri": 'http://foo', "method": 'PUT', "data": 'data'}))
+            call_rest_api(
+                ApiCall({"uri": "http://foo", "method": "PUT", "data": "data"})
+            )
 
 
 def test_invalid_command_none():
@@ -216,4 +273,8 @@ def test_invalid_command_list():
 
 def test_invalid_command_bad_uri():
     with pytest.raises(Exception):
-        call_rest_api(ApiCall({"uri": "foo", "method": "PUT", "data": "data", "headers": "headers"}))
+        call_rest_api(
+            ApiCall(
+                {"uri": "foo", "method": "PUT", "data": "data", "headers": "headers"}
+            )
+        )


### PR DESCRIPTION
The time has come (AI assisted vulnerability research, zero trust, and all that) to remove the capability to allow API calls to the sensitive endpoints solely on the basis of the request coming from `localhost`.

This means whoever uses the Python tooling or running the indexer with the `-U` option will have to configure and supply bearer token from now on. For the former it means using the pre-existing `-H` option to supply the `Authorization` HTTP header, for the latter using either the pre-existing `--token` option or setting the `indexerAuthenticationToken` [option](https://github.com/oracle/opengrok/wiki/Indexer-configuration) in the [read-only configuration](https://github.com/oracle/opengrok/wiki/Read-only-configuration). Speaking of which, the read-only configuration has to be used to configure the set of allowed tokens anyway. Combining these two the read-only configuration file contents can look like so:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<java version="11.0.8" class="java.beans.XMLDecoder">
    <object class="org.opengrok.indexer.configuration.Configuration">
        <void property="authenticationTokens">
            <void method="add">
                <string>INSERT_YOUR_BEARER_TOKEN_HERE</string>
            </void>
        </void>
        <void property="indexerAuthenticationToken">
            <string>INSERT_YOUR_BEARER_TOKEN_HERE</string>
        </void>
    </object>
</java>
```
In the Docker image this is done automatically. There, any pre-existing bearer tokens will stop working as they will be replaced by the automatically generated ones. Due to the nature of the image I don't consider this scenario to be ever used.

While there, I did a cleanup of the `/file` endpoints handling.

Will update [`opengrok-sync` configuration documentation](https://github.com/oracle/opengrok/wiki/Per-project-management-and-workflow#opengrok-sync), [HTTP headers documentation](https://github.com/oracle/opengrok/wiki/Per-project-management-and-workflow#http-headers) with the newly added `headers_file` directive and the [Apiary blueprint](https://opengrok.docs.apiary.io/#) once this is in.