### PR TITLE
bump pyenv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
       with:
         distribution: 'oracle'
         java-version: '21'
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      with:
+        python-version: '3.13'
     - name: Cache Maven packages
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
-        python-version: '3.10'
+        python-version: '3.13'
     - name: Install dependencies
       run: python3 -m pip install -r docker/requirements.txt
     - name: Install opengrok-tools so that pylint can perform the checks

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 min_version = 4.0
 env_list =
-    py310
+    py313
     type
 
 [testenv]


### PR DESCRIPTION
In most GA runners `tox` fails with:
```
py310: failed with could not find python interpreter matching any of the specs py310
```
This change remedies that by bumping the `pyenv` in `tox.ini` while also setting the Python version via `setup-python` action.