### PR TITLE
Align SLF4J NOP provider with the 2.x API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
         <apache-commons-lang3.version>3.18.0</apache-commons-lang3.version>
         <micrometer.version>1.14.1</micrometer.version>
         <mockito.version>5.17.0</mockito.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <commons-io.version>2.14.0</commons-io.version>
         <openapi-generator.version>7.15.0</openapi-generator.version>
     </properties>
@@ -101,6 +102,16 @@ Portions Copyright (c) 2018, 2020, Chris Fraire <cfraire@me.com>.
                 <artifactId>hamcrest-library</artifactId>
                 <version>${hamcrest.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-nop</artifactId>
+                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.bcel</groupId>

--- a/suggester/pom.xml
+++ b/suggester/pom.xml
@@ -18,7 +18,7 @@ information: Portions Copyright [yyyy] [name of copyright owner]
 
 CDDL HEADER END
 
-Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
 Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
 
 -->
@@ -130,11 +130,10 @@ Portions Copyright (c) 2020, Chris Fraire <cfraire@me.com>.
             <version>1.5.4</version>
         </dependency>
 
-        <!-- to get rid of SL4J warning messages -->
+        <!-- to get rid of SLF4J warning messages -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>1.7.30</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary
- manage `slf4j-api` and `slf4j-nop` at 2.0.18
- let the suggester use the managed NOP provider so the webapp no longer packages a 1.7 binding with a 2.x API

## Testing
- `./mvnw -q -pl suggester test -Dmaven.gitcommitid.skip=true`
- `./mvnw -q -pl opengrok-web -am package -DskipTests -Dmaven.gitcommitid.skip=true`
- verified the WAR contains `slf4j-api-2.0.18.jar` and `slf4j-nop-2.0.18.jar`
- verified `LoggerFactory` loads `org.slf4j.helpers.NOPLoggerFactory` without startup warnings

Fixes #5009