### PR TITLE
do not commit if there is no change in Javadocs

### DIFF
--- a/dev/javadoc.sh
+++ b/dev/javadoc.sh
@@ -34,6 +34,10 @@ if [[ -d ./javadoc ]]; then
 fi
 cp -Rf "$OPENGROK_BUILD_DIR/target/site/apidocs" ./javadoc
 git add -f ./javadoc
+if [[ -z $( git status -s ) ]]; then
+  echo "No change, bailing out"
+  exit 0
+fi
 git commit -m "Latest javadoc auto-pushed to branch $BRANCH"
 git push -fq origin "$BRANCH"
 


### PR DESCRIPTION
If there is no change to the Javadoc the pertaining workflow fails due to `git commit` reporting error:
```
Publishing OpenAPI document to gh-pages...

+ git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+ cd gh-pages
+ cp -f /home/runner/work/opengrok/opengrok/target/openapi-validation/index.html ./openapi.html
+ git add openapi.html
+ git commit -m 'Latest OpenAPI auto-pushed to branch gh-pages'
On branch gh-pages
Your branch is up to date with 'origin/gh-pages'.

nothing to commit, working tree clean
Error: Process completed with exit code 1.
```
This change avoids that.