### PR TITLE
replace wildcard CORS with allowlist

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/Configuration.java
@@ -302,6 +302,7 @@ public final class Configuration {
     private Set<String> authenticationTokens; // set of bearer tokens used by the webapp to validate access to certain API endpoints
     private String indexerAuthenticationToken;  // bearer token used by the indexer to communicate with the webapp
     private boolean allowInsecureTokens;    // whether to allow bearer tokens over plain HTTP (as opposed to HTTPS)
+    private Set<String> allowedOrigins; // set of origins allowed to read CORS-enabled API responses
 
     private int historyChunkCount;
     private boolean historyCachePerPartesEnabled = true;
@@ -553,6 +554,7 @@ public final class Configuration {
         // This list of calls is sorted alphabetically so please keep it.
         cmds = new HashMap<>();
         setAllowLeadingWildcard(true);
+        setAllowedOrigins(new HashSet<>());
         setAllowedSymlinks(new HashSet<>());
         setAnnotationCacheEnabled(false);
         setApiTimeout(300); // 5 minutes
@@ -1423,6 +1425,14 @@ public final class Configuration {
 
     public void setAllowInsecureTokens(boolean value) {
         this.allowInsecureTokens = value;
+    }
+
+    public Set<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(Set<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
     }
 
     public int getHistoryChunkCount() {

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/configuration/RuntimeEnvironment.java
@@ -2184,6 +2184,14 @@ public final class RuntimeEnvironment {
         syncWriteConfiguration(value, Configuration::setAllowInsecureTokens);
     }
 
+    public Set<String> getAllowedOrigins() {
+        return Collections.unmodifiableSet(syncReadConfiguration(Configuration::getAllowedOrigins));
+    }
+
+    public void setAllowedOrigins(Set<String> origins) {
+        syncWriteConfiguration(origins, Configuration::setAllowedOrigins);
+    }
+
     public void registerListener(ConfigurationChangedListener listener) {
         listeners.add(listener);
     }

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/configuration/RuntimeEnvironmentTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.indexer.configuration;
@@ -421,6 +421,18 @@ class RuntimeEnvironmentTest {
         assertFalse(instance.isIndexVersionedFilesOnly());
         instance.setIndexVersionedFilesOnly(true);
         assertTrue(instance.isIndexVersionedFilesOnly());
+    }
+
+    @Test
+    void testAllowedOrigins() {
+        RuntimeEnvironment instance = RuntimeEnvironment.getInstance();
+        final HashSet<String> origins = new HashSet<>(Arrays.asList("https://one.example.com", "https://two.example.com"));
+        try {
+            instance.setAllowedOrigins(origins);
+            assertEquals(origins, instance.getAllowedOrigins());
+        } finally {
+            instance.setAllowedOrigins(new HashSet<>());
+        }
     }
 
     @Test

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/CorsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/CorsFilter.java
@@ -17,12 +17,17 @@
  * CDDL HEADER END
  */
 
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ */
+
 package org.opengrok.web.api.v1.filter;
 
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.ext.Provider;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 
 @Provider
 @CorsEnable
@@ -30,18 +35,25 @@ public class CorsFilter implements ContainerResponseFilter {
 
     public static final String ALLOW_CORS_HEADER = "Access-Control-Allow-Origin";
     public static final String CORS_REQUEST_HEADER = "Origin";
+    public static final String VARY_HEADER = "Vary";
 
     /**
      * Method for ContainerResponseFilter.
      */
     @Override
     public void filter(ContainerRequestContext request, ContainerResponseContext response) {
+        String origin = request.getHeaderString(CORS_REQUEST_HEADER);
+
         // if there is no Origin header, then it is not a
-        // cross origin request. We don't do anything.
-        if (request.getHeaderString(CORS_REQUEST_HEADER) == null) {
+        // cross-origin request. We don't do anything.
+        if (origin == null) {
             return;
         }
 
-        response.getHeaders().add(ALLOW_CORS_HEADER, "*");
+        response.getHeaders().add(VARY_HEADER, CORS_REQUEST_HEADER);
+
+        if (RuntimeEnvironment.getInstance().getAllowedOrigins().contains(origin)) {
+            response.getHeaders().add(ALLOW_CORS_HEADER, origin);
+        }
     }
 }

--- a/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/CorsFilter.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/api/v1/filter/CorsFilter.java
@@ -50,6 +50,7 @@ public class CorsFilter implements ContainerResponseFilter {
             return;
         }
 
+        // The CORS response depends on Origin; make shared caches key this response accordingly.
         response.getHeaders().add(VARY_HEADER, CORS_REQUEST_HEADER);
 
         if (RuntimeEnvironment.getInstance().getAllowedOrigins().contains(origin)) {

--- a/opengrok-web/src/test/java/org/opengrok/web/CorsFilterTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/CorsFilterTest.java
@@ -19,6 +19,7 @@
 
 /*
  * Copyright (c) 2019, Shenghan Gao <gaoshenghan199123@gmail.com>.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.web;
 
@@ -26,10 +27,14 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.opengrok.indexer.configuration.RuntimeEnvironment;
 import org.opengrok.web.api.v1.filter.CorsFilter;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -38,14 +43,26 @@ import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
 
 class CorsFilterTest {
+    @AfterEach
+    void tearDown() {
+        RuntimeEnvironment.getInstance().setAllowedOrigins(Collections.emptySet());
+    }
+
     @Test
     void nonCorsTest() {
         testBoth(null, null);
     }
 
     @Test
-    void corsTest() {
-        testBoth("https://example.org", List.of("*"));
+    void disallowedCorsTest() {
+        RuntimeEnvironment.getInstance().setAllowedOrigins(Set.of("https://allowed.example.com"));
+        testBoth("https://denied.example.com", null);
+    }
+
+    @Test
+    void allowedCorsTest() {
+        RuntimeEnvironment.getInstance().setAllowedOrigins(Set.of("https://example.com"));
+        testBoth("https://example.com", List.of("https://example.com"));
     }
 
     private void testBoth(String origin, List<Object> headerValue) {

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;
@@ -82,6 +82,7 @@ class SearchControllerTest extends OGKJerseyTest {
         env.setHistoryEnabled(false);
         env.setProjectsEnabled(true);
         env.setDefaultProjectsFromNames(Collections.singleton("__all__"));
+        env.setAllowedOrigins(Collections.singleton("http://example.com"));
         env.getSuggesterConfig().setRebuildCronConfig(null);
         RepositoryFactory.initializeIgnoredNames(env);
 
@@ -92,6 +93,7 @@ class SearchControllerTest extends OGKJerseyTest {
     @AfterAll
     public static void tearDownClass() {
         repository.destroy();
+        env.setAllowedOrigins(Collections.emptySet());
     }
 
     @Test
@@ -100,7 +102,7 @@ class SearchControllerTest extends OGKJerseyTest {
                 .request()
                 .header(CORS_REQUEST_HEADER, "http://example.com")
                 .get();
-        assertEquals("*", response.getHeaderString(ALLOW_CORS_HEADER));
+        assertEquals("http://example.com", response.getHeaderString(ALLOW_CORS_HEADER));
     }
 
     @Test

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SuggesterControllerTest.java
@@ -49,6 +49,7 @@ import org.opengrok.web.api.v1.RestApp;
 import org.opengrok.web.api.v1.suggester.provider.filter.AuthorizationFilter;
 import org.opengrok.web.api.v1.suggester.provider.service.impl.SuggesterServiceImpl;
 
+import java.net.URL;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,6 +63,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
@@ -105,6 +107,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
     protected DeploymentContext configureDeployment() {
         RuntimeEnvironment.getInstance().setAuthenticationTokens(Collections.singleton(AUTH_TOKEN));
         RuntimeEnvironment.getInstance().setAllowInsecureTokens(true);
+        RuntimeEnvironment.getInstance().setAllowedOrigins(Collections.singleton("http://example.com"));
 
         return ServletDeploymentContext.forServlet(new ServletContainer(new RestApp())).build();
     }
@@ -119,7 +122,9 @@ class SuggesterControllerTest extends OGKJerseyTest {
         System.setProperty("sun.net.http.allowRestrictedHeaders", "true"); // necessary to test CORS from controllers
         repository = new TestRepository();
 
-        repository.create(SuggesterControllerTest.class.getClassLoader().getResource("sources"));
+        URL repositoryURL = SuggesterControllerTest.class.getClassLoader().getResource("sources");
+        assertNotNull(repositoryURL);
+        repository.create(repositoryURL);
 
         env.setHistoryEnabled(false);
         env.setProjectsEnabled(true);
@@ -136,6 +141,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
         repository.destroy();
         env.setAuthenticationTokens(Collections.emptySet());
         env.setAllowInsecureTokens(false);
+        env.setAllowedOrigins(Collections.emptySet());
     }
 
     @BeforeEach
@@ -162,7 +168,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .request()
                 .header(CORS_REQUEST_HEADER, "http://example.com")
                 .get();
-        assertEquals("*", response.getHeaderString(ALLOW_CORS_HEADER));
+        assertEquals("http://example.com", response.getHeaderString(ALLOW_CORS_HEADER));
     }
 
     @Test
@@ -188,7 +194,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .header(CORS_REQUEST_HEADER, "http://example.com")
                 .get();
 
-        assertEquals("*", response.getHeaderString(ALLOW_CORS_HEADER));
+        assertEquals("http://example.com", response.getHeaderString(ALLOW_CORS_HEADER));
     }
 
     @Test
@@ -270,7 +276,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .request()
                 .get(Result.class);
 
-        var suggestions = res.suggestions.stream().map(r -> r.phrase).collect(Collectors.toList());
+        var suggestions = res.suggestions.stream().map(r -> r.phrase).toList();
         assertTrue(suggestions.containsAll(Arrays.asList("me", "method", "message")));
     }
 
@@ -284,7 +290,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .get(Result.class);
 
         assertEquals(1, res.suggestions.size());
-        assertThat(res.suggestions.get(0).projects, containsInAnyOrder("java", "kotlin"));
+        assertThat(res.suggestions.getFirst().projects, containsInAnyOrder("java", "kotlin"));
     }
 
     @Test
@@ -458,7 +464,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .request()
                 .get(Result.class);
 
-        List<String> suggestions = res.suggestions.stream().map(r -> r.phrase).collect(Collectors.toList());
+        List<String> suggestions = res.suggestions.stream().map(r -> r.phrase).toList();
 
         assertEquals("text", suggestions.get(0));
         assertEquals("teach", suggestions.get(1));
@@ -496,7 +502,7 @@ class SuggesterControllerTest extends OGKJerseyTest {
                 .request()
                 .get(Result.class);
 
-        List<String> suggestions = res.suggestions.stream().map(r -> r.phrase).collect(Collectors.toList());
+        List<String> suggestions = res.suggestions.stream().map(r -> r.phrase).toList();
 
         assertEquals("args", suggestions.get(0));
         assertEquals("array", suggestions.get(1));


### PR DESCRIPTION
The wildcard CORS header returned by the webapp is not a good combination with authenticated endpoints. This change replaces that with list of allowed origins. Introduces the `allowedOrigins` configuration directive to configure a set of allowed origins.

The read-only configuration snippet:
```xml
  <void property="allowedOrigins">
   <void method="add">
    <string>https://moomin.example.com</string>
   </void>
   <void method="add">
    <string>https://snufkin.example.com</string>
   </void>
  </void>
```

Generated by GPT-5.5 (xhigh)

While there I also did some code smell fixes.

- [x] The [Webapp configuration wiki page](https://github.com/oracle/opengrok/wiki/Webapp-configuration) will be updated after the integration.