### PR TITLE
allow headers_file directive to be used at the top level

### DIFF
--- a/docker/sync.yml
+++ b/docker/sync.yml
@@ -1,8 +1,8 @@
+headers_file: /opengrok/etc/webapp_api_headers
 commands:
 - call:
     uri: '%URL%api/v1/messages'
     method: POST
-    headers_file: /opengrok/etc/webapp_api_headers
     data:
       messageLevel: warning
       duration: PT1H
@@ -29,7 +29,6 @@ commands:
     uri: '%URL%api/v1/messages?tag=%PROJECT%'
     method: DELETE
     data: 'resync + reindex in progress'
-    headers_file: /opengrok/etc/webapp_api_headers
     headers:
       'Content-type': 'text/plain'
     api_timeout: "$API_TIMEOUT"
@@ -38,7 +37,6 @@ cleanup:
     uri: '%URL%api/v1/messages?tag=%PROJECT%'
     method: DELETE
     data: 'resync + reindex in progress'
-    headers_file: /opengrok/etc/webapp_api_headers
     headers:
       'Content-type': 'text/plain'
     api_timeout: "$API_TIMEOUT"

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -38,11 +38,18 @@ from os import path
 
 from filelock import Timeout, FileLock
 
-from .utils.commandsequence import CommandSequence, CommandSequenceBase, CommandConfigurationException
+from .utils.commandsequence import (
+    CommandSequence,
+    CommandSequenceBase,
+    CommandConfigurationException,
+    HEADERS_FILE_PROPERTY,
+    HEADERS_PROPERTY,
+)
 from .utils.log import get_console_logger, get_class_basename, fatal
 from .utils.opengrok import list_indexed_projects, get_config_value
 from .utils.parsers import get_base_parser, add_http_headers, get_headers
 from .utils.readconfig import read_config
+from .utils.restful import read_headers_file
 from .utils.webutil import is_web_uri
 from .utils.exitvals import (
     FAILURE_EXITVAL,
@@ -55,6 +62,40 @@ if (major_version < 3):
     sys.exit(1)
 
 __version__ = "1.5"
+
+
+def update_headers_from_config(logger, config, headers):
+    """
+    Update HTTP headers with top-level configuration directives.
+    :param logger: logger to be used in this function
+    :param config: dictionary with opengrok-sync configuration
+    :param headers: dictionary with HTTP headers to update
+    :return updated HTTP headers dictionary
+    """
+    config_headers = config.get(HEADERS_PROPERTY)
+    if config_headers:
+        if not isinstance(config_headers, dict):
+            raise CommandConfigurationException("headers must be a dictionary")
+
+        logger.debug("Updating HTTP headers with headers from the configuration: {}".
+                     format(config_headers))
+        headers.update(config_headers)
+
+    config_headers_file = config.get(HEADERS_FILE_PROPERTY)
+    if config_headers_file:
+        if not isinstance(config_headers_file, str):
+            raise CommandConfigurationException("headers_file must be a string")
+
+        try:
+            file_headers = read_headers_file(config_headers_file)
+        except OSError as exc:
+            raise CommandConfigurationException(f"cannot open headers_file {config_headers_file}") from exc
+
+        logger.debug("Updating HTTP headers with headers from the configuration file {}: {}".
+                     format(config_headers_file, file_headers))
+        headers.update(file_headers)
+
+    return headers
 
 
 def worker(base):
@@ -219,11 +260,11 @@ def main():
         return FAILURE_EXITVAL
 
     headers = get_headers(args.header)
-    config_headers = config.get("headers")
-    if config_headers:
-        logger.debug("Updating HTTP headers with headers from the configuration: {}".
-                     format(config_headers))
-        headers.update(config_headers)
+    try:
+        headers = update_headers_from_config(logger, config, headers)
+    except CommandConfigurationException as exc:
+        logger.error("Invalid configuration: {}".format(exc))
+        return FAILURE_EXITVAL
 
     directory = args.directory
     if not args.directory and not args.project and not args.indexed:

--- a/tools/src/main/python/opengrok_tools/sync.py
+++ b/tools/src/main/python/opengrok_tools/sync.py
@@ -19,7 +19,7 @@
 #
 
 #
-# Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
 #
 
 """
@@ -61,7 +61,7 @@ if (major_version < 3):
     print("Need Python 3, you are running {}".format(major_version))
     sys.exit(1)
 
-__version__ = "1.5"
+__version__ = "1.6"
 
 
 def update_headers_from_config(logger, config, headers):

--- a/tools/src/test/python/test_sync.py
+++ b/tools/src/test/python/test_sync.py
@@ -20,17 +20,19 @@
 #
 
 #
-# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
 #
 
 import logging
+import os
+import tempfile
 
 import pytest
 from multiprocessing import pool
 
 from mockito import verify, ANY, patch
 
-from opengrok_tools.sync import do_sync
+from opengrok_tools.sync import do_sync, update_headers_from_config
 from opengrok_tools.utils.commandsequence import CommandConfigurationException
 from opengrok_tools.utils.exitvals import SUCCESS_EXITVAL
 
@@ -71,3 +73,51 @@ def test_dosync_check_config_invalid():
     with pytest.raises(CommandConfigurationException):
         do_sync(logging.INFO, commands, None, ["foo", "bar"], [],
                 "http://localhost:8080/source", 42, check_config=True)
+
+
+def test_update_headers_from_config():
+    logger = logging.getLogger("test_update_headers_from_config")
+    headers = {"CLI": "header", "Common": "cli"}
+    config_headers = {"Config": "header", "Common": "config"}
+    file_headers = {"File": "header", "Common": "file"}
+
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as headers_file:
+        for header, value in file_headers.items():
+            headers_file.write(f"{header}: {value}\n")
+
+    try:
+        assert update_headers_from_config(logger, {
+            "headers": config_headers,
+            "headers_file": headers_file.name,
+        }, headers) == {
+            "CLI": "header",
+            "Config": "header",
+            "File": "header",
+            "Common": "file",
+        }
+    finally:
+        os.remove(headers_file.name)
+
+
+def test_update_headers_from_config_invalid_headers():
+    logger = logging.getLogger("test_update_headers_from_config_invalid_headers")
+    with pytest.raises(CommandConfigurationException) as exc_info:
+        update_headers_from_config(logger, {"headers": "invalid"}, {})
+
+    assert str(exc_info.value) == "headers must be a dictionary"
+
+
+def test_update_headers_from_config_invalid_headers_file():
+    logger = logging.getLogger("test_update_headers_from_config_invalid_headers_file")
+    with pytest.raises(CommandConfigurationException) as exc_info:
+        update_headers_from_config(logger, {"headers_file": 42}, {})
+
+    assert str(exc_info.value) == "headers_file must be a string"
+
+
+def test_update_headers_from_config_missing_headers_file():
+    logger = logging.getLogger("test_update_headers_from_config_missing_headers_file")
+    with pytest.raises(CommandConfigurationException) as exc_info:
+        update_headers_from_config(logger, {"headers_file": "/does/not/exist"}, {})
+
+    assert str(exc_info.value).startswith("cannot open headers_file")


### PR DESCRIPTION
Follow-up for PR #4944 which introduced the `headers_file` configuration directive for the `opengrok-sync` configuration file. This change allows the directive to be used at the top level, simplifying the configuration file used in the Docker image.