### PR TITLE
do not push the image if the ref is foreign

### DIFF
--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -72,6 +72,11 @@ if [[ "$OPENGROK_REPO_SLUG" != "oracle/opengrok" ]]; then
 	exit 0
 fi
 
+if [[ "$OPENGROK_REF" != "refs/heads/master" && "$OPENGROK_REF" != refs/tags/* ]]; then
+	echo "Not pushing Docker image for ref $OPENGROK_REF"
+	exit 0
+fi
+
 if [[ -z $DOCKER_USERNAME ]]; then
 	echo "DOCKER_USERNAME is empty, exiting"
 	exit 1

--- a/dev/docker.sh
+++ b/dev/docker.sh
@@ -10,6 +10,10 @@
 # These are set via https://github.com/oracle/opengrok/settings/secrets
 #
 
+#
+# Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
+#
+
 set -e
 
 echo "Running linter"


### PR DESCRIPTION
The changes done in PR #4638 are not enough for Dependabot PRs. These still fail the Docker image workflow with `DOCKER_USERNAME is empty, exiting`. In such runs the `DOCKER_USERNAME` and `DOCKER_PAT` are empty. The `OPENGROK_REPO_SLUG` has value of `oracle/opengrok` and the `GITHUB_EVENT_NAME=push` so the checks in `docker.sh` will not exit out. The `OPENGROK_REF` has value such as `refs/heads/dependabot/github_actions/github/codeql-action-4.35.3`.

This is caused by Dependabot creating a branch in the `oracle/opengrok` repository and lacking access to the secrets [as documented](https://docs.github.com/en/enterprise-cloud@latest/code-security/reference/supply-chain-security/troubleshoot-dependabot/troubleshooting-dependabot-on-github-actions#accessing-secrets).

By checking the ref value these workflow runs can be detected. The `refs/heads/master` is needed even though the `master` branch is protected (from direct push) as it is used when merging a PR.
