### PR TITLE
extend CORS tests

### DIFF
--- a/opengrok-web/src/test/java/org/opengrok/web/CorsFilterTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/CorsFilterTest.java
@@ -66,6 +66,12 @@ class CorsFilterTest {
         testBoth("https://example.com", List.of("https://example.com"), List.of(CORS_REQUEST_HEADER));
     }
 
+    @Test
+    void wildcardAllowedOriginIsNotSpecial() {
+        RuntimeEnvironment.getInstance().setAllowedOrigins(Set.of("*"));
+        testBoth("https://example.com", null, List.of(CORS_REQUEST_HEADER));
+    }
+
     private void testBoth(String origin, List<Object> allowedOriginHeaderValue, List<Object> varyHeaderValue) {
         CorsFilter filter = new CorsFilter();
         ContainerRequestContext request = mock(ContainerRequestContext.class);

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/AnnotationControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/AnnotationControllerTest.java
@@ -56,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
+import static org.opengrok.web.api.v1.filter.CorsFilter.VARY_HEADER;
 
 class AnnotationControllerTest extends OGKJerseyTest {
 
@@ -177,5 +178,6 @@ class AnnotationControllerTest extends OGKJerseyTest {
                 .get();
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertNull(response.getHeaderString(ALLOW_CORS_HEADER));
+        assertEquals(CORS_REQUEST_HEADER, response.getHeaderString(VARY_HEADER));
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/AnnotationControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/AnnotationControllerTest.java
@@ -25,6 +25,7 @@ package org.opengrok.web.api.v1.controller;
 
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +35,7 @@ import org.opengrok.indexer.history.HistoryGuru;
 import org.opengrok.indexer.history.RepositoryFactory;
 import org.opengrok.indexer.index.Indexer;
 import org.opengrok.indexer.util.TestRepository;
+import org.opengrok.web.api.v1.filter.CorsFilter;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -50,7 +52,10 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
+import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
 
 class AnnotationControllerTest extends OGKJerseyTest {
 
@@ -63,12 +68,13 @@ class AnnotationControllerTest extends OGKJerseyTest {
 
     @Override
     protected Application configure() {
-        return new ResourceConfig(AnnotationController.class);
+        return new ResourceConfig(AnnotationController.class, CorsFilter.class);
     }
 
     @BeforeEach
     @Override
     public void setUp() throws Exception {
+        System.setProperty("sun.net.http.allowRestrictedHeaders", "true"); // necessary to test CORS from controllers
         super.setUp();
         repository = new TestRepository();
         final URL repositoryURL = HistoryGuru.class.getResource("/repositories");
@@ -79,6 +85,7 @@ class AnnotationControllerTest extends OGKJerseyTest {
         env.setDataRoot(repository.getDataRoot());
         env.setProjectsEnabled(true);
         env.setHistoryEnabled(true);
+        env.setAllowedOrigins(Set.of("http://example.com"));
         RepositoryFactory.initializeIgnoredNames(env);
 
         Indexer.getInstance().prepareIndexer(
@@ -99,6 +106,7 @@ class AnnotationControllerTest extends OGKJerseyTest {
         env.setProjects(new ConcurrentHashMap<>());
         env.setRepositories(new ArrayList<>());
         env.getProjectRepositoriesMap().clear();
+        env.setAllowedOrigins(Collections.emptySet());
 
         repository.destroy();
     }
@@ -158,5 +166,16 @@ class AnnotationControllerTest extends OGKJerseyTest {
         assertEquals(Arrays.asList("1/1", "1/1", "1/1", "1/1", "1/1", "1/1", "1/1", "1/1"),
                 versions);
         assertEquals(Collections.singleton(HASH_BB74B7E8), ids);
+    }
+
+    @Test
+    void testAnnotationCorsDeniedOrigin() {
+        Response response = target("annotation")
+                .queryParam("path", "git/Makefile")
+                .request()
+                .header(CORS_REQUEST_HEADER, "http://denied.example.com")
+                .get();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertNull(response.getHeaderString(ALLOW_CORS_HEADER));
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
@@ -70,6 +70,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
+import static org.opengrok.web.api.v1.filter.CorsFilter.VARY_HEADER;
 
 class FileControllerTest extends OGKJerseyTest {
 
@@ -194,7 +195,10 @@ class FileControllerTest extends OGKJerseyTest {
                 () -> assertEquals(Response.Status.OK.getStatusCode(), defsResponse.getStatus()),
                 () -> assertNull(contentResponse.getHeaderString(ALLOW_CORS_HEADER)),
                 () -> assertNull(genreResponse.getHeaderString(ALLOW_CORS_HEADER)),
-                () -> assertNull(defsResponse.getHeaderString(ALLOW_CORS_HEADER)));
+                () -> assertNull(defsResponse.getHeaderString(ALLOW_CORS_HEADER)),
+                () -> assertEquals(CORS_REQUEST_HEADER, contentResponse.getHeaderString(VARY_HEADER)),
+                () -> assertEquals(CORS_REQUEST_HEADER, genreResponse.getHeaderString(VARY_HEADER)),
+                () -> assertEquals(CORS_REQUEST_HEADER, defsResponse.getHeaderString(VARY_HEADER)));
     }
 
     @Test

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/FileControllerTest.java
@@ -68,6 +68,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
+import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
 
 class FileControllerTest extends OGKJerseyTest {
 
@@ -97,6 +99,7 @@ class FileControllerTest extends OGKJerseyTest {
     @BeforeEach
     @Override
     public void setUp() throws Exception {
+        System.setProperty("sun.net.http.allowRestrictedHeaders", "true"); // necessary to test CORS from controllers
         super.setUp();
         repository = new TestRepository();
         repository.create(HistoryGuru.class.getResource("/repositories"));
@@ -105,6 +108,7 @@ class FileControllerTest extends OGKJerseyTest {
         env.setDataRoot(repository.getDataRoot());
         env.setProjectsEnabled(true);
         env.setHistoryEnabled(true);
+        env.setAllowedOrigins(Set.of("http://example.com"));
         RepositoryFactory.initializeIgnoredNames(env);
 
         Indexer.getInstance().prepareIndexer(
@@ -130,6 +134,7 @@ class FileControllerTest extends OGKJerseyTest {
         env.getProjectRepositoriesMap().clear();
         env.setAuthenticationTokens(Collections.emptySet());
         env.setAllowInsecureTokens(false);
+        env.setAllowedOrigins(Collections.emptySet());
 
         repository.destroy();
     }
@@ -157,6 +162,39 @@ class FileControllerTest extends OGKJerseyTest {
                 .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
                 .get(String.class);
         assertEquals("PLAIN", genre);
+    }
+
+    @Test
+    void testFileCorsDeniedOrigin() {
+        Response contentResponse = target("file")
+                .path("content")
+                .queryParam("path", "git/header.h")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+                .header(CORS_REQUEST_HEADER, "http://denied.example.com")
+                .get();
+        Response genreResponse = target("file")
+                .path("genre")
+                .queryParam("path", validPath)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+                .header(CORS_REQUEST_HEADER, "http://denied.example.com")
+                .get();
+        Response defsResponse = target("file")
+                .path("defs")
+                .queryParam("path", validPath)
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+                .header(CORS_REQUEST_HEADER, "http://denied.example.com")
+                .get();
+
+        assertAll(
+                () -> assertEquals(Response.Status.OK.getStatusCode(), contentResponse.getStatus()),
+                () -> assertEquals(Response.Status.OK.getStatusCode(), genreResponse.getStatus()),
+                () -> assertEquals(Response.Status.OK.getStatusCode(), defsResponse.getStatus()),
+                () -> assertNull(contentResponse.getHeaderString(ALLOW_CORS_HEADER)),
+                () -> assertNull(genreResponse.getHeaderString(ALLOW_CORS_HEADER)),
+                () -> assertNull(defsResponse.getHeaderString(ALLOW_CORS_HEADER)));
     }
 
     @Test

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -54,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
+import static org.opengrok.web.api.v1.filter.CorsFilter.VARY_HEADER;
 import static org.opengrok.web.api.v1.controller.HistoryController.getHistoryDTO;
 
 class HistoryControllerTest extends OGKJerseyTest {
@@ -160,5 +161,6 @@ class HistoryControllerTest extends OGKJerseyTest {
                 .get();
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertNull(response.getHeaderString(ALLOW_CORS_HEADER));
+        assertEquals(CORS_REQUEST_HEADER, response.getHeaderString(VARY_HEADER));
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -39,16 +39,21 @@ import org.opengrok.indexer.index.Indexer;
 import org.opengrok.indexer.util.TestRepository;
 import org.opengrok.web.api.v1.controller.HistoryController.HistoryDTO;
 import org.opengrok.web.api.v1.controller.HistoryController.HistoryEntryDTO;
+import org.opengrok.web.api.v1.filter.CorsFilter;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
+import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
 import static org.opengrok.web.api.v1.controller.HistoryController.getHistoryDTO;
 
 class HistoryControllerTest extends OGKJerseyTest {
@@ -59,12 +64,13 @@ class HistoryControllerTest extends OGKJerseyTest {
 
     @Override
     protected Application configure() {
-        return new ResourceConfig(HistoryController.class);
+        return new ResourceConfig(HistoryController.class, CorsFilter.class);
     }
 
     @BeforeEach
     @Override
     public void setUp() throws Exception {
+        System.setProperty("sun.net.http.allowRestrictedHeaders", "true"); // necessary to test CORS from controllers
         super.setUp();
         repository = new TestRepository();
         repository.create(HistoryGuru.class.getResource("/repositories"));
@@ -73,6 +79,7 @@ class HistoryControllerTest extends OGKJerseyTest {
         env.setDataRoot(repository.getDataRoot());
         env.setProjectsEnabled(true);
         env.setHistoryEnabled(true);
+        env.setAllowedOrigins(Set.of("http://example.com"));
         RepositoryFactory.initializeIgnoredNames(env);
 
         Indexer.getInstance().prepareIndexer(
@@ -93,6 +100,7 @@ class HistoryControllerTest extends OGKJerseyTest {
         env.setProjects(new ConcurrentHashMap<>());
         env.setRepositories(new ArrayList<>());
         env.getProjectRepositoriesMap().clear();
+        env.setAllowedOrigins(Collections.emptySet());
 
         repository.destroy();
     }
@@ -141,5 +149,16 @@ class HistoryControllerTest extends OGKJerseyTest {
         History repoHistory = HistoryGuru.getInstance().getHistory(new File(repository.getSourceRoot(), path));
         assertEquals(history, getHistoryDTO(repoHistory.getHistoryEntries(size, start), repoHistory.getTags(),
                 start, size, repoHistory.getHistoryEntries().size()));
+    }
+
+    @Test
+    void testHistoryCorsDeniedOrigin() {
+        Response response = target("history")
+                .queryParam("path", "git")
+                .request()
+                .header(CORS_REQUEST_HEADER, "http://denied.example.com")
+                .get();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertNull(response.getHeaderString(ALLOW_CORS_HEADER));
     }
 }

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/HistoryControllerTest.java
@@ -18,7 +18,7 @@
  */
 
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
  */
 package org.opengrok.web.api.v1.controller;

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
@@ -103,6 +104,17 @@ class SearchControllerTest extends OGKJerseyTest {
                 .header(CORS_REQUEST_HEADER, "http://example.com")
                 .get();
         assertEquals("http://example.com", response.getHeaderString(ALLOW_CORS_HEADER));
+    }
+
+    @Test
+    void testSearchCorsDeniedOrigin() {
+        Response response = target(SearchController.PATH)
+                .queryParam(QueryParameters.FULL_SEARCH_PARAM, "dump")
+                .request()
+                .header(CORS_REQUEST_HEADER, "http://denied.example.com")
+                .get();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertNull(response.getHeaderString(ALLOW_CORS_HEADER));
     }
 
     @Test

--- a/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
+++ b/opengrok-web/src/test/java/org/opengrok/web/api/v1/controller/SearchControllerTest.java
@@ -53,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opengrok.web.api.v1.filter.CorsFilter.ALLOW_CORS_HEADER;
 import static org.opengrok.web.api.v1.filter.CorsFilter.CORS_REQUEST_HEADER;
+import static org.opengrok.web.api.v1.filter.CorsFilter.VARY_HEADER;
 
 class SearchControllerTest extends OGKJerseyTest {
 
@@ -115,6 +116,7 @@ class SearchControllerTest extends OGKJerseyTest {
                 .get();
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         assertNull(response.getHeaderString(ALLOW_CORS_HEADER));
+        assertEquals(CORS_REQUEST_HEADER, response.getHeaderString(VARY_HEADER));
     }
 
     @Test


### PR DESCRIPTION
Follow-up for PR #5012, extends the CORS tests to the individual controllers and added special test to make sure `*` in the `allowedOrigins` set is not treated as wildcard. The test specifically check the `Vary` header to make sure the CORS filter actually ran.

Generated by GPT-5.5 (xhigh).