### PR TITLE
persistent file path filtering

### DIFF
--- a/opengrok-web/src/main/webapp/WEB-INF/web.xml
+++ b/opengrok-web/src/main/webapp/WEB-INF/web.xml
@@ -10,7 +10,7 @@
     <context-param>
         <description>Full path to the configuration file where OpenGrok can read its configuration</description>
         <param-name>CONFIGURATION</param-name>
-        <param-value>/var/opengrok/etc/configuration.xml</param-value>
+        <param-value>c:\Users\srinivas\Desktop\second\data\configuration.xml</param-value>
     </context-param>
     <listener>
         <listener-class>org.opengrok.web.WebappListener</listener-class>

--- a/opengrok-web/src/main/webapp/WEB-INF/web.xml
+++ b/opengrok-web/src/main/webapp/WEB-INF/web.xml
@@ -10,7 +10,7 @@
     <context-param>
         <description>Full path to the configuration file where OpenGrok can read its configuration</description>
         <param-name>CONFIGURATION</param-name>
-        <param-value>c:\Users\srinivas\Desktop\second\data\configuration.xml</param-value>
+        <param-value>/var/opengrok/etc/configuration.xml</param-value>
     </context-param>
     <listener>
         <listener-class>org.opengrok.web.WebappListener</listener-class>

--- a/opengrok-web/src/main/webapp/default/style-1.0.6.css
+++ b/opengrok-web/src/main/webapp/default/style-1.0.6.css
@@ -1704,3 +1704,21 @@ a.ui-button:active,
     background: var(--og-control-bg);
     color: var(--og-message-active-fg);
 }
+
+/* File Path field layout and clear button styles */
+.path-search-container {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    width: 100%;
+}
+
+.path-search-container input.q {
+    flex-grow: 1;
+}
+
+.path-clear-btn {
+    padding: 1px 6px;
+    white-space: nowrap;
+}
+

