### PR TITLE
Only detect Perforce when a P4CONFIG marker is present

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/history/PerforceRepository.java
@@ -205,7 +205,39 @@ public class PerforceRepository extends Repository {
 
     @Override
     boolean isRepositoryFor(File file, CommandTimeoutType cmdType) {
+        // Unlike Git/Mercurial/etc., Perforce has no local marker directory, so
+        // historically OpenGrok probed *every* scanned directory by executing p4.
+        // That is expensive and, when a p4 client is configured via the
+        // environment, `p4 files`/`p4 dirs` can return depot paths for
+        // non-Perforce (e.g. Git) working trees, causing them to be misclassified
+        // as Perforce and their real history to be lost. Require local evidence of
+        // Perforce (a P4CONFIG marker file) before running any p4 command.
+        if (!hasPerforceEvidence(file)) {
+            return false;
+        }
         return isInP4Depot(file, cmdType);
+    }
+
+    /**
+     * Determine, without executing any external command, whether {@code file}
+     * plausibly belongs to a Perforce workspace. This is the case when a P4CONFIG
+     * marker file (named by the {@code P4CONFIG} environment variable, or
+     * {@code .p4config} by default) is present in the directory or any ancestor.
+     *
+     * @param file directory to test
+     * @return true if a P4CONFIG marker is found in the directory or an ancestor
+     */
+    static boolean hasPerforceEvidence(File file) {
+        String p4configName = System.getenv("P4CONFIG");
+        if (p4configName == null || p4configName.isEmpty()) {
+            p4configName = ".p4config";
+        }
+        for (File dir = file; dir != null; dir = dir.getParentFile()) {
+            if (new File(dir, p4configName).isFile()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean isP4Working() {

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/history/PerforceRepositoryTest.java
@@ -26,19 +26,26 @@ package org.opengrok.indexer.history;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.opengrok.indexer.condition.EnabledForRepository;
+import org.opengrok.indexer.configuration.CommandTimeoutType;
 import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.indexer.util.FileUtilities;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.AbstractMap.SimpleImmutableEntry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.indexer.condition.RepositoryInstalled.Type.PERFORCE;
+import static org.opengrok.indexer.history.PerforceRepository.hasPerforceEvidence;
 import static org.opengrok.indexer.history.PerforceRepository.protectPerforceFilename;
 import static org.opengrok.indexer.history.PerforceRepository.unprotectPerforceFilename;
 
@@ -132,6 +139,36 @@ class PerforceRepositoryTest {
                 }
             }
         }
+    }
+
+    @Test
+    void hasPerforceEvidenceReturnsFalseWithoutMarker(@TempDir Path dir) {
+        assertFalse(hasPerforceEvidence(dir.toFile()),
+                "A directory without a .p4config marker must not be treated as Perforce");
+    }
+
+    @Test
+    void hasPerforceEvidenceReturnsTrueWithMarker(@TempDir Path dir) throws Exception {
+        Files.createFile(dir.resolve(".p4config"));
+        assertTrue(hasPerforceEvidence(dir.toFile()),
+                "A directory containing a .p4config marker must be recognized as Perforce");
+    }
+
+    @Test
+    void hasPerforceEvidenceFindsMarkerInAncestor(@TempDir Path dir) throws Exception {
+        Files.createFile(dir.resolve(".p4config"));
+        Path nested = Files.createDirectories(dir.resolve("a/b/c"));
+        assertTrue(hasPerforceEvidence(nested.toFile()),
+                "A .p4config marker in an ancestor directory must be honored");
+    }
+
+    @Test
+    void isRepositoryForReturnsFalseWithoutMarker(@TempDir Path dir) {
+        // Without a Perforce marker, detection must short-circuit and never run p4,
+        // so that non-Perforce (e.g. Git) working trees are not misclassified.
+        PerforceRepository instance = new PerforceRepository();
+        assertFalse(instance.isRepositoryFor(dir.toFile(), CommandTimeoutType.INDEXER),
+                "isRepositoryFor must be false for a directory without a .p4config marker");
     }
 
     @Test


### PR DESCRIPTION
## Problem

`PerforceRepository` has no local repository marker (unlike `.git`, `.hg`, `.svn`, …). As a result, `isRepositoryFor()` probes **every scanned directory** by executing `p4 dirs`/`p4 files` whenever the `p4` binary is available.

This has two bad consequences on machines that only use other SCMs:

1. **Misclassification / lost history** — when a `p4` client is configured through the environment (`P4PORT`/`P4CLIENT`/`P4CONFIG`), `p4 files`/`p4 dirs` can return depot paths for directories that are actually Git working trees. Those trees get detected as Perforce, so their real (Git) history is never collected.
2. **Slow and noisy indexing** — `p4` is spawned in every non-repository directory during the discovery walk.

## Fix

Gate Perforce detection on **local evidence** before running any `p4` command: a P4CONFIG marker file (named by the `P4CONFIG` environment variable, defaulting to `.p4config`) present in the directory or one of its ancestors. This mirrors the marker-based detection already used by the other SCM implementations. Real Perforce workspaces that use the standard P4CONFIG convention are still detected; unrelated (e.g. Git) trees are no longer probed or misclassified.

## Tests

Added unit tests in `PerforceRepositoryTest` that do not require a running Perforce server:

- marker absent → not detected
- marker present → detected
- marker in an ancestor directory → detected
- `isRepositoryFor()` short-circuits (no `p4` invocation) without a marker

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 1
```

(The single skipped test is the pre-existing `@EnabledForRepository(PERFORCE)` integration test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
