### PR TITLE
launderRevision() vs. BitKeeper

### DIFF
--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Laundromat.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Laundromat.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.web;
 
@@ -67,7 +67,7 @@ public class Laundromat {
      * (non-logging) processing. The value is assumed to represent a revision string,
      * not including file path.
      * @return {@code null} if null or else {@code value} with anything besides
-     * alphanumeric or {@code :} or {@code .} characters removed.
+     * alphanumeric, {@code :}, or {@code .} characters removed.
      */
     public static String launderRevision(String value) {
         return replaceAll(value, "[^a-zA-Z0-9:.]", "");

--- a/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Laundromat.java
+++ b/opengrok-indexer/src/main/java/org/opengrok/indexer/web/Laundromat.java
@@ -67,10 +67,10 @@ public class Laundromat {
      * (non-logging) processing. The value is assumed to represent a revision string,
      * not including file path.
      * @return {@code null} if null or else {@code value} with anything besides
-     * alphanumeric or {@code :} characters removed.
+     * alphanumeric or {@code :} or {@code .} characters removed.
      */
     public static String launderRevision(String value) {
-        return replaceAll(value, "[^a-zA-Z0-9:]", "");
+        return replaceAll(value, "[^a-zA-Z0-9:.]", "");
     }
 
     /**

--- a/opengrok-indexer/src/test/java/org/opengrok/indexer/web/LaundromatTest.java
+++ b/opengrok-indexer/src/test/java/org/opengrok/indexer/web/LaundromatTest.java
@@ -19,7 +19,7 @@
 
 /*
  * Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  */
 package org.opengrok.indexer.web;
 
@@ -68,6 +68,20 @@ class LaundromatTest {
     @MethodSource("getParamsForTestLaunderServerName")
     void testLaunderServerName(Pair<String, String> param) {
         assertEquals(param.getLeft(), Laundromat.launderServerName(param.getRight()));
+    }
+
+    private static Stream<Pair<String, String>> getParamsForTestLaunderRevision() {
+        return Stream.of(Pair.of(null, null),
+                Pair.of("1.2.3", "1.2.3"),
+                Pair.of("1:2.3", "1:2.3"),
+                Pair.of("abc123:.def456", "abc-123:._def/456"),
+                Pair.of("", "?@#/"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getParamsForTestLaunderRevision")
+    void testLaunderRevision(Pair<String, String> param) {
+        assertEquals(param.getLeft(), Laundromat.launderRevision(param.getRight()));
     }
 
     private static Stream<Pair<String, String>> getParamsForTestLaunderUriPath() {

--- a/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
+++ b/opengrok-web/src/main/java/org/opengrok/web/PageConfig.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2011, Jens Elkner.
  * Portions Copyright (c) 2017, 2020, Chris Fraire <cfraire@me.com>.
  * Portions Copyright (c) 2023, Gino Augustine <gino.augustine@oracle.com>.
@@ -715,7 +715,8 @@ public class PageConfig {
 
     /**
      * Get the revision parameter {@code r} from the request.
-     * Anything besides alphanumeric and {@code :} is removed via {@link Laundromat#launderInput(String)}.
+     * Anything besides alphanumeric, {@code :}, or {@code .} is removed via
+     * {@link Laundromat#launderRevision(String)}.
      *
      * @return revision if found, an empty string otherwise.
      */


### PR DESCRIPTION
This change allows `.` in the revision string, needed for BitKeeper.