### PR TITLE
set Content-type HTTP header for the metrics API endpoint

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/Metrics.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer;
 
@@ -50,6 +50,8 @@ import java.util.stream.Collectors;
  * Generally, the web application publishes metrics to Prometheus and the Indexer to StatsD.
  */
 public final class Metrics {
+
+    private static final String PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Metrics.class);
 
@@ -121,6 +123,14 @@ public final class Metrics {
 
     public static PrometheusMeterRegistry getPrometheusRegistry() {
         return prometheusRegistry;
+    }
+
+    /**
+     * Get content type for Prometheus text exposition format.
+     * @return Prometheus text exposition content type
+     */
+    public static String getPrometheusContentType() {
+        return PROMETHEUS_CONTENT_TYPE;
     }
 
     private static StatsdMeterRegistry getStatsdRegistry() {

--- a/opengrok-web/src/main/java/org/opengrok/web/servlet/MetricsServlet.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/servlet/MetricsServlet.java
@@ -45,6 +45,7 @@ public class MetricsServlet extends HttpServlet {
 
     @Override
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) {
+        resp.setContentType(Metrics.getPrometheusContentType());
         try (PrintWriter pw = resp.getWriter()) {
             pw.print(Metrics.getPrometheusRegistry().scrape());
         } catch (IOException e) {

--- a/opengrok-web/src/main/java/org/opengrok/web/servlet/MetricsServlet.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/servlet/MetricsServlet.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web.servlet;
 

--- a/opengrok-web/src/test/java/org/opengrok/web/servlet/MetricsServletTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/servlet/MetricsServletTest.java
@@ -1,0 +1,58 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opengrok.web.servlet;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MetricsServletTest {
+
+    private static final String EXPECTED_PROMETHEUS_CONTENT_TYPE =
+            "text/plain; version=0.0.4; charset=utf-8";
+
+    @Test
+    void shouldSetPrometheusContentType() throws Exception {
+        MetricsServlet servlet = new MetricsServlet();
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+        when(response.getWriter()).thenReturn(printWriter);
+
+        servlet.doGet(request, response);
+
+        InOrder inOrder = inOrder(response);
+        inOrder.verify(response).setContentType(EXPECTED_PROMETHEUS_CONTENT_TYPE);
+        inOrder.verify(response).getWriter();
+        assertFalse(stringWriter.toString().isEmpty());
+    }
+}


### PR DESCRIPTION
When using recent version of Prometheus (3.5.3) against the metrics API endpoint, it failed with `"Failed to determine correct type of scrape target."` due to the absence of the `Content-type` header in the response. This change makes sure the header is added.

The workaround is to add `fallback_scrape_protocol` to the Prometheus configuration, e.g.:
```yml
  - job_name: foo
    metrics_path: '/source/metrics/prometheus'
    scheme: https
    fallback_scrape_protocol: PrometheusText0.0.4
    static_configs:
      - targets: ['foo.example.com:443']
```