### PR TITLE
Limit line length in Search API responses

### DIFF
--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/controller/SearchController.java
@@ -64,9 +64,18 @@ public class SearchController {
 
     private final SuggesterService suggester;
 
+    private static final int MAX_LINE_LENGTH = 500;
+
     @Inject
     public SearchController(SuggesterService suggester) {
         this.suggester = suggester;
+    }
+
+    static String truncateLine(String line) {
+        if (line == null || line.length() <= MAX_LINE_LENGTH) {
+            return line;
+        }
+        return line.substring(0, MAX_LINE_LENGTH) + " ...";
     }
 
     @GET
@@ -85,8 +94,7 @@ public class SearchController {
             @QueryParam(QueryParameters.MAXRESULTS_PARAM) final Integer maxResultsParam,
             @QueryParam(QueryParameters.START_PARAM) @DefaultValue(0 + "") final int startDocIndex,
             @QueryParam(QueryParameters.SORT_PARAM) @DefaultValue(DEFAULT_SORT_ORDER) final String sort,
-            @QueryParam(QueryParameters.MAXHITSPERFILE_PARAM) @DefaultValue("0") final int maxHitsPerFile
-    ) {
+            @QueryParam(QueryParameters.MAXHITSPERFILE_PARAM) @DefaultValue("0") final int maxHitsPerFile) {
         if ((maxResultsParam != null && maxResultsParam < 0) || startDocIndex < 0 || maxHitsPerFile < 0) {
             throw new WebApplicationException("Negative integer parameters are not allowed",
                     Response.Status.BAD_REQUEST);
@@ -123,7 +131,7 @@ public class SearchController {
                     .stream()
                     .collect(Collectors.groupingBy(Hit::getPath,
                             LinkedHashMap::new,
-                            Collectors.mapping(h -> new SearchHit(h.getLine(), h.getLineno(), h.getTag()),
+                            Collectors.mapping(h -> new SearchHit(truncateLine(h.getLine()), h.getLineno(), h.getTag()),
                                     Collectors.toList())));
 
             long duration = Duration.between(startTime, Instant.now()).toMillis();
@@ -150,8 +158,7 @@ public class SearchController {
                 final String type,
                 final SortOrder sortOrder,
                 final int maxHitsPerFile,
-                final int maxDocs
-        ) {
+                final int maxDocs) {
             engine = new SearchEngine(maxDocs);
             engine.setFreetext(full);
             engine.setDefinition(def);
@@ -167,8 +174,7 @@ public class SearchController {
                 final HttpServletRequest req,
                 final List<String> projects,
                 final int startDocIndex,
-                final int maxResults
-        ) {
+                final int maxResults) {
             Set<Project> allProjects = PageConfig.get(req).getProjectHelper().getAllProjects();
             int collected;
             if (projects == null || projects.isEmpty()) {
@@ -214,8 +220,7 @@ public class SearchController {
             int resultCount,
             Map<String, List<SearchHit>> results,
             int startDocument,
-            int endDocument
-    ) {
+            int endDocument) {
     }
 
     private record SearchHit(String line, String lineNumber, String tag) {

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
@@ -105,9 +106,11 @@ class SearchControllerTest extends OGKJerseyTest {
 
     @Test
     void testSearchReturnsResults() {
-        // "dump" is a method name defined in java/Main.java — verifies the index is live
+        // "dump" is a method name defined in java/Main.java — verifies the index is
+        // live
         // and the API returns a well-formed response.
-        GenericType<Map<String, Object>> type = new GenericType<>() { };
+        GenericType<Map<String, Object>> type = new GenericType<>() {
+        };
         Response response = target(SearchController.PATH)
                 .queryParam(QueryParameters.FULL_SEARCH_PARAM, "dump")
                 .request()
@@ -117,16 +120,17 @@ class SearchControllerTest extends OGKJerseyTest {
         Object resultsObj = body.get("results");
         assertNotNull(resultsObj);
         @SuppressWarnings("unchecked")
-        Map<String, List<Map<String, Object>>> results =
-                (Map<String, List<Map<String, Object>>>) resultsObj;
+        Map<String, List<Map<String, Object>>> results = (Map<String, List<Map<String, Object>>>) resultsObj;
         assertFalse(results.isEmpty());
     }
 
     @Test
     void testSearchResultsPreserveHitOrder() {
-        // Results presented by the search API must be stable w.r.t. file ordering across
+        // Results presented by the search API must be stable w.r.t. file ordering
+        // across
         // repeated calls, while preserving Lucene scoring order.
-        GenericType<Map<String, Object>> type = new GenericType<>() { };
+        GenericType<Map<String, Object>> type = new GenericType<>() {
+        };
         String firstKey1 = getFirstResultKey(type);
         String firstKey2 = getFirstResultKey(type);
         assertNotNull(firstKey1);
@@ -149,10 +153,13 @@ class SearchControllerTest extends OGKJerseyTest {
 
     @Test
     void testSearchResultsHaveLineNumbers() {
-        // maxhitsperfile defaults to 0 (unlimited) so all per-file hits carry a lineNumber.
-        // Restrict to Java source type to exclude XREFABLE binary files (jar, class, elf)
+        // maxhitsperfile defaults to 0 (unlimited) so all per-file hits carry a
+        // lineNumber.
+        // Restrict to Java source type to exclude XREFABLE binary files (jar, class,
+        // elf)
         // whose hits go through the Summarizer path and never carry a lineNumber.
-        GenericType<Map<String, Object>> type = new GenericType<>() { };
+        GenericType<Map<String, Object>> type = new GenericType<>() {
+        };
         Response response = target(SearchController.PATH)
                 .queryParam(QueryParameters.FULL_SEARCH_PARAM, "dump")
                 .queryParam(QueryParameters.TYPE_SEARCH_PARAM, "java")
@@ -160,28 +167,28 @@ class SearchControllerTest extends OGKJerseyTest {
                 .get();
         Map<String, Object> body = response.readEntity(type);
         @SuppressWarnings("unchecked")
-        Map<String, List<Map<String, Object>>> results =
-                (Map<String, List<Map<String, Object>>>) body.get("results");
+        Map<String, List<Map<String, Object>>> results = (Map<String, List<Map<String, Object>>>) body.get("results");
         assertNotNull(results);
         assertFalse(results.isEmpty());
-        results.values().forEach(hits ->
-                hits.forEach(hit -> {
-                    assertNotNull(hit.get("lineNumber"));
-                    assertFalse(hit.get("lineNumber").toString().isEmpty());
-                })
-        );
+        results.values().forEach(hits -> hits.forEach(hit -> {
+            assertNotNull(hit.get("lineNumber"));
+            assertFalse(hit.get("lineNumber").toString().isEmpty());
+        }));
     }
 
     /**
-     * Verify that resultCount reflects the true total number of matching documents and
-     * endDocument is derived from the document page size, not from the number of unique
+     * Verify that resultCount reflects the true total number of matching documents
+     * and
+     * endDocument is derived from the document page size, not from the number of
+     * unique
      * file paths in the grouped results map.
      */
     @Test
     @SuppressWarnings("unchecked")
     void testResultCountAndEndDocument() {
         int maxResults = 100;
-        GenericType<Map<String, Object>> type = new GenericType<>() { };
+        GenericType<Map<String, Object>> type = new GenericType<>() {
+        };
         Response response = target(SearchController.PATH)
                 .queryParam(QueryParameters.FULL_SEARCH_PARAM, "main")
                 .queryParam(QueryParameters.MAXRESULTS_PARAM, maxResults)
@@ -205,7 +212,8 @@ class SearchControllerTest extends OGKJerseyTest {
     }
 
     /**
-     * Without the {@code maxresults} parameter the page size must follow the configured
+     * Without the {@code maxresults} parameter the page size must follow the
+     * configured
      * {@code hitsPerPage * cachePages} rather than a hardcoded constant.
      */
     @Test
@@ -215,7 +223,8 @@ class SearchControllerTest extends OGKJerseyTest {
         env.setHitsPerPage(1);
         env.setCachePages(1);
         try {
-            GenericType<Map<String, Object>> type = new GenericType<>() { };
+            GenericType<Map<String, Object>> type = new GenericType<>() {
+            };
             Response response = target(SearchController.PATH)
                     .queryParam(QueryParameters.FULL_SEARCH_PARAM, "main")
                     .request()
@@ -264,7 +273,8 @@ class SearchControllerTest extends OGKJerseyTest {
     }
 
     /**
-     * {@code startDocIndex + maxResults} overflowing must be rejected rather than silently
+     * {@code startDocIndex + maxResults} overflowing must be rejected rather than
+     * silently
      * turning into a wrong (or unbounded) collection cap.
      */
     @Test
@@ -279,13 +289,15 @@ class SearchControllerTest extends OGKJerseyTest {
     }
 
     /**
-     * The largest non-overflowing page request must stay well-formed: a page far beyond the
+     * The largest non-overflowing page request must stay well-formed: a page far
+     * beyond the
      * match count comes back empty while resultCount reports the true total.
      */
     @Test
     @SuppressWarnings("unchecked")
     void testMaxNonOverflowingStartDocIndexReturnsEmptyPage() {
-        GenericType<Map<String, Object>> type = new GenericType<>() { };
+        GenericType<Map<String, Object>> type = new GenericType<>() {
+        };
         Response response = target(SearchController.PATH)
                 .queryParam(QueryParameters.FULL_SEARCH_PARAM, "dump")
                 .queryParam(QueryParameters.START_PARAM, Integer.MAX_VALUE - 1)
@@ -298,5 +310,47 @@ class SearchControllerTest extends OGKJerseyTest {
         assertTrue((int) json.get("resultCount") > 0, "resultCount must still report the true total");
         Map<String, ?> results = (Map<String, ?>) json.get("results");
         assertTrue(results.isEmpty(), "page beyond the match count must be empty");
+    }
+
+    @Test
+    void testTruncateLine() {
+        String longString = "A".repeat(1000);
+
+        String result = SearchController.truncateLine(longString);
+
+        assertEquals("A".repeat(500) + " ...", result);
+    }
+
+    @Test
+    void testTruncateShortLine() {
+        String line = "Hello";
+
+        assertEquals(line, SearchController.truncateLine(line));
+    }
+
+    @Test
+    void testTruncateNullLine() {
+        assertNull(SearchController.truncateLine(null));
+    }
+
+    @Test
+    void testTruncateExactBoundaryLine() {
+        // A line of exactly MAX_LINE_LENGTH (500) chars must NOT be truncated.
+        // This guards against an off-by-one error (< vs <=) in the boundary check.
+        String line = "A".repeat(500);
+        assertEquals(line, SearchController.truncateLine(line));
+    }
+
+    @Test
+    void testTruncateOneOverBoundaryLine() {
+        // A line of exactly MAX_LINE_LENGTH + 1 (501) chars must be truncated.
+        String line = "A".repeat(501);
+        assertEquals("A".repeat(500) + " ...", SearchController.truncateLine(line));
+    }
+
+    @Test
+    void testTruncateEmptyLine() {
+        // An empty string is within the limit and must be returned unchanged.
+        assertEquals("", SearchController.truncateLine(""));
     }
 }


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
