### PR TITLE
use indexer token for async API calls

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1614,7 +1614,8 @@ public final class RuntimeEnvironment {
             Response.StatusType statusType = response.getStatusInfo();
 
             if (response.getStatus() == Response.Status.ACCEPTED.getStatusCode()) {
-                Response apiResponse = new AsyncApiCallResult(getApiTimeout(), getConnectTimeout()).waitFor(response);
+                Response apiResponse = new AsyncApiCallResult(getApiTimeout(), getConnectTimeout(),
+                        getIndexerAuthenticationToken()).waitFor(response);
                 statusType = apiResponse.getStatusInfo();
             }
 

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerUtil.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/index/IndexerUtil.java
@@ -127,7 +127,8 @@ public class IndexerUtil {
             if (response.getStatus() == Response.Status.ACCEPTED.getStatusCode()) {
                 try {
                     RuntimeEnvironment env = RuntimeEnvironment.getInstance();
-                    response = new AsyncApiCallResult(env.getApiTimeout(), env.getConnectTimeout()).waitFor(response);
+                    response = new AsyncApiCallResult(env.getApiTimeout(), env.getConnectTimeout(),
+                            env.getIndexerAuthenticationToken()).waitFor(response);
                 } catch (InterruptedException e) {
                     LOGGER.log(Level.WARNING, "interrupted while waiting for API response", e);
                 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/AsyncApiCallResult.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/AsyncApiCallResult.java
@@ -23,9 +23,11 @@
 package org.opengrok.indexer.web;
 
 import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.opengrok.indexer.logger.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
@@ -38,10 +40,16 @@ public class AsyncApiCallResult {
 
     private final int apiTimeout;
     private final int connectTimeout;
+    private final String bearerToken;
 
     public AsyncApiCallResult(int apiTimeout, int connectTimeout) {
+        this(apiTimeout, connectTimeout, null);
+    }
+
+    public AsyncApiCallResult(int apiTimeout, int connectTimeout, @Nullable String bearerToken) {
         this.apiTimeout = apiTimeout;
         this.connectTimeout = connectTimeout;
+        this.bearerToken = bearerToken;
     }
 
     /**
@@ -78,15 +86,7 @@ public class AsyncApiCallResult {
 
         LOGGER.log(Level.FINER, "checking asynchronous API result on {0}", location);
         for (int i = 0; i < apiTimeout; i++) {
-            /*
-             * The Client object is not closed (e.g. assigned to within the try-with-resources block),
-             * because the response is returned from the method and when it is closed (perhaps in its own
-             * try-with-resources block), the owning Client object has to be still valid, otherwise
-             * Jersey/HK2 IllegalStateException will ensue.
-             */
-            response = ClientBuilder.newBuilder().
-                    connectTimeout(connectTimeout, TimeUnit.SECONDS).build().
-                    target(location).request().get();
+            response = getRequestBuilder(location).get();
             if (response.getStatus() == Response.Status.ACCEPTED.getStatusCode()) {
                 Thread.sleep(1000);
             } else {
@@ -100,10 +100,7 @@ public class AsyncApiCallResult {
         }
 
         LOGGER.log(Level.FINER, "making DELETE API request to {0}", location);
-        // Ditto w.r.t. closing the Client object as in the cycle above.
-        try (Response deleteResponse = ClientBuilder.newBuilder().
-                connectTimeout(connectTimeout, TimeUnit.SECONDS).build().
-                target(location).request().delete()) {
+        try (Response deleteResponse = getRequestBuilder(location).delete()) {
             if (deleteResponse.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
                 LOGGER.log(Level.WARNING, "DELETE API call to {0} failed with HTTP error {1}",
                         new Object[]{location, response.getStatusInfo()});
@@ -111,5 +108,22 @@ public class AsyncApiCallResult {
         }
 
         return response;
+    }
+
+    private Invocation.Builder getRequestBuilder(@NotNull String location) {
+        /*
+         * The Client object is not closed (e.g. assigned to within the try-with-resources block),
+         * because the response is returned from the method and when it is closed (perhaps in its own
+         * try-with-resources block), the owning Client object has to be still valid, otherwise
+         * Jersey/HK2 IllegalStateException will ensue.
+         */
+        Invocation.Builder request = ClientBuilder.newBuilder().
+                connectTimeout(connectTimeout, TimeUnit.SECONDS).build().
+                target(location).request();
+        if (bearerToken != null) {
+            request.header(HttpHeaders.AUTHORIZATION, "Bearer " + bearerToken);
+        }
+
+        return request;
     }
 }

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/AsyncApiCallResult.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/AsyncApiCallResult.java
@@ -42,10 +42,38 @@ public class AsyncApiCallResult {
     private final int connectTimeout;
     private final String bearerToken;
 
+    /**
+     * Creates a new {@code AsyncApiCallResult} instance with the given API and connection timeouts.
+     * <p>
+     * This is a convenience constructor equivalent to calling
+     * {@link #AsyncApiCallResult(int, int, String) AsyncApiCallResult(apiTimeout, connectTimeout, null)}.
+     * See {@link #AsyncApiCallResult(int, int, String)} for detailed parameter semantics.
+     * </p>
+     *
+     * @param apiTimeout     maximum time to wait, in seconds, for the asynchronous API
+     *                       call to complete
+     * @param connectTimeout connection timeout, in seconds, used for each HTTP request
+     */
     public AsyncApiCallResult(int apiTimeout, int connectTimeout) {
         this(apiTimeout, connectTimeout, null);
     }
 
+    /**
+     * Creates a new {@code AsyncApiCallResult} instance with the given timeouts and
+     * optional bearer token for authorization.
+     * <p>
+     * The {@code apiTimeout} parameter specifies the maximum duration, in seconds,
+     * to wait for completion of the asynchronous API call. The {@code connectTimeout}
+     * parameter specifies the connection timeout, in seconds, for each HTTP request.
+     * When {@code bearerToken} is not {@code null}, it is sent as a {@code Bearer}
+     * authorization header with all outgoing requests.
+     *
+     * @param apiTimeout     maximum time to wait, in seconds, for the asynchronous API
+     *                       call to complete
+     * @param connectTimeout connection timeout, in seconds, used for each HTTP request
+     * @param bearerToken    optional bearer token used for authenticated calls; when
+     *                       not {@code null}, an {@code Authorization} header is added
+     */
     public AsyncApiCallResult(int apiTimeout, int connectTimeout, @Nullable String bearerToken) {
         this.apiTimeout = apiTimeout;
         this.connectTimeout = connectTimeout;

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/AsyncApiCallResultTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/AsyncApiCallResultTest.java
@@ -31,11 +31,13 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -67,8 +69,8 @@ class AsyncApiCallResultTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = Response.Status.class, names = {"OK", "INTERNAL_SERVER_ERROR"})
-    void waitForCompletesImmediately(Response.Status deleteStatus) throws Exception {
+    @MethodSource("waitForCompletesImmediatelyArgs")
+    void waitForCompletesImmediately(Response.Status deleteStatus, String bearerToken) throws Exception {
         int apiTimeout = 3;
         int connectTimeout = 1;
 
@@ -86,40 +88,35 @@ class AsyncApiCallResultTest {
         when(deleteResponse.getStatusInfo()).thenReturn(deleteStatus);
 
         ClientBuilder firstBuilder = mock(ClientBuilder.class);
-        Client firstClient = mock(Client.class);
-        WebTarget firstTarget = mock(WebTarget.class);
-        Invocation.Builder getInvocationBuilder = mock(Invocation.Builder.class);
-
         ClientBuilder secondBuilder = mock(ClientBuilder.class);
-        Client secondClient = mock(Client.class);
-        WebTarget secondTarget = mock(WebTarget.class);
-        Invocation.Builder deleteInvocationBuilder = mock(Invocation.Builder.class);
-
-        when(firstBuilder.connectTimeout(anyLong(), eq(TimeUnit.SECONDS))).thenReturn(firstBuilder);
-        when(firstBuilder.build()).thenReturn(firstClient);
-        when(firstClient.target(location)).thenReturn(firstTarget);
-        when(firstTarget.request()).thenReturn(getInvocationBuilder);
+        Invocation.Builder getInvocationBuilder = mockGetRequestBuilder(location, firstBuilder);
+        Invocation.Builder deleteInvocationBuilder = mockGetRequestBuilder(location, secondBuilder);
         when(getInvocationBuilder.get()).thenReturn(statusResponse);
-
-        when(secondBuilder.connectTimeout(anyLong(), eq(TimeUnit.SECONDS))).thenReturn(secondBuilder);
-        when(secondBuilder.build()).thenReturn(secondClient);
-        when(secondClient.target(location)).thenReturn(secondTarget);
-        when(secondTarget.request()).thenReturn(deleteInvocationBuilder);
         when(deleteInvocationBuilder.delete()).thenReturn(deleteResponse);
 
         try (MockedStatic<ClientBuilder> clientBuilderStatic = org.mockito.Mockito.mockStatic(ClientBuilder.class)) {
             // First newBuilder() call is for GET polling, second one is for DELETE cleanup.
             clientBuilderStatic.when(ClientBuilder::newBuilder).thenReturn(firstBuilder, secondBuilder);
 
-            Response result = new AsyncApiCallResult(apiTimeout, connectTimeout).waitFor(initial);
+            Response result = newAsyncApiCallResult(apiTimeout, connectTimeout, bearerToken).waitFor(initial);
 
             assertSame(statusResponse, result);
+            verifyAuthorizationHeader(getInvocationBuilder, bearerToken);
             verify(getInvocationBuilder).get();
+            verifyAuthorizationHeader(deleteInvocationBuilder, bearerToken);
             verify(deleteInvocationBuilder).delete();
             verify(firstBuilder).connectTimeout(connectTimeout, TimeUnit.SECONDS);
             verify(secondBuilder).connectTimeout(connectTimeout, TimeUnit.SECONDS);
             verify(deleteResponse).close();
         }
+    }
+
+    private static Stream<Arguments> waitForCompletesImmediatelyArgs() {
+        return Stream.of(Response.Status.OK, Response.Status.INTERNAL_SERVER_ERROR).
+                flatMap(status -> Stream.of(
+                        Arguments.of(status, null),
+                        Arguments.of(status, "secret")
+                ));
     }
 
     @Test
@@ -180,5 +177,35 @@ class AsyncApiCallResultTest {
                     )
             );
         }
+    }
+
+    private static Invocation.Builder mockGetRequestBuilder(String location, ClientBuilder builder) {
+        Client client = mock(Client.class);
+        WebTarget target = mock(WebTarget.class);
+        Invocation.Builder invocationBuilder = mock(Invocation.Builder.class);
+
+        when(builder.connectTimeout(anyLong(), eq(TimeUnit.SECONDS))).thenReturn(builder);
+        when(builder.build()).thenReturn(client);
+        when(client.target(location)).thenReturn(target);
+        when(target.request()).thenReturn(invocationBuilder);
+
+        return invocationBuilder;
+    }
+
+    private static AsyncApiCallResult newAsyncApiCallResult(int apiTimeout, int connectTimeout, String bearerToken) {
+        if (bearerToken == null) {
+            return new AsyncApiCallResult(apiTimeout, connectTimeout);
+        }
+
+        return new AsyncApiCallResult(apiTimeout, connectTimeout, bearerToken);
+    }
+
+    private static void verifyAuthorizationHeader(Invocation.Builder invocationBuilder, String bearerToken) {
+        if (bearerToken == null) {
+            verify(invocationBuilder, Mockito.never()).header(eq(HttpHeaders.AUTHORIZATION), Mockito.any());
+            return;
+        }
+
+        verify(invocationBuilder).header(HttpHeaders.AUTHORIZATION, "Bearer " + bearerToken);
     }
 }


### PR DESCRIPTION
Fix for the missing indexer authorization token header in the asynchronous API requests. Bittersweet w.r.t. timing as this is done after the recent test coverage inception of the async API class in PR #4965.

Tested with the auth token passed to the indexer via read-only configuration.

Co-authored with Codex (GPT-5.5)