### PR TITLE
add Java record definition

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/CtagsReader.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/CtagsReader.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis;
@@ -100,7 +100,8 @@ public class CtagsReader {
         //        KIND("kind"),
         LINE("line"),
         //        NAMESPACE("namespace"), //this is not defined in above format docs, but both universal and exuberant ctags use it
-        //        PROGRAM("program"), //this is not defined in above format docs, but both universal and exuberant ctags use it
+//        PROGRAM("program"), //this is not defined in above format docs, but both universal and exuberant ctags use it
+        RECORD("record"),
         SIGNATURE("signature");
 
         //NOTE: if you edit above, always consult below charCmpEndOffset
@@ -122,12 +123,13 @@ public class CtagsReader {
          * enough to get rid of disambiguation.
          * <p>TODO:
          * <p>NOTE this is a big tradeoff in terms of input data, e.g. field
-         * "find" will be considered "file" and overwrite the value, so if
-         * ctags will send us buggy input, we will output buggy data TOO!
+         * some unknown field with the same prefix as a consumed field will
+         * overwrite the value, so if ctags will send us buggy input, we will
+         * output buggy data TOO!
          * NO VALIDATION happens of input - but then we gain LOTS of speed, due to
          * not comparing the same field names again and again fully.
          */
-        private static final int CHAR_CMP_END_OFFSET = 0;
+        private static final int CHAR_CMP_END_OFFSET = 1;
 
         /**
          * Quickly get if the field name matches allowed/consumed ones.
@@ -220,7 +222,10 @@ public class CtagsReader {
 
         String lnum = fields.get(tagFields.LINE);
         String signature = fields.get(tagFields.SIGNATURE);
-        String classInher = fields.get(tagFields.CLASS);
+        String namespace = fields.get(tagFields.CLASS);
+        if (namespace == null) {
+            namespace = fields.get(tagFields.RECORD);
+        }
 
         final String whole;
         final String match;
@@ -243,7 +248,7 @@ public class CtagsReader {
         // Bug #809: Keep track of which symbols have already been
         // seen to prevent duplicating them in memory.
 
-        final String type = classInher == null ? kind : kind + " in " + classInher;
+        final String type = namespace == null ? kind : kind + " in " + namespace;
 
         int lineno;
         try {
@@ -255,7 +260,7 @@ public class CtagsReader {
         }
 
         CpatIndex cidx = bestIndexOfTag(lineno, whole, def);
-        addTag(defs, cidx.lineno, def, type, match, classInher, signature,
+        addTag(defs, cidx.lineno, def, type, match, namespace, signature,
             cidx.lineStart, cidx.lineEnd);
 
         if (signature != null && !signature.equals("()") &&

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/XrefStyle.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/XrefStyle.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2011, Jens Elkner.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
@@ -55,6 +55,7 @@ public class XrefStyle {
         new XrefStyle("local", "xl", null),
         new XrefStyle("variable", "xv", "Variable"),
         new XrefStyle("class", "xc", "Class"),
+        new XrefStyle("record", "xr", "Record"),
         new XrefStyle("package", "xp", "Package"),
         new XrefStyle("interface", "xi", "Interface"),
         new XrefStyle("namespace", "xn", "Namespace"),

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/Consts.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/analysis/java/Consts.java
@@ -70,6 +70,7 @@ public class Consts {
         kwd.add("private");
         kwd.add("protected");
         kwd.add("public");
+        kwd.add("record");
         kwd.add("return");
         kwd.add("sealed");
         kwd.add("short");

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/CtagsTest.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
+import org.opengrok.indexer.util.Executor;
 import org.opengrok.indexer.util.TestRepository;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -42,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  *
@@ -88,6 +91,12 @@ class CtagsTest {
         String path = repository.getSourceRoot() + File.separator
                 + fileName.replace('/', File.separatorChar);
         return ctags.doCtags(new File(path).getAbsolutePath());
+    }
+
+    private static Definitions getDefsFromResource(String resourceName) throws Exception {
+        URL resourceURL = CtagsTest.class.getClassLoader().getResource(resourceName);
+        assertNotNull(resourceURL);
+        return ctags.doCtags(new File(resourceURL.toURI()).getAbsolutePath());
     }
 
     @ParameterizedTest
@@ -152,6 +161,43 @@ class CtagsTest {
             }
         }
         assertEquals(names.length, count, "function count");
+    }
+
+    @Test
+    void javaRecordDefinitions() throws Exception {
+        assumeTrue(ctagsSupportsJavaRecordKind(), "ctags does not support Java record tags");
+
+        Definitions result = getDefsFromResource("analysis/java/SearchHit.java");
+        assertAll(
+                () -> assertTrue(result.getTags().stream().anyMatch(tag ->
+                        tag.symbol.equals("SearchHit") &&
+                        tag.namespace == null &&
+                        tag.type.equals("record") &&
+                        tag.signature.equals("(String path, LineRange range, double score)"))),
+                () -> assertTrue(result.getTags().stream().anyMatch(tag ->
+                        tag.symbol.equals("LineRange") &&
+                        tag.namespace.equals("SearchHit") &&
+                        tag.type.equals("record in SearchHit") &&
+                        tag.signature.equals("(int startLine, int endLine)"))),
+                () -> assertTrue(result.getTags().stream().anyMatch(tag ->
+                        tag.symbol.equals("isStrongMatch") &&
+                        tag.namespace.equals("SearchHit") &&
+                        tag.type.equals("method in SearchHit"))),
+                () -> assertTrue(result.getTags().stream().anyMatch(tag ->
+                        tag.symbol.equals("spansMultipleLines") &&
+                        tag.namespace.equals("SearchHit.LineRange") &&
+                        tag.type.equals("method in SearchHit.LineRange")))
+        );
+    }
+
+    private static boolean ctagsSupportsJavaRecordKind() {
+        String ctagsBinary = RuntimeEnvironment.getInstance().getCtags();
+        Executor executor = new Executor(new String[]{ctagsBinary, "--list-kinds-full=Java"});
+        if (executor.exec(false) != 0) {
+            return false;
+        }
+        String output = executor.getOutputString();
+        return output != null && output.lines().anyMatch(line -> line.matches("^r\\s+record\\s+.*"));
     }
 
     @ParameterizedTest

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/java/JavaSymbolTokenizerTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/java/JavaSymbolTokenizerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.java;
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
@@ -85,5 +86,12 @@ class JavaSymbolTokenizerTest {
                     },
                     termsFor);
         }
+    }
+
+    @Test
+    void shouldTreatRecordAsKeyword() {
+        String[] termsFor = getTermsFor(new StringReader(
+                "public record SearchHit(String path, LineRange range, double score) {}"));
+        assertArrayEquals(new String[] {"SearchHit", "String", "path", "LineRange", "range", "score"}, termsFor);
     }
 }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/java/JavaXrefTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/analysis/java/JavaXrefTest.java
@@ -18,15 +18,22 @@
  */
 
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2019, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.analysis.java;
 
 import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.analysis.AbstractAnalyzer;
+import org.opengrok.indexer.analysis.CtagsReader;
+import org.opengrok.indexer.analysis.Definitions;
+import org.opengrok.indexer.analysis.WriteXrefArgs;
 import org.opengrok.indexer.analysis.XrefTestBase;
 import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.indexer.util.StreamUtils.readTagsFromResource;
 
 /**
@@ -49,5 +56,34 @@ class JavaXrefTest extends XrefTestBase {
         writeAndCompare(new JavaAnalyzerFactory(),
                 "analysis/java/truncated.jav",
                 "analysis/java/truncated_xref.html", null, 1);
+    }
+
+    @Test
+    void shouldStyleRecordDefinition() throws IOException {
+        String source = """
+                package example;
+
+                public record SearchHit(String path, LineRange range, double score) {}
+                """;
+        Definitions defs = parseTags("SearchHit\tSearchHit.java\t/^public record SearchHit"
+                + "(String path, LineRange range, double score) {}$/;\""
+                + "\trecord\tline:3\tsignature:(String path, LineRange range, double score)\n");
+
+        AbstractAnalyzer analyzer = new JavaAnalyzerFactory().getAnalyzer();
+        StringWriter out = new StringWriter();
+        WriteXrefArgs args = new WriteXrefArgs(new StringReader(source), out);
+        args.setDefs(defs);
+        analyzer.writeXref(args);
+
+        String xref = out.toString();
+        assertTrue(xref.contains("<b>record</b>"));
+        assertTrue(xref.contains("class=\"xr intelliWindow-symbol\""));
+        assertTrue(xref.contains("[\"Record\",\"xr\",[[\"SearchHit\",3]]]"));
+    }
+
+    private static Definitions parseTags(String tags) {
+        CtagsReader reader = new CtagsReader();
+        tags.lines().forEach(reader::readLine);
+        return reader.getDefinitions();
     }
 }

--- a/opengrok-indexer/src/test/resources/analysis/java/SearchHit.java
+++ b/opengrok-indexer/src/test/resources/analysis/java/SearchHit.java
@@ -1,0 +1,37 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ */
+package org.opensolaris.opengrok.analysis.java;
+
+public record SearchHit(String path, LineRange range, double score) {
+
+    public boolean isStrongMatch() {
+        return score >= 0.75;
+    }
+
+    record LineRange(int startLine, int endLine) {
+
+        public boolean spansMultipleLines() {
+            return endLine > startLine;
+        }
+    }
+}

--- a/opengrok-web/src/main/webapp/default/print-1.0.3.css
+++ b/opengrok-web/src/main/webapp/default/print-1.0.3.css
@@ -374,6 +374,7 @@ a.xa     { /* argument */           color: #60c; font-weight: bold;             
 a.xl     { /* local */              color: #963; font-weight: bold;                     }
 a.xv     { /* variable */           color: #c30; font-weight: bold;                     }
 a.xc     { /* class */              color: #909; font-weight: bold; font-style: italic; }
+a.xr     { /* record */             color: #909; font-weight: bold; font-style: italic; }
 a.xp     { /* package */            color: #909; font-weight: bold; font-style: italic; }
 a.xi     { /* interface */          color: #909; font-weight: bold; font-style: italic; }
 a.xn     { /* namespace */          color: #909; font-weight: bold; font-style: italic; }

--- a/opengrok-web/src/main/webapp/default/style-1.0.6.css
+++ b/opengrok-web/src/main/webapp/default/style-1.0.6.css
@@ -995,6 +995,7 @@ a.xa               { /* argument           */ color: var(--og-symbol-arg-fg);   
 a.xl               { /* local              */ color: var(--og-symbol-local-fg);       font-weight: bold;                     }
 a.xv               { /* variable           */ color: var(--og-symbol-variable-fg);       font-weight: bold;                     }
 a.xc               { /* class              */ color: var(--og-symbol-type-fg);       font-weight: bold; font-style: italic; }
+a.xr               { /* record             */ color: var(--og-symbol-type-fg);       font-weight: bold; font-style: italic; }
 a.xp               { /* package            */ color: var(--og-symbol-type-fg);       font-weight: bold; font-style: italic; }
 a.xi               { /* interface          */ color: var(--og-symbol-type-fg);       font-weight: bold; font-style: italic; }
 a.xn               { /* namespace          */ color: var(--og-symbol-type-fg);       font-weight: bold; font-style: italic; }

--- a/opengrok-web/src/main/webapp/httpheader.jspf
+++ b/opengrok-web/src/main/webapp/httpheader.jspf
@@ -46,8 +46,8 @@ org.opengrok.web.Scripts"
     PageConfig cfg = PageConfig.get(request);
     String styleDir = cfg.getCssDir();
     String ctxPath = request.getContextPath();
-    String dstyle = styleDir + '/' + "style-1.0.5.min.css";
-    String pstyle = styleDir + '/' + "print-1.0.2.min.css";
+    String dstyle = styleDir + '/' + "style-1.0.6.min.css";
+    String pstyle = styleDir + '/' + "print-1.0.3.min.css";
     String mstyle = styleDir + '/' + "mandoc-1.0.0.min.css";
 %><!DOCTYPE html>
 <html lang="en"


### PR DESCRIPTION
This change adds the support for Java `record` definition. The matching offset bump in `CtagsReader` might slow ctags output parsing a bit, however given there are multiple tag classes that begin with `r` this is unavoidable.

Requires the latest Universal ctags built from source.

xref of a Lucene source file using `record` before and after:
<img width="4036" height="1212" alt="obrazek" src="https://github.com/user-attachments/assets/394eb81f-097f-41a1-96fe-3f813f155fa4" />

Assisted by Codex (5.5-xhigh)