--- a/opengrok-web/src/main/webapp/js/utils-0.0.48.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.48.js
@@ -2294,7 +2294,7 @@ function scope_on_scroll() {
  * @returns true if on search page, false otherwise
  */
 function isOnSearchPage() {
-    return $(document.documentElement).hasClass('search');
+    return $(document.documentElement).hasClass('search') || $(document.documentElement).hasClass('s');
 }
 
 function checkIsOnSearchPage() {

--- a/opengrok-web/src/main/webapp/js/utils-0.0.48.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.48.js
@@ -1624,9 +1624,7 @@ $(document).ready(function () {
         if (storedPath && $('#path').length && !$('#path').val() && getParameter('path') === undefined) {
             $('#path').val(storedPath);
         }
-    } catch (e) {
-        console.warn("sessionStorage is unavailable:", e);
-    }
+    } catch (e) {}
 
     // Intercept clicks on symbol links to append the persistent file path
     $(document).on('mousedown click', 'a[href*="search?"]', function (e) {
@@ -2392,9 +2390,7 @@ function searchSubmit(form) {
             } else {
                 sessionStorage.removeItem('opengrok_search_path');
             }
-        } catch (e) {
-            console.warn("sessionStorage is unavailable:", e);
-        }
+        } catch (e) {}
     }
 
     let submitInitiator = '';

--- a/opengrok-web/src/main/webapp/js/utils-0.0.48.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.48.js
@@ -1629,24 +1629,26 @@ $(document).ready(function () {
     }
 
     // Intercept clicks on symbol links to append the persistent file path
-    $(document).on('click', 'a', function (e) {
+    $(document).on('mousedown click', 'a[href*="search?"]', function (e) {
+        // Let the browser handle ctrl/cmd/shift/middle clicks naturally
+        if (e.ctrlKey || e.metaKey || e.shiftKey || e.which === 2) return;
+
         const href = $(this).attr('href');
         if (!href) return;
         
-        if (href.indexOf('defs=') !== -1 || href.indexOf('refs=') !== -1) {
-            try {
-                const url = new URL(href, window.location.origin);
+        try {
+            const url = new URL(href, window.location.origin);
+            if (url.searchParams.has('defs') || url.searchParams.has('refs')) {
                 if (!url.searchParams.has('path')) {
                     const storedPath = sessionStorage.getItem('opengrok_search_path');
                     if (storedPath) {
                         url.searchParams.set('path', storedPath);
-                        e.preventDefault();
-                        window.location.href = url.pathname + url.search + url.hash;
+                        $(this).attr('href', url.pathname + url.search + url.hash);
                     }
                 }
-            } catch (err) {
-                // Ignore malformed URLs
             }
+        } catch (err) {
+            // Silently ignore malformed URLs
         }
     });
 });

--- a/opengrok-web/src/main/webapp/js/utils-0.0.48.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.48.js
@@ -1617,6 +1617,39 @@ $(document).ready(function () {
     init_markdown_converter();
 
     restoreFocusAfterSearchSubmit();
+
+    // Pre-populate the File Path field with the stored one if it's currently empty and not overridden in URL
+    try {
+        const storedPath = sessionStorage.getItem('opengrok_search_path');
+        if (storedPath && $('#path').length && !$('#path').val() && getParameter('path') === undefined) {
+            $('#path').val(storedPath);
+        }
+    } catch (e) {
+        console.warn("sessionStorage is unavailable:", e);
+    }
+
+    // Intercept clicks on symbol links to append the persistent file path
+    $(document).on('click', 'a.intelliWindow-symbol, a.search-defs, a.search-refs', function (e) {
+        const href = $(this).attr('href');
+        if (!href) return;
+        
+        try {
+            const url = new URL(href, window.location.origin);
+            // Verify it runs a symbol query
+            if (url.searchParams.has('refs') || url.searchParams.has('defs')) {
+                if (!url.searchParams.has('path')) {
+                    const storedPath = sessionStorage.getItem('opengrok_search_path');
+                    if (storedPath) {
+                        url.searchParams.set('path', storedPath);
+                        e.preventDefault();
+                        window.location.href = url.pathname + url.search + url.hash;
+                    }
+                }
+            }
+        } catch (err) {
+            // Ignore malformed URLs
+        }
+    });
 });
 
 /**
@@ -2179,6 +2212,21 @@ function clearSearchFrom() {
         $(this).val("");
     });
     $("#type").searchableOptionList().selectRadio("");
+    try {
+        sessionStorage.removeItem('opengrok_search_path');
+    } catch (e) {}
+}
+
+function clearFilePath() {
+    $('#path').val('');
+    try {
+        sessionStorage.removeItem('opengrok_search_path');
+    } catch (e) {}
+    if (isOnSearchPage()) {
+        $('#sbox').submit();
+    } else {
+        $('#path').focus();
+    }
 }
 
 function getSelectedProjectNames() {
@@ -2334,6 +2382,20 @@ function preprocess_searched_projects(form) {
  * @param {HTMLFormElement} form
  */
 function searchSubmit(form) {
+    // Save the path field value to sessionStorage
+    const pathVal = $('#path').val();
+    if (pathVal !== undefined) {
+        try {
+            if (pathVal) {
+                sessionStorage.setItem('opengrok_search_path', pathVal);
+            } else {
+                sessionStorage.removeItem('opengrok_search_path');
+            }
+        } catch (e) {
+            console.warn("sessionStorage is unavailable:", e);
+        }
+    }
+
     let submitInitiator = '';
     if (textInputHasFocus()) {
         submitInitiator = document.activeElement.getAttribute('id');

--- a/opengrok-web/src/main/webapp/js/utils-0.0.48.js
+++ b/opengrok-web/src/main/webapp/js/utils-0.0.48.js
@@ -1629,14 +1629,13 @@ $(document).ready(function () {
     }
 
     // Intercept clicks on symbol links to append the persistent file path
-    $(document).on('click', 'a.intelliWindow-symbol, a.search-defs, a.search-refs', function (e) {
+    $(document).on('click', 'a', function (e) {
         const href = $(this).attr('href');
         if (!href) return;
         
-        try {
-            const url = new URL(href, window.location.origin);
-            // Verify it runs a symbol query
-            if (url.searchParams.has('refs') || url.searchParams.has('defs')) {
+        if (href.indexOf('defs=') !== -1 || href.indexOf('refs=') !== -1) {
+            try {
+                const url = new URL(href, window.location.origin);
                 if (!url.searchParams.has('path')) {
                     const storedPath = sessionStorage.getItem('opengrok_search_path');
                     if (storedPath) {
@@ -1645,9 +1644,9 @@ $(document).ready(function () {
                         window.location.href = url.pathname + url.search + url.hash;
                     }
                 }
+            } catch (err) {
+                // Ignore malformed URLs
             }
-        } catch (err) {
-            // Ignore malformed URLs
         }
     });
 });

--- a/opengrok-web/src/main/webapp/menu.jspf
+++ b/opengrok-web/src/main/webapp/menu.jspf
@@ -172,10 +172,15 @@ document.domReady.push(function() { domReadyMenu(); });
     <tr>
         <td><label for="<%= QueryParameters.PATH_SEARCH_PARAM %>"
               title="Path or parts of it (no need to use separators)">File&nbsp;Path</label></td>
-        <td colspan="2"><input class="q" tabindex="4"
-            name="<%= QueryParameters.PATH_SEARCH_PARAM %>"
-            id="<%= QueryParameters.PATH_SEARCH_PARAM %>" type="text" value="<%=
-            Util.formQuoteEscape(queryParams.getPath()) %>"/></td>
+        <td colspan="2">
+            <div class="path-search-container">
+                <input class="q" tabindex="4"
+                    name="<%= QueryParameters.PATH_SEARCH_PARAM %>"
+                    id="<%= QueryParameters.PATH_SEARCH_PARAM %>" type="text" value="<%=
+                    Util.formQuoteEscape(queryParams.getPath()) %>"/>
+                <button type="button" id="clear-path-btn" class="btn path-clear-btn" onclick="clearFilePath();" title="Clear File Path" aria-label="Clear File Path">Clear</button>
+            </div>
+        </td>
     </tr>
     <tr>
         <td><label for="<%= QueryParameters.HIST_SEARCH_PARAM %>"


### PR DESCRIPTION
Adds persistent File Path filtering for symbol navigation by preserving the active path value in sessionStorage and propagating it to refs/defs search links. Also introduces a Clear button for the File Path field and updates the UI layout to keep the input and button aligned while preserving native browser navigation behavior.

Fixes #2882.