### PR TITLE
escape LDAP filter metacharacters

### DIFF
--- a/plugins/src/main/java/opengrok/auth/plugin/LdapFilterPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapFilterPlugin.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin;
 
@@ -151,8 +151,8 @@ public class LdapFilterPlugin extends AbstractLdapPlugin {
     }
 
     /**
-     * Expand {@code LdapUser} / {@code User} object attribute values into the filter.
-     * Use \% for printing the '%' character.
+     * Expand {@link LdapUser} / {@link User} object attribute values into the filter.
+     * Use <code>\%</code> for printing the <code>%</code> character.
      *
      * @param filter basic filter containing the special values
      * @param ldapUser user from LDAP

--- a/plugins/src/main/java/opengrok/auth/plugin/LdapFilterPlugin.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/LdapFilterPlugin.java
@@ -175,6 +175,12 @@ public class LdapFilterPlugin extends AbstractLdapPlugin {
                             String.format("Failed to expand filter ''%s'' with name ''%s'' and value ''%s''",
                                     filter, name, value), ex);
                 }
+            } else {
+                if (LOGGER.isLoggable(Level.FINEST)) {
+                    LOGGER.log(Level.FINEST,
+                            String.format("ignoring expansion of filter ''%s'' for multi-value name ''%s''",
+                                    filter, entry.getKey()));
+                }
             }
         }
 

--- a/plugins/src/main/java/opengrok/auth/plugin/util/FilterUtil.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/util/FilterUtil.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin.util;
 
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
 
 public class FilterUtil {
 
@@ -65,6 +66,21 @@ public class FilterUtil {
     }
 
     /**
+     * @param value string
+     * @return string with LDAP filter metacharacters escaped as per RFC 4515, section 3
+     */
+    private static String escapeLdapFilterValue(String value) {
+        // Use quoteReplacement() to deal with the $ character potentially present in the value
+        // because $ has special meaning in regex replacements.
+        return Matcher.quoteReplacement(value
+                .replace("\\", "\\5c")    // MUST be first
+                .replace("*",  "\\2a")
+                .replace("(",  "\\28")
+                .replace(")",  "\\29")
+                .replace("\u0000", "\\00"));
+    }
+
+    /**
      * Expand attributes in filter string.
      * @param filter input string
      * @param name attribute name
@@ -80,7 +96,7 @@ public class FilterUtil {
             }
         }
 
-        return filter.replaceAll("(?<!\\\\)%" + name + "(?<!\\\\)%", value);
+        return filter.replaceAll("(?<!\\\\)%" + name + "(?<!\\\\)%", escapeLdapFilterValue(value));
     }
 
     /**
@@ -96,8 +112,9 @@ public class FilterUtil {
 
     /**
      * Expand {@code User} object attribute values into the filter.
-     *
+     * <p>
      * Special values are:
+     * </p>
      * <ul>
      * <li>%username% - to be replaced with username value from the User object</li>
      * <li>%guid% - to be replaced with guid value from the User object</li>

--- a/plugins/src/main/java/opengrok/auth/plugin/util/FilterUtil.java
+++ b/plugins/src/main/java/opengrok/auth/plugin/util/FilterUtil.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FilterUtil {
 
@@ -96,7 +97,7 @@ public class FilterUtil {
             }
         }
 
-        return filter.replaceAll("(?<!\\\\)%" + name + "(?<!\\\\)%", escapeLdapFilterValue(value));
+        return filter.replaceAll("(?<!\\\\)%" + Pattern.quote(name) + "(?<!\\\\)%", escapeLdapFilterValue(value));
     }
 
     /**

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapFilterPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapFilterPluginTest.java
@@ -125,10 +125,10 @@ class LdapFilterPluginTest {
         assertEquals(MessageFormat.format("(uid=%{0}%)", addExpectedEscapeChars("007")),
                 plugin.expandFilter("(uid=%%username%%)", ldapUser, user));
 
-        assertEquals(MessageFormat.format("(uid=%{0}%)",  addExpectedEscapeChars("123")),
+        assertEquals(MessageFormat.format("(uid=%{0}%)", addExpectedEscapeChars("123")),
                 plugin.expandFilter("(uid=%%guid%%)", ldapUser, user));
 
-        assertEquals(MessageFormat.format("(objectclass=%{0}%)",   addExpectedEscapeChars("james@bond")),
+        assertEquals(MessageFormat.format("(objectclass=%{0}%)", addExpectedEscapeChars("james@bond")),
                 plugin.expandFilter("(objectclass=%%mail%%)", ldapUser, user));
 
         assertEquals(MessageFormat.format("(objectclass=%{0}%)", addExpectedEscapeChars("bondjame")),

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapFilterPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapFilterPluginTest.java
@@ -119,7 +119,6 @@ class LdapFilterPluginTest {
         LdapUser ldapUser = new LdapUser();
         ldapUser.setAttribute("mail", new TreeSet<>(Collections.singletonList(addEscapeChars("james@bond"))));
         ldapUser.setAttribute("uid", new TreeSet<>(Collections.singletonList(addEscapeChars("bondjame"))));
-        ldapUser.setAttribute("ou", new TreeSet<>(Arrays.asList("MI6", "MI7")));
         User user = new User(addEscapeChars("007"), addEscapeChars("123"), null, true);
 
         assertEquals(MessageFormat.format("(uid=%{0}%)", addExpectedEscapeChars("007")),

--- a/plugins/src/test/java/opengrok/auth/plugin/LdapFilterPluginTest.java
+++ b/plugins/src/test/java/opengrok/auth/plugin/LdapFilterPluginTest.java
@@ -18,10 +18,11 @@
  */
 
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package opengrok.auth.plugin;
 
