### PR TITLE
Fix modified file paths windows

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/IncomingFilter.java
@@ -119,7 +119,7 @@ public class IncomingFilter implements ContainerRequestFilter, ConfigurationChan
                 LOGGER.log(Level.FINEST, "allowing request to {0} based on authentication token", sanitizedPath);
                 return;
             } else {
-                LOGGER.log(Level.FINEST, "request to {0} has a valid token however is not secure", sanitizedPath);
+                LOGGER.log(Level.WARNING, "request to {0} has a valid token however is not secure", sanitizedPath);
             }
         }
 

--- a/opengrok-web/src/main/webapp/history.jsp
+++ b/opengrok-web/src/main/webapp/history.jsp
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright 2011 Jens Elkner.
 Portions Copyright (c) 2018-2020, Chris Fraire <cfraire@me.com>.
 --%>
@@ -404,6 +404,7 @@ document.domReady.push(function() {domReadyHistory();});
                 if (files != null) {
                 %><div class="filelist-hidden"><br/><%
                     for (String ifile : files) {
+                        ifile = Util.fixPathIfWindows(ifile);
                         String jfile = Util.stripPathPrefix(path, ifile);
                         if (Objects.equals(rev, "")) {
                 %>


### PR DESCRIPTION
This change fixes the encoding of file paths in the modified file list in history view on Windows.

While there, I changed the log level of a message warning about API token being used in the clear.