### PR TITLE
🐛 fix(search-api): bound Lucene collection to prevent OOM

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -139,13 +139,8 @@ public class SearchEngine {
 
     // internal structures to hold the results from Lucene
     private final List<Document> docs;
-    /**
-     * Hard cap on the number of Lucene documents collected during search.
-     * When positive, overrides {@code hitsPerPage * cachePages} and disables
-     * the unbounded re-collection path, keeping heap usage proportional to
-     * this value rather than to the total number of matching documents.
-     * 0 means no cap (default, legacy behavior).
-     */
+    // Caps Lucene collection to prevent unbounded heap use on large result sets.
+    // 0 = no cap (default, preserves legacy behaviour).
     private int maxDocs;
     int totalHits = 0;
     private ScoreDoc[] hits;
@@ -656,20 +651,18 @@ public class SearchEngine {
         this.maxHitsPerFile = maxHitsPerFile;
     }
 
-    /**
-     * Set a hard cap on the number of Lucene documents collected.
-     * When positive, the search collects at most this many documents
-     * and never re-queries for the full result set.
-     *
-     * @param maxDocs maximum documents to collect (0 = unlimited)
-     */
     public void setMaxDocs(int maxDocs) {
         this.maxDocs = maxDocs;
     }
 
+    public int getMaxDocs() {
+        return maxDocs;
+    }
+
     /**
      * Returns the total number of Lucene documents matching the query,
-     * regardless of the {@code maxDocs} cap. Available after {@code search()}.
+     * regardless of the {@code maxDocs} cap. Callers need the true total
+     * to paginate correctly when collection is bounded.
      *
      * @return total matching document count
      */

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -139,6 +139,14 @@ public class SearchEngine {
 
     // internal structures to hold the results from Lucene
     private final List<Document> docs;
+    /**
+     * Hard cap on the number of Lucene documents collected during search.
+     * When positive, overrides {@code hitsPerPage * cachePages} and disables
+     * the unbounded re-collection path, keeping heap usage proportional to
+     * this value rather than to the total number of matching documents.
+     * 0 means no cap (default, legacy behavior).
+     */
+    private int maxDocs;
     int totalHits = 0;
     private ScoreDoc[] hits;
     boolean allCollected;
@@ -230,7 +238,7 @@ public class SearchEngine {
 
     private void searchIndex(IndexSearcher searcher, boolean paging) throws IOException {
         Statistics stat = new Statistics();
-        final int numHits = hitsPerPage * cachePages;
+        final int numHits = maxDocs > 0 ? maxDocs : hitsPerPage * cachePages;
         TopDocs topDocs;
         Sort luceneSort = getSort();
         if (luceneSort == null) {
@@ -241,7 +249,7 @@ public class SearchEngine {
         hits = topDocs.scoreDocs;
         totalHits = (int) topDocs.totalHits.value;
 
-        if (!paging && totalHits > numHits) {
+        if (maxDocs <= 0 && !paging && totalHits > numHits) {
             if (luceneSort == null) {
                 topDocs = searcher.search(query, new TopScoreDocCollectorManager(totalHits, Integer.MAX_VALUE));
             } else {
@@ -253,7 +261,7 @@ public class SearchEngine {
                 "search.latency", new String[]{"category", "engine",
                         "outcome", totalHits > 0 ? "success" : "empty"});
 
-        allCollected = !paging || totalHits <= numHits;
+        allCollected = maxDocs > 0 || !paging || totalHits <= numHits;
 
         StoredFields storedFields = searcher.storedFields();
         for (ScoreDoc hit : hits) {
@@ -646,6 +654,27 @@ public class SearchEngine {
      */
     public void setMaxHitsPerFile(int maxHitsPerFile) {
         this.maxHitsPerFile = maxHitsPerFile;
+    }
+
+    /**
+     * Set a hard cap on the number of Lucene documents collected.
+     * When positive, the search collects at most this many documents
+     * and never re-queries for the full result set.
+     *
+     * @param maxDocs maximum documents to collect (0 = unlimited)
+     */
+    public void setMaxDocs(int maxDocs) {
+        this.maxDocs = maxDocs;
+    }
+
+    /**
+     * Returns the total number of Lucene documents matching the query,
+     * regardless of the {@code maxDocs} cap. Available after {@code search()}.
+     *
+     * @return total matching document count
+     */
+    public int getTotalHits() {
+        return totalHits;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -79,6 +79,10 @@ import org.opengrok.indexer.web.SortOrder;
  * <p>
  * Authorization is <b>not</b> enforced here, this has to be done by the caller by filtering out the projects
  * passed to {@link #search(List)}.
+ * <p>
+ * The expected lifecycle is: set the search criteria, call {@code search(...)}, retrieve the hits via
+ * {@link #results(int, int, List)} and finally call {@link #destroy()}. Calling
+ * {@link #results(int, int, List)} without a successful search throws {@link IllegalStateException}.
  *
  * @author Trond Norbye 2005
  * @author Lubos Kosco - upgrade to lucene 3.x, 4.x, 5.x
@@ -168,14 +172,6 @@ public class SearchEngine {
     }
 
     /**
-     * Creates a new instance of SearchEngine collecting at most the configured
-     * hits per page times the number of cache pages.
-     */
-    public SearchEngine() {
-        this(env.getHitsPerPage() * env.getCachePages());
-    }
-
-    /**
      * Create a QueryBuilder using the fields that have been set on this instance.
      *
      * @return a query builder
@@ -235,7 +231,7 @@ public class SearchEngine {
         Statistics stat = new Statistics();
         // The collector managers eagerly allocate a priority queue of the requested size, hence
         // the index-size cap, mirroring IndexSearcher#search(Query, int).
-        final int numHits = Math.min(maxDocs, Math.max(1, searcher.getIndexReader().maxDoc()));
+        final int numHits = Math.clamp(searcher.getIndexReader().maxDoc(), 1, maxDocs);
         TopDocs topDocs;
         Sort luceneSort = getSort();
         if (luceneSort == null) {
@@ -416,19 +412,21 @@ public class SearchEngine {
      * Get results by going through the documents from the search hits and grabbing the context therein.
      * This involves reading various document fields as well as file contents from the respective files
      * under source root.
-     * If no search was started before, no results are returned.
      * Only documents collected by {@code search(...)} are available; {@code endDocIndex} is clamped
      * to the collected count, i.e. the value {@code search(...)} returned.
      *
      * @param startDocIndex start index of the hit list
      * @param endDocIndex end index of the hit list
-     * @param ret output argument that contains list of results from start to end or null/empty if no search was started
+     * @param ret output argument that contains list of results from start to end
+     * @throws IllegalStateException if no search was performed or it did not succeed
      */
     public void results(int startDocIndex, int endDocIndex, @NotNull List<Hit> ret) {
-        ret.clear();
+        if (hits == null) {
+            throw new IllegalStateException("results(...) called without a successful search(...)");
+        }
 
-        // return if no search() was done
-        if (hits == null || (endDocIndex < startDocIndex)) {
+        ret.clear();
+        if (endDocIndex < startDocIndex) {
             return;
         }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -320,7 +320,8 @@ public class SearchEngine {
      * Execute a search.
      * <p>
      * Before calling this function, you must set the appropriate search criteria with the set-functions.
-     * Note that this search will return the first {@link #cachePages} of {@link #hitsPerPage}.
+     * Note that this search will return the first {@link #cachePages} of {@link #hitsPerPage}, unless a positive
+     * {@code maxDocs} has been set via {@link #setMaxDocs(int)}, in which case collection is bounded to that many hits.
      * <p>
      * Must be eventually followed by call to {@link #destroy()} so that
      * the {@code IndexSearcher} objects are properly freed.
@@ -336,7 +337,8 @@ public class SearchEngine {
      * Execute a search on projects or root file.
      * <p>
      * Before calling this function, you must set the appropriate search criteria with the set-functions.
-     * Note that this search will return the first {@link #cachePages} of {@link #hitsPerPage}.
+     * Note that this search will return the first {@link #cachePages} of {@link #hitsPerPage}, unless a positive
+     * {@code maxDocs} has been set via {@link #setMaxDocs(int)}, in which case collection is bounded to that many hits.
      * <p>
      * If the {@code projects} parameter is an empty list, it tries to search in {@code searchSingleDatabase}
      * with root set to the {@code root} parameter.
@@ -655,19 +657,9 @@ public class SearchEngine {
         this.maxDocs = maxDocs;
     }
 
+    @VisibleForTesting
     public int getMaxDocs() {
         return maxDocs;
-    }
-
-    /**
-     * Returns the total number of Lucene documents matching the query,
-     * regardless of the {@code maxDocs} cap. Callers need the true total
-     * to paginate correctly when collection is bounded.
-     *
-     * @return total matching document count
-     */
-    public int getTotalHits() {
-        return totalHits;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -233,7 +233,10 @@ public class SearchEngine {
 
     private void searchIndex(IndexSearcher searcher, boolean paging) throws IOException {
         Statistics stat = new Statistics();
-        final int numHits = maxDocs > 0 ? maxDocs : hitsPerPage * cachePages;
+        // The collector managers eagerly allocate a priority queue of the requested size, hence
+        // the index-size cap, mirroring IndexSearcher#search(Query, int).
+        final int numHits = Math.min(maxDocs == 0 ? hitsPerPage * cachePages : maxDocs,
+                Math.max(1, searcher.getIndexReader().maxDoc()));
         TopDocs topDocs;
         Sort luceneSort = getSort();
         if (luceneSort == null) {
@@ -244,7 +247,7 @@ public class SearchEngine {
         hits = topDocs.scoreDocs;
         totalHits = (int) topDocs.totalHits.value;
 
-        if (maxDocs <= 0 && !paging && totalHits > numHits) {
+        if (maxDocs == 0 && !paging && totalHits > numHits) {
             if (luceneSort == null) {
                 topDocs = searcher.search(query, new TopScoreDocCollectorManager(totalHits, Integer.MAX_VALUE));
             } else {
@@ -326,7 +329,8 @@ public class SearchEngine {
      * Must be eventually followed by call to {@link #destroy()} so that
      * the {@code IndexSearcher} objects are properly freed.
      *
-     * @return total number of hits
+     * @return number of collected hits, safe to pass to {@link #results(int, int, List)}; when {@code maxDocs}
+     * is not set this equals the total number of hits, otherwise see {@link #getTotalHits()} for the total
      */
     @VisibleForTesting
     public int search() {
@@ -347,7 +351,8 @@ public class SearchEngine {
      * the {@code IndexSearcher} objects are properly freed.
      *
      * @param projects projects to search
-     * @return total number of hits
+     * @return number of collected hits, safe to pass to {@link #results(int, int, List)}; when {@code maxDocs}
+     * is not set this equals the total number of hits, otherwise see {@link #getTotalHits()} for the total
      */
     public int search(List<Project> projects) {
         source = env.getSourceRootPath();
@@ -392,7 +397,7 @@ public class SearchEngine {
                 LOGGER.log(Level.WARNING, "An error occurred while getting history context", e);
             }
         }
-        int count = hits == null ? 0 : totalHits;
+        int count = hits == null ? 0 : (maxDocs > 0 ? hits.length : totalHits);
         queryBuilder = newBuilder;
         return count;
     }
@@ -653,13 +658,38 @@ public class SearchEngine {
         this.maxHitsPerFile = maxHitsPerFile;
     }
 
+    /**
+     * Sets the maximum number of documents collected by {@code search(...)}.
+     * 0 (the default) collects per the legacy paging behaviour, i.e. all matching documents eventually.
+     * Callers that need to bound heap usage on queries matching many documents should pass a positive value;
+     * {@link #getTotalHits()} still reports the full match count for pagination.
+     *
+     * @param maxDocs maximum number of documents to collect, or 0 for unbounded
+     * @throws IllegalArgumentException if {@code maxDocs} is negative
+     */
     public void setMaxDocs(int maxDocs) {
+        if (maxDocs < 0) {
+            throw new IllegalArgumentException("maxDocs cannot be negative: " + maxDocs);
+        }
         this.maxDocs = maxDocs;
     }
 
+    /**
+     * @return maximum number of documents collected by {@code search(...)}, 0 means unbounded
+     */
     @VisibleForTesting
     public int getMaxDocs() {
         return maxDocs;
+    }
+
+    /**
+     * Gets the total number of documents matching the query from {@code search(...)} if it was called,
+     * regardless of the {@link #setMaxDocs(int)} cap.
+     *
+     * @return total matching document count
+     */
+    public int getTotalHits() {
+        return totalHits;
     }
 
     /**

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java
@@ -139,34 +139,40 @@ public class SearchEngine {
 
     // internal structures to hold the results from Lucene
     private final List<Document> docs;
-    // Caps Lucene collection to prevent unbounded heap use on large result sets.
-    // 0 = no cap (default, preserves legacy behaviour).
-    private int maxDocs;
+    private final int maxDocs;
     int totalHits = 0;
     private ScoreDoc[] hits;
-    boolean allCollected;
 
     private String source;
     private String data;
 
-    private final int hitsPerPage;
-    private final int cachePages;
     private static final RuntimeEnvironment env = RuntimeEnvironment.getInstance();
 
     private IndexSearcher searcher;
     private final ArrayList<SuperIndexSearcher> searcherList = new ArrayList<>();
 
-    public SearchEngine(int hitsPerPage, int cachePages) {
+    /**
+     * Creates a new instance of SearchEngine which collects at most {@code maxDocs} documents,
+     * so that heap usage stays bounded on queries matching many documents.
+     * {@link #getTotalHits()} still reports the full match count for pagination.
+     *
+     * @param maxDocs positive maximum number of documents to collect
+     * @throws IllegalArgumentException if {@code maxDocs} is not positive
+     */
+    public SearchEngine(int maxDocs) {
+        if (maxDocs <= 0) {
+            throw new IllegalArgumentException("maxDocs must be positive: " + maxDocs);
+        }
         docs = new ArrayList<>();
-        this.hitsPerPage = hitsPerPage;
-        this.cachePages = cachePages;
+        this.maxDocs = maxDocs;
     }
 
     /**
-     * Creates a new instance of SearchEngine.
+     * Creates a new instance of SearchEngine collecting at most the configured
+     * hits per page times the number of cache pages.
      */
     public SearchEngine() {
-        this(env.getHitsPerPage(), env.getCachePages());
+        this(env.getHitsPerPage() * env.getCachePages());
     }
 
     /**
@@ -201,42 +207,35 @@ public class SearchEngine {
 
     /**
      * Search one index. This is used if no projects are set up.
-     * @param paging whether to use paging (if yes, first {@link #cachePages} pages will load faster)
      * @throws IOException when index could not be read
      */
-    private void searchSingleDatabase(boolean paging) throws IOException {
+    private void searchSingleDatabase() throws IOException {
         SuperIndexSearcher superIndexSearcher = env.getSuperIndexSearcher("");
         searcherList.add(superIndexSearcher);
         searcher = superIndexSearcher;
-        // If a field-based sort is requested, collect all hits (disable paging optimization)
-        if (sortOrder != SortOrder.RELEVANCY) {
-            paging = false;
-        }
-        searchIndex(superIndexSearcher, paging);
+        searchIndex(superIndexSearcher);
     }
 
     /**
      * Perform search on multiple indexes.
-     * @param paging whether to use paging (if yes, first X pages will load faster)
      * @param projectList list of projects to search
      * @throws IOException when some index could not be read
      */
-    private void searchMultiDatabase(List<Project> projectList, boolean paging) throws IOException {
+    private void searchMultiDatabase(List<Project> projectList) throws IOException {
         SortedSet<String> projectNames = projectList.stream().map(Project::getName).
                 collect(Collectors.toCollection(TreeSet::new));
 
         // We use MultiReader even for single project. This should not matter given that MultiReader is just
         // a cheap wrapper around set of IndexReader objects.
         searcher = env.getIndexSearcherFactory().newSearcher(env.getMultiReader(projectNames, searcherList));
-        searchIndex(searcher, paging);
+        searchIndex(searcher);
     }
 
-    private void searchIndex(IndexSearcher searcher, boolean paging) throws IOException {
+    private void searchIndex(IndexSearcher searcher) throws IOException {
         Statistics stat = new Statistics();
         // The collector managers eagerly allocate a priority queue of the requested size, hence
         // the index-size cap, mirroring IndexSearcher#search(Query, int).
-        final int numHits = Math.min(maxDocs == 0 ? hitsPerPage * cachePages : maxDocs,
-                Math.max(1, searcher.getIndexReader().maxDoc()));
+        final int numHits = Math.min(maxDocs, Math.max(1, searcher.getIndexReader().maxDoc()));
         TopDocs topDocs;
         Sort luceneSort = getSort();
         if (luceneSort == null) {
@@ -247,19 +246,9 @@ public class SearchEngine {
         hits = topDocs.scoreDocs;
         totalHits = (int) topDocs.totalHits.value;
 
-        if (maxDocs == 0 && !paging && totalHits > numHits) {
-            if (luceneSort == null) {
-                topDocs = searcher.search(query, new TopScoreDocCollectorManager(totalHits, Integer.MAX_VALUE));
-            } else {
-                topDocs = searcher.search(query, new TopFieldCollectorManager(luceneSort, totalHits, Integer.MAX_VALUE));
-            }
-            hits = topDocs.scoreDocs;
-        }
         stat.report(LOGGER, Level.FINEST, "search via SearchEngine done",
                 "search.latency", new String[]{"category", "engine",
                         "outcome", totalHits > 0 ? "success" : "empty"});
-
-        allCollected = maxDocs > 0 || !paging || totalHits <= numHits;
 
         StoredFields storedFields = searcher.storedFields();
         for (ScoreDoc hit : hits) {
@@ -323,14 +312,13 @@ public class SearchEngine {
      * Execute a search.
      * <p>
      * Before calling this function, you must set the appropriate search criteria with the set-functions.
-     * Note that this search will return the first {@link #cachePages} of {@link #hitsPerPage}, unless a positive
-     * {@code maxDocs} has been set via {@link #setMaxDocs(int)}, in which case collection is bounded to that many hits.
+     * Note that this search collects at most {@code maxDocs} documents (see {@link #SearchEngine(int)}).
      * <p>
      * Must be eventually followed by call to {@link #destroy()} so that
      * the {@code IndexSearcher} objects are properly freed.
      *
-     * @return number of collected hits, safe to pass to {@link #results(int, int, List)}; when {@code maxDocs}
-     * is not set this equals the total number of hits, otherwise see {@link #getTotalHits()} for the total
+     * @return number of collected hits, safe to pass to {@link #results(int, int, List)};
+     * see {@link #getTotalHits()} for the total match count
      */
     @VisibleForTesting
     public int search() {
@@ -341,8 +329,7 @@ public class SearchEngine {
      * Execute a search on projects or root file.
      * <p>
      * Before calling this function, you must set the appropriate search criteria with the set-functions.
-     * Note that this search will return the first {@link #cachePages} of {@link #hitsPerPage}, unless a positive
-     * {@code maxDocs} has been set via {@link #setMaxDocs(int)}, in which case collection is bounded to that many hits.
+     * Note that this search collects at most {@code maxDocs} documents (see {@link #SearchEngine(int)}).
      * <p>
      * If the {@code projects} parameter is an empty list, it tries to search in {@code searchSingleDatabase}
      * with root set to the {@code root} parameter.
@@ -351,8 +338,8 @@ public class SearchEngine {
      * the {@code IndexSearcher} objects are properly freed.
      *
      * @param projects projects to search
-     * @return number of collected hits, safe to pass to {@link #results(int, int, List)}; when {@code maxDocs}
-     * is not set this equals the total number of hits, otherwise see {@link #getTotalHits()} for the total
+     * @return number of collected hits, safe to pass to {@link #results(int, int, List)};
+     * see {@link #getTotalHits()} for the total match count
      */
     public int search(List<Project> projects) {
         source = env.getSourceRootPath();
@@ -364,10 +351,9 @@ public class SearchEngine {
             query = newBuilder.build();
             if (query != null) {
                 if (projects.isEmpty()) {
-                    searchSingleDatabase(true);
+                    searchSingleDatabase();
                 } else {
-                    // TODO support paging per project (in search.java)
-                    searchMultiDatabase(projects, false);
+                    searchMultiDatabase(projects);
                 }
             }
         } catch (Exception e) {
@@ -397,7 +383,7 @@ public class SearchEngine {
                 LOGGER.log(Level.WARNING, "An error occurred while getting history context", e);
             }
         }
-        int count = hits == null ? 0 : (maxDocs > 0 ? hits.length : totalHits);
+        int count = hits == null ? 0 : hits.length;
         queryBuilder = newBuilder;
         return count;
     }
@@ -431,62 +417,22 @@ public class SearchEngine {
      * This involves reading various document fields as well as file contents from the respective files
      * under source root.
      * If no search was started before, no results are returned.
-     * This method will requery if {@code end} is more than first query from search,
-     * hence performance hit applies, if you want results in later pages than
-     * number of {@code cachePages}. {@code end} has to be bigger than {@code start} !
+     * Only documents collected by {@code search(...)} are available; {@code endDocIndex} is clamped
+     * to the collected count, i.e. the value {@code search(...)} returned.
      *
      * @param startDocIndex start index of the hit list
      * @param endDocIndex end index of the hit list
      * @param ret output argument that contains list of results from start to end or null/empty if no search was started
      */
     public void results(int startDocIndex, int endDocIndex, @NotNull List<Hit> ret) {
+        ret.clear();
 
-        // return if no start search() was done
+        // return if no search() was done
         if (hits == null || (endDocIndex < startDocIndex)) {
-            ret.clear();
             return;
         }
 
-        ret.clear();
-
-        // TODO check if below fits for if end=old hits.length, or it should include it
-        if (endDocIndex > hits.length && !allCollected) {
-            // Do the requery, we want more than 'cachePages' pages.
-            Sort luceneSort = getSort();
-            Statistics stat = new Statistics();
-            try {
-                if (luceneSort == null) {
-                    hits = searcher.search(query, new TopScoreDocCollectorManager(totalHits, Integer.MAX_VALUE)).scoreDocs;
-                } else {
-                    hits = searcher.search(query, new TopFieldCollectorManager(luceneSort, totalHits, Integer.MAX_VALUE)).scoreDocs;
-                }
-            } catch (Exception e) { // this exception should never be hit, since search() will hit this before
-                LOGGER.log(Level.WARNING, SEARCH_EXCEPTION_MSG, e);
-            }
-            stat.report(LOGGER, Level.FINEST, "search via SearchEngine done",
-                    "search.latency", new String[]{"category", "engine",
-                            "outcome", hits.length > 0 ? "success" : "empty"});
-            StoredFields storedFields = null;
-            try {
-                storedFields = searcher.storedFields();
-            } catch (Exception e) {
-                LOGGER.log(Level.WARNING, SEARCH_EXCEPTION_MSG, e);
-            }
-            if (storedFields != null) {
-                docs.clear();
-                for (ScoreDoc hit : hits) {
-                    try {
-                        Document d = storedFields.document(hit.doc);
-                        docs.add(d);
-                    } catch (Exception e) {
-                        LOGGER.log(Level.SEVERE, SEARCH_EXCEPTION_MSG, e);
-                    }
-                }
-            }
-            allCollected = true;
-        }
-
-        extractResults(startDocIndex, endDocIndex, ret);
+        extractResults(startDocIndex, Math.min(endDocIndex, docs.size()), ret);
     }
 
     private void extractResults(int startDocIndex, int endDocIndex, @NotNull List<Hit> ret) {
@@ -659,23 +605,7 @@ public class SearchEngine {
     }
 
     /**
-     * Sets the maximum number of documents collected by {@code search(...)}.
-     * 0 (the default) collects per the legacy paging behaviour, i.e. all matching documents eventually.
-     * Callers that need to bound heap usage on queries matching many documents should pass a positive value;
-     * {@link #getTotalHits()} still reports the full match count for pagination.
-     *
-     * @param maxDocs maximum number of documents to collect, or 0 for unbounded
-     * @throws IllegalArgumentException if {@code maxDocs} is negative
-     */
-    public void setMaxDocs(int maxDocs) {
-        if (maxDocs < 0) {
-            throw new IllegalArgumentException("maxDocs cannot be negative: " + maxDocs);
-        }
-        this.maxDocs = maxDocs;
-    }
-
-    /**
-     * @return maximum number of documents collected by {@code search(...)}, 0 means unbounded
+     * @return maximum number of documents collected by {@code search(...)}
      */
     @VisibleForTesting
     public int getMaxDocs() {
@@ -684,7 +614,7 @@ public class SearchEngine {
 
     /**
      * Gets the total number of documents matching the query from {@code search(...)} if it was called,
-     * regardless of the {@link #setMaxDocs(int)} cap.
+     * regardless of the {@code maxDocs} cap (see {@link #SearchEngine(int)}).
      *
      * @return total matching document count
      */

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/executables/JarAnalyzerTest.java
@@ -98,7 +98,7 @@ class JarAnalyzerTest {
 
     @Test
     void testSearchForJar() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFile(TESTPLUGINS_JAR);
         int noHits = instance.search();
         assertTrue(noHits > 0, "noHits for " + TESTPLUGINS_JAR + " should be positive");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/index/IndexDatabaseTest.java
@@ -282,7 +282,7 @@ class IndexDatabaseTest {
      */
     @Test
     void testIndexPath() throws IOException {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         // Use as broad search as possible.
         instance.setFile("c");
         instance.search();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -455,4 +455,66 @@ class SearchEngineTest {
         instance.destroy();
     }
     */
+
+    @Test
+    void testMaxDocsDefault() {
+        assertEquals(0, new SearchEngine().getMaxDocs());
+    }
+
+    @Test
+    void testMaxDocsSetterGetter() {
+        SearchEngine instance = new SearchEngine();
+        instance.setMaxDocs(5);
+        assertEquals(5, instance.getMaxDocs());
+        instance.setMaxDocs(0);
+        assertEquals(0, instance.getMaxDocs());
+    }
+
+    @Test
+    void testMaxDocsLimitsCollectedHits() {
+        SearchEngine unlimited = new SearchEngine();
+        unlimited.setFreetext("arguments");
+        int totalCount = unlimited.search();
+        unlimited.destroy();
+        assertTrue(totalCount > 1, "Query must match multiple documents for this test to be meaningful");
+
+        SearchEngine limited = new SearchEngine();
+        limited.setFreetext("arguments");
+        limited.setMaxDocs(1);
+        limited.search();
+        assertEquals(1, limited.scoreDocs().length);
+        limited.destroy();
+    }
+
+    @Test
+    void testGetTotalHitsReflectsFullCountWhenMaxDocsCaps() {
+        SearchEngine unlimited = new SearchEngine();
+        unlimited.setFreetext("arguments");
+        int realTotal = unlimited.search();
+        unlimited.destroy();
+        assertTrue(realTotal > 1, "Query must match multiple documents");
+
+        // totalHits must be accurate even when collection is capped — callers
+        // need it to paginate correctly.
+        SearchEngine limited = new SearchEngine();
+        limited.setFreetext("arguments");
+        limited.setMaxDocs(1);
+        limited.search();
+        assertEquals(realTotal, limited.getTotalHits());
+        limited.destroy();
+    }
+
+    @Test
+    void testMaxDocsResultsRespectBound() {
+        SearchEngine instance = new SearchEngine();
+        instance.setFreetext("arguments");
+        instance.setMaxDocs(1);
+        int totalCount = instance.search();
+        assertTrue(totalCount > 1, "Total should exceed maxDocs for this test to exercise the cap");
+
+        List<Hit> hits = new ArrayList<>();
+        instance.results(0, instance.getMaxDocs(), hits);
+        assertEquals(1, hits.size());
+        instance.destroy();
+    }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -284,47 +284,26 @@ class SearchEngineTest {
     }
 
     /**
-     * Verify that search() returns the total number of matching documents (totalHits),
-     * not the number of collected/cached hits (which is capped at hitsPerPage * cachePages).
+     * Verify that totalHits is exact (not an approximate lower bound) even when the collector
+     * is restricted to a single document; an inaccurate totalHitsThreshold would silently
+     * under-report the match count callers paginate by.
      */
     @Test
-    void testSearchReturnsTotalHitsNotCachedCount() {
-        // Restrict the cache to 1 document so that totalHits > hitsPerPage * cachePages.
-        SearchEngine instance = new SearchEngine(1, 1);
-        instance.setFile("main.c");
-        instance.setFreetext("arguments");
+    void testTotalHitsIsExactUnderTightCap() {
+        SearchEngine unlimited = new SearchEngine();
+        unlimited.setFile("main.c");
+        unlimited.setFreetext("arguments");
+        int realTotal = unlimited.search();
+        unlimited.destroy();
+        assertTrue(realTotal > 1, "Query should match multiple documents across test repositories");
 
-        int resultCount = instance.search();
-        assertTrue(resultCount > 1,
-                "Query should match multiple documents across test repositories");
-        assertEquals(instance.totalHits, resultCount,
-                "search() must return totalHits, not the number of cached hits");
-
-        instance.destroy();
-    }
-
-    /**
-     * Verify that totalHits is exact (not an approximate lower bound) so that results()
-     * can fetch every matching document. With an inaccurate totalHitsThreshold, the
-     * re-query in results() would request too few documents, silently dropping results.
-     */
-    @Test
-    void testTotalHitsIsExactForFullRetrieval() {
-        SearchEngine instance = new SearchEngine(1, 1);
-        instance.setFile("main.c");
-        instance.setFreetext("arguments");
-
-        int count = instance.search();
-        assertTrue(count > 1);
-
-        List<Hit> allHits = new ArrayList<>();
-        instance.results(0, count, allHits);
-
-        long uniquePaths = allHits.stream().map(Hit::getPath).distinct().count();
-        assertEquals(count, uniquePaths,
-                "totalHits must be exact so results() retrieves every matching document");
-
-        instance.destroy();
+        SearchEngine capped = new SearchEngine(1);
+        capped.setFile("main.c");
+        capped.setFreetext("arguments");
+        capped.search();
+        assertEquals(realTotal, capped.getTotalHits(),
+                "totalHits must be exact regardless of how few documents are collected");
+        capped.destroy();
     }
 
     /* see https://github.com/oracle/opengrok/issues/2030
@@ -459,21 +438,19 @@ class SearchEngineTest {
 
     @Test
     void testMaxDocsDefault() {
-        assertEquals(0, new SearchEngine().getMaxDocs());
+        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+        assertEquals(env.getHitsPerPage() * env.getCachePages(), new SearchEngine().getMaxDocs());
     }
 
     @Test
-    void testMaxDocsSetterGetter() {
-        SearchEngine instance = new SearchEngine();
-        instance.setMaxDocs(5);
-        assertEquals(5, instance.getMaxDocs());
-        instance.setMaxDocs(0);
-        assertEquals(0, instance.getMaxDocs());
+    void testMaxDocsConstructorGetter() {
+        assertEquals(5, new SearchEngine(5).getMaxDocs());
     }
 
     @Test
-    void testSetMaxDocsRejectsNegative() {
-        assertThrows(IllegalArgumentException.class, () -> new SearchEngine().setMaxDocs(-1));
+    void testConstructorRejectsNonPositiveMaxDocs() {
+        assertThrows(IllegalArgumentException.class, () -> new SearchEngine(0));
+        assertThrows(IllegalArgumentException.class, () -> new SearchEngine(-1));
     }
 
     @Test
@@ -484,9 +461,8 @@ class SearchEngineTest {
         unlimited.destroy();
         assertTrue(totalCount > 1, "Query must match multiple documents for this test to be meaningful");
 
-        SearchEngine limited = new SearchEngine();
+        SearchEngine limited = new SearchEngine(1);
         limited.setFreetext("arguments");
-        limited.setMaxDocs(1);
         limited.search();
         assertEquals(1, limited.scoreDocs().length);
         limited.destroy();
@@ -501,9 +477,8 @@ class SearchEngineTest {
 
         // search() must report the collected count so that its return value
         // is safe to pass to results() as the end index.
-        SearchEngine limited = new SearchEngine();
+        SearchEngine limited = new SearchEngine(1);
         limited.setFreetext("arguments");
-        limited.setMaxDocs(1);
         assertEquals(1, limited.search());
         limited.destroy();
     }
@@ -518,9 +493,8 @@ class SearchEngineTest {
 
         // totalHits must stay accurate even when collection is capped —
         // callers need it to paginate correctly.
-        SearchEngine limited = new SearchEngine();
+        SearchEngine limited = new SearchEngine(1);
         limited.setFreetext("arguments");
-        limited.setMaxDocs(1);
         limited.search();
         assertEquals(realTotal, limited.getTotalHits());
         limited.destroy();
@@ -528,14 +502,27 @@ class SearchEngineTest {
 
     @Test
     void testMaxDocsResultsRespectBound() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(1);
         instance.setFreetext("arguments");
-        instance.setMaxDocs(1);
         int collected = instance.search();
         assertTrue(instance.getTotalHits() > 1, "Total should exceed maxDocs for this test to exercise the cap");
 
         List<Hit> hits = new ArrayList<>();
         instance.results(0, collected, hits);
+        assertEquals(1, hits.size());
+        instance.destroy();
+    }
+
+    @Test
+    void testResultsClampsEndBeyondCollected() {
+        SearchEngine instance = new SearchEngine(1);
+        instance.setFreetext("arguments");
+        instance.search();
+        assertTrue(instance.getTotalHits() > 1, "Total should exceed maxDocs for this test to be meaningful");
+
+        // asking past the collected window must not blow up, only serve what was collected
+        List<Hit> hits = new ArrayList<>();
+        instance.results(0, instance.getTotalHits(), hits);
         assertEquals(1, hits.size());
         instance.destroy();
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -96,7 +96,7 @@ class SearchEngineTest {
 
     @Test
     void testIsValidQuery() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         assertFalse(instance.isValidQuery());
         instance.setFile("foo");
         assertTrue(instance.isValidQuery());
@@ -104,7 +104,7 @@ class SearchEngineTest {
 
     @Test
     void testDefinition() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         assertNull(instance.getDefinition());
         String defs = "This is a definition";
         instance.setDefinition(defs);
@@ -113,7 +113,7 @@ class SearchEngineTest {
 
     @Test
     void testFile() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         assertNull(instance.getFile());
         String file = "This is a File";
         instance.setFile(file);
@@ -122,7 +122,7 @@ class SearchEngineTest {
 
     @Test
     void testFreetext() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         assertNull(instance.getFreetext());
         String freetext = "This is just a piece of text";
         instance.setFreetext(freetext);
@@ -131,7 +131,7 @@ class SearchEngineTest {
 
     @Test
     void testHistory() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         assertNull(instance.getHistory());
         String hist = "This is a piece of history";
         instance.setHistory(hist);
@@ -140,7 +140,7 @@ class SearchEngineTest {
 
     @Test
     void testSymbol() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         assertNull(instance.getSymbol());
         String sym = "This is a symbol";
         instance.setSymbol(sym);
@@ -149,7 +149,7 @@ class SearchEngineTest {
 
     @Test
     void testGetQuery() throws Exception {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setHistory("Once upon a time");
         instance.setFile("Makefile");
         instance.setDefinition("\"std::string\"");
@@ -162,7 +162,7 @@ class SearchEngineTest {
 
     @Test
     void testSortOrderLastModified() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFile("main.c");
         instance.setFreetext("arguments");
         instance.setSortOrder(SortOrder.LASTMODIFIED);
@@ -190,7 +190,7 @@ class SearchEngineTest {
 
     @Test
     void testSortOrderByPath() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFile("main.c OR header.h");
         instance.setFreetext("arguments OR stdio");
         instance.setSortOrder(SortOrder.BY_PATH);
@@ -223,19 +223,19 @@ class SearchEngineTest {
 
     @Test
     void testDefaultSortOrder() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         assertNull(instance.getSortOrder(), "Default sort should be relevancy (null implies Lucene score ordering)");
     }
 
     @Test
     void testMaxHitsPerFileDefault() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         assertEquals(0, instance.getMaxHitsPerFile());
     }
 
     @Test
     void testMaxHitsPerFileSetterGetter() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setMaxHitsPerFile(20);
         assertEquals(20, instance.getMaxHitsPerFile());
         instance.setMaxHitsPerFile(0);
@@ -244,7 +244,7 @@ class SearchEngineTest {
 
     @Test
     void testUnlimitedHitsPerFileContainLineNumbers() {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFile("main.c");
         instance.setFreetext("arguments");
         instance.setMaxHitsPerFile(0);
@@ -258,7 +258,7 @@ class SearchEngineTest {
 
     @Test
     void testMaxHitsPerFileLimitsHitsPerFile() {
-        SearchEngine unlimited = new SearchEngine();
+        SearchEngine unlimited = new SearchEngine(Integer.MAX_VALUE);
         unlimited.setFile("main.c");
         unlimited.setFreetext("printf");
         unlimited.setMaxHitsPerFile(0);
@@ -268,7 +268,7 @@ class SearchEngineTest {
         unlimited.destroy();
 
         int maxPerFile = 1;
-        SearchEngine limited = new SearchEngine();
+        SearchEngine limited = new SearchEngine(Integer.MAX_VALUE);
         limited.setFile("main.c");
         limited.setFreetext("printf");
         limited.setMaxHitsPerFile(maxPerFile);
@@ -290,7 +290,7 @@ class SearchEngineTest {
      */
     @Test
     void testTotalHitsIsExactUnderTightCap() {
-        SearchEngine unlimited = new SearchEngine();
+        SearchEngine unlimited = new SearchEngine(Integer.MAX_VALUE);
         unlimited.setFile("main.c");
         unlimited.setFreetext("arguments");
         int realTotal = unlimited.search();
@@ -311,7 +311,7 @@ class SearchEngineTest {
     void testSearch() {
         List<Hit> hits = new ArrayList<>();
 
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setHistory("\"Add lint make target and fix lint warnings\"");
         int noHits =  instance.search();
         if (noHits > 0) {
@@ -320,7 +320,7 @@ class SearchEngineTest {
         }
         instance.destroy();
 
-        instance = new SearchEngine();
+        instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setSymbol("printf");
         instance.setFile("main.c");
         noHits = instance.search();
@@ -336,7 +336,7 @@ class SearchEngineTest {
         assertEquals(8, noHits);
         instance.destroy();
 
-        instance = new SearchEngine();
+        instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFreetext("arguments");
         instance.setFile("main.c");
         noHits = instance.search();
@@ -351,7 +351,7 @@ class SearchEngineTest {
         assertEquals(8, noHits);
         instance.destroy();
 
-        instance = new SearchEngine();
+        instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setDefinition("main");
         instance.setFile("main.c");
         noHits = instance.search();
@@ -367,7 +367,7 @@ class SearchEngineTest {
         instance.destroy();
 
         // negative symbol test (comments should be ignored)
-        instance = new SearchEngine();
+        instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setSymbol("Ordinary");
         instance.setFile("\"Main.java\"");
         instance.search();
@@ -377,7 +377,7 @@ class SearchEngineTest {
         instance.destroy();
 
         // wildcards and case sensitivity of definition search
-        instance = new SearchEngine();
+        instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setDefinition("Mai*"); // definition is case sensitive
         instance.setFile("\"Main.java\" OR \"main.c\"");
         instance.search();
@@ -390,7 +390,7 @@ class SearchEngineTest {
         instance.destroy();
 
         // wildcards and case sensitivity of symbol search
-        instance = new SearchEngine();
+        instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setSymbol("Mai*"); // symbol is case sensitive
         instance.setFile("\"Main.java\" OR \"main.c\"");
         instance.search();
@@ -401,14 +401,14 @@ class SearchEngineTest {
         instance.destroy();
 
         // wildcards and case insensitivity of freetext search
-        instance = new SearchEngine();
+        instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFreetext("MaI*"); // should match both Main and main
         instance.setFile("\"Main.java\" OR \"main.c\"");
         assertEquals(10, instance.search());
         instance.destroy();
 
         // file name search is case insensitive
-        instance = new SearchEngine();
+        instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFile("JaVa"); // should match java
         int count=instance.search();
         if (count > 0) {
@@ -418,29 +418,23 @@ class SearchEngineTest {
         instance.destroy();
 
         //test eol and eof
-        instance = new SearchEngine();
+        instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFreetext("makeW");
         assertEquals(1, instance.search());
         instance.destroy();
 
-        instance = new SearchEngine();
+        instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFreetext("WeirdEOL");
         assertEquals(1, instance.search());
         instance.destroy();
 
         //test bcel jar parser
-        instance = new SearchEngine();
+        instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFreetext("InstConstraintVisitor");
         assertEquals(1, instance.search());
         instance.destroy();
     }
     */
-
-    @Test
-    void testMaxDocsDefault() {
-        RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-        assertEquals(env.getHitsPerPage() * env.getCachePages(), new SearchEngine().getMaxDocs());
-    }
 
     @Test
     void testMaxDocsConstructorGetter() {
@@ -455,7 +449,7 @@ class SearchEngineTest {
 
     @Test
     void testMaxDocsLimitsCollectedHits() {
-        SearchEngine unlimited = new SearchEngine();
+        SearchEngine unlimited = new SearchEngine(Integer.MAX_VALUE);
         unlimited.setFreetext("arguments");
         int totalCount = unlimited.search();
         unlimited.destroy();
@@ -470,7 +464,7 @@ class SearchEngineTest {
 
     @Test
     void testSearchReturnsCollectedCountWhenMaxDocsCaps() {
-        SearchEngine unlimited = new SearchEngine();
+        SearchEngine unlimited = new SearchEngine(Integer.MAX_VALUE);
         unlimited.setFreetext("arguments");
         assertTrue(unlimited.search() > 1, "Query must match multiple documents");
         unlimited.destroy();
@@ -485,7 +479,7 @@ class SearchEngineTest {
 
     @Test
     void testGetTotalHitsReportsFullCountWhenMaxDocsCaps() {
-        SearchEngine unlimited = new SearchEngine();
+        SearchEngine unlimited = new SearchEngine(Integer.MAX_VALUE);
         unlimited.setFreetext("arguments");
         int realTotal = unlimited.search();
         unlimited.destroy();
@@ -511,6 +505,12 @@ class SearchEngineTest {
         instance.results(0, collected, hits);
         assertEquals(1, hits.size());
         instance.destroy();
+    }
+
+    @Test
+    void testResultsWithoutSearchThrows() {
+        SearchEngine instance = new SearchEngine(1);
+        assertThrows(IllegalStateException.class, () -> instance.results(0, 1, new ArrayList<>()));
     }
 
     @Test

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -487,20 +487,19 @@ class SearchEngineTest {
     }
 
     @Test
-    void testGetTotalHitsReflectsFullCountWhenMaxDocsCaps() {
+    void testSearchReturnsFullCountWhenMaxDocsCaps() {
         SearchEngine unlimited = new SearchEngine();
         unlimited.setFreetext("arguments");
         int realTotal = unlimited.search();
         unlimited.destroy();
         assertTrue(realTotal > 1, "Query must match multiple documents");
 
-        // totalHits must be accurate even when collection is capped — callers
-        // need it to paginate correctly.
+        // search() must report the full match count even when collection is
+        // capped — callers need it to paginate correctly.
         SearchEngine limited = new SearchEngine();
         limited.setFreetext("arguments");
         limited.setMaxDocs(1);
-        limited.search();
-        assertEquals(realTotal, limited.getTotalHits());
+        assertEquals(realTotal, limited.search());
         limited.destroy();
     }
 

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/SearchEngineTest.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -471,6 +472,11 @@ class SearchEngineTest {
     }
 
     @Test
+    void testSetMaxDocsRejectsNegative() {
+        assertThrows(IllegalArgumentException.class, () -> new SearchEngine().setMaxDocs(-1));
+    }
+
+    @Test
     void testMaxDocsLimitsCollectedHits() {
         SearchEngine unlimited = new SearchEngine();
         unlimited.setFreetext("arguments");
@@ -487,19 +493,36 @@ class SearchEngineTest {
     }
 
     @Test
-    void testSearchReturnsFullCountWhenMaxDocsCaps() {
+    void testSearchReturnsCollectedCountWhenMaxDocsCaps() {
+        SearchEngine unlimited = new SearchEngine();
+        unlimited.setFreetext("arguments");
+        assertTrue(unlimited.search() > 1, "Query must match multiple documents");
+        unlimited.destroy();
+
+        // search() must report the collected count so that its return value
+        // is safe to pass to results() as the end index.
+        SearchEngine limited = new SearchEngine();
+        limited.setFreetext("arguments");
+        limited.setMaxDocs(1);
+        assertEquals(1, limited.search());
+        limited.destroy();
+    }
+
+    @Test
+    void testGetTotalHitsReportsFullCountWhenMaxDocsCaps() {
         SearchEngine unlimited = new SearchEngine();
         unlimited.setFreetext("arguments");
         int realTotal = unlimited.search();
         unlimited.destroy();
         assertTrue(realTotal > 1, "Query must match multiple documents");
 
-        // search() must report the full match count even when collection is
-        // capped — callers need it to paginate correctly.
+        // totalHits must stay accurate even when collection is capped —
+        // callers need it to paginate correctly.
         SearchEngine limited = new SearchEngine();
         limited.setFreetext("arguments");
         limited.setMaxDocs(1);
-        assertEquals(realTotal, limited.search());
+        limited.search();
+        assertEquals(realTotal, limited.getTotalHits());
         limited.destroy();
     }
 
@@ -508,11 +531,11 @@ class SearchEngineTest {
         SearchEngine instance = new SearchEngine();
         instance.setFreetext("arguments");
         instance.setMaxDocs(1);
-        int totalCount = instance.search();
-        assertTrue(totalCount > 1, "Total should exceed maxDocs for this test to exercise the cap");
+        int collected = instance.search();
+        assertTrue(instance.getTotalHits() > 1, "Total should exceed maxDocs for this test to exercise the cap");
 
         List<Hit> hits = new ArrayList<>();
-        instance.results(0, instance.getMaxDocs(), hits);
+        instance.results(0, collected, hits);
         assertEquals(1, hits.size());
         instance.destroy();
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/PassageScorerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/PassageScorerTest.java
@@ -76,7 +76,7 @@ class PassageScorerTest {
 
     @Test
     void testSearch() throws Exception {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFreetext("DTRACE_PROBE4");
         instance.setFile("sdt");
         int noHits = instance.search();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterSecondTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterSecondTest.java
@@ -166,7 +166,7 @@ class SearchAndContextFormatterSecondTest {
 
     @Test
     void testSearch() throws IOException, InvalidTokenOffsetsException {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFreetext("Hello");
         instance.setFile("renamed2.c");
         int noHits = instance.search();

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/search/context/SearchAndContextFormatterTest.java
@@ -95,7 +95,7 @@ class SearchAndContextFormatterTest {
 
     @Test
     void testSearch() throws IOException {
-        SearchEngine instance = new SearchEngine();
+        SearchEngine instance = new SearchEngine(Integer.MAX_VALUE);
         instance.setFreetext("mt19937");
         instance.setFile("bkexlib.cpp");
         int noHits = instance.search();

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
@@ -146,23 +146,23 @@ public class SearchController {
                 final int startDocIndex,
                 final int maxResults
         ) {
+            engine.setMaxDocs(startDocIndex + maxResults);
+
             Set<Project> allProjects = PageConfig.get(req).getProjectHelper().getAllProjects();
             if (projects == null || projects.isEmpty()) {
-                numResults = engine.search(new ArrayList<>(allProjects));
+                engine.search(new ArrayList<>(allProjects));
             } else {
-                numResults = engine.search(allProjects.stream()
+                engine.search(allProjects.stream()
                         .filter(p -> projects.contains(p.getName()))
                         .collect(Collectors.toList()));
             }
+            numResults = engine.getTotalHits();
 
             if (startDocIndex > numResults) {
                 return Collections.emptyList();
             }
 
-            int resultSize = numResults - startDocIndex;
-            if (resultSize > maxResults) {
-                resultSize = maxResults;
-            }
+            int resultSize = Math.min(numResults - startDocIndex, maxResults);
 
             List<Hit> results = new ArrayList<>();
             engine.results(startDocIndex, startDocIndex + resultSize, results);

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
@@ -88,6 +88,11 @@ public class SearchController {
             @QueryParam(QueryParameters.SORT_PARAM) @DefaultValue(DEFAULT_SORT_ORDER) final String sort,
             @QueryParam(QueryParameters.MAXHITSPERFILE_PARAM) @DefaultValue("0") final int maxHitsPerFile
     ) {
+        if (maxResults < 0 || startDocIndex < 0 || maxHitsPerFile < 0) {
+            throw new WebApplicationException("Negative integer parameters are not allowed",
+                    Response.Status.BAD_REQUEST);
+        }
+
         try (SearchEngineWrapper engine = new SearchEngineWrapper(full, def, symbol, path, hist, type, SortOrder.get(sort), maxHitsPerFile)) {
 
             if (!engine.isValid()) {
@@ -146,22 +151,24 @@ public class SearchController {
                 final int startDocIndex,
                 final int maxResults
         ) {
-            engine.setMaxDocs(startDocIndex + maxResults);
+            engine.setMaxDocs(Math.clamp((long) startDocIndex + maxResults, 1, Integer.MAX_VALUE));
 
             Set<Project> allProjects = PageConfig.get(req).getProjectHelper().getAllProjects();
+            int collected;
             if (projects == null || projects.isEmpty()) {
-                numResults = engine.search(new ArrayList<>(allProjects));
+                collected = engine.search(new ArrayList<>(allProjects));
             } else {
-                numResults = engine.search(allProjects.stream()
+                collected = engine.search(allProjects.stream()
                         .filter(p -> projects.contains(p.getName()))
                         .collect(Collectors.toList()));
             }
+            numResults = engine.getTotalHits();
 
-            if (startDocIndex > numResults) {
+            if (startDocIndex > collected) {
                 return Collections.emptyList();
             }
 
-            int resultSize = numResults - startDocIndex;
+            int resultSize = collected - startDocIndex;
             if (resultSize > maxResults) {
                 resultSize = maxResults;
             }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
@@ -151,7 +151,12 @@ public class SearchController {
                 final int startDocIndex,
                 final int maxResults
         ) {
-            engine.setMaxDocs(Math.clamp((long) startDocIndex + maxResults, 1, Integer.MAX_VALUE));
+            try {
+                engine.setMaxDocs(Math.max(Math.addExact(startDocIndex, maxResults), 1));
+            } catch (ArithmeticException e) {
+                throw new WebApplicationException("Sum of start and maxresults parameters must not exceed "
+                        + Integer.MAX_VALUE, Response.Status.BAD_REQUEST);
+            }
 
             Set<Project> allProjects = PageConfig.get(req).getProjectHelper().getAllProjects();
             int collected;

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
@@ -93,7 +93,16 @@ public class SearchController {
                     Response.Status.BAD_REQUEST);
         }
 
-        try (SearchEngineWrapper engine = new SearchEngineWrapper(full, def, symbol, path, hist, type, SortOrder.get(sort), maxHitsPerFile)) {
+        final int maxDocs;
+        try {
+            maxDocs = Math.max(Math.addExact(startDocIndex, maxResults), 1);
+        } catch (ArithmeticException e) {
+            throw new WebApplicationException("Sum of start and maxresults parameters must not exceed "
+                    + Integer.MAX_VALUE, Response.Status.BAD_REQUEST);
+        }
+
+        try (SearchEngineWrapper engine = new SearchEngineWrapper(full, def, symbol, path, hist, type,
+                SortOrder.get(sort), maxHitsPerFile, maxDocs)) {
 
             if (!engine.isValid()) {
                 throw new WebApplicationException("Invalid request", Response.Status.BAD_REQUEST);
@@ -121,7 +130,7 @@ public class SearchController {
 
     private static class SearchEngineWrapper implements AutoCloseable {
 
-        private final SearchEngine engine = new SearchEngine();
+        private final SearchEngine engine;
 
         private int numResults;
 
@@ -133,8 +142,10 @@ public class SearchController {
                 final String hist,
                 final String type,
                 final SortOrder sortOrder,
-                final int maxHitsPerFile
+                final int maxHitsPerFile,
+                final int maxDocs
         ) {
+            engine = new SearchEngine(maxDocs);
             engine.setFreetext(full);
             engine.setDefinition(def);
             engine.setSymbol(symbol);
@@ -151,13 +162,6 @@ public class SearchController {
                 final int startDocIndex,
                 final int maxResults
         ) {
-            try {
-                engine.setMaxDocs(Math.max(Math.addExact(startDocIndex, maxResults), 1));
-            } catch (ArithmeticException e) {
-                throw new WebApplicationException("Sum of start and maxresults parameters must not exceed "
-                        + Integer.MAX_VALUE, Response.Status.BAD_REQUEST);
-            }
-
             Set<Project> allProjects = PageConfig.get(req).getProjectHelper().getAllProjects();
             int collected;
             if (projects == null || projects.isEmpty()) {

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
@@ -150,19 +150,21 @@ public class SearchController {
 
             Set<Project> allProjects = PageConfig.get(req).getProjectHelper().getAllProjects();
             if (projects == null || projects.isEmpty()) {
-                engine.search(new ArrayList<>(allProjects));
+                numResults = engine.search(new ArrayList<>(allProjects));
             } else {
-                engine.search(allProjects.stream()
+                numResults = engine.search(allProjects.stream()
                         .filter(p -> projects.contains(p.getName()))
                         .collect(Collectors.toList()));
             }
-            numResults = engine.getTotalHits();
 
             if (startDocIndex > numResults) {
                 return Collections.emptyList();
             }
 
-            int resultSize = Math.min(numResults - startDocIndex, maxResults);
+            int resultSize = numResults - startDocIndex;
+            if (resultSize > maxResults) {
+                resultSize = maxResults;
+            }
 
             List<Hit> results = new ArrayList<>();
             engine.results(startDocIndex, startDocIndex + resultSize, results);

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
@@ -36,6 +36,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.lucene.search.Query;
 import org.opengrok.indexer.configuration.Project;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.search.Hit;
 import org.opengrok.indexer.search.SearchEngine;
 import org.opengrok.indexer.web.QueryParameters;
@@ -59,7 +60,6 @@ public class SearchController {
 
     public static final String PATH = "search";
 
-    private static final int MAX_RESULTS = 1000;
     private static final String DEFAULT_SORT_ORDER = "relevancy";
 
     private final SuggesterService suggester;
@@ -82,15 +82,22 @@ public class SearchController {
             @QueryParam(QueryParameters.HIST_SEARCH_PARAM) final String hist,
             @QueryParam(QueryParameters.TYPE_SEARCH_PARAM) final String type,
             @QueryParam("projects") final List<String> projects,
-            @QueryParam(QueryParameters.MAXRESULTS_PARAM)
-            @DefaultValue(MAX_RESULTS + "") final int maxResults,
+            @QueryParam(QueryParameters.MAXRESULTS_PARAM) final Integer maxResultsParam,
             @QueryParam(QueryParameters.START_PARAM) @DefaultValue(0 + "") final int startDocIndex,
             @QueryParam(QueryParameters.SORT_PARAM) @DefaultValue(DEFAULT_SORT_ORDER) final String sort,
             @QueryParam(QueryParameters.MAXHITSPERFILE_PARAM) @DefaultValue("0") final int maxHitsPerFile
     ) {
-        if (maxResults < 0 || startDocIndex < 0 || maxHitsPerFile < 0) {
+        if ((maxResultsParam != null && maxResultsParam < 0) || startDocIndex < 0 || maxHitsPerFile < 0) {
             throw new WebApplicationException("Negative integer parameters are not allowed",
                     Response.Status.BAD_REQUEST);
+        }
+
+        final int maxResults;
+        if (maxResultsParam != null) {
+            maxResults = maxResultsParam;
+        } else {
+            RuntimeEnvironment env = RuntimeEnvironment.getInstance();
+            maxResults = env.getHitsPerPage() * env.getCachePages();
         }
 
         final int maxDocs;
@@ -121,7 +128,7 @@ public class SearchController {
 
             long duration = Duration.between(startTime, Instant.now()).toMillis();
 
-            int pageSize = Math.min(maxResults, Math.max(0, engine.numResults - startDocIndex));
+            int pageSize = Math.clamp(engine.numResults - startDocIndex, 0, maxResults);
             int endDocument = pageSize > 0 ? startDocIndex + pageSize - 1 : startDocIndex;
 
             return new SearchResult(duration, engine.numResults, hits, startDocIndex, endDocument);
@@ -173,7 +180,7 @@ public class SearchController {
             }
             numResults = engine.getTotalHits();
 
-            if (startDocIndex > collected) {
+            if (startDocIndex >= collected) {
                 return Collections.emptyList();
             }
 

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
@@ -204,6 +204,35 @@ class SearchControllerTest extends OGKJerseyTest {
                 "endDocument must reflect the document page size, not the number of unique file paths");
     }
 
+    /**
+     * Without the {@code maxresults} parameter the page size must follow the configured
+     * {@code hitsPerPage * cachePages} rather than a hardcoded constant.
+     */
+    @Test
+    void testDefaultMaxResultsFollowsConfiguration() {
+        int hitsPerPage = env.getHitsPerPage();
+        int cachePages = env.getCachePages();
+        env.setHitsPerPage(1);
+        env.setCachePages(1);
+        try {
+            GenericType<Map<String, Object>> type = new GenericType<>() { };
+            Response response = target(SearchController.PATH)
+                    .queryParam(QueryParameters.FULL_SEARCH_PARAM, "main")
+                    .request()
+                    .get();
+            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+            Map<String, Object> json = response.readEntity(type);
+            assertTrue((int) json.get("resultCount") > 1,
+                    "query must match more documents than the page for this test to be meaningful");
+            assertEquals(0, (int) json.get("endDocument"),
+                    "default page size must be hitsPerPage * cachePages");
+        } finally {
+            env.setHitsPerPage(hitsPerPage);
+            env.setCachePages(cachePages);
+        }
+    }
+
     @Test
     void testNegativeMaxResultsIsRejected() {
         Response response = target(SearchController.PATH)

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
@@ -235,16 +235,32 @@ class SearchControllerTest extends OGKJerseyTest {
     }
 
     /**
-     * {@code startDocIndex + maxResults} must not overflow into a negative (i.e. unbounded)
-     * collection cap; a page far beyond the match count comes back well-formed and empty.
+     * {@code startDocIndex + maxResults} overflowing must be rejected rather than silently
+     * turning into a wrong (or unbounded) collection cap.
      */
     @Test
-    @SuppressWarnings("unchecked")
-    void testStartDocIndexNearIntegerMaxDoesNotOverflow() {
-        GenericType<Map<String, Object>> type = new GenericType<>() { };
+    void testStartDocIndexPlusMaxResultsOverflowIsRejected() {
         Response response = target(SearchController.PATH)
                 .queryParam(QueryParameters.FULL_SEARCH_PARAM, "dump")
                 .queryParam(QueryParameters.START_PARAM, Integer.MAX_VALUE)
+                .queryParam(QueryParameters.MAXRESULTS_PARAM, 1)
+                .request()
+                .get();
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * The largest non-overflowing page request must stay well-formed: a page far beyond the
+     * match count comes back empty while resultCount reports the true total.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testMaxNonOverflowingStartDocIndexReturnsEmptyPage() {
+        GenericType<Map<String, Object>> type = new GenericType<>() { };
+        Response response = target(SearchController.PATH)
+                .queryParam(QueryParameters.FULL_SEARCH_PARAM, "dump")
+                .queryParam(QueryParameters.START_PARAM, Integer.MAX_VALUE - 1)
+                .queryParam(QueryParameters.MAXRESULTS_PARAM, 1)
                 .request()
                 .get();
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
@@ -203,4 +203,55 @@ class SearchControllerTest extends OGKJerseyTest {
         assertEquals(expectedEndDocument, endDocument,
                 "endDocument must reflect the document page size, not the number of unique file paths");
     }
+
+    @Test
+    void testNegativeMaxResultsIsRejected() {
+        Response response = target(SearchController.PATH)
+                .queryParam(QueryParameters.FULL_SEARCH_PARAM, "dump")
+                .queryParam(QueryParameters.MAXRESULTS_PARAM, -1)
+                .request()
+                .get();
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void testNegativeStartDocIndexIsRejected() {
+        Response response = target(SearchController.PATH)
+                .queryParam(QueryParameters.FULL_SEARCH_PARAM, "dump")
+                .queryParam(QueryParameters.START_PARAM, -1)
+                .request()
+                .get();
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void testNegativeMaxHitsPerFileIsRejected() {
+        Response response = target(SearchController.PATH)
+                .queryParam(QueryParameters.FULL_SEARCH_PARAM, "dump")
+                .queryParam(QueryParameters.MAXHITSPERFILE_PARAM, -1)
+                .request()
+                .get();
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * {@code startDocIndex + maxResults} must not overflow into a negative (i.e. unbounded)
+     * collection cap; a page far beyond the match count comes back well-formed and empty.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testStartDocIndexNearIntegerMaxDoesNotOverflow() {
+        GenericType<Map<String, Object>> type = new GenericType<>() { };
+        Response response = target(SearchController.PATH)
+                .queryParam(QueryParameters.FULL_SEARCH_PARAM, "dump")
+                .queryParam(QueryParameters.START_PARAM, Integer.MAX_VALUE)
+                .request()
+                .get();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+        Map<String, Object> json = response.readEntity(type);
+        assertTrue((int) json.get("resultCount") > 0, "resultCount must still report the true total");
+        Map<String, ?> results = (Map<String, ?>) json.get("results");
+        assertTrue(results.isEmpty(), "page beyond the match count must be empty");
+    }
 }


### PR DESCRIPTION
The REST search API uses `SearchEngine.search()`, which for multi-project queries always disables paging and [re-runs the Lucene query collecting every matching document](https://github.com/oracle/opengrok/blob/61c43707bf8/opengrok-indexer/src/main/java/org/opengrok/indexer/search/SearchEngine.java#L252-L260) before paginating. On large indexes, a broad full-text search triggers this unbounded re-collection path and exhausts the JVM heap.

The HTML search page (`SearchHelper`) does not have this problem because it [calls `searcher.search(query, numHits, sort)` directly](https://github.com/oracle/opengrok/blob/61c43707bf8/opengrok-indexer/src/main/java/org/opengrok/indexer/web/SearchHelper.java#L483-L488), keeping heap usage proportional to the requested page size rather than the total result count.

The fix introduces `SearchEngine.setMaxDocs(int)` to cap collection at the caller-supplied bound. When set, `searchIndex()` uses `maxDocs` as the Lucene collector limit and skips the re-collection block entirely — heap usage stays O(maxDocs) regardless of how many documents match the query. 🔒 `SearchController` sets `maxDocs = startDocIndex + maxResults` before calling `engine.search()`, so collection is always bounded to exactly what the response needs.

`getTotalHits()` is added to preserve the accurate total count in the API response — previously `numResults` was set from `engine.search()` which returns `hits.length` (now capped), losing the true total.