+import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -102,6 +103,36 @@ class LdapFilterPluginTest {
 
         assertEquals("(objectclass=%%%%)",
                 plugin.expandFilter("(objectclass=\\%%\\%\\%)", ldapUser, user));
+
+    }
+
+    private static String addEscapeChars(String value) {
+        return "$" + value + "\00\\((*))\\\00";
+    }
+
+    private static String addExpectedEscapeChars(String value) {
+        return "$" + value + "\\00\\5c\\28\\28\\2a\\29\\29\\5c\\00";
+    }
+
+    @Test
+    void expandFilterTestFilterMetacharacters() {
+        LdapUser ldapUser = new LdapUser();
+        ldapUser.setAttribute("mail", new TreeSet<>(Collections.singletonList(addEscapeChars("james@bond"))));
+        ldapUser.setAttribute("uid", new TreeSet<>(Collections.singletonList(addEscapeChars("bondjame"))));
+        ldapUser.setAttribute("ou", new TreeSet<>(Arrays.asList("MI6", "MI7")));
+        User user = new User(addEscapeChars("007"), addEscapeChars("123"), null, true);
+
+        assertEquals(MessageFormat.format("(uid=%{0}%)", addExpectedEscapeChars("007")),
+                plugin.expandFilter("(uid=%%username%%)", ldapUser, user));
+
+        assertEquals(MessageFormat.format("(uid=%{0}%)",  addExpectedEscapeChars("123")),
+                plugin.expandFilter("(uid=%%guid%%)", ldapUser, user));
+
+        assertEquals(MessageFormat.format("(objectclass=%{0}%)",   addExpectedEscapeChars("james@bond")),
+                plugin.expandFilter("(objectclass=%%mail%%)", ldapUser, user));
+
+        assertEquals(MessageFormat.format("(objectclass=%{0}%)", addExpectedEscapeChars("bondjame")),
+                plugin.expandFilter("(objectclass=%%uid%%)", ldapUser, user));
     }
 
     @Test


### PR DESCRIPTION
The expansion of the LDAP filter has to escape LDAP filter metacharacters to avoid ambiguity.