### PR TITLE
Fix project classification for projects without repository info

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -1683,10 +1683,11 @@ public final class RuntimeEnvironment {
 
             // add project to the groups
             for (Group group : copy) {
-                if (repository_map.get(project) == null) {
-                    group.addProject(project);
-                } else {
+                List<RepositoryInfo> repositories = repository_map.get(project);
+                if (repositories != null && !repositories.isEmpty()) {
                     group.addRepository(project);
+                } else {
+                    group.addProject(project);
                 }
                 project.addGroup(group);
             }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
@@ -912,6 +912,17 @@ class RuntimeEnvironmentTest {
         assertEquals(0, group2.getProjects().size());
         assertEquals(2, group2.getRepositories().size());
 
+        // empty repository map entries classify as projects
+        env.getProjectRepositoriesMap().put(project1, new ArrayList<>());
+        env.populateGroups(new TreeSet<>(env.getGroups().values()), new TreeSet<>(env.getProjects().values()));
+
+        assertEquals(1, group1.getProjects().size());
+        assertEquals(0, group1.getRepositories().size());
+        assertEquals(1, group2.getProjects().size());
+        assertEquals(1, group2.getRepositories().size());
+
+        env.getProjectRepositoriesMap().put(project1, Arrays.asList(repository1));
+
         // remove a single repository object => project1 will become a simple project
         env.getProjectRepositoriesMap().remove(project1);
         env.getRepositories().remove(repository1);

--- a/opengrok-web/src/main/java/org/opengrok/web/ProjectHelper.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/ProjectHelper.java
@@ -146,6 +146,11 @@ public final class ProjectHelper {
                 .collect(Collectors.toList());
     }
 
+    private boolean hasRepositories(Project project) {
+        List<RepositoryInfo> repositories = cfg.getEnv().getProjectRepositoriesMap().get(project);
+        return repositories != null && !repositories.isEmpty();
+    }
+
     /**
      * Generates ungrouped projects and repositories.
      */
@@ -157,10 +162,10 @@ public final class ProjectHelper {
 
             // If no group matches the project, add it to not-grouped projects.
             if (copy.isEmpty()) {
-                if (cfg.getEnv().getProjectRepositoriesMap().get(project) == null) {
-                    ungroupedProjects.add(project);
-                } else {
+                if (hasRepositories(project)) {
                     ungroupedRepositories.add(project);
+                } else {
+                    ungroupedProjects.add(project);
                 }
             }
         }

--- a/opengrok-web/src/test/java/org/opengrok/web/ProjectHelperTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/ProjectHelperTest.java
@@ -42,6 +42,7 @@ import org.opengrok.indexer.history.RepoRepository;
 import org.opengrok.indexer.history.RepositoryInfo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -301,6 +302,23 @@ class ProjectHelperTest extends ProjectHelperTestBase {
         for (Project p : result) {
             assertTrue(p.getName().startsWith("allowed_"));
         }
+    }
+
+    @Test
+    void testEmptyRepositoryMapEntryIsUngroupedProject() {
+        Project project = new Project("allowed_empty_repository_entry");
+        project.setIndexed(true);
+        env.getProjects().put(project.getName(), project);
+        getRepositoriesMap().put(project, new ArrayList<>());
+
+        cfg = PageConfig.get(getRequest());
+        helper = cfg.getProjectHelper();
+
+        assertTrue(helper.getUngroupedProjects().contains(project));
+        assertFalse(helper.getUngroupedRepositories().contains(project));
+
+        env.getProjects().remove(project.getName());
+        getRepositoriesMap().remove(project);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the {OpenGrok project. In order to accept changes from the "outside world", all contributors should "sign" the [Oracle Contributor Agreement](www.oracle.com/technetwork/community/oca-486395.html) . 
OCA basically means that you won't be sueing Oracle over code you donate to {OpenGrok project (and similar way, that Oracle won't sue you over your patch :-D ).
If you have already signed OCA or are from Oracle, then ignore this message, you just need to sign once for all patches to {OpenGrok.
Alternative is to provide a written acceptance of OCA line into the comment of specific pull request (and ideally sign, scan and mail back OCA to Oracle in parallel), but this simple acceptance is only valid for single pull request.
-->
Projects can be present in the project-repository map without having usable repository information.
The index page classification currently treats map membership as enough to classify a project as
a repository. This can move projects without repository history out of the Projects section.

This change classifies a project as a repository only when the corresponding RepositoryInfo list
is non-null and non-empty, and applies the same rule to grouped projects.