### PR TITLE
bump CodeQL analyze to 4.36.3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,4 +40,4 @@ jobs:
       uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4


### PR DESCRIPTION
The recent CodeQL version update bumped just the `init` https://github.com/oracle/opengrok/commit/70baff33ce139bb6d51347ae758cecd9dbce02a5. This made `analyze` step fail with `Error: Loaded a configuration file for version '4.36.3', but running version '4.36.2'`. This change bumps the `analyze` as well.